### PR TITLE
eval_runner.py supports num_episodes

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -122,15 +122,14 @@ def main():
 
                     policy = get_policy_from_job(job)
 
-                    # priority of setting num_steps is: job -> policy -> args_cli
-                    # jobs may need different num_steps than the default num_steps from the policy or the args_cli
-                    if job.num_steps is None:
+                    # Resolve simulation length: num_steps and num_episodes are mutually exclusive.
+                    # Priority: job config -> policy length -> CLI default
+                    if job.num_steps is None and job.num_episodes is None:
                         if policy.has_length():
                             job.num_steps = policy.length()
                         else:
                             job.num_steps = args_cli.num_steps
-                    # TODO (xinjieyao, 2026-02-19): add num_episodes support
-                    metrics = rollout_policy(env, policy, num_steps=job.num_steps, num_episodes=None)
+                    metrics = rollout_policy(env, policy, num_steps=job.num_steps, num_episodes=job.num_episodes)
 
                     job_manager.complete_job(job, metrics=metrics, status=Status.COMPLETED)
 

--- a/isaaclab_arena/evaluation/job_manager.py
+++ b/isaaclab_arena/evaluation/job_manager.py
@@ -24,6 +24,7 @@ class Job:
         arena_env_args: list[str],
         policy_type: str,
         num_steps: int = None,
+        num_episodes: int = None,
         policy_config_dict: dict = None,
         status: Status = None,
     ):
@@ -33,7 +34,8 @@ class Job:
             name: Job name, used to identify the job in the queue and in the logs.
             arena_env_args: arguments for configuring the arena environment
             num_envs: Number of environments to simulate
-            num_steps: Number of steps to run the policy for
+            num_steps: Number of steps to run the policy for (mutually exclusive with num_episodes)
+            num_episodes: Number of episodes to run the policy for (mutually exclusive with num_steps)
             policy_type: Type of policy to use
             policy_config_dict: Dictionary configuration for the policy.
             status: Job status (defaults to PENDING)
@@ -41,8 +43,12 @@ class Job:
         self.name = name
         self.arena_env_args = arena_env_args
         assert num_envs > 0, "num_envs must be greater than 0"
+        assert not (
+            num_steps is not None and num_episodes is not None
+        ), f"Job '{name}': num_steps and num_episodes are mutually exclusive, got both"
         self.num_envs = num_envs
         self.num_steps = num_steps
+        self.num_episodes = num_episodes
         self.policy_type = policy_type
         self.policy_config_dict = policy_config_dict if policy_config_dict is not None else {}
         self.status = status if status is not None else Status.PENDING
@@ -78,8 +84,11 @@ class Job:
         if "num_steps" in data and data["num_steps"] is not None:
             num_steps = data["num_steps"]
         else:
-            # will fall back to default num_steps from the policy or the simulation app config
             num_steps = None
+        if "num_episodes" in data and data["num_episodes"] is not None:
+            num_episodes = data["num_episodes"]
+        else:
+            num_episodes = None
         if "status" in data and data["status"] is not None:
             status = Status(data["status"])
         else:
@@ -92,6 +101,7 @@ class Job:
             policy_type=data["policy_type"],
             num_envs=num_envs,
             num_steps=num_steps,
+            num_episodes=num_episodes,
             policy_config_dict=data["policy_config_dict"],
             status=status,
         )
@@ -223,7 +233,7 @@ class JobManager:
         """Print information about the jobs."""
 
         # print using pretty table as data fields may have various lengths
-        table = PrettyTable(field_names=["Job Name", "Status", "Policy Type", "Num Envs", "Num Steps"])
+        table = PrettyTable(field_names=["Job Name", "Status", "Policy Type", "Num Envs", "Num Steps", "Num Episodes"])
         for job in self.all_jobs:
-            table.add_row([job.name, job.status.value, job.policy_type, job.num_envs, job.num_steps])
+            table.add_row([job.name, job.status.value, job.policy_type, job.num_envs, job.num_steps, job.num_episodes])
         print(table)


### PR DESCRIPTION
## Summary
The evaluation runner supported running on a number or steps (num_steps). It was missing the option to run on a number of episodes. 

- Provide the possibilty to pass a `num_episodes` the evalution job should run on.
