### PR TITLE
Fix rst formatting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -202,6 +202,7 @@ TABLE OF CONTENTS
    :caption: Advanced
 
    pages/advanced/private_omniverse
+   pages/advanced/assets_management
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary

Added `assets_management` to the _Advanced section_ toctree to remove the Sphinx warning:

`checking consistency... /workspaces/isaaclab_arena/docs/pages/advanced/assets_management.rst: WARNING: document isn't included in any toctree [toc.not_included]`
