### PR TITLE
docs: comprehensive README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `ArenaEnvBuilder` composes these primitives into a standard `ManagerBasedRLE
 
 ## Why Isaac Lab Arena?
 
-With the rise of generalist robot policies (e.g., [GR00T N](https://developer.nvidia.com/isaac/gr00t), [pi0](https://www.physicalintelligence.company/), [SmolVLA](https://huggingface.co/HuggingFaceTB/SmolVLA-base)), there is an urgent need to evaluate these policies across many diverse tasks and environments. Traditional approaches suffer from:
+With the rise of generalist robot policies (e.g., [GR00T N](https://developer.nvidia.com/isaac/gr00t), [pi0](https://www.physicalintelligence.company/), [SmolVLA](https://huggingface.co/docs/lerobot/smolvla)), there is an urgent need to evaluate these policies across many diverse tasks and environments. Traditional approaches suffer from:
 
 - **Code duplication** — each task variation (different object, different robot) requires a near-copy of the same configuration
 - **Maintenance burden** — N robots × M objects × K scenes = an explosion of configs to keep in sync


### PR DESCRIPTION
Picks up the work from #461 (hajan:improve-readme), which couldn't pass CI due to a missing NVCR token on the fork.

## Changes

- Add pre-alpha status warning banner
- Add version/platform/license badges
- Add quick-start installation section
- Add composability overview table (Scene / Embodiment / Task)
- Add usage example (kitchen pick-and-place)
- Add project structure tree (including missing `isaaclab_arena_environments/` and `isaaclab_arena_examples/`)
- Add version compatibility table (with corrected Isaac Sim 5.0.0 for `release/0.1.1`)
- Add ecosystem, contributing, support, and citation sections
- Restore "Made with ❤️ by the NVIDIA Robotics Team" footer