### PR TITLE
Remove tagged flag for asset.

### DIFF
--- a/isaac_arena/assets/asset.py
+++ b/isaac_arena/assets/asset.py
@@ -18,11 +18,6 @@ class Asset:
     Base class for all assets.
     """
 
-    # TODO(alexmillane, 2025.09.08): Get rid of this flag.
-    # We should be able to use the tags attribute directly.
-    # A "None" tag should be treated as "untagged".
-    tagged: bool = True
-
     def __init__(self, name: str, tags: list[str] | None = None, **kwargs):
         # NOTE: Cooperative Multiple Inheritance Pattern.
         # Calling super even though this is a base class to support

--- a/isaac_arena/assets/asset_registry.py
+++ b/isaac_arena/assets/asset_registry.py
@@ -35,8 +35,6 @@ class Registry(metaclass=SingletonMeta):
         """
         assert component.name not in self.components, f"component {component.name} already registered"
         assert component.name is not None, "component name is not set"
-        if component.tagged:
-            assert component.tags is not None, "Asset tags are not set"
         self.components[component.name] = component
 
     def is_registered(self, name: str) -> bool:

--- a/isaac_arena/teleop_devices/teleop_device_base.py
+++ b/isaac_arena/teleop_devices/teleop_device_base.py
@@ -19,7 +19,6 @@ from typing import Any
 class TeleopDeviceBase(ABC):
 
     name: str | None = None
-    tagged: bool = False
 
     def __init__(self):
         self._teleop_device_cfg: Any | None = None


### PR DESCRIPTION
## Summary
Remove now useless `Asset.tagged`.

## Detailed description
- `Asset.tags = None` indicates that the asset is untagged. Having an explicit member is redundant and allows for the possibility that the two members disagree (i.e. it introduces an unnecessary class invariant).
