### PR TITLE
Fix model path assertion to allow HuggingFace model IDs

### DIFF
--- a/isaaclab_arena_gr00t/policy/gr00t_core.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_core.py
@@ -95,6 +95,7 @@ def load_gr00t_policy_from_config(policy_config: Gr00tClosedloopPolicyConfig) ->
         AssertionError: If ``policy_config.model_path`` does not exist.
     """
     model_path = policy_config.model_path
+    # HuggingFace Hub repo IDs use "owner/repo" format (e.g. "nvidia/GR00T-N1.6-DROID").
     is_hf_id = bool(model_path and "/" in model_path and not model_path.startswith(("/", ".")))
     assert (
         Path(model_path).exists() or is_hf_id


### PR DESCRIPTION
## Summary

`load_gr00t_policy_from_config in gr00t_core.py` asserted that model_path must exist as a local filesystem path, which rejected valid HuggingFace Hub model IDs (e.g. nvidia/GR00T-N1.6-DROID).


