### PR TITLE
Fix sequential task check for desired_subtask_success_state

### DIFF
--- a/isaaclab_arena/tasks/sequential_task_base.py
+++ b/isaaclab_arena/tasks/sequential_task_base.py
@@ -164,7 +164,7 @@ class SequentialTaskBase(TaskBase):
             current_subtask_success_func = subtasks[current_subtask_idx].get_termination_cfg().success.func
             current_subtask_success_params = subtasks[current_subtask_idx].get_termination_cfg().success.params
             result = current_subtask_success_func(env, **current_subtask_success_params)[env_idx]
-            
+
             if result:
                 env._subtask_success_state[env_idx][current_subtask_idx] = True
                 if current_subtask_idx < len(subtasks) - 1:


### PR DESCRIPTION
## Summary

Sequential tasks have an option for users to specify the precise subtask success state at the end of the sequence of tasks in order to be a true success. 

This MR fixes a bug with this feature and implements a proper `desired_subtask_success_state` check by computing the current success state of all subtasks and use those values in the check.

Previously the check was done using `env._subtask_success_state` which is "monotonic" and does not reflect the true current subtask success state, essentially nullifying this feature. 


