### PR TITLE
Fix post merge gr00t docker issue

### DIFF
--- a/docker/push_to_ngc.sh
+++ b/docker/push_to_ngc.sh
@@ -84,7 +84,7 @@ if [ "$PUSH_TO_NGC" = true ]; then
 
     # Tag and push the image to NGC.
     echo "Pushing container to ${NGC_PATH}."
-    docker tag ${ISAAC_ARENA_IMAGE_NAME} ${NGC_PATH}
+    docker tag ${DOCKER_IMAGE_NAME} ${NGC_PATH}
     docker push ${NGC_PATH}
     echo "Pushing complete."
 


### PR DESCRIPTION
## Summary
CI Post-merge docker always pushes the `latest` docker to `cuda_gr00t` ngc path

## Detailed description
Docker image was set as default without specifying versions, causing it pushes the latest (without GR00T deps) to the NGC path with served as the gr00t docker.
Specified the image name with correct version as the fix.
