### PR TITLE
Mount IsaacLab submodule directory

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -129,6 +129,7 @@ else
                     "--gpus=all"
                     "-v" "./docs:${WORKDIR}/docs"
                     "-v" "./isaac_arena:${WORKDIR}/isaac_arena"
+                    "-v" "./submodules/IsaacLab:${WORKDIR}/submodules/IsaacLab"
                     "-v" "$DATASETS_HOST_MOUNT_DIRECTORY:/datasets"
                     "-v" "$MODELS_HOST_MOUNT_DIRECTORY:/models"
                     "-v" "$EVAL_HOST_MOUNT_DIRECTORY:/eval"


### PR DESCRIPTION
## Summary
Fixes the CloudXr instances not being found when entering AR mode.

The submodule we have access to in the submodule was just a copy. For some workflows we need access to on-the-fly changes on the host side. One example is the CloudXr server we launch on the host in the submodule directory which only then creates runfiles which in turn are required by IsaacLab within the container. 

Changes breaking this made it in through [MR](https://github.com/isaac-sim/isaac_arena/pull/71/files#diff-f6c013bcc6aafeba1cb42835e7185514a3a794d17cae289b990abd74955796ecR97-R101)