### PR TITLE
Move license headers to spdx

### DIFF
--- a/.github/LICENSE_HEADER.txt
+++ b/.github/LICENSE_HEADER.txt
@@ -1,0 +1,4 @@
+Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: IsaacLab Arena CI
 
 on:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: GitHub Pages
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 repos:
   - repo: https://github.com/python/black
     rev: 24.3.0
@@ -50,3 +55,14 @@ repos:
       - id: rst-backticks
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.1
+    hooks:
+      - id: insert-license
+        files: \.(py|ya?ml)$
+        args:
+          # - --remove-header    # Remove existing license headers. Useful when updating license.
+          - --license-filepath
+          - .github/LICENSE_HEADER.txt
+          - --use-current-year
+        exclude: "submodules/"

--- a/docs/_ext/isaaclab_arena_doc_tools.py
+++ b/docs/_ext/isaaclab_arena_doc_tools.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/docs/helpers.py
+++ b/docs/helpers.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #

--- a/isaaclab_arena/__init__.py
+++ b/isaaclab_arena/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/affordances/__init__.py
+++ b/isaaclab_arena/affordances/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/affordances/affordance_base.py
+++ b/isaaclab_arena/affordances/affordance_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 

--- a/isaaclab_arena/affordances/openable.py
+++ b/isaaclab_arena/affordances/openable.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.envs.manager_based_env import ManagerBasedEnv

--- a/isaaclab_arena/affordances/pressable.py
+++ b/isaaclab_arena/affordances/pressable.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.envs.manager_based_env import ManagerBasedEnv

