### PR TITLE
Fix CI pip install to use Isaac Sim Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       - &install_project_step
         name: Install project and link isaac-sim
         run: |
-          pip install --no-cache-dir -e .
+          /isaac-sim/python.sh -m pip install --no-cache-dir -e .
           [ -e ./submodules/IsaacLab/_isaac_sim ] || ln -s /isaac-sim ./submodules/IsaacLab/_isaac_sim
 
       # Run the tests (excluding the gr00t related tests)


### PR DESCRIPTION
Fixes the following pip install error in our CI set up:
```
Run pip install --no-cache-dir -e .
error: externally-managed-environment
[...]
```

Bare `pip` in the isaaclab_arena container resolves to the system Python, which is PEP 668-protected and refuses system-wide installs. Use /isaac-sim/python.sh -m pip instead.