### PR TITLE
add deps for policy post-training

### DIFF
--- a/docker/setup/install_gr00t_deps.sh
+++ b/docker/setup/install_gr00t_deps.sh
@@ -105,6 +105,7 @@ $PYTHON_CMD -m pip install \
     peft==0.17.0 \
     protobuf==3.20.3 \
     onnx==1.17.0 \
+    deepspeed==0.17.6 \
     tyro \
     pytest
 


### PR DESCRIPTION
Following SQA bug [here](https://nvbugspro.nvidia.com/bug/5930150), missing deps only for multi-gpu training.
GR00T includes it from a recent commit. Verified locally.