### PR TITLE
multi-versioned docs (#272)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,16 +136,23 @@ jobs:
     steps:
       # Setup.
       - *install_git_step
+      - *mark_repo_safe_step
       - *cleanup_step
-      - *checkout_step
+
+      # Checkout all branches, and tags, such that sphinx-multiversion can build the docs for all versions.
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       # Build docs
       - name: Build docs
+        working-directory: ./docs
         run: |
-          cd docs
           pip3 install -r requirements.txt
-          make SPHINXOPTS=-W html
-          touch ./_build/html/.nojekyll
+          make SPHINXOPTS=-W multi-docs
+          touch ./_build/.nojekyll
 
   build_and_push_image_post_merge:
     name: Build & push NGC image (post-merge)

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   deploy_docs:
     name: Deploy the docs
-    runs-on: [self-hosted, zurich]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 30
 
     container:
@@ -54,8 +54,8 @@ jobs:
         run: |
           cd docs
           pip3 install -r requirements.txt
-          make SPHINXOPTS=-W html
-          touch ./_build/html/.nojekyll
+          make SPHINXOPTS=-W multi-docs
+          touch ./_build/.nojekyll
 
       - name: Copy redirect file
         run: |

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,12 +10,18 @@ BUILDDIR         = _build
 
 
 # Put it first so that "make" without argument is like "make help".
+.PHONY: help Makefile
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+
+.PHONY: multi-docs
+multi-docs:
+	@sphinx-multiversion --verbose "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	@cp _redirect/index.html $(BUILDDIR)/index.html
+
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)/current" $(SPHINXOPTS) $(O)

--- a/docs/_redirect/index.html
+++ b/docs/_redirect/index.html
@@ -3,6 +3,6 @@
   <head>
     <title>Redirecting to the latest Isaac Lab Arena documentation</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./html/index.html">
+    <meta http-equiv="refresh" content="0; url=./main/index.html">
   </head>
 </html>

--- a/docs/_templates/versioning.html
+++ b/docs/_templates/versioning.html
@@ -1,0 +1,21 @@
+{% if versions %}
+<nav class="bd-links bd-docs-nav">
+    <div class="bd-toc-item navbar-nav">
+      <ul class="nav bd-sidenav">
+        <li class="toctree-l1 has-children" style="display: flex; justify-content: center; align-items: center; flex-direction: column;">
+          <div  style ="text-align:center;">
+            <label for="version-select" style="font-weight: bold; display: block;">Version</label>
+          </div>
+          <select id="version-select" class="version-dropdown" style="margin: 0 auto; display: block;" onchange="location = this.value;">
+            {%- for item in versions.branches %}
+            <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
+            {%- endfor %}
+            {%- for item in versions.tags|reverse %}
+            <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
+            {%- endfor %}
+          </select>
+        </li>
+      </ul>
+    </div>
+</nav>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ extensions = [
     "sphinx_tabs.tabs",
     "sphinx_design",
     "sphinx_copybutton",
+    "sphinx_multiversion",
     "isaaclab_arena_doc_tools",
 ]
 
@@ -87,7 +88,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "venv_docs"]
+exclude_patterns = ["_build", "_templates", "Thumbs.db", ".DS_Store", "venv_docs"]
 
 # Be picky about missing references
 nitpicky = True  # warns on broken references
@@ -119,20 +120,19 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = []
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
+# Versioning
+smv_remote_whitelist = r"^.*$"
+smv_branch_whitelist = r"^(main|release/.*)$"
+smv_tag_whitelist = r"^v.*$"
+html_sidebars = {"**": ["versioning.html", "sidebar-nav-bs"]}
 # Todos
 todo_include_todos = True
 
 # Linkcheck
-# NOTE(alexmillane, 2025-05-09): The links in the main example page are relative links
-# which are only valid post-build. linkcheck doesn't like this. So here we ignore
-# links to the example pages via html.
-linkcheck_ignore = [
-    # r'pages/torch_examples_.*\.html',    # Ignore all pages/torch_examples_*.html links
-]
+linkcheck_ignore = []
 
 temporary_linkcheck_ignore = [
     # TemporaryLinkcheckIgnore(

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx==8.2.3
+sphinx-multiversion==0.2.4
 sphinx_copybutton==0.5.2
 sphinx_tabs==3.4.7
 nvidia-sphinx-theme==0.0.8


### PR DESCRIPTION
## Summary
Move the multi-versioned docs now that we have multiple version of Isaac Lab Arena.

## Detailed description
- Means users can read the version of the docs that shipped the release that they're using.

<img width="1130" height="625" alt="version_sidebar" src="https://github.com/user-attachments/assets/b06372cd-9bed-4a1d-99b8-9480c279ebb4" />

## Summary
Short description of the change (max 50 chars)

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
