### PR TITLE
Cherry-pick: Fix Dockerfile pip usage and add SSL cert support for Lightwheel SDK …

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -36,13 +36,15 @@ ENV ISAACLAB_PATH=${WORKDIR}/submodules/IsaacLab
 ENV TERM=xterm
 # Symlink isaac sim to IsaacLab
 RUN ln -s /isaac-sim/ ${WORKDIR}/submodules/IsaacLab/_isaac_sim
-# Install IsaacLab dependencies
-RUN for DIR in ${WORKDIR}/submodules/IsaacLab/source/isaaclab*/; do /isaac-sim/python.sh -m pip install --no-deps -e "$DIR"; done
 # Logs and other stuff appear under dist-packages per default, so this dir has to be writeable.
 RUN chmod 777 -R /isaac-sim/kit/
 # Make /isaac-sim directory traversable and readable by all users
 # This is needed when entrypoint switches to non-root user
 RUN chmod a+x /isaac-sim
+# Upgrade Isaac Sim's pip to avoid version warnings and build issues
+RUN /isaac-sim/python.sh -m pip install --upgrade pip
+# Install IsaacLab dependencies
+RUN for DIR in ${WORKDIR}/submodules/IsaacLab/source/isaaclab*/; do /isaac-sim/python.sh -m pip install --no-deps -e "$DIR"; done
 # NOTE(alexmillane, 2026-02-10): We started having issues with flatdict 4.0.1 installation
 # during IsaacLab install. We install here with build isolation which seems to fix the issue.
 RUN /isaac-sim/python.sh -m pip install flatdict==4.0.1 --no-build-isolation

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -137,6 +137,8 @@ else
                     "-v" "/tmp/.X11-unix:/tmp/.X11-unix:rw"
                     "-v" "/var/run/docker.sock:/var/run/docker.sock"
                     "-v" "$HOME/.Xauthority:/root/.Xauthority"
+                    # Mount host SSL certificate store so the container trusts CA certs
+                    "-v" "/etc/ssl/certs:/etc/ssl/certs:ro"
                     "--env" "DISPLAY"
                     "--env" "ACCEPT_EULA=Y"
                     "--env" "PRIVACY_CONSENT=Y"
@@ -147,11 +149,9 @@ else
                     # Setting envs for XR: https://isaac-sim.github.io/IsaacLab/v2.1.0/source/how-to/cloudxr_teleoperation.html#run-isaac-lab-with-the-cloudxr-runtime
                     "--env" "XDG_RUNTIME_DIR=${WORKDIR}/submodules/IsaacLab/openxr/run"
                     "--env" "XR_RUNTIME_JSON=${WORKDIR}/submodules/IsaacLab/openxr/share/openxr/1/openxr_cloudxr.json"
-                    # NOTE(alexmillane, 2025.07.23): This looks a bit suspect to me. We should be running
-                    # as a user inside the container, not root. I've left it in for now, but we should
-                    # remove it, if indeed it's not needed.
-                    # "--env" "OMNI_KIT_ALLOW_ROOT=1"
                     "--env" "ISAACLAB_PATH=${WORKDIR}/submodules/IsaacLab"
+                    # Tell requests/urllib3 to use the system cert bundle
+                    "--env" "REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
                     )
 
     # map omniverse auth or config so we have connection to the dev nucleus


### PR DESCRIPTION
Cherry pick of #449

## Summary
- Fix Dockerfile pip usage and add SSL cert support for Lightwheel SDK

## Detailed description
- Copy(with small modifications) of MR from external contributor https://github.com/isaac-sim/IsaacLab-Arena/pull/423
