### PR TITLE
Reenable pre-commit.

### DIFF
--- a/isaaclab_arena/tasks/open_door_task.py
+++ b/isaaclab_arena/tasks/open_door_task.py
@@ -5,6 +5,7 @@
 
 import numpy as np
 from dataclasses import MISSING
+
 import isaaclab.envs.mdp as mdp_isaac_lab
 from isaaclab.envs.common import ViewerCfg
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig


### PR DESCRIPTION
## Summary
Re-enables pre-commit in CI.

## Detailed description
- During the refactoring and switch to public CI, `pre-commit` was broken.
- This MR fixes it.