### PR TITLE
Stop eval_runner.py on job failure by default

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -138,10 +138,11 @@ def main():
                         metrics_logger.append_job_metrics(job.name, metrics)
 
                 except Exception as e:
-                    # continue with the next job even if one fails
                     job_manager.complete_job(job, metrics={}, status=Status.FAILED)
                     print(f"Job {job.name} failed with error: {e}")
                     print(f"Traceback: {traceback.format_exc()}")
+                    if not args_cli.continue_on_error:
+                        raise
 
                 finally:
                     # Only stop env if it was successfully created

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -14,3 +14,9 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default="isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json",
         help="Path to the eval jobs config file.",
     )
+    parser.add_argument(
+        "--continue_on_error",
+        action="store_true",
+        default=False,
+        help="Continue evaluation with remaining jobs when a job fails instead of stopping immediately.",
+    )


### PR DESCRIPTION
## Summary


Change the `eval_runner.py` default behavior to stop immediately when a job fails, instead of silently continuing with remaining jobs. Prevents spinning up full simulation environments for subsequent jobs when they will all fail for the same reason (e.g. missing model path or memory/ Cuda errors).

Adds a `--continue_on_error` CLI flag to _opt into the previous_ behavior of running all remaining jobs even after a failure.
