### PR TITLE
Add docs compilation for DLI course

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ html_css_files = ["custom.css"]
 
 # Versioning
 smv_remote_whitelist = r"^.*$"
-smv_branch_whitelist = r"^(main|release/.*)$"
+smv_branch_whitelist = r"^(demos/dli|main|release/.*)$"
 smv_tag_whitelist = r"^v.*$"
 html_sidebars = {"**": ["versioning.html", "sidebar-nav-bs"]}
 # Todos


### PR DESCRIPTION
## Summary
Additionally compiles a version of the docs specifically for the DLI course.

## Detailed description
- We're locking the DLI course to a SHA
- This means that as development continues, the docs become outdated.
- We add a (temporary) version of the docs also locked to the SHA of the DLI course.
