### PR TITLE
Doc fix hf path

### DIFF
--- a/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
@@ -359,11 +359,15 @@ can be fed to the robot to control its actions.
 
    .. code-block:: bash
 
+      _tmp="$DATASET_DIR/_hf_download" && \
       hf download \
          nvidia/Arena-GR1-Manipulation-PlaceItemCloseDoor-Task \
          ranch_bottle_into_fridge/ranch_bottle_into_fridge_annotated.hdf5 \
          --repo-type dataset \
-         --local-dir $DATASET_DIR
+         --local-dir "$_tmp" && \
+      mkdir -p "$DATASET_DIR" && \
+      mv "$_tmp/ranch_bottle_into_fridge/ranch_bottle_into_fridge_annotated.hdf5" "$DATASET_DIR/" && \
+      rm -rf "$_tmp"
 
 
 Step 2: Validate the Environment by Replaying the Dataset
@@ -376,7 +380,7 @@ Replay the downloaded dataset to verify the environment setup:
    python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
      --device cpu \
      --enable_cameras \
-     --dataset_file "${DATASET_DIR}/ranch_bottle_into_fridge/ranch_bottle_into_fridge_annotated.hdf5" \
+     --dataset_file "${DATASET_DIR}/ranch_bottle_into_fridge_annotated.hdf5" \
      put_item_in_fridge_and_close_door \
      --object ranch_dressing_bottle \
      --embodiment gr1_pink

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -65,7 +65,7 @@ Run the recording script:
 
    python isaaclab_arena/scripts/imitation_learning/record_demos.py \
      --device cpu \
-     --dataset_file $DATASET_DIR/ranch_bottle_into_fridge/ranch_bottle_into_fridge_recorded.hdf5 \
+     --dataset_file $DATASET_DIR/ranch_bottle_into_fridge_recorded.hdf5 \
      --num_demos 10 \
      --num_success_steps 10 \
      put_item_in_fridge_and_close_door \
@@ -118,7 +118,7 @@ Follow these steps to record teleoperation demonstrations:
 
 
 The script will automatically save successful demonstrations to an HDF5 file
-at ``$DATASET_DIR/ranch_bottle_into_fridge/ranch_bottle_into_fridge_recorded.hdf5``.
+at ``$DATASET_DIR/ranch_bottle_into_fridge_recorded.hdf5``.
 
 
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_3_data_generation.rst
@@ -41,11 +41,15 @@ To skip this step, you can download the pre-annotated dataset as described below
 
    .. code-block:: bash
 
+      _tmp="$DATASET_DIR/_hf_download" && \
       hf download \
          nvidia/Arena-GR1-Manipulation-PlaceItemCloseDoor-Task \
          ranch_bottle_into_fridge/ranch_bottle_into_fridge_annotated.hdf5 \
          --repo-type dataset \
-         --local-dir $DATASET_DIR
+         --local-dir "$_tmp" && \
+      mkdir -p "$DATASET_DIR" && \
+      mv "$_tmp/ranch_bottle_into_fridge/ranch_bottle_into_fridge_annotated.hdf5" "$DATASET_DIR/" && \
+      rm -rf "$_tmp"
 
 To start the annotation process run the following command:
 
@@ -92,11 +96,15 @@ This step can be skipped by downloading the pre-generated dataset as described b
 
    .. code-block:: bash
 
+      _tmp="$DATASET_DIR/_hf_download" && \
       hf download \
          nvidia/Arena-GR1-Manipulation-PlaceItemCloseDoor-Task \
          ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100.hdf5 \
          --repo-type dataset \
-         --local-dir $DATASET_DIR
+         --local-dir "$_tmp" && \
+      mkdir -p "$DATASET_DIR" && \
+      mv "$_tmp/ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100.hdf5" "$DATASET_DIR/" && \
+      rm -rf "$_tmp"
 
 Generate the dataset:
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -30,11 +30,15 @@ pre-generated dataset from Hugging Face as described below.
 
    .. code-block:: bash
 
+      _tmp="$DATASET_DIR/_hf_download" && \
       hf download \
          nvidia/Arena-GR1-Manipulation-PlaceItemCloseDoor-Task \
-         ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100.hdf5 \
+         --include "ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100.hdf5" \
          --repo-type dataset \
-         --local-dir $DATASET_DIR
+         --local-dir "$_tmp" && \
+      mkdir -p "$DATASET_DIR" && \
+      mv "$_tmp/ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100.hdf5" "$DATASET_DIR/" && \
+      rm -rf "$_tmp"
 
 
 Step 1: Convert to LeRobot Format
@@ -52,12 +56,17 @@ Note that this conversion step can be skipped by downloading the pre-converted L
 
    .. code-block:: bash
 
+      _tmp="$DATASET_DIR/_hf_download" && \
       hf download \
          nvidia/Arena-GR1-Manipulation-PlaceItemCloseDoor-Task \
          --include "ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100/lerobot/*" \
          --repo-type dataset \
-         --local-dir $DATASET_DIR/ranch_bottle_into_fridge_generated_100/lerobot
+         --local-dir "$_tmp" && \
+      mkdir -p "$DATASET_DIR" && \
+      mv "$_tmp/ranch_bottle_into_fridge/ranch_bottle_into_fridge_generated_100" "$DATASET_DIR/" && \
+      rm -rf "$_tmp"
 
+   This places the LeRobot data at ``$DATASET_DIR/ranch_bottle_into_fridge_generated_100/lerobot``.
    If you download this dataset, you can skip the conversion step below and continue to the next step.
 
 
@@ -139,7 +148,6 @@ We provide three post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --no-resume \
          --dataloader_num_workers=16 \
          --use-wandb \
          --embodiment_tag=GR1 \


### PR DESCRIPTION
## Summary
HF cli preserves folder structure, updating download cmds to overwrite folder structure.

Fix SQA [593015](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5930150), [5930246](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5930246) [5929515](https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/5929515)