### PR TITLE
Parse docker run tabular view correctly

### DIFF
--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -22,11 +22,15 @@ Launch the Container
 .. tabs::
     .. tab:: Default
 
-        :docker_run_default:
+        .. code-block:: bash
+
+            ./docker/run_docker.sh
 
     .. tab:: With GR00T Dependencies
 
-        :docker_run_gr00t:
+        .. code-block:: bash
+
+            ./docker/run_docker.sh -g
 
 Optionally verify installation by running tests:
 


### PR DESCRIPTION
## Summary
Fixes the layout of the tabular view of starting either the default or gr00t docker.

`:docker_run_gr00t:` and `:docker_run_default:` are not properly parsed when used in a tabluar view context.