### PR TITLE
Fix: flatdict causing ci failure

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -40,6 +40,9 @@ RUN ln -s /isaac-sim/ ${WORKDIR}/submodules/IsaacLab/_isaac_sim
 RUN for DIR in ${WORKDIR}/submodules/IsaacLab/source/isaaclab*/; do pip install --no-deps -e "$DIR"; done
 # Logs and other stuff appear under dist-packages per default, so this dir has to be writeable.
 RUN chmod 777 -R /isaac-sim/kit/
+# NOTE(alexmillane, 2026-02-10): We started having issues with flatdict 4.0.1 installation
+# during IsaacLab install. We install here with build isolation which seems to fix the issue.
+RUN /isaac-sim/python.sh -m pip install flatdict==4.0.1 --no-build-isolation
 # Install isaaclab
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 


### PR DESCRIPTION
## Summary
Fix installation error of flatdict which was causing failures in CI.

## Detailed description
- No we install flatdict without build isolation such that it's already installed when Isaac Lab gets to installing it.
