### PR TITLE
Update asset library to Isaac Lab - Arena Nucleus drive location

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -39,6 +39,7 @@ class LibraryBackground(Background):
             **kwargs,
         )
 
+
 # TODO(peterd, 2025.11.05): Update all OV drive paths to use {ISAACLAB_NUCLEUS_DIR}
 # alias prior to public release once assets are synced to S3
 @register_asset

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -44,6 +44,7 @@ class LibraryObject(Object):
             **kwargs,
         )
 
+
 # TODO(peterd, 2025.11.05): Update all OV drive paths to use {ISAACLAB_NUCLEUS_DIR}
 # alias prior to public release once assets are synced to S3
 @register_asset


### PR DESCRIPTION
## Summary
Lab 2.3 has been released so the Arena assets can be safely migrated to the Isaac Lab Arena Nucleus staging area.
This PR updates the USD asset paths in background/object library to the ones in the Isaac Lab Arena Nucleus drive, and adds a note to update to the S3 Nucleus alias once assets are synced to S3.

This Nucleus drive is the final staging area for Isaac Lab - Arena assets. 

