### PR TITLE
Add hdr library and use robolab hdr

### DIFF
--- a/isaaclab_arena/assets/asset_registry.py
+++ b/isaaclab_arena/assets/asset_registry.py
@@ -10,6 +10,7 @@ from isaaclab_arena.utils.singleton import SingletonMeta
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.asset import Asset
+    from isaaclab_arena.assets.hdr import HDR
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
     from isaaclab_arena.policy.policy_base import PolicyBase
 
@@ -38,7 +39,7 @@ class Registry(metaclass=SingletonMeta):
             key (str): The name of the component.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before checking
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry)):
+        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRRegistry)):
             ensure_assets_registered()
         return key in self._components
 
@@ -52,7 +53,7 @@ class Registry(metaclass=SingletonMeta):
             Any: The component.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry)):
+        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRRegistry)):
             ensure_assets_registered()
         assert key in self._components, f"component {key} not found, please check if requested component is registered"
         return self._components[key]
@@ -64,7 +65,7 @@ class Registry(metaclass=SingletonMeta):
             list[str]: The list of keys.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry)):
+        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRRegistry)):
             ensure_assets_registered()
         return list(self._components.keys())
 
@@ -169,6 +170,49 @@ class PolicyRegistry(Registry):
         return self.get_component_by_name(name)
 
 
+class HDRRegistry(Registry):
+    """Registry for HDR/EXR environment map textures."""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_hdr_by_name(self, name: str) -> type["HDR"]:
+        """Gets an HDR class by name.
+
+        Args:
+            name (str): The name of the HDR.
+        """
+        ensure_assets_registered()
+        return self.get_component_by_name(name)
+
+    def get_hdrs_by_tag(self, tag: str) -> list[type["HDR"]]:
+        """Gets a list of HDR classes that have the given tag.
+
+        Args:
+            tag (str): The tag to filter by.
+
+        Returns:
+            list[type[HDR]]: The matching HDR classes.
+        """
+        ensure_assets_registered()
+        return [hdr for hdr in self._components.values() if tag in hdr.tags]
+
+    def get_random_hdr_by_tag(self, tag: str) -> type["HDR"]:
+        """Gets a random HDR class which has the given tag.
+
+        Args:
+            tag (str): The tag to filter by.
+
+        Returns:
+            type[HDR]: A random HDR class.
+        """
+        ensure_assets_registered()
+        hdrs = self.get_hdrs_by_tag(tag)
+        if len(hdrs) == 0:
+            raise ValueError(f"No HDRs found with tag {tag}")
+        return random.choice(hdrs)
+
+
 # Lazy registration to avoid circular imports
 _assets_registered = False
 
@@ -180,6 +224,7 @@ def ensure_assets_registered():
         # Import modules to trigger asset registration via decorators
         import isaaclab_arena.assets.background_library  # noqa: F401
         import isaaclab_arena.assets.device_library  # noqa: F401
+        import isaaclab_arena.assets.hdr_library  # noqa: F401
         import isaaclab_arena.assets.object_library  # noqa: F401
         import isaaclab_arena.assets.retargeter_library  # noqa: F401
         import isaaclab_arena.embodiments  # noqa: F401

--- a/isaaclab_arena/assets/hdr.py
+++ b/isaaclab_arena/assets/hdr.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Literal
+
+# The texture format types supported by Isaac Sim's DomeLightCfg.
+TextureFormat = Literal["automatic", "latlong", "mirroredBall", "angular", "cubeMapVerticalCross"]
+
+
+class HDR:
+    """An HDR/EXR environment map texture for dome lights.
+
+    Example usage::
+
+        dome_light = asset_registry.get_asset_by_name("light")()
+        dome_light.add_hdr("home_office_robolab")
+    """
+
+    def __init__(
+        self,
+        name: str,
+        texture_file: str,
+        tags: list[str] | None = None,
+        description: str = "",
+        texture_format: TextureFormat = "latlong",
+    ):
+        self.name = name
+        self.texture_file = texture_file
+        self.tags = tags or []
+        self.description = description
+        self.texture_format = texture_format
+
+    def __repr__(self) -> str:
+        return f"HDR(name={self.name!r}, texture_file={self.texture_file!r})"

