### PR TITLE
Move back to mapping the whole repo.

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -135,13 +135,7 @@ else
                     "--net=host"
                     "--runtime=nvidia"
                     "--gpus=all"
-                    "-v" "./docs:${WORKDIR}/docs"
-                    "-v" "./isaaclab_arena:${WORKDIR}/isaaclab_arena"
-                    "-v" "./isaaclab_arena_g1:${WORKDIR}/isaaclab_arena_g1"
-                    "-v" "./isaaclab_arena_gr00t:${WORKDIR}/isaaclab_arena_gr00t"
-                    "-v" "./docker:${WORKDIR}/docker"
-                    "-v" "./.github:${WORKDIR}/.github"
-                    "-v" "./submodules/IsaacLab:${WORKDIR}/submodules/IsaacLab"
+                    "-v" ".:${WORKDIR}"
                     $(add_volume_if_it_exists $DATASETS_HOST_MOUNT_DIRECTORY /datasets)
                     $(add_volume_if_it_exists $MODELS_HOST_MOUNT_DIRECTORY /models)
                     $(add_volume_if_it_exists $EVAL_HOST_MOUNT_DIRECTORY /eval)


### PR DESCRIPTION
## Summary
Revert to mapping the whole repo in the dev docker.

## Detailed description
- Previously we changed to mapping only specific folders in the repo.
- This was done for docker build speed (I believe?)
- The issue is that we want (even if occasionally) to work on all folders in the repo, within the dev docker.
- This reverts to mapping the whole repo.
