### PR TITLE
Increase episode length

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -38,7 +38,7 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     # Overriding defaults from base class
     sim: SimulationCfg = SimulationCfg(dt=1 / 200, render_interval=2)
     decimation: int = 4
-    episode_length_s: float = 30.0
+    episode_length_s: float = 50.0
     wait_for_textures: bool = False
 
 


### PR DESCRIPTION
## Summary
Increment episode length to prevent loco-manip reset() before box is dropped.

## Detailed description
- Increase episode_length_s to 70s, such that
a. it still triggers reset if the policy gets stuck in between
b. it supports rollout to the frame where the box can be dropped
- Include policy reset for those truncated env_ids, although truncation are not used for now.

In v0.2 I think `episode_length_s` shall be coupled with task, instead of env.