### PR TITLE
Get combine config class to work when combining config classes with s…

### DIFF
--- a/isaac_arena/tests/test_configclass.py
+++ b/isaac_arena/tests/test_configclass.py
@@ -18,6 +18,35 @@ from isaaclab.utils import configclass
 from isaac_arena.utils.configclass import combine_configclasses
 
 
+def test_combine_configclasses_with_multiple_inheritance():
+
+    # Side A - A class with a base class
+    @configclass
+    class FooCfgBase:
+        a: int = 1
+        b: int = 2
+
+    @configclass
+    class FooCfg(FooCfgBase):
+        c: int = 3
+        a: int = 4
+
+    # Side B - A class without a base class
+    @configclass
+    class BarCfg(FooCfgBase):
+        d: int = 4
+        e: int = 5
+
+    # Combine the two classes
+    CombinedCfg = combine_configclasses("CombinedCfg", FooCfg, BarCfg, bases=(FooCfgBase,))
+    assert CombinedCfg().d() == 4
+    assert CombinedCfg().c() == 3
+    assert CombinedCfg().b() == 2
+    assert CombinedCfg().a() == 4
+    assert CombinedCfg().e() == 5
+    assert isinstance(CombinedCfg(), FooCfgBase)
+
+
 def test_combine_configclasses_with_inheritance():
 
     # Side A - A class with a base class

--- a/isaac_arena/utils/configclass.py
+++ b/isaac_arena/utils/configclass.py
@@ -147,7 +147,8 @@ def combine_configclasses(name: str, *input_configclasses: type, bases: tuple[ty
             if current_field.name in field_map:
                 previous_field = field_map[current_field.name]
                 # same → skip; different types → error; else last wins
-                if previous_field.type == current_field.type:
+                # The 1 field index is the type
+                if previous_field[1] == current_field.type:
                     continue
                 raise ValueError(f"Field {current_field.name} has different types in the input configclasses")
             field_info = get_field_info(current_field)


### PR DESCRIPTION
Extend combine config classes to take in classes inheriting from the same base class

## Summary
Earlier when inheriting from the same base class the duplication assert throws an error. Now this is checked and fixed.
