### PR TITLE
Update InstructionDisplay API usage in record_demos.py

### DIFF
--- a/isaaclab_arena/scripts/record_demos.py
+++ b/isaaclab_arena/scripts/record_demos.py
@@ -305,7 +305,7 @@ def setup_ui(label_text: str, env: gym.Env) -> InstructionDisplay:
     Returns:
         InstructionDisplay: The configured instruction display object
     """
-    instruction_display = InstructionDisplay(args_cli.teleop_device)
+    instruction_display = InstructionDisplay(args_cli.xr)
     if not args_cli.xr:
         window = EmptyWindow(env, "Instruction")
         with window.ui_window_elements["main_vstack"]:


### PR DESCRIPTION
## Summary
The InstructionDisplay used in record_demos.py was [updated](https://github.com/isaac-sim/IsaacLab/commit/454c3d2f62fa7f0587525c50bc99c97ef54df660#diff-31a4d5810a5ef9223aafccf0d2aa84d59da2cfdfdb9ada68e5af85531162cefaL24) in Lab 2.3 and should be passed a [boolean flag](https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab_mimic/isaaclab_mimic/ui/instruction_display.py#L23) indicating if XR is enabled instead of the teleop device.

This PR fixes the bug where a crash occurs when trying to run the script with non XR devices (keyboard, spacemouse)
