### PR TITLE
Add tenacity install to dockerfile

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -121,6 +121,9 @@ COPY docs ${WORKDIR}/docs
 # Install IsaacLab Arena
 RUN /isaac-sim/python.sh -m pip install -e ${WORKDIR}/
 
+# Install tenacity for use with Plotly
+RUN /isaac-sim/python.sh -m pip install tenacity
+
 # Set an alias to run the isaac lab python interpreter.
 RUN echo "alias python='/isaac-sim/python.sh'" >> /etc/bash.bashrc
 RUN echo "alias pip3='/isaac-sim/python.sh -m pip'" >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary
Add tenacity install to dockerfile so Plotly can be used in `dummy_object_placer_notebook.py`
