### PR TITLE
CI Unit tests run seperately from IsaacSim jobs DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,29 @@ jobs:
         with:
           extra_args: --all-files --verbose
 
+  unit_tests:
+    name: Unit tests (no Isaac Sim)
+    runs-on: [self-hosted, gpu]
+    timeout-minutes: 10
+    needs: [pre_commit]
+
+    container:
+      image: python:3.11-slim
+
+    steps:
+      - *install_git_step
+      - *cleanup_step
+      - *mark_repo_safe_step
+      - *checkout_step
+
+      - name: Install dependencies for unit tests
+        run: |
+          pip install --no-cache-dir -e .
+          pip install pytest torch
+
+      - name: Run unit tests
+        run: pytest -sv -m unit isaaclab_arena/tests/
+
   test:
     name: Run tests
     runs-on: [self-hosted, gpu]
@@ -121,12 +144,12 @@ jobs:
           pip install --no-cache-dir -e .
           [ -e ./submodules/IsaacLab/_isaac_sim ] || ln -s /isaac-sim ./submodules/IsaacLab/_isaac_sim
 
-      # Run the tests (excluding the gr00t related tests)
+      # Run the tests (excluding the gr00t related tests and unit tests which run separately)
       - name: Run pytest excluding policy-related tests. First we run all tests without cameras.
-        run: /isaac-sim/python.sh -m pytest -sv -m "not with_cameras" isaaclab_arena/tests/
+        run: /isaac-sim/python.sh -m pytest -sv -m "not with_cameras and not unit" isaaclab_arena/tests/
 
       - name: Run pytest excluding policy-related tests. Now we run all tests with cameras.
-        run: /isaac-sim/python.sh -m pytest -sv -m with_cameras isaaclab_arena/tests/
+        run: /isaac-sim/python.sh -m pytest -sv -m "with_cameras and not unit" isaaclab_arena/tests/
 
 
   test_policy:
@@ -192,7 +215,7 @@ jobs:
     name: Build & push NGC image (post-merge)
     runs-on: [self-hosted, gpu]
     timeout-minutes: 90
-    needs: [test, test_policy]       # only push if tests passed
+    needs: [unit_tests, test, test_policy]       # only push if tests passed
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     container:

--- a/isaaclab_arena/tests/test_configclass.py
+++ b/isaaclab_arena/tests/test_configclass.py
@@ -3,7 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from isaaclab.utils import configclass
+
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
 
 from isaaclab_arena.utils.configclass import combine_configclasses
 

--- a/isaaclab_arena/tests/test_job_manager.py
+++ b/isaaclab_arena/tests/test_job_manager.py
@@ -3,7 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from isaaclab_arena.evaluation.job_manager import Job, JobManager, Status
+
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
 
 
 def test_job_from_dict():

--- a/isaaclab_arena/tests/test_object_placer_reproducibility.py
+++ b/isaaclab_arena/tests/test_object_placer_reproducibility.py
@@ -5,7 +5,12 @@
 
 """Tests for ObjectPlacer and RelationSolver reproducibility."""
 
+import pytest
+
 from isaaclab_arena.assets.dummy_object import DummyObject
+
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.relation_solver import RelationSolver

--- a/isaaclab_arena/tests/test_pose.py
+++ b/isaaclab_arena/tests/test_pose.py
@@ -3,7 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from isaaclab_arena.utils.pose import Pose
+
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
 
 
 def test_pose_composition():

--- a/isaaclab_arena/tests/test_relation_loss.py
+++ b/isaaclab_arena/tests/test_relation_loss.py
@@ -5,6 +5,11 @@
 
 import torch
 
+import pytest
+
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
+
 from isaaclab_arena.relations.loss_primitives import (
     linear_band_loss,
     single_boundary_linear_loss,

--- a/isaaclab_arena/tests/test_relation_loss_strategies.py
+++ b/isaaclab_arena/tests/test_relation_loss_strategies.py
@@ -9,6 +9,9 @@ import torch
 
 import pytest
 
+# Mark all tests in this module as unit tests (no Isaac Sim required)
+pytestmark = pytest.mark.unit
+
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.relation_loss_strategies import NextToLossStrategy, OnLossStrategy
 from isaaclab_arena.relations.relations import NextTo, On, Side

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     with_cameras: test requires enable_cameras=True
+    unit: pure unit test that does not require Isaac Sim


### PR DESCRIPTION
## Summary
DO NOT MERGE.

CI takes a lot of time: 

```
test (without cameras) ~13 min
test (with cameras) ~7 min
test total ~25 min
test_policy ~28 min
```

Introduces a new unit pytest marker and a dedicated CI job to run pure unit tests separately from Isaac Sim integration tests. Should allow unit tests to run in parallel with integration tests in a lightweight container.