### PR TITLE
Pre-install jupyter in our container.

### DIFF
--- a/docker/Dockerfile.isaac_arena
+++ b/docker/Dockerfile.isaac_arena
@@ -38,7 +38,9 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 ################################
 # NOTE(alexmillane, 2025-07-22): Dependencies are installed in the IsaacSim version of python.
 RUN /isaac-sim/python.sh -m pip install --upgrade pip && \
-  /isaac-sim/python.sh -m pip install pytest
+  /isaac-sim/python.sh -m pip install \
+  pytest \
+  jupyter
 
 # Install isaac-arena
 RUN /isaac-sim/python.sh -m pip install -e /workspaces/isaac_arena/


### PR DESCRIPTION
## Summary
Pre-install jupyter in our docker image.

## Detailed description
- We were getting permission issues installing once the container has started, which led to needing to run the jupyter server as root.
- The container starts up with jupyter installed,
- and the server can be run with user permissions.
