### PR TITLE
Bugfix gr00t import error running zero action policy

### DIFF
--- a/isaaclab_arena/policy/policy_registry.py
+++ b/isaaclab_arena/policy/policy_registry.py
@@ -3,19 +3,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.policy.replay_action_policy import ReplayActionPolicy
-from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy
-from isaaclab_arena_gr00t.gr00t_closedloop_policy import Gr00tClosedloopPolicy
-from isaaclab_arena_gr00t.replay_lerobot_action_policy import ReplayLerobotActionPolicy
-
-POLICIES = {
-    "zero_action": ZeroActionPolicy,
-    "replay": ReplayActionPolicy,
-    "replay_lerobot": ReplayLerobotActionPolicy,
-    "gr00t_closedloop": Gr00tClosedloopPolicy,
-}
-
 
 def get_policy_cls(policy_type: str) -> type:
-    """Get the policy class for the given policy type."""
-    return POLICIES[policy_type]
+    """Get the policy class for the given policy type.
+
+    Uses lazy imports to avoid requiring optional dependencies like gr00t
+    unless they're actually being used.
+    """
+    if policy_type == "zero_action":
+        from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy
+
+        return ZeroActionPolicy
+    elif policy_type == "replay":
+        from isaaclab_arena.policy.replay_action_policy import ReplayActionPolicy
+
+        return ReplayActionPolicy
+    elif policy_type == "replay_lerobot":
+        from isaaclab_arena_gr00t.replay_lerobot_action_policy import ReplayLerobotActionPolicy
+
+        return ReplayLerobotActionPolicy
+    elif policy_type == "gr00t_closedloop":
+        from isaaclab_arena_gr00t.gr00t_closedloop_policy import Gr00tClosedloopPolicy
+
+        return Gr00tClosedloopPolicy
+    else:
+        raise ValueError(
+            f"Unknown policy type: {policy_type}. Available types: zero_action, replay, replay_lerobot,"
+            " gr00t_closedloop"
+        )


### PR DESCRIPTION
## Summary
Fix a recently introduced bug that zero action policy currently fails with gr00t module import error.

## Detailed description
- Running zero action policy in docker without gr00t flag fails with module import error.
- This issue is introduced from Commit a4ffee4.
- Use lazy import to avoid this.


