### PR TITLE
Fix docker entrypoint failure when host user is 'ubuntu'

### DIFF
--- a/docker/setup/entrypoint.sh
+++ b/docker/setup/entrypoint.sh
@@ -12,12 +12,15 @@ set -euo pipefail
 # at the end of the dockerfile
 ldconfig
 
-# Add the group of the user. User/group ID of the host user are set through env variables when calling docker run further down.
+# Remove any existing user with the same name (userdel may also remove its primary group)
+userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
+userdel ubuntu 2>/dev/null || true
+
+# Add the group of the user AFTER userdel, since userdel may have removed the primary group.
+# User/group ID of the host user are set through env variables when calling docker run further down.
 groupadd --force --gid "$DOCKER_RUN_GROUP_ID" "$DOCKER_RUN_GROUP_NAME"
 
 # Re-add the user
-userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
-userdel ubuntu || true
 useradd --no-log-init \
         --uid "$DOCKER_RUN_USER_ID" \
         --gid "$DOCKER_RUN_GROUP_NAME" \


### PR DESCRIPTION
## Problem

When the host username is `ubuntu`, `docker/run_docker.sh` fails at container startup with:

```
userdel: user 'ubuntu' does not exist
useradd: group 'ubuntu' does not exist
```

## Root Cause

In `entrypoint.sh`, `groupadd --force` runs **before** `userdel ubuntu`. Since the base image already has a `ubuntu` user/group, the sequence is:

1. `groupadd --force` — group `ubuntu` already exists, no-op
2. `userdel ubuntu` — deletes the user **and** its primary group
3. `useradd --gid ubuntu` — fails because the group was removed in step 2

## Fix

Move `userdel` calls **before** `groupadd`, so the group is always (re)created after any prior user/group removal.