--- a/isaaclab_arena/assets/__init__.py
+++ b/isaaclab_arena/assets/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/assets/asset.py
+++ b/isaaclab_arena/assets/asset.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
 class Asset:
     """
     Base class for all assets.

--- a/isaaclab_arena/assets/asset_registry.py
+++ b/isaaclab_arena/assets/asset_registry.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import random
 from typing import TYPE_CHECKING, Any
 

--- a/isaaclab_arena/assets/background.py
+++ b/isaaclab_arena/assets/background.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.utils.pose import Pose

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_arena.assets.background import Background

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from abc import ABC, abstractmethod
 from enum import Enum

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 
 from isaaclab_arena.affordances.openable import Openable

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from contextlib import contextmanager
 
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg

--- a/isaaclab_arena/assets/object_utils.py
+++ b/isaaclab_arena/assets/object_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pxr import Usd
 
 from isaaclab_arena.assets.object_base import ObjectType

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena.assets.asset_registry import AssetRegistry, DeviceRegistry
 
 

--- a/isaaclab_arena/cli/__init__.py
+++ b/isaaclab_arena/cli/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab.app import AppLauncher

--- a/isaaclab_arena/embodiments/__init__.py
+++ b/isaaclab_arena/embodiments/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .franka.franka import *
 from .g1.g1 import *
 from .gr1t2.gr1t2 import *

--- a/isaaclab_arena/embodiments/common/__init__.py
+++ b/isaaclab_arena/embodiments/common/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/embodiments/common/mimic_utils.py
+++ b/isaaclab_arena/embodiments/common/mimic_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from collections.abc import Sequence
 

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 
 from isaaclab.envs import ManagerBasedRLMimicEnv

--- a/isaaclab_arena/embodiments/franka/__init__.py
+++ b/isaaclab_arena/embodiments/franka/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from collections.abc import Sequence
 from typing import Any

--- a/isaaclab_arena/embodiments/franka/observations.py
+++ b/isaaclab_arena/embodiments/franka/observations.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.assets import Articulation

--- a/isaaclab_arena/embodiments/g1/__init__.py
+++ b/isaaclab_arena/embodiments/g1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from collections.abc import Sequence
 from dataclasses import MISSING

--- a/isaaclab_arena/embodiments/gr1t2/__init__.py
+++ b/isaaclab_arena/embodiments/gr1t2/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/embodiments/gr1t2/gr1t2.py
+++ b/isaaclab_arena/embodiments/gr1t2/gr1t2.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import tempfile
 import torch
 from collections.abc import Sequence

--- a/isaaclab_arena/environments/__init__.py
+++ b/isaaclab_arena/environments/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import argparse

--- a/isaaclab_arena/environments/isaaclab_arena_environment.py
+++ b/isaaclab_arena/environments/isaaclab_arena_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from dataclasses import MISSING

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.envs import ManagerBasedRLEnvCfg
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
 from isaaclab.sim import SimulationCfg

--- a/isaaclab_arena/examples/__init__.py
+++ b/isaaclab_arena/examples/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/examples/compile_env_notebook.py
+++ b/isaaclab_arena/examples/compile_env_notebook.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # %%
 
 import torch

--- a/isaaclab_arena/examples/example_env_notebook.py
+++ b/isaaclab_arena/examples/example_env_notebook.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # %%
 
 import torch

--- a/isaaclab_arena/examples/example_environments/__init__.py
+++ b/isaaclab_arena/examples/example_environments/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/examples/example_environments/cli.py
+++ b/isaaclab_arena/examples/example_environments/cli.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import importlib
 from typing import Any

--- a/isaaclab_arena/examples/example_environments/example_environment_base.py
+++ b/isaaclab_arena/examples/example_environments/example_environment_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 from abc import ABC, abstractmethod
 

--- a/isaaclab_arena/examples/example_environments/galileo_g1_locomanip_pick_and_place_environment.py
+++ b/isaaclab_arena/examples/example_environments/galileo_g1_locomanip_pick_and_place_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.example_environment_base import ExampleEnvironmentBase

--- a/isaaclab_arena/examples/example_environments/galileo_pick_and_place_environment.py
+++ b/isaaclab_arena/examples/example_environments/galileo_pick_and_place_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.example_environment_base import ExampleEnvironmentBase

--- a/isaaclab_arena/examples/example_environments/gr1_open_microwave_environment.py
+++ b/isaaclab_arena/examples/example_environments/gr1_open_microwave_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.example_environment_base import ExampleEnvironmentBase

--- a/isaaclab_arena/examples/example_environments/kitchen_pick_and_place_environment.py
+++ b/isaaclab_arena/examples/example_environments/kitchen_pick_and_place_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.example_environment_base import ExampleEnvironmentBase

--- a/isaaclab_arena/examples/example_environments/press_button_environment.py
+++ b/isaaclab_arena/examples/example_environments/press_button_environment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.example_environment_base import ExampleEnvironmentBase

--- a/isaaclab_arena/examples/policy_runner.py
+++ b/isaaclab_arena/examples/policy_runner.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import random
 import torch

--- a/isaaclab_arena/examples/policy_runner_cli.py
+++ b/isaaclab_arena/examples/policy_runner_cli.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 
 from isaaclab_arena.examples.example_environments.cli import get_isaaclab_arena_example_environment_cli_parser

--- a/isaaclab_arena/metrics/__init__.py
+++ b/isaaclab_arena/metrics/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/metrics/door_moved_rate.py
+++ b/isaaclab_arena/metrics/door_moved_rate.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from dataclasses import MISSING
 

--- a/isaaclab_arena/metrics/metric_base.py
+++ b/isaaclab_arena/metrics/metric_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from abc import ABC, abstractmethod
 

--- a/isaaclab_arena/metrics/metrics.py
+++ b/isaaclab_arena/metrics/metrics.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import h5py
 import numpy as np
 import pathlib

--- a/isaaclab_arena/metrics/object_moved.py
+++ b/isaaclab_arena/metrics/object_moved.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from dataclasses import MISSING
 

--- a/isaaclab_arena/metrics/recorder_manager_utils.py
+++ b/isaaclab_arena/metrics/recorder_manager_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.managers import DatasetExportMode
 from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
 

--- a/isaaclab_arena/metrics/success_rate.py
+++ b/isaaclab_arena/metrics/success_rate.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/isaaclab_arena/orchestrator/__init__.py
+++ b/isaaclab_arena/orchestrator/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/orchestrator/orchestrator_base.py
+++ b/isaaclab_arena/orchestrator/orchestrator_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase

--- a/isaaclab_arena/policy/__init__.py
+++ b/isaaclab_arena/policy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 from abc import ABC, abstractmethod

--- a/isaaclab_arena/policy/replay_action_policy.py
+++ b/isaaclab_arena/policy/replay_action_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 from gymnasium.spaces.dict import Dict as GymSpacesDict

--- a/isaaclab_arena/policy/zero_action_policy.py
+++ b/isaaclab_arena/policy/zero_action_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 from gymnasium.spaces.dict import Dict as GymSpacesDict

--- a/isaaclab_arena/scene/__init__.py
+++ b/isaaclab_arena/scene/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Union
 
 from isaaclab.assets import AssetBaseCfg, RigidObjectCfg

--- a/isaaclab_arena/scripts/__init__.py
+++ b/isaaclab_arena/scripts/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/scripts/annotate_demos.py
+++ b/isaaclab_arena/scripts/annotate_demos.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2024-2025, The Isaac Lab Project Developers.
 # All rights reserved.
 #

--- a/isaaclab_arena/scripts/generate_dataset.py
+++ b/isaaclab_arena/scripts/generate_dataset.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2024-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/isaaclab_arena/scripts/record_demos.py
+++ b/isaaclab_arena/scripts/record_demos.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/isaaclab_arena/scripts/replay_demos.py
+++ b/isaaclab_arena/scripts/replay_demos.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/isaaclab_arena/scripts/teleop.py
+++ b/isaaclab_arena/scripts/teleop.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #

--- a/isaaclab_arena/tasks/__init__.py
+++ b/isaaclab_arena/tasks/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/tasks/dummy_task.py
+++ b/isaaclab_arena/tasks/dummy_task.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.envs.common import ViewerCfg
 
 from isaaclab_arena.tasks.task_base import TaskBase

--- a/isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py
+++ b/isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 from dataclasses import MISSING

--- a/isaaclab_arena/tasks/open_door_task.py
+++ b/isaaclab_arena/tasks/open_door_task.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from dataclasses import MISSING
 

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from dataclasses import MISSING
 

--- a/isaaclab_arena/tasks/press_button_task.py
+++ b/isaaclab_arena/tasks/press_button_task.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 from dataclasses import MISSING
 

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/isaaclab_arena/tasks/terminations.py
+++ b/isaaclab_arena/tasks/terminations.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.assets import RigidObject

--- a/isaaclab_arena/teleop_devices/__init__.py
+++ b/isaaclab_arena/teleop_devices/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .avp_handtracking import *
 from .keyboard import *
 from .spacemouse import *

--- a/isaaclab_arena/teleop_devices/avp_handtracking.py
+++ b/isaaclab_arena/teleop_devices/avp_handtracking.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/isaaclab_arena/teleop_devices/keyboard.py
+++ b/isaaclab_arena/teleop_devices/keyboard.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/isaaclab_arena/teleop_devices/spacemouse.py
+++ b/isaaclab_arena/teleop_devices/spacemouse.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/isaaclab_arena/teleop_devices/teleop_device_base.py
+++ b/isaaclab_arena/teleop_devices/teleop_device_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 

--- a/isaaclab_arena/terms/__init__.py
+++ b/isaaclab_arena/terms/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/terms/articulations.py
+++ b/isaaclab_arena/terms/articulations.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import torch

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.envs import ManagerBasedEnv

--- a/isaaclab_arena/terms/transforms.py
+++ b/isaaclab_arena/terms/transforms.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import torch

--- a/isaaclab_arena/tests/__init__.py
+++ b/isaaclab_arena/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/tests/policy/test_convert_hdf5_to_lerobot.py
+++ b/isaaclab_arena/tests/policy/test_convert_hdf5_to_lerobot.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import shutil
 
 import pandas as pd

--- a/isaaclab_arena/tests/policy/test_gr00t_closedloop_policy.py
+++ b/isaaclab_arena/tests/policy/test_gr00t_closedloop_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from isaaclab_arena.tests.utils.constants import TestConstants

--- a/isaaclab_arena/tests/policy/test_gr00t_deps.py
+++ b/isaaclab_arena/tests/policy/test_gr00t_deps.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test suite for GR00T dependencies.
 

--- a/isaaclab_arena/tests/policy/test_policy_runner.py
+++ b/isaaclab_arena/tests/policy/test_policy_runner.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_subprocess
 

--- a/isaaclab_arena/tests/policy/test_replay_lerobot_action_policy.py
+++ b/isaaclab_arena/tests/policy/test_replay_lerobot_action_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_subprocess
 

--- a/isaaclab_arena/tests/test_affordance_base.py
+++ b/isaaclab_arena/tests/test_affordance_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function

--- a/isaaclab_arena/tests/test_asset_registry.py
+++ b/isaaclab_arena/tests/test_asset_registry.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/test_camera_observation.py
+++ b/isaaclab_arena/tests/test_camera_observation.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/test_configclass.py
+++ b/isaaclab_arena/tests/test_configclass.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.utils import configclass
 
 from isaaclab_arena.utils.configclass import combine_configclasses

--- a/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_config.yaml
+++ b/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Gr00tDatasetConfig Example Configuration
 # This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
 # Example for G1 locomanipulation task

--- a/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the Gr00tClosedloopPolicy class for G1 locomanipulation task
 model_path: /checkpoints/gn1_5_g1_galileo_box_npnp/checkpoint-20000
 # model_path: /datasets/ckpts/gn1_5_g1_galileo_box_npnp_ckpts/100_v2/

--- a/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_replay_action_config.yaml
+++ b/isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_replay_action_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the ReplayLerobotActionPolicy class for G1 locomanipulation task
 dataset_path: isaaclab_arena/tests/test_data/test_g1_locomanip_lerobot/
 action_horizon: 16

--- a/isaaclab_arena/tests/test_data/test_gr1_manip_lerobot/test_gr1_manip_replay_action_config.yaml
+++ b/isaaclab_arena/tests/test_data/test_gr1_manip_lerobot/test_gr1_manip_replay_action_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the ReplayLerobotActionPolicy class for G1 locomanipulation task
 # TODO(xinjie.yao, 2025-09-30): change Hardcoded dataset_path to some releasable path
 dataset_path: isaaclab_arena/tests/test_data/test_gr1_manip_lerobot/

--- a/isaaclab_arena/tests/test_detect_object_type.py
+++ b/isaaclab_arena/tests/test_detect_object_type.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/test_device_registry.py
+++ b/isaaclab_arena/tests/test_device_registry.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_door_moved_rate_metric.py
+++ b/isaaclab_arena/tests/test_door_moved_rate_metric.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import math
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_events.py
+++ b/isaaclab_arena/tests/test_events.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/test_g1_wbc_embodiment.py
+++ b/isaaclab_arena/tests/test_g1_wbc_embodiment.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_object_of_type_base.py
+++ b/isaaclab_arena/tests/test_object_of_type_base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/test_object_on_termination.py
+++ b/isaaclab_arena/tests/test_object_on_termination.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_open_door.py
+++ b/isaaclab_arena/tests/test_open_door.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 

--- a/isaaclab_arena/tests/test_press_coffee_machine_button.py
+++ b/isaaclab_arena/tests/test_press_coffee_machine_button.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import torch
 

--- a/isaaclab_arena/tests/test_reference_objects.py
+++ b/isaaclab_arena/tests/test_reference_objects.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_robot_initial_position.py
+++ b/isaaclab_arena/tests/test_robot_initial_position.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 import tqdm

--- a/isaaclab_arena/tests/test_simulation_app_context.py
+++ b/isaaclab_arena/tests/test_simulation_app_context.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
 
 TEST_ARG = 123

--- a/isaaclab_arena/tests/test_success_rate_metric.py
+++ b/isaaclab_arena/tests/test_success_rate_metric.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 

--- a/isaaclab_arena/tests/utils/__init__.py
+++ b/isaaclab_arena/tests/utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/tests/utils/constants.py
+++ b/isaaclab_arena/tests/utils/constants.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 

--- a/isaaclab_arena/tests/utils/simulation.py
+++ b/isaaclab_arena/tests/utils/simulation.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 import tqdm
 from collections.abc import Callable

--- a/isaaclab_arena/tests/utils/subprocess.py
+++ b/isaaclab_arena/tests/utils/subprocess.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import atexit
 import os
 import subprocess

--- a/isaaclab_arena/utils/__init__.py
+++ b/isaaclab_arena/utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import inspect
 import numpy as np
 from contextlib import suppress

--- a/isaaclab_arena/utils/configclass.py
+++ b/isaaclab_arena/utils/configclass.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import dataclasses
 import keyword
 import types

--- a/isaaclab_arena/utils/isaaclab_utils/__init__.py
+++ b/isaaclab_arena/utils/isaaclab_utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/utils/isaaclab_utils/resets.py
+++ b/isaaclab_arena/utils/isaaclab_utils/resets.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.envs import ManagerBasedEnv

--- a/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
+++ b/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import os
 import sys

--- a/isaaclab_arena/utils/joint_utils.py
+++ b/isaaclab_arena/utils/joint_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 from isaaclab.envs.manager_based_env import ManagerBasedEnv

--- a/isaaclab_arena/utils/locomanip_mimic_patch.py
+++ b/isaaclab_arena/utils/locomanip_mimic_patch.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import copy
 import torch

--- a/isaaclab_arena/utils/math.py
+++ b/isaaclab_arena/utils/math.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 
 

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import torch
 from dataclasses import dataclass
 

--- a/isaaclab_arena/utils/reload_modules.py
+++ b/isaaclab_arena/utils/reload_modules.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
 def reload_arena_modules():
     """Reload all isaaclab_arena modules."""
     import importlib

--- a/isaaclab_arena/utils/singleton.py
+++ b/isaaclab_arena/utils/singleton.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
 class SingletonMeta(type):
     """
     Metaclass that overrides __call__ so that only one instance

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pxr import Usd, UsdPhysics
 
 