--- a/isaaclab_arena/assets/hdr_library.py
+++ b/isaaclab_arena/assets/hdr_library.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from isaaclab_arena.assets.hdr import HDR, TextureFormat
+from isaaclab_arena.assets.object_library import ISAACLAB_STAGING_NUCLEUS_DIR
+from isaaclab_arena.assets.register import register_hdr
+
+
+class LibraryHDR(HDR):
+    """Base class for HDRs in the library which are defined in this file."""
+
+    name: str
+    tags: list[str]
+    texture_file: str
+    texture_format: TextureFormat = "latlong"
+    description: str = ""
+
+    def __init__(self):
+        super().__init__(
+            name=self.name,
+            texture_file=self.texture_file,
+            tags=self.tags,
+            description=self.description,
+            texture_format=self.texture_format,
+        )
+
+
+@register_hdr
+class HomeOfficeHDRRobolab(LibraryHDR):
+    name = "home_office_robolab"
+    tags = ["indoor"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/home_office.exr"
+
+
+@register_hdr
+class EmptyWarehouseHDRRobolab(LibraryHDR):
+    name = "empty_warehouse_robolab"
+    tags = ["indoor", "industrial"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/empty_warehouse.hdr"
+
+
+@register_hdr
+class AerodynamicsWorkshopHDRRobolab(LibraryHDR):
+    name = "aerodynamics_workshop_robolab"
+    tags = ["indoor", "industrial"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/aerodynamics_workshop.hdr"
+
+
+@register_hdr
+class BilliardHallHDRRobolab(LibraryHDR):
+    name = "billiard_hall_robolab"
+    tags = ["indoor"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/billiard_hall.hdr"
+
+
+@register_hdr
+class BrownPhotostudioHDRRobolab(LibraryHDR):
+    name = "brown_photostudio_robolab"
+    tags = ["indoor", "studio"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/brown_photostudio.hdr"
+
+
+@register_hdr
+class BlindsHDRRobolab(LibraryHDR):
+    name = "blinds_robolab"
+    tags = ["indoor", "kitchen"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/blinds_2k.hdr"
+
+
+@register_hdr
+class KiaraInteriorHDRRobolab(LibraryHDR):
+    name = "kiara_interior_robolab"
+    tags = ["indoor", "kitchen"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/kiara_interior_2k.hdr"
+
+
+@register_hdr
+class GarageHDRRobolab(LibraryHDR):
+    name = "garage_robolab"
+    tags = ["indoor"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/garage_2k.hdr"
+
+
+@register_hdr
+class WoodenLoungeHDRRobolab(LibraryHDR):
+    name = "wooden_lounge_robolab"
+    tags = ["indoor"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/wooden_lounge_2k.hdr"
+
+
+@register_hdr
+class PhotoStudioHDRRobolab(LibraryHDR):
+    name = "photo_studio_robolab"
+    tags = ["indoor", "studio"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/photo_studio_01_2k.hdr"
+
+
+@register_hdr
+class CarpentryShopHDRRobolab(LibraryHDR):
+    name = "carpentry_shop_robolab"
+    tags = ["indoor", "workshop"]
+    texture_file = f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/indoors/carpentry_shop_01_2k.hdr"

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -417,9 +417,18 @@ class GroundPlane(LibraryObject):
 
 
 @register_asset
-class Light(LibraryObject):
-    """
-    A dome light.
+class DomeLight(LibraryObject):
+    """A dome light, optionally textured with an HDR environment map.
+
+    The light can be used plain (uniform color) or combined with an HDR
+    texture via :meth:`add_hdr`::
+
+        dome_light = asset_registry.get_asset_by_name("light")()
+        dome_light.add_hdr("home_office_robolab")
+
+    You can also pass the HDR name or instance directly to the constructor::
+
+        dome_light = asset_registry.get_asset_by_name("light")(hdr="home_office_robolab")
     """
 
     name = "light"
@@ -435,9 +444,41 @@ class Light(LibraryObject):
         prim_path: str | None = default_prim_path,
         initial_pose: Pose | None = None,
         spawner_cfg: sim_utils.DomeLightCfg = default_spawner_cfg,
+        hdr: "str | HDR | None" = None,  # noqa: F821
     ):
         self.spawner_cfg = spawner_cfg
         super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose)
+        if hdr is not None:
+            self.add_hdr(hdr)
+
+    def add_hdr(self, hdr: "str | type[HDR] | HDR") -> None:  # noqa: F821
+        """Attach an HDR environment map texture to this dome light.
+
+        Args:
+            hdr: An :class:`HDR` instance, an HDR class (will be instantiated),
+                or a string name that will be looked up in the :class:`HDRRegistry`.
+        """
+        from isaaclab_arena.assets.asset_registry import HDRRegistry
+        from isaaclab_arena.assets.hdr import HDR
+
+        if isinstance(hdr, str):
+            hdr = HDRRegistry().get_hdr_by_name(hdr)
+        # If it's a class (not yet instantiated), instantiate it.
+        if isinstance(hdr, type) and issubclass(hdr, HDR):
+            hdr = hdr()
+        assert isinstance(hdr, HDR), f"Expected HDR class, instance, or string name, got {type(hdr)}"
+
+        # Rebuild the spawner cfg with the HDR texture while preserving
+        # user-specified intensity and other settings.
+        self.spawner_cfg = sim_utils.DomeLightCfg(
+            texture_file=hdr.texture_file,
+            texture_format=hdr.texture_format,  # type: ignore[arg-type]
+            intensity=self.spawner_cfg.intensity,
+            color=self.spawner_cfg.color,
+            visible_in_primary_ray=True,
+        )
+        # Re-initialize the object cfg so the scene picks up the change.
+        self.object_cfg = self._init_object_cfg()
 
 
 @register_asset

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -3,7 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.assets.asset_registry import AssetRegistry, DeviceRegistry, PolicyRegistry, RetargeterRegistry
+from isaaclab_arena.assets.asset_registry import (
+    AssetRegistry,
+    DeviceRegistry,
+    HDRRegistry,
+    PolicyRegistry,
+    RetargeterRegistry,
+)
 
 
 # Decorator to register an asset with the AssetRegistry.
@@ -41,4 +47,13 @@ def register_policy(cls):
         print(f"WARNING: Policy {cls.name} is already registered. Doing nothing.")
     else:
         PolicyRegistry().register(cls, cls.name)
+    return cls
+
+
+# Decorator to register an HDR with the HDRRegistry.
+def register_hdr(cls):
+    if HDRRegistry().is_registered(cls.name):
+        print(f"WARNING: HDR {cls.name} is already registered. Doing nothing.")
+    else:
+        HDRRegistry().register(cls, cls.name)
     return cls

--- a/isaaclab_arena_environments/droid_pick_and_place_srl_environment.py
+++ b/isaaclab_arena_environments/droid_pick_and_place_srl_environment.py
@@ -23,7 +23,6 @@ class DroidPickAndPlaceSRLEnvironment(ExampleEnvironmentBase):
         from isaaclab.envs.common import ViewerCfg
 
         from isaaclab_arena.assets.object_base import ObjectType
-        from isaaclab_arena.assets.object_library import ISAACLAB_STAGING_NUCLEUS_DIR
         from isaaclab_arena.assets.object_reference import ObjectReference
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.scene.scene import Scene
@@ -43,14 +42,10 @@ class DroidPickAndPlaceSRLEnvironment(ExampleEnvironmentBase):
             object_type=ObjectType.RIGID,
         )
 
-        # TODO(cvolk): Introduce a hdr_registry instead of hardcoding the path here.
-        light_spawner_cfg = sim_utils.DomeLightCfg(
-            texture_file=f"{ISAACLAB_STAGING_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/backgrounds/default/home_office.exr",
-            intensity=500.0,
-            visible_in_primary_ray=True,
-            texture_format="latlong",
+        light = self.asset_registry.get_asset_by_name("light")(
+            spawner_cfg=sim_utils.DomeLightCfg(intensity=500.0),
         )
-        light = self.asset_registry.get_asset_by_name("light")(spawner_cfg=light_spawner_cfg)
+        light.add_hdr("billiard_hall_robolab")
 
         embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
             enable_cameras=args_cli.enable_cameras,

--- a/isaaclab_arena_environments/example_environment_base.py
+++ b/isaaclab_arena_environments/example_environment_base.py
@@ -18,10 +18,11 @@ class ExampleEnvironmentBase(ABC):
     name: str | None = None
 
     def __init__(self):
-        from isaaclab_arena.assets.asset_registry import AssetRegistry, DeviceRegistry
+        from isaaclab_arena.assets.asset_registry import AssetRegistry, DeviceRegistry, HDRRegistry
 
         self.asset_registry = AssetRegistry()
         self.device_registry = DeviceRegistry()
+        self.hdr_registry = HDRRegistry()
 
     @abstractmethod
     def get_env(self, args_cli: argparse.Namespace):  # -> IsaacLabArenaEnvironment:


### PR DESCRIPTION
## Summary

Previously, applying an HDR texture to a dome light required manually constructing a DomeLightCfg with a hardcoded Nucleus path (eg in droid_pick_and_place_srl_environment.py). 

- Introduces an `HDRRegistry` for managing HDR/EXR environment map textures, following the same patterns used by `AssetRegistry` for objects and backgrounds. This replaces hardcoded texture file paths in environment definitions.

- Adds some of  the [RoboLab Backgrounds](https://gitlab-master.nvidia.com/xuningy/robolab/-/tree/main/assets/backgrounds?ref_type=heads)  to the HDRRegistry.


Now a texture can be directly added to a light instance. For example via:
```
# Create a dome light and attach an HDR by name
light = asset_registry.get_asset_by_name("light")()
light.add_hdr("billiard_hall_robolab")

# Or pass it directly to the constructor
light = asset_registry.get_asset_by_name("light")(hdr="billiard_hall_robolab")
```