### PR TITLE
Move torchrun to an alias to avoid many binaries being added to path.

### DIFF
--- a/docker/setup/install_gr00t_deps.sh
+++ b/docker/setup/install_gr00t_deps.sh
@@ -36,6 +36,6 @@ echo "Installing flash-attn..."
 
 # Ensure pytorch torchrun script is in PATH
 echo "Ensuring pytorch torchrun script is in PATH..."
-echo "export PATH=/isaac-sim/kit/python/bin:${PATH}" >> /etc/environment
+echo "alias torchrun='/isaac-sim/kit/python/bin/torchrun'" >> /etc/bash.bashrc
 
 echo "GR00T dependencies installation completed successfully"

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -56,7 +56,7 @@ Note that this conversion step can be skipped by downloading the pre-converted L
          nvidia/Arena-GR1-Manipulation-Task \
          --include lerobot/* \
          --repo-type dataset \
-         --local-dir $DATASET_DIR
+         --local-dir $DATASET_DIR/arena_gr1_manipulation_dataset_generated
 
    If you download this dataset, you can skip the conversion step below and continue to the next step.
 


### PR DESCRIPTION
## Summary
Move to `torchrun` as an alias in the gr00t docker.

## Detailed description
- The prior approach added a whole bunch of other binaries.
- One of which, `hf` had some issues.
- This approach only takes `torchrun` from `/isaac-sim/python/bin`
- Addresses: [5653626](https://nvbugspro.nvidia.com/bug/5653626)
