### PR TITLE
Doc fix on training cmds for static manip

### DIFF
--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -102,6 +102,7 @@ We post-train the GR00T N1.5 policy on the task.
 
 The GR00T N1.5 policy has 3 billion parameters so post training is an an expensive operation.
 We provide two post-training options:
+
 * Best Quality: 8 GPUs with 48GB memory
 * Low Hardware Requirements: 1 GPU with 24GB memory
 
@@ -167,7 +168,7 @@ We provide two post-training options:
          cd submodules/Isaac-GR00T
 
          python scripts/gr00t_finetune.py \
-         --dataset_path=$DATASET_DIR/arena_g1_loco_manipulation_dataset_generated/lerobot \
+         --dataset_path=$DATASET_DIR/arena_gr1_manipulation_dataset_generated/lerobot \
          --output_dir=$MODELS_DIR \
          --data_config=fourier_gr1_arms_only \
          --batch_size=24 \


### PR DESCRIPTION
One-line doc fix. 

Update dataset dir to GR1 manip, instead of G1 locomanip.