### PR TITLE
Fix AR handtracking using record_demos.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ python scripts/environments/teleoperation/teleop_se3_agent.py \
 
 The following are example commands used for the mimic gen pipeline.
 
-For recording demos with the gr1 robot
+For recording demos with the gr1 robot and the Apple Vision Pro:
+Launch the [CloudXR runtime as explained here](https://isaac-sim.github.io/IsaacLab/main/source/how-to/cloudxr_teleoperation.html#:~:text=container%20with%20Docker-,Isaac%20Lab,-can%20be%20run) in a separate terminal.
+The environment variables `XDG_RUNTIME_DIR` and `XR_RUNTIME_JSON` are already set within the Isaac_arena docker.
+
 ```bash
-python submodules/IsaacLab/scripts/tools/record_demos.py \
-    --teleop_device dualhandtracking_abs \
+python isaac_arena/scripts/record_demos.py \
+    --teleop_device avp_handtracking \
     --embodiment gr1 \
     --background packing_table_pick_and_place \
     --task PickPlace-GR1T2 \

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -146,6 +146,9 @@ else
                     "--env" "DOCKER_RUN_GROUP_NAME=$(id -gn)"
                     "--env" "OMNI_USER=\$omni-api-token"
                     "--env" "OMNI_PASS=$OMNI_PASS"
+                    # Setting envs for XR: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/how-to/cloudxr_teleoperation.html#run-isaac-lab-with-the-cloudxr-runtime
+                    "--env" "XDG_RUNTIME_DIR=/workspaces/isaac_arena/submodules/IsaacLab/openxr/run"
+                    "--env" "XR_RUNTIME_JSON=/workspaces/isaac_arena/submodules/IsaacLab/openxr/share/openxr/1/openxr_cloudxr.json"
                     # NOTE(alexmillane, 2025.07.23): This looks a bit suspect to me. We should be running
                     # as a user inside the container, not root. I've left it in for now, but we should
                     # remove it, if indeed it's not needed.

--- a/isaac_arena/assets/asset_registry.py
+++ b/isaac_arena/assets/asset_registry.py
@@ -165,6 +165,6 @@ from isaac_arena.assets.background import *  # noqa: F403, F401
 from isaac_arena.assets.objects import *  # noqa: F403, F401
 from isaac_arena.embodiments.franka.franka import *  # noqa: F403, F401
 from isaac_arena.embodiments.gr1t2.gr1t2 import *  # noqa: F403, F401
-from isaac_arena.teleop_devices.avp import *  # noqa: F403, F401
+from isaac_arena.teleop_devices.avp_handtracking import *  # noqa: F403, F401
 from isaac_arena.teleop_devices.keyboard import *  # noqa: F403, F401
 from isaac_arena.teleop_devices.spacemouse import *  # noqa: F403, F401

--- a/isaac_arena/scripts/record_demos.py
+++ b/isaac_arena/scripts/record_demos.py
@@ -267,7 +267,7 @@ def setup_teleop_device(callbacks: dict[str, Callable]) -> object:
                 teleop_interface = Se3SpaceMouse(Se3SpaceMouseCfg(pos_sensitivity=0.2, rot_sensitivity=0.5))
             else:
                 omni.log.error(f"Unsupported teleop device: {args_cli.teleop_device}")
-                omni.log.error("Supported devices: keyboard, spacemouse, avp")
+                omni.log.error("Supported devices: keyboard, spacemouse, avp_handtracking")
                 exit(1)
 
             # Add callbacks to fallback device

--- a/isaac_arena/scripts/teleop.py
+++ b/isaac_arena/scripts/teleop.py
@@ -186,7 +186,7 @@ def main() -> None:
                 )
             else:
                 omni.log.error(f"Unsupported teleop device: {args_cli.teleop_device}")
-                omni.log.error("Supported devices: keyboard, spacemouse, gamepad, avp")
+                omni.log.error("Supported devices: keyboard, spacemouse, gamepad, avp_handtracking")
                 env.close()
                 simulation_app.close()
                 return

--- a/isaac_arena/teleop_devices/avp_handtracking.py
+++ b/isaac_arena/teleop_devices/avp_handtracking.py
@@ -27,7 +27,7 @@ class HandTrackingTeleopDevice(TeleopDeviceBase):
 
     NUM_OPENXR_HAND_JOINTS = 26
 
-    name = "avp"
+    name = "avp_handtracking"
 
     def __init__(self):
         super().__init__()
@@ -35,7 +35,7 @@ class HandTrackingTeleopDevice(TeleopDeviceBase):
     def build_cfg(self, *, sim_device: str | None = None, actions: object | None = None, xr_cfg: object | None = None):
         return DevicesCfg(
             devices={
-                "avp": OpenXRDeviceCfg(
+                "avp_handtracking": OpenXRDeviceCfg(
                     retargeters=[
                         GR1T2RetargeterCfg(
                             enable_visualization=True,

--- a/isaac_arena/tests/test_device_registry.py
+++ b/isaac_arena/tests/test_device_registry.py
@@ -21,7 +21,7 @@ from isaac_arena.tests.utils.subprocess import run_simulation_app_function_in_se
 
 NUM_STEPS = 2
 HEADLESS = True
-DEVICE_NAMES = ["avp", "spacemouse", "keyboard"]
+DEVICE_NAMES = ["avp_handtracking", "spacemouse", "keyboard"]
 
 
 def _test_all_devices_in_registry(simulation_app):


### PR DESCRIPTION
## Summary
Fixes to run the `record_demos.py` script using the apple vision pro.

During runtime, the hand is still flickering and needs further investigation.

## Detailed description
- Add the required environment variables `XDG_RUNTIME_DIR` & `XR_RUNTIME_JSON` to the docker environment
- Rename `avp` to  `avp_handtracking` as `/submodules/IsaacLab/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py` requires `"handtracking" in self.teleop_device.lower()`
