### PR TITLE
Fix imitation_learning script path in doc

### DIFF
--- a/docs/pages/concepts/concept_teleop_devices_design.rst
+++ b/docs/pages/concepts/concept_teleop_devices_design.rst
@@ -71,18 +71,18 @@ Usage Examples
 .. code-block:: bash
 
    # Basic keyboard control
-   python isaaclab_arena/scripts/teleop.py --teleop_device keyboard kitchen_pick_and_place
+   python isaaclab_arena/scripts/imitation_learning/teleop.py --teleop_device keyboard kitchen_pick_and_place
 
 **SpaceMouse Control**
 
 .. code-block:: bash
 
    # Precise manipulation with SpaceMouse
-   python isaaclab_arena/scripts/teleop.py --teleop_device spacemouse kitchen_pick_and_place --sensitivity 2.0
+   python isaaclab_arena/scripts/imitation_learning/teleop.py --teleop_device spacemouse kitchen_pick_and_place --sensitivity 2.0
 
 **Hand Tracking**
 
 .. code-block:: bash
 
    # VR hand tracking for humanoid control
-   python isaaclab_arena/scripts/teleop.py --teleop_device avp_handtracking gr1_open_microwave
+   python isaaclab_arena/scripts/imitation_learning/teleop.py --teleop_device avp_handtracking gr1_open_microwave

--- a/docs/pages/example_workflows/locomanipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_1_environment_setup.rst
@@ -171,7 +171,7 @@ Replay the downloaded dataset to verify the environment setup
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/replay_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
      --device cpu \
      --enable_cameras \
      --dataset_file ${DATASET_DIR}/arena_g1_loco_manipulation_dataset_generated_small.hdf5 \

--- a/docs/pages/example_workflows/locomanipulation/step_2_data_generation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_data_generation.rst
@@ -47,7 +47,7 @@ Generate the dataset:
 .. code-block:: bash
 
    # Generate 100 demonstrations
-   python isaaclab_arena/scripts/generate_dataset.py \
+   python isaaclab_arena/scripts/imitation_learning/generate_dataset.py \
      --headless \
      --enable_cameras \
      --mimic \
@@ -70,7 +70,7 @@ To visualize the data produced, you can replay the dataset using the following c
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/replay_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
      --device cpu \
      --enable_cameras \
      --dataset_file $DATASET_DIR/arena_g1_loco_manipulation_dataset_generated.hdf5 \

--- a/docs/pages/example_workflows/static_manipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_1_environment_setup.rst
@@ -151,7 +151,7 @@ Replay the downloaded dataset to verify the environment setup:
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/replay_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
      --device cpu \
      --enable_cameras \
      --dataset_file "${DATASET_DIR}/arena_gr1_manipulation_dataset_generated.hdf5" \

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -63,7 +63,7 @@ Run the recording script:
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/record_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/record_demos.py \
      --device cpu \
      --dataset_file $DATASET_DIR/arena_gr1_manipulation_dataset_recorded.hdf5 \
      --num_demos 10 \

--- a/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
@@ -52,7 +52,7 @@ To start the annotation process run the following command:
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/annotate_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/annotate_demos.py \
      --device cpu \
      --input_file $DATASET_DIR/arena_gr1_manipulation_dataset_recorded.hdf5 \
      --output_file $DATASET_DIR/arena_gr1_manipulation_dataset_annotated.hdf5 \
@@ -96,7 +96,7 @@ Generate the dataset:
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/generate_dataset.py \
+   python isaaclab_arena/scripts/imitation_learning/generate_dataset.py \
      --device cpu \
      --generation_num_trials 50 \
      --num_envs 10 \
@@ -122,7 +122,7 @@ To do so, run the following command:
 
 .. code-block:: bash
 
-   python isaaclab_arena/scripts/replay_demos.py \
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
      --device cpu \
      --enable_cameras \
      --dataset_file $DATASET_DIR/arena_gr1_manipulation_dataset_generated.hdf5 \


### PR DESCRIPTION
## Summary
Fix the incorrect paths for imitation_learning scripts

## Detailed description
Scripts after moved to imitation_learning subfolder as part of https://github.com/isaac-sim/IsaacLab-Arena/pull/287 but the documentation are outdated.
