### PR TITLE
Change string to compare as we now call a device openxr

### DIFF
--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -72,7 +72,8 @@ if args_cli.enable_pinocchio:
     # pinocchio is required by the Pink IK controllers and the GR1T2 retargeter
     import pinocchio  # noqa: F401
 
-    # Extremely hacky way to enable xr args. Please fix this.
+    # TODO(cvolk): XR mode is inferred from teleop device name via string matching.
+    # Ideally, AppLauncher or the device config would auto-detect XR requirements.
     if "openxr" in args_cli.teleop_device.lower():
         app_launcher_args["xr"] = True
 


### PR DESCRIPTION
## Summary
Dirty fix to get the new teleop device name working
