### PR TITLE
Include python dir in PATH var for multi-gpu torchrun

### DIFF
--- a/docker/setup/install_gr00t_deps.sh
+++ b/docker/setup/install_gr00t_deps.sh
@@ -36,6 +36,6 @@ echo "Installing flash-attn..."
 
 # Ensure pytorch torchrun script is in PATH
 echo "Ensuring pytorch torchrun script is in PATH..."
-export PATH="/isaac-sim/kit/python/bin:${PATH}"
+export PATH=/isaac-sim/kit/python/bin:${PATH}
 
 echo "GR00T dependencies installation completed successfully"


### PR DESCRIPTION
Multi-gpu post-training requires calling `pytorch`'s native `torchrun`, while in single-gpu's case, it calls `python` instead. 
Include it in the `PATH` var to make it callable.

Fix to https://nvbugspro.nvidia.com/bug/5653626

