### PR TITLE
Fix issues with qpsolvers.

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -45,7 +45,7 @@ RUN chmod 777 -R /isaac-sim/kit/
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 
 # Patch for osqp in IsaacLab. Downgrade qpsolvers
-# TODO(alexmillane): Watch the thread here:
+# TODO(alexmillane): Watch the thread here: https://nvidia.slack.com/archives/C06HLQ6CB41/p1764680205807019
 #                    and remove this thread when IsaacLab has a fix.
 RUN if python -c "import qpsolvers; print(qpsolvers.available_solvers)" | grep -q "osqp"; then \
         echo "OSQP is installed. You can remove this clause from the Arena dockerfile."; \


### PR DESCRIPTION
## Summary
Patch breakage to Isaac Lab 2.3 due to `qpsolvers` upgrade.

## Detailed description
- Manually downgrade `qpsolvers` to `4.8.1` while we wait for a proper fix from Isaac Lab.

## Todo
- Back this change out when an official fix is available.