--- a/isaaclab_arena_g1/__init__.py
+++ b/isaaclab_arena_g1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_env/__init__.py
+++ b/isaaclab_arena_g1/g1_env/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_env/config/__init__.py
+++ b/isaaclab_arena_g1/g1_env/config/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_env/config/lab_g1_joints_order_43dof.yaml
+++ b/isaaclab_arena_g1/g1_env/config/lab_g1_joints_order_43dof.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 "left_hip_pitch_joint": 0
 "right_hip_pitch_joint": 1
 "waist_yaw_joint": 2

--- a/isaaclab_arena_g1/g1_env/config/loco_manip_g1_joints_order_43dof.yaml
+++ b/isaaclab_arena_g1/g1_env/config/loco_manip_g1_joints_order_43dof.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 'left_hip_pitch_joint': 0
 'left_hip_roll_joint': 1
 'left_hip_yaw_joint': 2

--- a/isaaclab_arena_g1/g1_env/g1_constants.py
+++ b/isaaclab_arena_g1/g1_env/g1_constants.py
@@ -1,5 +1,9 @@
-"""Constants for G1 robot joint limits (from URDF)."""
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 
+"""Constants for G1 robot joint limits (from URDF)."""
 
 # G1 Joint Limit Values (from URDF)
 # Format: [min_limit, max_limit]

