### PR TITLE
Fixed the mismatched first frame in converting lerobot

### DIFF
--- a/isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py
+++ b/isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py
@@ -536,8 +536,11 @@ def convert_hdf5_to_lerobot(config: Gr00tDatasetConfig):
         assert config.pov_cam_name_sim in trajectory["camera_obs"]
 
         frames = np.array(trajectory["camera_obs"][config.pov_cam_name_sim])
-        # remove last frame due to how Lab reports observations
-        frames = frames[:-1]
+
+        # The HDF5 dataset can include the previous episode's last render as the
+        # first frame of the current episode because camera_obs is captured in pre-step before finishing reset.
+        # Drop that first frame to align the episode length.
+        frames = frames[1:]
         assert len(frames) == length
         queue.put((new_video_path, frames, config.fps, "image"))
 


### PR DESCRIPTION
## Summary
Fixed the mismatched first frame in lerobot dataset. #339 

The camera frames are updated during the next simulation render, but we now recorded `obs_buf["camera_obs"]` in [pre-step](https://github.com/isaac-sim/IsaacLab-Arena/blob/78083f33a0bf7d081a4a78b0da42f750e058da02/isaaclab_arena/scripts/imitation_learning/generate_dataset.py#L98) before that update occurs, so the buffer still contains the last rendered frame from the previous episode, and that gets saved as the first frame of the new episode. 

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
