### PR TITLE
Fix isaaclab not found

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -41,6 +41,9 @@ RUN ln -s /isaac-sim/ ${WORKDIR}/submodules/IsaacLab/_isaac_sim
 RUN for DIR in ${WORKDIR}/submodules/IsaacLab/source/isaaclab*/; do pip install --no-deps -e "$DIR"; done
 # Logs and other stuff appear under dist-packages per default, so this dir has to be writeable.
 RUN chmod 777 -R /isaac-sim/kit/
+
+# during IsaacLab install. We install here with build isolation which seems to fix the issue.
+RUN /isaac-sim/python.sh -m pip install flatdict==4.0.1 --no-build-isolation
 # Install isaaclab
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 


### PR DESCRIPTION
## Summary
Multiple instances have been reporting issues with issaclab pkg not found.

## Detailed description
- Reported issues: [issue/396](https://github.com/isaac-sim/IsaacLab-Arena/issues/396), [internal](https://nvidia.slack.com/archives/C097CP8FG67/p1772046202486269?thread_ts=1764966857.105999&cid=C097CP8FG67)
- Adding Flatdict installation fixes the lab missing issue