--- a/isaaclab_arena_g1/g1_env/g1_supplemental_info.py
+++ b/isaaclab_arena_g1/g1_env/g1_supplemental_info.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass, field
 
 import isaaclab_arena_g1.g1_env.g1_constants as g1_constants

--- a/isaaclab_arena_g1/g1_env/mdp/__init__.py
+++ b/isaaclab_arena_g1/g1_env/mdp/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_env/mdp/actions/__init__.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_joint_action.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_joint_action.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import numpy as np

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_joint_action_cfg.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_joint_action_cfg.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import MISSING
 
 from isaaclab.managers.action_manager import ActionTerm, ActionTermCfg

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import numpy as np

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab.managers.action_manager import ActionTerm
 from isaaclab.utils import configclass
 

--- a/isaaclab_arena_g1/g1_env/mdp/g1_events.py
+++ b/isaaclab_arena_g1/g1_env/mdp/g1_events.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import torch

--- a/isaaclab_arena_g1/g1_env/mdp/g1_observations.py
+++ b/isaaclab_arena_g1/g1_env/mdp/g1_observations.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import copy

--- a/isaaclab_arena_g1/g1_env/robot_model.py
+++ b/isaaclab_arena_g1/g1_env/robot_model.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import os
 import yaml

--- a/isaaclab_arena_g1/g1_whole_body_controller/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import MISSING, asdict, dataclass
 from typing import Literal
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_homie_v2.yaml
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_homie_v2.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Default joint angles for legs
 default_angles: [-0.1, 0.0, 0.0, 0.3, -0.2, 0.0,
                  -0.1, 0.0, 0.0, 0.3, -0.2, 0.0,

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 
 import pink

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/solver.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/solver.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/action_constants.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/action_constants.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Constants for the WBC PINK action."""
 
 # Action dimensions

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/base.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/base.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_decoupled_whole_body_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_decoupled_whole_body_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 
 from isaaclab_arena_g1.g1_env.robot_model import RobotModel

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import collections
 import numpy as np
 import pathlib

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/identity_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/identity_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.base import WBCPolicy

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/policy_constants.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/policy_constants.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Constants for the WBC policy."""
 
 G1_NUM_JOINTS = 43

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/wbc_policy_factory.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/wbc_policy_factory.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from isaaclab_arena_g1.g1_env.robot_model import RobotModel
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.config.configs import BaseConfig
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.base import WBCPolicy

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/__init__.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Literal
 
 from isaaclab.utils.assets import retrieve_file_path

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/homie_utils.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/homie_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import yaml
 from typing import Any

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/p_controller.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/p_controller.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/isaaclab_arena_gr00t/__init__.py
+++ b/isaaclab_arena_gr00t/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_gr00t/config/__init__.py
+++ b/isaaclab_arena_gr00t/config/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_gr00t/config/dataset_config.py
+++ b/isaaclab_arena_gr00t/config/dataset_config.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/isaaclab_arena_gr00t/config/g1/43dof_joint_space.yaml
+++ b/isaaclab_arena_gr00t/config/g1/43dof_joint_space.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 joints:
   "left_hip_pitch_joint": 0
   "right_hip_pitch_joint": 1

--- a/isaaclab_arena_gr00t/config/g1/__init__.py
+++ b/isaaclab_arena_gr00t/config/g1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_gr00t/config/g1/gr00t_43dof_joint_space.yaml
+++ b/isaaclab_arena_gr00t/config/g1/gr00t_43dof_joint_space.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Expected input & output joint names following listed order for groot state/action space
 joints:
   left_leg:

--- a/isaaclab_arena_gr00t/config/g1_locomanip_config.yaml
+++ b/isaaclab_arena_gr00t/config/g1_locomanip_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Gr00tDatasetConfig Example Configuration
 # This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
 # Example for G1 locomanipulation task

--- a/isaaclab_arena_gr00t/config/gr1/36dof_joint_space.yaml
+++ b/isaaclab_arena_gr00t/config/gr1/36dof_joint_space.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # GR1 Robot Joint Configuration used in the action joint space
 # Maps joint names to joint indices for easy reference
 joints:

--- a/isaaclab_arena_gr00t/config/gr1/54dof_joint_space.yaml
+++ b/isaaclab_arena_gr00t/config/gr1/54dof_joint_space.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # GR1 Robot Joint Configuration used in the action joint space
 # Maps joint names to joint indices for easy reference
 joints:

--- a/isaaclab_arena_gr00t/config/gr1/__init__.py
+++ b/isaaclab_arena_gr00t/config/gr1/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_gr00t/config/gr1/gr00t_26dof_joint_space.yaml
+++ b/isaaclab_arena_gr00t/config/gr1/gr00t_26dof_joint_space.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Expected input & output joint names following listed order for groot state/action space
 joints:
   left_arm:

--- a/isaaclab_arena_gr00t/config/gr1_manip_config.yaml
+++ b/isaaclab_arena_gr00t/config/gr1_manip_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Gr00tDatasetConfig Example Configuration
 # This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
 # Example for GR1 tabletop manipulation task

--- a/isaaclab_arena_gr00t/data_config.py
+++ b/isaaclab_arena_gr00t/data_config.py
@@ -1,8 +1,14 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 External data configuration module for UnitreeG1 WBC simulation.
 This module can be loaded as an external config using:
 isaaclab_arena_gr00t.data_config:UnitreeG1SimWBCDataConfig
 """
+
 from gr00t.data.dataset import ModalityConfig
 from gr00t.data.transform.base import ComposedModalityTransform, ModalityTransform
 from gr00t.data.transform.concat import ConcatTransform

--- a/isaaclab_arena_gr00t/data_utils/__init__.py
+++ b/isaaclab_arena_gr00t/data_utils/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_gr00t/data_utils/convert_hdf5_to_lerobot.py
+++ b/isaaclab_arena_gr00t/data_utils/convert_hdf5_to_lerobot.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import h5py
 import json
 import multiprocessing as mp

--- a/isaaclab_arena_gr00t/data_utils/image_conversion.py
+++ b/isaaclab_arena_gr00t/data_utils/image_conversion.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/isaaclab_arena_gr00t/data_utils/io_utils.py
+++ b/isaaclab_arena_gr00t/data_utils/io_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import collections
 import json
 import numpy as np

--- a/isaaclab_arena_gr00t/data_utils/joints_conversion.py
+++ b/isaaclab_arena_gr00t/data_utils/joints_conversion.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 

--- a/isaaclab_arena_gr00t/data_utils/robot_eef_pose.py
+++ b/isaaclab_arena_gr00t/data_utils/robot_eef_pose.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 from dataclasses import dataclass

--- a/isaaclab_arena_gr00t/data_utils/robot_joints.py
+++ b/isaaclab_arena_gr00t/data_utils/robot_joints.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import numpy as np
 import torch
 from dataclasses import dataclass

--- a/isaaclab_arena_gr00t/g1_locomanip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/g1_locomanip_gr00t_closedloop_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the Gr00tClosedloopPolicy class for G1 locomanipulation task
 # NOTE(alexmillane, 2025-10-31): The model path here aligns with the model used in the static manipulation tutorial.
 model_path: /models/isaaclab_arena/locomanipulation_tutorial/checkpoint-20000

--- a/isaaclab_arena_gr00t/g1_locomanip_replay_action_config.yaml
+++ b/isaaclab_arena_gr00t/g1_locomanip_replay_action_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the ReplayLerobotActionPolicy class for G1 locomanipulation task
 dataset_path: /datasets/isaaclab_arena/locomanipulation_tutorial/arena_g1_loco_manipulation_dataset_generated/lerobot/
 action_horizon: 16

--- a/isaaclab_arena_gr00t/gr00t_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/gr00t_closedloop_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import numpy as np
 import torch

--- a/isaaclab_arena_gr00t/gr1_manip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/gr1_manip_gr00t_closedloop_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the Gr00tClosedloopPolicy class for GR1 tabletop manipulation task
 # NOTE(alexmillane, 2025-10-31): The model path here aligns with the model used in the static manipulation tutorial.
 model_path: /models/isaaclab_arena/static_manipulation_tutorial/checkpoint-20000

--- a/isaaclab_arena_gr00t/gr1_manip_replay_action_config.yaml
+++ b/isaaclab_arena_gr00t/gr1_manip_replay_action_config.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # This file shows how to configure the Gr00tClosedloopPolicy class for GR1 tabletop manipulation task
 dataset_path: "/datasets/isaaclab_arena/static_manipulation_tutorial/arena_gr1_manipulation_dataset_generated/lerobot/"
 

--- a/isaaclab_arena_gr00t/policy_config.py
+++ b/isaaclab_arena_gr00t/policy_config.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path

--- a/isaaclab_arena_gr00t/replay_lerobot_action_policy.py
+++ b/isaaclab_arena_gr00t/replay_lerobot_action_policy.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import gymnasium as gym
 import numpy as np
 import torch

--- a/osmo/finetune.yaml
+++ b/osmo/finetune.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 2
 workflow:
   name: {{ workflow_name }}

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,7 @@
+# Copyright (c) 2025, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
 #
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-#
-# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
-# property and proprietary rights in and to this material, related
-# documentation and any modifications thereto. Any use, reproduction,
-# disclosure or distribution of this material and related documentation
-# without an express license agreement from NVIDIA CORPORATION or
-# its affiliates is strictly prohibited.
-#
+# SPDX-License-Identifier: Apache-2.0
 """Installation script for the 'isaaclab_arena' python package."""
 
 from setuptools import find_packages, setup


### PR DESCRIPTION
## Summary
Move to SPDX license headers

## Detailed description
- Added a pre-commit rule which automatically adds the header (take from IsaacLab)
- Changed all the headers from listing part of Apache, to listing the SPDX version.
- Added a contributor list.
- Partly addresses: https://nvbugspro.nvidia.com/bug/5672357