### PR TITLE
Fix reference to coffeemachine asset

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -185,7 +185,7 @@ class CoffeeMachine(LibraryObject, Pressable):
     name = "coffee_machine"
     tags = ["object", "pressable"]
     file_path, object_name, metadata = object_loader.acquire_by_registry(
-        registry_type="fixtures", registry_name=["coffee_machine"], file_type="USD"
+        registry_type="fixtures", file_name="CoffeeMachine108", file_type="USD"
     )
     usd_path = file_path
     object_type = ObjectType.ARTICULATION


### PR DESCRIPTION
## Summary
Currently, all our tests fail on CI because of wrong coffee machine asset is loaded. LW changed their reference to coffee machine registry without communication.
