### PR TITLE
Restore torchrun changes and move HF to alias instead

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -67,8 +67,8 @@ ENV LW_API_ENDPOINT="https://api-dev.lightwheel.net"
 # HuggingFace for downloading datasets and models.
 # NOTE(alexmillane, 2025-10-28): For some reason the CLI has issues when installed in the IsaacSim version of python.
 RUN pip install huggingface-hub[cli]
-# Add huggingface CLI to PATH (for both root and regular users)
-RUN echo 'export PATH=$PATH:/root/.local/bin:$HOME/.local/bin' >> /etc/bash.bashrc
+# Create alias for hf command to use the system-installed version
+RUN echo "alias hf='/usr/local/bin/hf'" >> /etc/bash.bashrc
 
 ###############################
 # Install GR00T and CUDA 12.8 #

--- a/docker/setup/install_gr00t_deps.sh
+++ b/docker/setup/install_gr00t_deps.sh
@@ -36,6 +36,6 @@ echo "Installing flash-attn..."
 
 # Ensure pytorch torchrun script is in PATH
 echo "Ensuring pytorch torchrun script is in PATH..."
-echo "export PATH=/isaac-sim/kit/python/bin:${PATH}" >> /etc/environment
+echo "export PATH=/isaac-sim/kit/python/bin:\$PATH" >> /etc/bash.bashrc
 
 echo "GR00T dependencies installation completed successfully"


### PR DESCRIPTION
## Summary
Move hf to alias in docker container

## Detailed description
- Restore prior approach to enable torch run
- only moving torchrun did not work with multi-gpu training
