### PR TITLE
Update G1 robot USD path

### DIFF
--- a/isaac_arena/embodiments/g1/g1.py
+++ b/isaac_arena/embodiments/g1/g1.py
@@ -31,6 +31,7 @@ from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers.action_manager import ActionTermCfg
 from isaaclab.sensors import CameraCfg  # noqa: F401
 from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
 import isaac_arena.terms.transforms as transforms_terms
 from isaac_arena.arena_g1.g1_env.mdp import g1_events as g1_events_mdp
@@ -39,7 +40,6 @@ from isaac_arena.arena_g1.g1_env.mdp.actions.g1_decoupled_wbc_joint_action_cfg i
 from isaac_arena.arena_g1.g1_env.mdp.actions.g1_decoupled_wbc_pink_action_cfg import G1DecoupledWBCPinkActionCfg
 from isaac_arena.assets.register import register_asset
 from isaac_arena.embodiments.embodiment_base import EmbodimentBase
-from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaac_arena.utils.isaaclab_utils.resets import reset_all_articulation_joints
 from isaac_arena.utils.pose import Pose
 


### PR DESCRIPTION
## Summary
The G1 robot is already on the Isaac Nucleus drive that is synced to S3. This updates the USD path from the hardcoded Nucleus one (which is only accessible with NV login), to one using Isaac Lab's carb based directory path, enabling automatically pulling the publicly accessible S3 version of the asset.

