### PR TITLE
Fix RigidObjectSet handling in kitchen pick-and-place environment

### DIFF
--- a/isaaclab_arena_environments/kitchen_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/kitchen_pick_and_place_environment.py
@@ -41,7 +41,7 @@ class KitchenPickAndPlaceEnvironment(ExampleEnvironmentBase):
             "or --object_set for multiple objects across environments where --num_envs == len(object_set)."
         )
 
-        # Create the pick-up object: either a single object or a set of objects
+        # Create the pick-up object: Either a single object or a set of objects
         if has_object_set:
             objects = [self.asset_registry.get_asset_by_name(obj)() for obj in args_cli.object_set]
             pick_up_object = RigidObjectSet(name="object_set", objects=objects)


### PR DESCRIPTION
## Summary
Unifies `pick_up_object` variable to hold either a single `Object` or `RigidObjectSet`.

The `PickAndPlaceTask` always received the single `pick_up_object` instead of the `object_set` when using `--object_set`.
(The single `pick_up_object` whose cli argument can't be None and the `object_set` were being added to the scene, causing duplicate objects to spawn.) Users could pass both `--object` and `--object_set` simultaneously with no error.
