### PR TITLE
Fix sphinx documentation build error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "venv_docs"]
 
 # Be picky about missing references
 nitpicky = True  # warns on broken references


### PR DESCRIPTION
## Summary
Building the docs `make html` resulted in  numerous warnings related to the toctree
```
/workspaces/isaac_arena/docs/venv_docs/lib/python3.11/site-packages/imagesize-1.4.1.dist-info/LICENSE.rst: WARNING: document isn't included in any toctree [toc.not_included]
/workspaces/isaac_arena/docs/venv_docs/lib/python3.11/site-packages/prompt_toolkit-3.0.52.dist-info/licenses/AUTHORS.rst: WARNING: document isn't included in any toctree [toc.not_included]
[...]
```

Exclude the `venv_docs` directory from scanning.


