### PR TITLE
Fix pre-merge docs CI to validate PR changes

### DIFF
--- a/docs/pages/quickstart/first_arena_env.rst
+++ b/docs/pages/quickstart/first_arena_env.rst
@@ -6,7 +6,7 @@ to compose your first simple IsaacLab Arena environment by combining assets, sce
 
 Once within the docker container, run the following command to compile your first IsaacLab Arena environment:
 
-.. caode-block:: bash
+.. code-block:: bash
 
     python isaaclab_arena/examples/compile_env_notebook.py
 


### PR DESCRIPTION
## Summary

The `build_docs_pre_merge` job was running `make multi-docs`, which builds documentation from remote branches and tags rather than the PR's working tree. This resulted in untested doc-changes being merged to main.

In `gh-pages.yml`, the workflow still (correctly) uses multi-docs for testing our deployment.
