### PR TITLE
Fix CI submodule fetch to use pinned SHA directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         name: Checkout Code
         uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: false
           # LFS checkout here somehow causes issues when LFS stuff changes over time.
           # So I do LFS manually in a step after.
           # lfs: true
@@ -115,6 +115,23 @@ jobs:
       - *checkout_step
       - *git_lfs_step
 
+      # Fetch each submodule at its exact pinned SHA using a depth-1 fetch of that
+      # specific commit. This avoids the fragility of actions/checkout's shallow
+      # submodule fetch, which fails when the pinned commit is no longer at the tip
+      # of the submodule repo's default branch.
+      - &fetch_submodules_step
+        name: Fetch submodules at pinned SHA
+        run: |
+          for submod in submodules/IsaacLab submodules/Isaac-GR00T; do
+            sha=$(git ls-files -s "$submod" | awk '{print $2}')
+            url=$(git config --file .gitmodules "submodule.${submod}.url" | sed 's|git@github.com:|https://github.com/|')
+            mkdir -p "$submod"
+            git -C "$submod" init
+            git -C "$submod" remote add origin "$url" 2>/dev/null || true
+            git -C "$submod" fetch --depth=1 origin "$sha"
+            git -C "$submod" checkout FETCH_HEAD
+          done
+
       - &install_project_step
         name: Install project and link isaac-sim
         run: |
@@ -150,6 +167,7 @@ jobs:
       - *mark_repo_safe_step
       - *checkout_step
       - *git_lfs_step
+      - *fetch_submodules_step
       - *install_project_step
 
       # Run the policy (GR00T) related tests.


### PR DESCRIPTION
## Summary

CI was failing with:
```
fatal: Fetched in submodule path 'submodules/IsaacLab', but it did not contain <sha>. Direct fetching of that commit failed.
```

`actions/checkout` fetches submodules with `--depth=1` against the submodule repo's default branch tip. When the pinned submodule commit is no longer at that tip (i.e. the submodule repo has moved forward), the shallow fetch can't find it. This is a deterministic failure — re-running CI hits the same error.

## Fix

Disable submodule fetching in `actions/checkout` (`submodules: false`) and add an explicit `fetch_submodules_step` that for each submodule:
1. Reads the pinned SHA from the git index (`git ls-files -s`)
2. Initialises a bare repo in the submodule directory
3. Fetches only that exact commit: `git fetch --depth=1 origin <sha>`

This is fast (one commit, no history) and robust regardless of where the submodule repo's HEAD is.