### PR TITLE
Add missing @configclass decorator

### DIFF
--- a/isaac_arena/environments/isaac_arena_manager_based_env.py
+++ b/isaac_arena/environments/isaac_arena_manager_based_env.py
@@ -52,6 +52,7 @@ class IsaacArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
             )
 
 
+@configclass
 class IsaacArenaManagerBasedMimicEnvCfg(IsaacArenaManagerBasedRLEnvCfg, MimicEnvCfg):
     """Configuration for an Isaac Arena environment."""
 


### PR DESCRIPTION
## Summary
Add missing @configclass decorator to `class IsaacArenaManagerBasedMimicEnvCfg(IsaacArenaManagerBasedRLEnvCfg, MimicEnvCfg):`


## Detailed description
- Corrects a mistake in #30 