### PR TITLE
Batch Support for AxisAlignedBoundingBox

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ Guidelines for modifications:
 * Sangeeta Subramanian <sangeetas@nvidia.com> (NVIDIA)
 * Vikram Ramasamy <viiik-inside, vramasamy@nvidia.com> (NVIDIA)
 * Xinjie Yao <xyao-nv, xyao@nvidia.com> (NVIDIA)
+* Zihao Xiao <zhx06, zihaox@nvidia.com> (NVIDIA)
 
 ## LightWheel AI
 

--- a/isaaclab_arena/assets/object_set.py
+++ b/isaaclab_arena/assets/object_set.py
@@ -88,7 +88,7 @@ class RigidObjectSet(Object):
         Returns the bounding box with the greatest z-extent among all objects in the set.
         This is a heuristic to avoid objects spawning inside their support surfaces.
         """
-        return max(self.objects, key=lambda obj: obj.get_bounding_box().size[2]).get_bounding_box()
+        return max(self.objects, key=lambda obj: obj.get_bounding_box().size[0, 2].item()).get_bounding_box()
 
     def get_contact_sensor_cfg(self, contact_against_prim_paths: list[str] | None = None) -> ContactSensorCfg:
         # We override this function from the parent class because in some assets, the rigid body

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -152,6 +152,8 @@ class ObjectPlacer:
         first_anchor = next(obj for obj in objects if obj in anchor_objects)
         anchor_bbox = first_anchor.get_world_bounding_box()
 
+        cx, cy, cz = float(anchor_bbox.center[0, 0]), float(anchor_bbox.center[0, 1]), float(anchor_bbox.center[0, 2])
+
         positions: dict[Object | ObjectReference, tuple[float, float, float]] = {}
         for obj in objects:
             if obj in anchor_objects:
@@ -159,7 +161,7 @@ class ObjectPlacer:
             elif any(isinstance(r, On) for r in obj.get_relations()):
                 positions[obj] = self._compute_on_guided_position(obj, anchor_objects, anchor_bbox, generator)
             else:
-                positions[obj] = anchor_bbox.center  # no spatial guidance; solver handles placement
+                positions[obj] = (cx, cy, cz)
         return positions
 
     def _get_on_parent_world_bbox(
@@ -220,7 +222,7 @@ class ObjectPlacer:
         )
 
         # Z: place child's bottom face at parent top + clearance
-        z = parent_bbox.max_point[0, 2] + on_relation.clearance_m - child_bbox.min_point[0, 2]
+        z = float(parent_bbox.max_point[0, 2] + on_relation.clearance_m - child_bbox.min_point[0, 2])
 
         return (x, y, z)
 
@@ -251,7 +253,7 @@ class ObjectPlacer:
         low = parent_min - child_min
         high = parent_max - child_max
         if low >= high:
-            return (parent_min + parent_max) / 2.0
+            return float((parent_min + parent_max) / 2.0)
         return float(low + (high - low) * torch.rand(1, generator=generator).item())
 
     def _validate_on_relations(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -205,22 +205,22 @@ class ObjectPlacer:
         child_bbox = obj.get_bounding_box()
 
         x = self._sample_axis_position(
-            parent_bbox.min_point[0],
-            parent_bbox.max_point[0],
-            child_bbox.min_point[0],
-            child_bbox.max_point[0],
+            parent_bbox.min_point[0, 0],
+            parent_bbox.max_point[0, 0],
+            child_bbox.min_point[0, 0],
+            child_bbox.max_point[0, 0],
             generator,
         )
         y = self._sample_axis_position(
-            parent_bbox.min_point[1],
-            parent_bbox.max_point[1],
-            child_bbox.min_point[1],
-            child_bbox.max_point[1],
+            parent_bbox.min_point[0, 1],
+            parent_bbox.max_point[0, 1],
+            child_bbox.min_point[0, 1],
+            child_bbox.max_point[0, 1],
             generator,
         )
 
         # Z: place child's bottom face at parent top + clearance
-        z = parent_bbox.max_point[2] + on_relation.clearance_m - child_bbox.min_point[2]
+        z = parent_bbox.max_point[0, 2] + on_relation.clearance_m - child_bbox.min_point[0, 2]
 
         return (x, y, z)
 

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -284,9 +284,11 @@ class ObjectPlacer:
                         print(f"  On relation: '{obj.name}' XY outside parent (retrying)")
                     return False
                 # 3. Z: same as OnLossStrategy; child_bottom in (parent_top, parent_top+clearance_m], within on_relation_z_tolerance_m.
-                parent_top_z = parent_world.max_point[2]
+                parent_local_top_z: float = parent.get_bounding_box().max_point[2]
+                child_local_bottom_z: float = obj.get_bounding_box().min_point[2]
+                parent_top_z = parent_local_top_z + positions[parent][2]
                 clearance_m = rel.clearance_m
-                child_bottom_z = child_world.min_point[2]
+                child_bottom_z = child_local_bottom_z + positions[obj][2]
                 eps_z = self.params.on_relation_z_tolerance_m
                 if child_bottom_z <= parent_top_z - eps_z or child_bottom_z > parent_top_z + clearance_m + eps_z:
                     if self.params.verbose:

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -275,17 +275,17 @@ class ObjectPlacer:
                 parent_world = parent.get_bounding_box().translated(positions[parent])
                 # 1 & 2: Same as OnLossStrategy X/Y band (child's footprint within parent).
                 if (
-                    child_world.min_point[0] < parent_world.min_point[0]
-                    or child_world.max_point[0] > parent_world.max_point[0]
-                    or child_world.min_point[1] < parent_world.min_point[1]
-                    or child_world.max_point[1] > parent_world.max_point[1]
+                    child_world.min_point[0, 0] < parent_world.min_point[0, 0]
+                    or child_world.max_point[0, 0] > parent_world.max_point[0, 0]
+                    or child_world.min_point[0, 1] < parent_world.min_point[0, 1]
+                    or child_world.max_point[0, 1] > parent_world.max_point[0, 1]
                 ):
                     if self.params.verbose:
                         print(f"  On relation: '{obj.name}' XY outside parent (retrying)")
                     return False
                 # 3. Z: same as OnLossStrategy; child_bottom in (parent_top, parent_top+clearance_m], within on_relation_z_tolerance_m.
-                parent_local_top_z: float = parent.get_bounding_box().max_point[2]
-                child_local_bottom_z: float = obj.get_bounding_box().min_point[2]
+                parent_local_top_z: float = parent.get_bounding_box().max_point[0, 2].item()
+                child_local_bottom_z: float = obj.get_bounding_box().min_point[0, 2].item()
                 parent_top_z = parent_local_top_z + positions[parent][2]
                 clearance_m = rel.clearance_m
                 child_bottom_z = child_local_bottom_z + positions[obj][2]
@@ -309,7 +309,7 @@ class ObjectPlacer:
                 a_world = a.get_bounding_box().translated(positions[a])
                 b_world = b.get_bounding_box().translated(positions[b])
 
-                if a_world.overlaps(b_world, margin=self.params.min_separation_m):
+                if a_world.overlaps(b_world, margin=self.params.min_separation_m).item():
                     if self.params.verbose:
                         print(f"  Overlap between '{a.name}' and '{b.name}'")
                     return False

--- a/isaaclab_arena/relations/relation_loss_strategies.py
+++ b/isaaclab_arena/relations/relation_loss_strategies.py
@@ -158,12 +158,12 @@ class NextToLossStrategy(RelationLossStrategy):
 
         # Parent world extents from the world bounding box
         if cfg.direction == Direction.POSITIVE:
-            parent_edge = parent_world_bbox.max_point[cfg.primary_axis]
-            child_offset = child_bbox.min_point[cfg.primary_axis]
+            parent_edge = parent_world_bbox.max_point[0, cfg.primary_axis]
+            child_offset = child_bbox.min_point[0, cfg.primary_axis]
             penalty_side = "less"
         else:
-            parent_edge = parent_world_bbox.min_point[cfg.primary_axis]
-            child_offset = child_bbox.max_point[cfg.primary_axis]
+            parent_edge = parent_world_bbox.min_point[0, cfg.primary_axis]
+            child_offset = child_bbox.max_point[0, cfg.primary_axis]
             penalty_side = "greater"
 
         # 1. Half-plane loss: child must be on correct side of parent edge
@@ -175,10 +175,10 @@ class NextToLossStrategy(RelationLossStrategy):
         )
 
         # 2. Band position loss: child placed at target position within parent's perpendicular extent
-        parent_band_min = parent_world_bbox.min_point[cfg.band_axis]
-        parent_band_max = parent_world_bbox.max_point[cfg.band_axis]
-        valid_band_min = parent_band_min - child_bbox.min_point[cfg.band_axis]
-        valid_band_max = parent_band_max - child_bbox.max_point[cfg.band_axis]
+        parent_band_min = parent_world_bbox.min_point[0, cfg.band_axis]
+        parent_band_max = parent_world_bbox.max_point[0, cfg.band_axis]
+        valid_band_min = parent_band_min - child_bbox.min_point[0, cfg.band_axis]
+        valid_band_max = parent_band_max - child_bbox.max_point[0, cfg.band_axis]
         # Convert cross_position_ratio [-1, 1] to interpolation factor [0, 1]: -1 = min, 0 = center, 1 = max
         t = (relation.cross_position_ratio + 1.0) / 2.0
         target_band_pos = valid_band_min + t * (valid_band_max - valid_band_min)
@@ -199,19 +199,19 @@ class NextToLossStrategy(RelationLossStrategy):
             band_axis_name = cfg.band_axis.name
             print(
                 f"    [NextTo] {relation.side.value}: child_{axis_name.lower()}="
-                f"{child_pos[cfg.primary_axis].item():.4f}, parent_edge={parent_edge:.4f},"
+                f"{child_pos[cfg.primary_axis].item():.4f}, parent_edge={parent_edge.item():.4f},"
                 f" loss={half_plane_loss.item():.6f}"
             )
             print(
                 f"    [NextTo] {band_axis_name} band: child_{band_axis_name.lower()}="
-                f"{child_pos[cfg.band_axis].item():.4f}, target={target_band_pos:.4f}"
+                f"{child_pos[cfg.band_axis].item():.4f}, target={target_band_pos.item():.4f}"
                 f" (cross_position_ratio={relation.cross_position_ratio:.2f},"
-                f" range=[{valid_band_min:.4f}, {valid_band_max:.4f}]),"
+                f" range=[{valid_band_min.item():.4f}, {valid_band_max.item():.4f}]),"
                 f" loss={band_loss.item():.6f}"
             )
             print(
                 f"    [NextTo] Distance: child_{axis_name.lower()}="
-                f"{child_pos[cfg.primary_axis].item():.4f}, target={target_pos:.4f},"
+                f"{child_pos[cfg.primary_axis].item():.4f}, target={target_pos.item():.4f},"
                 f" loss={distance_loss.item():.6f}"
             )
 
@@ -257,19 +257,19 @@ class OnLossStrategy(RelationLossStrategy):
             Weighted loss tensor.
         """
         # Parent world-space extents from the world bounding box
-        parent_x_min = parent_world_bbox.min_point[0]
-        parent_x_max = parent_world_bbox.max_point[0]
-        parent_y_min = parent_world_bbox.min_point[1]
-        parent_y_max = parent_world_bbox.max_point[1]
-        parent_z_max = parent_world_bbox.max_point[2]  # Top surface
+        parent_x_min = parent_world_bbox.min_point[0, 0]
+        parent_x_max = parent_world_bbox.max_point[0, 0]
+        parent_y_min = parent_world_bbox.min_point[0, 1]
+        parent_y_max = parent_world_bbox.max_point[0, 1]
+        parent_z_max = parent_world_bbox.max_point[0, 2]  # Top surface
 
         # Compute valid position ranges such that child's entire footprint is within parent
-        # Child left edge = child_pos[0] + child_bbox.min_point[0], must be >= parent_x_min
-        # Child right edge = child_pos[0] + child_bbox.max_point[0], must be <= parent_x_max
-        valid_x_min = parent_x_min - child_bbox.min_point[0]  # child's left at parent's left
-        valid_x_max = parent_x_max - child_bbox.max_point[0]  # child's right at parent's right
-        valid_y_min = parent_y_min - child_bbox.min_point[1]
-        valid_y_max = parent_y_max - child_bbox.max_point[1]
+        # Child left edge = child_pos[0] + child_bbox.min_point[0, 0], must be >= parent_x_min
+        # Child right edge = child_pos[0] + child_bbox.max_point[0, 0], must be <= parent_x_max
+        valid_x_min = parent_x_min - child_bbox.min_point[0, 0]  # child's left at parent's left
+        valid_x_max = parent_x_max - child_bbox.max_point[0, 0]  # child's right at parent's right
+        valid_y_min = parent_y_min - child_bbox.min_point[0, 1]
+        valid_y_max = parent_y_max - child_bbox.max_point[0, 1]
 
         # 1. X band loss: child's footprint entirely within parent's X extent
         x_band_loss = linear_band_loss(
@@ -288,19 +288,22 @@ class OnLossStrategy(RelationLossStrategy):
         )
 
         # 3. Z point loss: child bottom = parent top + clearance
-        target_z = parent_z_max + relation.clearance_m - child_bbox.min_point[2]
+        target_z = parent_z_max + relation.clearance_m - child_bbox.min_point[0, 2]
         z_loss = single_point_linear_loss(child_pos[2], target_z, slope=self.slope)
 
         if self.debug:
             print(
-                f"    [On] X: child_pos={child_pos[0].item():.4f}, valid_range=[{valid_x_min:.4f},"
-                f" {valid_x_max:.4f}], loss={x_band_loss.item():.6f}"
+                f"    [On] X: child_pos={child_pos[0].item():.4f}, valid_range=[{valid_x_min.item():.4f},"
+                f" {valid_x_max.item():.4f}], loss={x_band_loss.item():.6f}"
             )
             print(
-                f"    [On] Y: child_pos={child_pos[1].item():.4f}, valid_range=[{valid_y_min:.4f},"
-                f" {valid_y_max:.4f}], loss={y_band_loss.item():.6f}"
+                f"    [On] Y: child_pos={child_pos[1].item():.4f}, valid_range=[{valid_y_min.item():.4f},"
+                f" {valid_y_max.item():.4f}], loss={y_band_loss.item():.6f}"
             )
-            print(f"    [On] Z: child_pos={child_pos[2].item():.4f}, target={target_z:.4f}, loss={z_loss.item():.6f}")
+            print(
+                f"    [On] Z: child_pos={child_pos[2].item():.4f}, target={target_z.item():.4f},"
+                f" loss={z_loss.item():.6f}"
+            )
 
         total_loss = x_band_loss + y_band_loss + z_loss
         return relation.relation_loss_weight * total_loss
@@ -346,16 +349,16 @@ class NoCollisionLossStrategy(RelationLossStrategy):
         """
         # Parent world extents from the world bounding box, expanded by clearance_m
         c = relation.clearance_m
-        parent_x_min = parent_world_bbox.min_point[0] - c
-        parent_x_max = parent_world_bbox.max_point[0] + c
-        parent_y_min = parent_world_bbox.min_point[1] - c
-        parent_y_max = parent_world_bbox.max_point[1] + c
-        parent_z_min = parent_world_bbox.min_point[2] - c
-        parent_z_max = parent_world_bbox.max_point[2] + c
+        parent_x_min = parent_world_bbox.min_point[0, 0] - c
+        parent_x_max = parent_world_bbox.max_point[0, 0] + c
+        parent_y_min = parent_world_bbox.min_point[0, 1] - c
+        parent_y_max = parent_world_bbox.max_point[0, 1] + c
+        parent_z_min = parent_world_bbox.min_point[0, 2] - c
+        parent_z_max = parent_world_bbox.max_point[0, 2] + c
 
         # Child world extents
-        child_world_min = child_pos + torch.tensor(child_bbox.min_point, dtype=child_pos.dtype, device=child_pos.device)
-        child_world_max = child_pos + torch.tensor(child_bbox.max_point, dtype=child_pos.dtype, device=child_pos.device)
+        child_world_min = child_pos + child_bbox.min_point[0]
+        child_world_max = child_pos + child_bbox.max_point[0]
 
         # 1. Per-axis overlap: zero when separated; else overlap length (default slope 1.0 gives length in m)
         overlap_x = interval_overlap_axis_loss(child_world_min[0], child_world_max[0], parent_x_min, parent_x_max)
@@ -369,15 +372,18 @@ class NoCollisionLossStrategy(RelationLossStrategy):
         if self.debug:
             print(
                 f"    [NoCollision] X: overlap={overlap_x.item():.6f} (child_x=[{child_world_min[0].item():.4f},"
-                f" {child_world_max[0].item():.4f}], parent_x=[{parent_x_min:.4f}, {parent_x_max:.4f}])"
+                f" {child_world_max[0].item():.4f}], parent_x=[{parent_x_min.item():.4f},"
+                f" {parent_x_max.item():.4f}])"
             )
             print(
                 f"    [NoCollision] Y: overlap={overlap_y.item():.6f} (child_y=[{child_world_min[1].item():.4f},"
-                f" {child_world_max[1].item():.4f}], parent_y=[{parent_y_min:.4f}, {parent_y_max:.4f}])"
+                f" {child_world_max[1].item():.4f}], parent_y=[{parent_y_min.item():.4f},"
+                f" {parent_y_max.item():.4f}])"
             )
             print(
                 f"    [NoCollision] Z: overlap={overlap_z.item():.6f} (child_z=[{child_world_min[2].item():.4f},"
-                f" {child_world_max[2].item():.4f}], parent_z=[{parent_z_min:.4f}, {parent_z_max:.4f}])"
+                f" {child_world_max[2].item():.4f}], parent_z=[{parent_z_min.item():.4f},"
+                f" {parent_z_max.item():.4f}])"
             )
             print(f"    [NoCollision] volume={overlap_volume.item():.6f}, loss={total_loss.item():.6f}")
 

--- a/isaaclab_arena/relations/relation_solver.py
+++ b/isaaclab_arena/relations/relation_solver.py
@@ -238,8 +238,10 @@ def _print_relation_debug(
 
     print(f"\n=== {obj.name} -> {type(relation).__name__}({relation.parent.name}) ===")
     print(f"  Child pos: ({child_pos[0].item():.4f}, {child_pos[1].item():.4f}, {child_pos[2].item():.4f})")
-    print(f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
-          f" size={child_bbox.size[0].tolist()}")
+    print(
+        f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
+        f" size={child_bbox.size[0].tolist()}"
+    )
     print(f"  Parent pos: ({parent_pos[0].item():.4f}, {parent_pos[1].item():.4f}, {parent_pos[2].item():.4f})")
     print(
         f"  Parent world bbox: min={parent_world_bbox.min_point[0].tolist()},"
@@ -283,6 +285,8 @@ def _print_unary_relation_debug(
     )
     print(f"\n=== {obj.name} -> {type(relation).__name__}({target_str}) ===")
     print(f"  Child pos: ({child_pos[0].item():.4f}, {child_pos[1].item():.4f}, {child_pos[2].item():.4f})")
-    print(f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
-          f" size={child_bbox.size[0].tolist()}")
+    print(
+        f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
+        f" size={child_bbox.size[0].tolist()}"
+    )
     print(f"  Loss: {loss.item():.6f}")

--- a/isaaclab_arena/relations/relation_solver.py
+++ b/isaaclab_arena/relations/relation_solver.py
@@ -238,21 +238,34 @@ def _print_relation_debug(
 
     print(f"\n=== {obj.name} -> {type(relation).__name__}({relation.parent.name}) ===")
     print(f"  Child pos: ({child_pos[0].item():.4f}, {child_pos[1].item():.4f}, {child_pos[2].item():.4f})")
-    print(f"  Child bbox: min={child_bbox.min_point}, max={child_bbox.max_point}, size={child_bbox.size}")
+    print(f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
+          f" size={child_bbox.size[0].tolist()}")
     print(f"  Parent pos: ({parent_pos[0].item():.4f}, {parent_pos[1].item():.4f}, {parent_pos[2].item():.4f})")
     print(
-        f"  Parent world bbox: min={parent_world_bbox.min_point}, max={parent_world_bbox.max_point},"
-        f" size={parent_world_bbox.size}"
+        f"  Parent world bbox: min={parent_world_bbox.min_point[0].tolist()},"
+        f" max={parent_world_bbox.max_point[0].tolist()}, size={parent_world_bbox.size[0].tolist()}"
     )
 
     # Child world extents
-    child_x_range = (child_pos[0].item() + child_bbox.min_point[0], child_pos[0].item() + child_bbox.max_point[0])
-    child_y_range = (child_pos[1].item() + child_bbox.min_point[1], child_pos[1].item() + child_bbox.max_point[1])
+    child_x_range = (
+        child_pos[0].item() + child_bbox.min_point[0, 0].item(),
+        child_pos[0].item() + child_bbox.max_point[0, 0].item(),
+    )
+    child_y_range = (
+        child_pos[1].item() + child_bbox.min_point[0, 1].item(),
+        child_pos[1].item() + child_bbox.max_point[0, 1].item(),
+    )
 
     print(f"  Child world X: [{child_x_range[0]:.4f}, {child_x_range[1]:.4f}]")
     print(f"  Child world Y: [{child_y_range[0]:.4f}, {child_y_range[1]:.4f}]")
-    print(f"  Parent world X: [{parent_world_bbox.min_point[0]:.4f}, {parent_world_bbox.max_point[0]:.4f}]")
-    print(f"  Parent world Y: [{parent_world_bbox.min_point[1]:.4f}, {parent_world_bbox.max_point[1]:.4f}]")
+    print(
+        f"  Parent world X: [{parent_world_bbox.min_point[0, 0].item():.4f},"
+        f" {parent_world_bbox.max_point[0, 0].item():.4f}]"
+    )
+    print(
+        f"  Parent world Y: [{parent_world_bbox.min_point[0, 1].item():.4f},"
+        f" {parent_world_bbox.max_point[0, 1].item():.4f}]"
+    )
     print(f"  Loss: {loss.item():.6f}")
 
 
@@ -270,5 +283,6 @@ def _print_unary_relation_debug(
     )
     print(f"\n=== {obj.name} -> {type(relation).__name__}({target_str}) ===")
     print(f"  Child pos: ({child_pos[0].item():.4f}, {child_pos[1].item():.4f}, {child_pos[2].item():.4f})")
-    print(f"  Child bbox: min={child_bbox.min_point}, max={child_bbox.max_point}, size={child_bbox.size}")
+    print(f"  Child bbox: min={child_bbox.min_point[0].tolist()}, max={child_bbox.max_point[0].tolist()},"
+          f" size={child_bbox.size[0].tolist()}")
     print(f"  Loss: {loss.item():.6f}")

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -125,6 +125,11 @@ class NoCollision(Relation):
     unordered pair once.
 
     Note: Loss computation is handled by NoCollisionLossStrategy in relation_loss_strategies.py.
+
+    NOTE: If both A.add_relation(NoCollision(B)) and B.add_relation(NoCollision(A)) are present,
+    the solver will compute the loss twice and the relation graph becomes cyclic, which can cause
+    issues during environment creation. Deduplication or cycle detection should be addressed at a
+    higher level.
     """
 
     def __init__(

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -9,10 +9,6 @@ import torch
 
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
-# =============================================================================
-# Single-env tests (N=1, properties return (1, 3) or (1,) tensors)
-# =============================================================================
-
 
 def test_bounding_box_single_env_properties():
     """Single env: properties return tensors with leading dim 1."""
@@ -65,11 +61,6 @@ def test_bounding_box_single_env_get_corners_at():
     assert corners.shape == (1, 8, 3)
     corners_offset = aabb.get_corners_at(pos=torch.tensor([10.0, 0.0, 0.0]))
     torch.testing.assert_close(corners_offset[0, 0], corners[0, 0] + torch.tensor([10.0, 0.0, 0.0]))
-
-
-# =============================================================================
-# Multi-env batch tests (N>1, properties return (N, 3) or (N,) tensors)
-# =============================================================================
 
 
 def test_bounding_box_multi_env_properties():

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -3,72 +3,73 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for AxisAlignedBoundingBox with batch dimension support."""
+"""Tests for AxisAlignedBoundingBox with always-tensor API."""
 
 import torch
 
-import pytest
-
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
+
 # =============================================================================
-# Single-env backward-compatibility tests (properties return tuples / floats)
+# Single-env tests (N=1, properties return (1, 3) or (1,) tensors)
 # =============================================================================
 
 
 def test_bounding_box_single_env_properties():
-    """Single env: properties return tuples/floats matching the original dataclass API."""
+    """Single env: properties return tensors with leading dim 1."""
     aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 4.0, 0.2))
     assert aabb.num_envs == 1
-    assert isinstance(aabb.min_point, tuple)
-    assert aabb.min_point == (0.0, 0.0, 0.0)
-    assert aabb.max_point == (2.0, 4.0, pytest.approx(0.2, abs=1e-6))
-    assert aabb.size == (2.0, 4.0, pytest.approx(0.2, abs=1e-6))
-    assert aabb.center == (1.0, 2.0, pytest.approx(0.1, abs=1e-6))
-    assert aabb.top_surface_z == pytest.approx(0.2, abs=1e-6)
-    assert isinstance(aabb.top_surface_z, float)
+    assert isinstance(aabb.min_point, torch.Tensor)
+    assert aabb.min_point.shape == (1, 3)
+    torch.testing.assert_close(aabb.min_point, torch.tensor([[0.0, 0.0, 0.0]]))
+    torch.testing.assert_close(aabb.max_point[0, 2], torch.tensor(0.2), atol=1e-6, rtol=0)
+    torch.testing.assert_close(aabb.size, torch.tensor([[2.0, 4.0, 0.2]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(aabb.center, torch.tensor([[1.0, 2.0, 0.1]]), atol=1e-6, rtol=0)
+    assert isinstance(aabb.top_surface_z, torch.Tensor)
+    assert aabb.top_surface_z.shape == (1,)
+    torch.testing.assert_close(aabb.top_surface_z, torch.tensor([0.2]), atol=1e-6, rtol=0)
 
 
 def test_bounding_box_single_env_transforms():
     """Single env: translated, scaled, centered, rotated return AABBs with correct values."""
     aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 1.0, 0.5))
     moved = aabb.translated((1.0, 2.0, 0.5))
-    assert moved.min_point == (1.0, 2.0, 0.5)
-    assert moved.max_point == (3.0, 3.0, 1.0)
+    torch.testing.assert_close(moved.min_point, torch.tensor([[1.0, 2.0, 0.5]]))
+    torch.testing.assert_close(moved.max_point, torch.tensor([[3.0, 3.0, 1.0]]))
 
     scaled = aabb.scaled((2.0, 0.5, 3.0))
-    assert scaled.max_point == (4.0, 0.5, 1.5)
+    torch.testing.assert_close(scaled.max_point, torch.tensor([[4.0, 0.5, 1.5]]))
 
     centered = AxisAlignedBoundingBox(min_point=(2.0, 4.0, 0.0), max_point=(4.0, 6.0, 2.0)).centered()
-    assert centered.center == pytest.approx((0.0, 0.0, 0.0), abs=1e-6)
+    torch.testing.assert_close(centered.center, torch.tensor([[0.0, 0.0, 0.0]]), atol=1e-6, rtol=0)
 
     rotated = aabb.rotated_90_around_z(1)
-    assert rotated.min_point == pytest.approx((-1.0, 0.0, 0.0), abs=1e-6)
-    assert rotated.max_point == pytest.approx((0.0, 2.0, 0.5), abs=1e-6)
+    torch.testing.assert_close(rotated.min_point, torch.tensor([[-1.0, 0.0, 0.0]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rotated.max_point, torch.tensor([[0.0, 2.0, 0.5]]), atol=1e-6, rtol=0)
 
 
 def test_bounding_box_single_env_overlaps():
-    """Single env: overlaps() returns a Python bool; margin widens the check."""
+    """Single env: overlaps() returns a (1,) bool tensor; margin widens the check."""
     a = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(1.0, 1.0, 1.0))
     b = AxisAlignedBoundingBox(min_point=(0.5, 0.5, 0.0), max_point=(1.5, 1.5, 0.5))
-    assert a.overlaps(b) is True
+    assert a.overlaps(b).item() is True
 
     c = AxisAlignedBoundingBox(min_point=(1.05, 0.0, 0.0), max_point=(2.0, 1.0, 1.0))
-    assert a.overlaps(c) is False
-    assert a.overlaps(c, margin=0.1) is True
+    assert a.overlaps(c).item() is False
+    assert a.overlaps(c, margin=0.1).item() is True
 
 
 def test_bounding_box_single_env_get_corners_at():
-    """Single env: get_corners_at() returns (8, 3) tensor offset by pos."""
+    """Single env: get_corners_at() returns (1, 8, 3) tensor offset by pos."""
     aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(1.0, 1.0, 1.0))
     corners = aabb.get_corners_at()
-    assert corners.shape == (8, 3)
+    assert corners.shape == (1, 8, 3)
     corners_offset = aabb.get_corners_at(pos=torch.tensor([10.0, 0.0, 0.0]))
-    torch.testing.assert_close(corners_offset[0], corners[0] + torch.tensor([10.0, 0.0, 0.0]))
+    torch.testing.assert_close(corners_offset[0, 0], corners[0, 0] + torch.tensor([10.0, 0.0, 0.0]))
 
 
 # =============================================================================
-# Multi-env batch tests (properties return tensors)
+# Multi-env batch tests (N>1, properties return (N, 3) or (N,) tensors)
 # =============================================================================
 
 

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -9,7 +9,6 @@ import torch
 
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
-
 # =============================================================================
 # Single-env tests (N=1, properties return (1, 3) or (1,) tensors)
 # =============================================================================

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AxisAlignedBoundingBox with batch dimension support."""
+
+import pytest
+import torch
+
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+
+# =============================================================================
+# Single-env backward-compatibility tests (properties return tuples / floats)
+# =============================================================================
+
+
+def test_bounding_box_single_env_properties():
+    """Single env: properties return tuples/floats matching the original dataclass API."""
+    aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 4.0, 0.2))
+    assert aabb.num_envs == 1
+    assert isinstance(aabb.min_point, tuple)
+    assert aabb.min_point == (0.0, 0.0, 0.0)
+    assert aabb.max_point == (2.0, 4.0, pytest.approx(0.2, abs=1e-6))
+    assert aabb.size == (2.0, 4.0, pytest.approx(0.2, abs=1e-6))
+    assert aabb.center == (1.0, 2.0, pytest.approx(0.1, abs=1e-6))
+    assert aabb.top_surface_z == pytest.approx(0.2, abs=1e-6)
+    assert isinstance(aabb.top_surface_z, float)
+
+
+def test_bounding_box_single_env_transforms():
+    """Single env: translated, scaled, centered, rotated return AABBs with correct values."""
+    aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 1.0, 0.5))
+    moved = aabb.translated((1.0, 2.0, 0.5))
+    assert moved.min_point == (1.0, 2.0, 0.5)
+    assert moved.max_point == (3.0, 3.0, 1.0)
+
+    scaled = aabb.scaled((2.0, 0.5, 3.0))
+    assert scaled.max_point == (4.0, 0.5, 1.5)
+
+    centered = AxisAlignedBoundingBox(min_point=(2.0, 4.0, 0.0), max_point=(4.0, 6.0, 2.0)).centered()
+    assert centered.center == pytest.approx((0.0, 0.0, 0.0), abs=1e-6)
+
+    rotated = aabb.rotated_90_around_z(1)
+    assert rotated.min_point == pytest.approx((-1.0, 0.0, 0.0), abs=1e-6)
+    assert rotated.max_point == pytest.approx((0.0, 2.0, 0.5), abs=1e-6)
+
+
+def test_bounding_box_single_env_overlaps():
+    """Single env: overlaps() returns a Python bool; margin widens the check."""
+    a = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(1.0, 1.0, 1.0))
+    b = AxisAlignedBoundingBox(min_point=(0.5, 0.5, 0.0), max_point=(1.5, 1.5, 0.5))
+    assert a.overlaps(b) is True
+
+    c = AxisAlignedBoundingBox(min_point=(1.05, 0.0, 0.0), max_point=(2.0, 1.0, 1.0))
+    assert a.overlaps(c) is False
+    assert a.overlaps(c, margin=0.1) is True
+
+
+def test_bounding_box_single_env_get_corners_at():
+    """Single env: get_corners_at() returns (8, 3) tensor offset by pos."""
+    aabb = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(1.0, 1.0, 1.0))
+    corners = aabb.get_corners_at()
+    assert corners.shape == (8, 3)
+    corners_offset = aabb.get_corners_at(pos=torch.tensor([10.0, 0.0, 0.0]))
+    torch.testing.assert_close(corners_offset[0], corners[0] + torch.tensor([10.0, 0.0, 0.0]))
+
+
+# =============================================================================
+# Multi-env batch tests (properties return tensors)
+# =============================================================================
+
+
+def test_bounding_box_multi_env_properties():
+    """Multi-env: properties return (N, 3) or (N,) tensors."""
+    aabb = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[0.0, 0.0, 0.0], [1.0, 2.0, 0.0]]),
+        max_point=torch.tensor([[1.0, 1.0, 1.0], [3.0, 4.0, 0.5]]),
+    )
+    assert aabb.num_envs == 2
+    assert isinstance(aabb.min_point, torch.Tensor)
+    assert aabb.size.shape == (2, 3)
+    torch.testing.assert_close(aabb.size[1], torch.tensor([2.0, 2.0, 0.5]))
+    torch.testing.assert_close(aabb.center[0], torch.tensor([0.5, 0.5, 0.5]))
+    assert aabb.top_surface_z.shape == (2,)
+    torch.testing.assert_close(aabb.top_surface_z, torch.tensor([1.0, 0.5]))
+
+
+def test_bounding_box_multi_env_transforms():
+    """Multi-env: translated, scaled, centered, rotated operate per-env."""
+    aabb = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+        max_point=torch.tensor([[2.0, 1.0, 0.5], [3.0, 1.0, 0.5]]),
+    )
+    moved = aabb.translated(torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]))
+    torch.testing.assert_close(moved.min_point[0], torch.tensor([1.0, 0.0, 0.0]))
+    torch.testing.assert_close(moved.min_point[1], torch.tensor([0.0, 1.0, 0.0]))
+
+    rotated = aabb.rotated_90_around_z(1)
+    torch.testing.assert_close(rotated.min_point[0], torch.tensor([-1.0, 0.0, 0.0]))
+    torch.testing.assert_close(rotated.max_point[1], torch.tensor([0.0, 3.0, 0.5]))
+
+    centered = aabb.centered()
+    torch.testing.assert_close(centered.center, torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]))
+
+
+def test_bounding_box_multi_env_overlaps():
+    """Multi-env vs single-env: overlaps() returns (N,) bool tensor via broadcasting."""
+    batched = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[0.0, 0.0, 0.0], [2.0, 2.0, 0.0]]),
+        max_point=torch.tensor([[1.0, 1.0, 1.0], [3.0, 3.0, 1.0]]),
+    )
+    other = AxisAlignedBoundingBox(min_point=(0.5, 0.5, 0.0), max_point=(1.5, 1.5, 0.5))
+    result = batched.overlaps(other)
+    assert isinstance(result, torch.Tensor)
+    assert result[0].item() is True
+    assert result[1].item() is False
+
+
+def test_bounding_box_multi_env_get_corners_at():
+    """Multi-env: get_corners_at() returns (N, 8, 3) tensor."""
+    aabb = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+        max_point=torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]),
+    )
+    corners = aabb.get_corners_at()
+    assert corners.shape == (2, 8, 3)
+    corners_with_pos = aabb.get_corners_at(pos=torch.tensor([[10.0, 0.0, 0.0], [20.0, 0.0, 0.0]]))
+    torch.testing.assert_close(corners_with_pos[1, 0], corners[1, 0] + torch.tensor([20.0, 0.0, 0.0]))

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -5,11 +5,11 @@
 
 """Tests for AxisAlignedBoundingBox with batch dimension support."""
 
-import pytest
 import torch
 
-from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+import pytest
 
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 # =============================================================================
 # Single-env backward-compatibility tests (properties return tuples / floats)

--- a/isaaclab_arena/tests/test_no_collision_loss.py
+++ b/isaaclab_arena/tests/test_no_collision_loss.py
@@ -197,7 +197,7 @@ def test_relation_solver_no_collision_produces_separated_positions():
     bbox_a = box_a.get_bounding_box().translated(pos_a)
     bbox_b = box_b.get_bounding_box().translated(pos_b)
 
-    assert not bbox_a.overlaps(bbox_b), f"Solver should separate boxes; box_a at {pos_a}, box_b at {pos_b}"
+    assert not bbox_a.overlaps(bbox_b).item(), f"Solver should separate boxes; box_a at {pos_a}, box_b at {pos_b}"
 
 
 def test_relation_solver_no_collision_same_inputs_reproducible():

--- a/isaaclab_arena/tests/test_object_placer_init.py
+++ b/isaaclab_arena/tests/test_object_placer_init.py
@@ -40,10 +40,10 @@ def test_on_init_x_y_within_parent_footprint():
     child_bbox = box.get_bounding_box()
     desk_world = desk.get_world_bounding_box()
 
-    assert x + child_bbox.min_point[0] >= desk_world.min_point[0] - 1e-6
-    assert x + child_bbox.max_point[0] <= desk_world.max_point[0] + 1e-6
-    assert y + child_bbox.min_point[1] >= desk_world.min_point[1] - 1e-6
-    assert y + child_bbox.max_point[1] <= desk_world.max_point[1] + 1e-6
+    assert x + child_bbox.min_point[0, 0] >= desk_world.min_point[0, 0] - 1e-6
+    assert x + child_bbox.max_point[0, 0] <= desk_world.max_point[0, 0] + 1e-6
+    assert y + child_bbox.min_point[0, 1] >= desk_world.min_point[0, 1] - 1e-6
+    assert y + child_bbox.max_point[0, 1] <= desk_world.max_point[0, 1] + 1e-6
 
 
 def test_on_init_z_places_bottom_at_parent_top():
@@ -63,8 +63,8 @@ def test_on_init_z_places_bottom_at_parent_top():
     child_bbox = box.get_bounding_box()
     desk_world = desk.get_world_bounding_box()
 
-    child_bottom = z + child_bbox.min_point[2]
-    expected_bottom = desk_world.max_point[2] + clearance_m
+    child_bottom = z + child_bbox.min_point[0, 2]
+    expected_bottom = desk_world.max_point[0, 2] + clearance_m
     assert abs(child_bottom - expected_bottom) < 1e-6
 
 
@@ -88,8 +88,8 @@ def test_on_init_clamps_to_center_when_child_wider_than_parent():
 
     x, y, _ = positions[big_box]
     desk_world = desk.get_world_bounding_box()
-    center_x = (desk_world.min_point[0] + desk_world.max_point[0]) / 2.0
-    center_y = (desk_world.min_point[1] + desk_world.max_point[1]) / 2.0
+    center_x = (desk_world.min_point[0, 0] + desk_world.max_point[0, 0]) / 2.0
+    center_y = (desk_world.min_point[0, 1] + desk_world.max_point[0, 1]) / 2.0
 
     assert abs(x - center_x) < 1e-6
     assert abs(y - center_y) < 1e-6
@@ -109,7 +109,7 @@ def test_no_on_relation_initializes_at_anchor_center():
 
     x, y, z = positions[box]
     desk_world = desk.get_world_bounding_box()
-    center = desk_world.center
+    center = desk_world.center[0]
 
     assert abs(x - center[0]) < 1e-6
     assert abs(y - center[1]) < 1e-6
@@ -138,11 +138,11 @@ def test_on_non_anchor_parent_with_anchor_grandparent_uses_proxy():
     desk_world = desk.get_world_bounding_box()
 
     # Mug's parent (plate) is non-anchor with On(desk): uses desk's bbox as proxy
-    assert desk_world.min_point[0] <= x <= desk_world.max_point[0]
-    assert desk_world.min_point[1] <= y <= desk_world.max_point[1]
+    assert desk_world.min_point[0, 0] <= x <= desk_world.max_point[0, 0]
+    assert desk_world.min_point[0, 1] <= y <= desk_world.max_point[0, 1]
     # Z: desk top (0.1) + clearance (0.0) - mug bbox min_z (0.0) = 0.1
     mug_bbox = mug.get_bounding_box()
-    assert abs(z - (desk_world.max_point[2] + 0.0 - mug_bbox.min_point[2])) < 1e-6
+    assert abs(z - (desk_world.max_point[0, 2] + 0.0 - mug_bbox.min_point[0, 2])) < 1e-6
 
 
 def test_on_non_anchor_parent_without_on_uses_fallback_bbox():
@@ -167,10 +167,10 @@ def test_on_non_anchor_parent_without_on_uses_fallback_bbox():
     desk_world = desk.get_world_bounding_box()
 
     # Parent (stand) has no On relation: falls back to desk's world bbox
-    assert desk_world.min_point[0] <= x <= desk_world.max_point[0]
-    assert desk_world.min_point[1] <= y <= desk_world.max_point[1]
+    assert desk_world.min_point[0, 0] <= x <= desk_world.max_point[0, 0]
+    assert desk_world.min_point[0, 1] <= y <= desk_world.max_point[0, 1]
     # Z: desk.max_z (fallback) + clearance (0.0) - mug.min_z (0.0) = 0.1
-    assert abs(z - (desk_world.max_point[2] + 0.0 - mug.get_bounding_box().min_point[2])) < 1e-6
+    assert abs(z - (desk_world.max_point[0, 2] + 0.0 - mug.get_bounding_box().min_point[0, 2])) < 1e-6
 
 
 def test_on_init_reproducible_with_placement_seed():

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -36,25 +36,25 @@ class AxisAlignedBoundingBox:
         assert self._min_point.shape[-1] == 3
 
     @staticmethod
-    def _to_batched_tensor(v: tuple[float, float, float] | torch.Tensor) -> torch.Tensor:
+    def _to_batched_tensor(value: tuple[float, float, float] | torch.Tensor) -> torch.Tensor:
         """Convert tuple, 1-D tensor, or (N, 3) tensor to (N, 3) float32 tensor."""
-        if isinstance(v, tuple):
-            return torch.tensor([v], dtype=torch.float32)
-        if v.dim() == 1:
-            return v.unsqueeze(0).float()
-        return v.float()
+        if isinstance(value, tuple):
+            return torch.tensor([value], dtype=torch.float32)
+        if value.dim() == 1:
+            return value.unsqueeze(0).float()
+        return value.float()
 
-    def _format_output(self, t: torch.Tensor):
+    def _format_output(self, tensor: torch.Tensor):
         """Return tuple when N=1, tensor when N>1."""
         if self._min_point.shape[0] == 1:
-            return tuple(t[0].tolist())
-        return t
+            return tuple(tensor[0].tolist())
+        return tensor
 
-    def _format_scalar(self, t: torch.Tensor):
+    def _format_scalar(self, tensor: torch.Tensor):
         """Return float when N=1, tensor when N>1."""
         if self._min_point.shape[0] == 1:
-            return t.item()
-        return t
+            return tensor.item()
+        return tensor
 
     @property
     def min_point(self) -> tuple[float, float, float] | torch.Tensor:
@@ -102,17 +102,17 @@ class AxisAlignedBoundingBox:
             Tensor of shape (8, 3) for N=1 or (N, 8, 3) for N>1,
             with corners ordered: bottom 4, then top 4.
         """
-        mn, mx = self._min_point, self._max_point
+        min_pt, max_pt = self._min_point, self._max_point
         corners = torch.stack(
             [
-                torch.stack([mn[:, 0], mn[:, 1], mn[:, 2]], dim=1),
-                torch.stack([mx[:, 0], mn[:, 1], mn[:, 2]], dim=1),
-                torch.stack([mx[:, 0], mx[:, 1], mn[:, 2]], dim=1),
-                torch.stack([mn[:, 0], mx[:, 1], mn[:, 2]], dim=1),
-                torch.stack([mn[:, 0], mn[:, 1], mx[:, 2]], dim=1),
-                torch.stack([mx[:, 0], mn[:, 1], mx[:, 2]], dim=1),
-                torch.stack([mx[:, 0], mx[:, 1], mx[:, 2]], dim=1),
-                torch.stack([mn[:, 0], mx[:, 1], mx[:, 2]], dim=1),
+                torch.stack([min_pt[:, 0], min_pt[:, 1], min_pt[:, 2]], dim=1),  # Bottom-front-left
+                torch.stack([max_pt[:, 0], min_pt[:, 1], min_pt[:, 2]], dim=1),  # Bottom-front-right
+                torch.stack([max_pt[:, 0], max_pt[:, 1], min_pt[:, 2]], dim=1),  # Bottom-back-right
+                torch.stack([min_pt[:, 0], max_pt[:, 1], min_pt[:, 2]], dim=1),  # Bottom-back-left
+                torch.stack([min_pt[:, 0], min_pt[:, 1], max_pt[:, 2]], dim=1),  # Top-front-left
+                torch.stack([max_pt[:, 0], min_pt[:, 1], max_pt[:, 2]], dim=1),  # Top-front-right
+                torch.stack([max_pt[:, 0], max_pt[:, 1], max_pt[:, 2]], dim=1),  # Top-back-right
+                torch.stack([min_pt[:, 0], max_pt[:, 1], max_pt[:, 2]], dim=1),  # Top-back-left
             ],
             dim=1,
         )
@@ -133,8 +133,8 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox with scaled dimensions.
         """
-        s = self._to_batched_tensor(scale)
-        return AxisAlignedBoundingBox(min_point=self._min_point * s, max_point=self._max_point * s)
+        scale = self._to_batched_tensor(scale)
+        return AxisAlignedBoundingBox(min_point=self._min_point * scale, max_point=self._max_point * scale)
 
     def translated(self, offset: tuple[float, float, float] | torch.Tensor) -> "AxisAlignedBoundingBox":
         """Return a new bounding box translated by an offset.
@@ -145,8 +145,8 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox with translated position.
         """
-        o = self._to_batched_tensor(offset)
-        return AxisAlignedBoundingBox(min_point=self._min_point + o, max_point=self._max_point + o)
+        offset = self._to_batched_tensor(offset)
+        return AxisAlignedBoundingBox(min_point=self._min_point + offset, max_point=self._max_point + offset)
 
     def centered(self) -> "AxisAlignedBoundingBox":
         """Return a new bounding box centered around the origin.
@@ -157,8 +157,8 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox centered at origin.
         """
-        c = (self._min_point + self._max_point) * 0.5
-        return AxisAlignedBoundingBox(min_point=self._min_point - c, max_point=self._max_point - c)
+        center = (self._min_point + self._max_point) * 0.5
+        return AxisAlignedBoundingBox(min_point=self._min_point - center, max_point=self._max_point - center)
 
     def overlaps(self, other: "AxisAlignedBoundingBox", margin: float = 0.0) -> bool | torch.Tensor:
         """Check if two AABBs overlap in 3D.

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -9,57 +9,87 @@ This module provides functions for:
 - Computing bounding boxes from USD assets
 - Calculating placement poses based on semantic relationships (e.g., "on_top_of")
 - Supporting randomized placement with specified constraints
+- AxisAlignedBoundingBox with always-tensor storage supporting single (N=1) and batched (N>1) modes
 """
 
 import torch
-from dataclasses import dataclass
 
 from isaaclab_arena.utils.pose import Pose
 
 
-@dataclass
 class AxisAlignedBoundingBox:
-    """Axis-aligned bounding box storing local extents. Use get_corners_at(pos) for world-space corners."""
+    """Axis-aligned bounding box storing local extents. Use get_corners_at(pos) for world-space corners.
 
-    min_point: tuple[float, float, float]
-    """Local minimum extent (x, y, z) relative to object origin."""
+    Stores min/max extents as (N, 3) tensors where N is the number of environments.
+    Properties return tuples/floats when N=1 and tensors when N>1.
+    Constructor accepts tuples, 1D tensors, or (N, 3) tensors.
+    """
 
-    max_point: tuple[float, float, float]
-    """Local maximum extent (x, y, z) relative to object origin."""
+    def __init__(
+        self,
+        min_point: tuple[float, float, float] | torch.Tensor,
+        max_point: tuple[float, float, float] | torch.Tensor,
+    ):
+        self._min_point = self._to_batched_tensor(min_point)
+        self._max_point = self._to_batched_tensor(max_point)
+        assert self._min_point.shape == self._max_point.shape
+        assert self._min_point.shape[-1] == 3
 
-    def __post_init__(self):
-        assert isinstance(self.min_point, tuple)
-        assert isinstance(self.max_point, tuple)
-        assert len(self.min_point) == 3
-        assert len(self.max_point) == 3
+    @staticmethod
+    def _to_batched_tensor(v: tuple[float, float, float] | torch.Tensor) -> torch.Tensor:
+        """Convert tuple, 1-D tensor, or (N, 3) tensor to (N, 3) float32 tensor."""
+        if isinstance(v, tuple):
+            return torch.tensor([v], dtype=torch.float32)
+        if v.dim() == 1:
+            return v.unsqueeze(0).float()
+        return v.float()
+
+    def _format_output(self, t: torch.Tensor):
+        """Return tuple when N=1, tensor when N>1."""
+        if self._min_point.shape[0] == 1:
+            return tuple(t[0].tolist())
+        return t
+
+    def _format_scalar(self, t: torch.Tensor):
+        """Return float when N=1, tensor when N>1."""
+        if self._min_point.shape[0] == 1:
+            return t.item()
+        return t
 
     @property
-    def size(self) -> tuple[float, float, float]:
+    def min_point(self) -> tuple[float, float, float] | torch.Tensor:
+        """Local minimum extent (x, y, z) relative to object origin."""
+        return self._format_output(self._min_point)
+
+    @property
+    def max_point(self) -> tuple[float, float, float] | torch.Tensor:
+        """Local maximum extent (x, y, z) relative to object origin."""
+        return self._format_output(self._max_point)
+
+    @property
+    def num_envs(self) -> int:
+        """Number of environments (leading dimension N)."""
+        return self._min_point.shape[0]
+
+    @property
+    def size(self) -> tuple[float, float, float] | torch.Tensor:
         """Returns the size (width, depth, height) of the bounding box."""
-        return (
-            self.max_point[0] - self.min_point[0],
-            self.max_point[1] - self.min_point[1],
-            self.max_point[2] - self.min_point[2],
-        )
+        return self._format_output(self._max_point - self._min_point)
 
     @property
-    def center(self) -> tuple[float, float, float]:
+    def center(self) -> tuple[float, float, float] | torch.Tensor:
         """Returns the center point of the bounding box."""
-        return (
-            (self.min_point[0] + self.max_point[0]) / 2.0,
-            (self.min_point[1] + self.max_point[1]) / 2.0,
-            (self.min_point[2] + self.max_point[2]) / 2.0,
-        )
+        return self._format_output((self._min_point + self._max_point) * 0.5)
 
     @property
-    def top_surface_z(self) -> float:
+    def top_surface_z(self) -> float | torch.Tensor:
         """Returns the z-coordinate of the top surface."""
-        return self.max_point[2]
+        return self._format_scalar(self._max_point[:, 2])
 
     @property
-    def bottom_surface_z(self) -> float:
+    def bottom_surface_z(self) -> float | torch.Tensor:
         """Returns the z-coordinate of the bottom surface."""
-        return self.min_point[2]
+        return self._format_scalar(self._min_point[:, 2])
 
     def get_corners_at(self, pos: torch.Tensor | None = None) -> torch.Tensor:
         """Get 8 corners of this bounding box, optionally offset by position.
@@ -69,25 +99,32 @@ class AxisAlignedBoundingBox:
                  If None, returns corners in local/object frame.
 
         Returns:
-            Tensor of shape (8, 3) with corners ordered: bottom 4, then top 4.
+            Tensor of shape (8, 3) for N=1 or (N, 8, 3) for N>1,
+            with corners ordered: bottom 4, then top 4.
         """
-        if pos is None:
-            # Local corners directly from min_point/max_point
-            min_pt, max_pt = self.min_point, self.max_point
-            return torch.tensor([
-                [min_pt[0], min_pt[1], min_pt[2]],  # Bottom-front-left
-                [max_pt[0], min_pt[1], min_pt[2]],  # Bottom-front-right
-                [max_pt[0], max_pt[1], min_pt[2]],  # Bottom-back-right
-                [min_pt[0], max_pt[1], min_pt[2]],  # Bottom-back-left
-                [min_pt[0], min_pt[1], max_pt[2]],  # Top-front-left
-                [max_pt[0], min_pt[1], max_pt[2]],  # Top-front-right
-                [max_pt[0], max_pt[1], max_pt[2]],  # Top-back-right
-                [min_pt[0], max_pt[1], max_pt[2]],  # Top-back-left
-            ])
-        else:
-            return self.get_corners_at(pos=None) + pos
+        mn, mx = self._min_point, self._max_point
+        corners = torch.stack(
+            [
+                torch.stack([mn[:, 0], mn[:, 1], mn[:, 2]], dim=1),
+                torch.stack([mx[:, 0], mn[:, 1], mn[:, 2]], dim=1),
+                torch.stack([mx[:, 0], mx[:, 1], mn[:, 2]], dim=1),
+                torch.stack([mn[:, 0], mx[:, 1], mn[:, 2]], dim=1),
+                torch.stack([mn[:, 0], mn[:, 1], mx[:, 2]], dim=1),
+                torch.stack([mx[:, 0], mn[:, 1], mx[:, 2]], dim=1),
+                torch.stack([mx[:, 0], mx[:, 1], mx[:, 2]], dim=1),
+                torch.stack([mn[:, 0], mx[:, 1], mx[:, 2]], dim=1),
+            ],
+            dim=1,
+        )
+        if pos is not None:
+            if pos.dim() == 1:
+                pos = pos.unsqueeze(0)
+            corners = corners + pos.unsqueeze(1)
+        if self._min_point.shape[0] == 1:
+            return corners.squeeze(0)
+        return corners
 
-    def scaled(self, scale: tuple[float, float, float]) -> "AxisAlignedBoundingBox":
+    def scaled(self, scale: tuple[float, float, float] | torch.Tensor) -> "AxisAlignedBoundingBox":
         """Return a new bounding box with scale applied.
 
         Args:
@@ -96,20 +133,10 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox with scaled dimensions.
         """
-        return AxisAlignedBoundingBox(
-            min_point=(
-                self.min_point[0] * scale[0],
-                self.min_point[1] * scale[1],
-                self.min_point[2] * scale[2],
-            ),
-            max_point=(
-                self.max_point[0] * scale[0],
-                self.max_point[1] * scale[1],
-                self.max_point[2] * scale[2],
-            ),
-        )
+        s = self._to_batched_tensor(scale)
+        return AxisAlignedBoundingBox(min_point=self._min_point * s, max_point=self._max_point * s)
 
-    def translated(self, offset: tuple[float, float, float]) -> "AxisAlignedBoundingBox":
+    def translated(self, offset: tuple[float, float, float] | torch.Tensor) -> "AxisAlignedBoundingBox":
         """Return a new bounding box translated by an offset.
 
         Args:
@@ -118,18 +145,8 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox with translated position.
         """
-        return AxisAlignedBoundingBox(
-            min_point=(
-                self.min_point[0] + offset[0],
-                self.min_point[1] + offset[1],
-                self.min_point[2] + offset[2],
-            ),
-            max_point=(
-                self.max_point[0] + offset[0],
-                self.max_point[1] + offset[1],
-                self.max_point[2] + offset[2],
-            ),
-        )
+        o = self._to_batched_tensor(offset)
+        return AxisAlignedBoundingBox(min_point=self._min_point + o, max_point=self._max_point + o)
 
     def centered(self) -> "AxisAlignedBoundingBox":
         """Return a new bounding box centered around the origin.
@@ -140,21 +157,10 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox centered at origin.
         """
-        c = self.center
-        return AxisAlignedBoundingBox(
-            min_point=(
-                self.min_point[0] - c[0],
-                self.min_point[1] - c[1],
-                self.min_point[2] - c[2],
-            ),
-            max_point=(
-                self.max_point[0] - c[0],
-                self.max_point[1] - c[1],
-                self.max_point[2] - c[2],
-            ),
-        )
+        c = (self._min_point + self._max_point) * 0.5
+        return AxisAlignedBoundingBox(min_point=self._min_point - c, max_point=self._max_point - c)
 
-    def overlaps(self, other: "AxisAlignedBoundingBox", margin: float = 0.0) -> bool:
+    def overlaps(self, other: "AxisAlignedBoundingBox", margin: float = 0.0) -> bool | torch.Tensor:
         """Check if two AABBs overlap in 3D.
 
         Args:
@@ -163,16 +169,19 @@ class AxisAlignedBoundingBox:
                 rejects placements where the gap is smaller than margin.
 
         Returns:
-            True if the volumes overlap (or are closer than margin).
+            bool when both are N=1, or (N,) bool tensor when batched.
         """
-        return (
-            self.max_point[0] + margin > other.min_point[0]
-            and other.max_point[0] + margin > self.min_point[0]
-            and self.max_point[1] + margin > other.min_point[1]
-            and other.max_point[1] + margin > self.min_point[1]
-            and self.max_point[2] + margin > other.min_point[2]
-            and other.max_point[2] + margin > self.min_point[2]
+        result = (
+            (self._max_point[:, 0] + margin > other._min_point[:, 0])
+            & (other._max_point[:, 0] + margin > self._min_point[:, 0])
+            & (self._max_point[:, 1] + margin > other._min_point[:, 1])
+            & (other._max_point[:, 1] + margin > self._min_point[:, 1])
+            & (self._max_point[:, 2] + margin > other._min_point[:, 2])
+            & (other._max_point[:, 2] + margin > self._min_point[:, 2])
         )
+        if result.numel() == 1:
+            return bool(result.item())
+        return result
 
     def rotated_90_around_z(self, quarters: int) -> "AxisAlignedBoundingBox":
         """Rotate AABB by quarters * 90° around Z axis.
@@ -185,29 +194,25 @@ class AxisAlignedBoundingBox:
         Returns:
             New AxisAlignedBoundingBox rotated around Z axis.
         """
-        min_x, min_y, min_z = self.min_point
-        max_x, max_y, max_z = self.max_point
-
         quarters = quarters % 4
+        min_x, min_y, min_z = self._min_point[:, 0], self._min_point[:, 1], self._min_point[:, 2]
+        max_x, max_y, max_z = self._max_point[:, 0], self._max_point[:, 1], self._max_point[:, 2]
         if quarters == 0:
-            return AxisAlignedBoundingBox(
-                min_point=(min_x, min_y, min_z),
-                max_point=(max_x, max_y, max_z),
-            )
+            return AxisAlignedBoundingBox(min_point=self._min_point.clone(), max_point=self._max_point.clone())
         elif quarters == 1:  # 90° CCW
             return AxisAlignedBoundingBox(
-                min_point=(-max_y, min_x, min_z),
-                max_point=(-min_y, max_x, max_z),
+                min_point=torch.stack([-max_y, min_x, min_z], dim=1),
+                max_point=torch.stack([-min_y, max_x, max_z], dim=1),
             )
         elif quarters == 2:  # 180°
             return AxisAlignedBoundingBox(
-                min_point=(-max_x, -max_y, min_z),
-                max_point=(-min_x, -min_y, max_z),
+                min_point=torch.stack([-max_x, -max_y, min_z], dim=1),
+                max_point=torch.stack([-min_x, -min_y, max_z], dim=1),
             )
         else:  # 270° CCW / -90° (quarters == 3)
             return AxisAlignedBoundingBox(
-                min_point=(min_y, -max_x, min_z),
-                max_point=(max_y, -min_x, max_z),
+                min_point=torch.stack([min_y, -max_x, min_z], dim=1),
+                max_point=torch.stack([max_y, -min_x, max_z], dim=1),
             )
 
 

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -20,8 +20,8 @@ from isaaclab_arena.utils.pose import Pose
 class AxisAlignedBoundingBox:
     """Axis-aligned bounding box storing local extents. Use get_corners_at(pos) for world-space corners.
 
-    Stores min/max extents as (N, 3) tensors where N is the number of environments.
-    Properties return tuples/floats when N=1 and tensors when N>1.
+    Stores min/max extents as (N, 3) float32 tensors where N is the number of environments.
+    All properties consistently return tensors: (N, 3) for point values, (N,) for scalars.
     Constructor accepts tuples, 1D tensors, or (N, 3) tensors.
     """
 
@@ -44,27 +44,15 @@ class AxisAlignedBoundingBox:
             return value.unsqueeze(0).float()
         return value.float()
 
-    def _format_output(self, tensor: torch.Tensor):
-        """Return tuple when N=1, tensor when N>1."""
-        if self._min_point.shape[0] == 1:
-            return tuple(tensor[0].tolist())
-        return tensor
-
-    def _format_scalar(self, tensor: torch.Tensor):
-        """Return float when N=1, tensor when N>1."""
-        if self._min_point.shape[0] == 1:
-            return tensor.item()
-        return tensor
+    @property
+    def min_point(self) -> torch.Tensor:
+        """Local minimum extent (x, y, z) relative to object origin. Shape (N, 3)."""
+        return self._min_point
 
     @property
-    def min_point(self) -> tuple[float, float, float] | torch.Tensor:
-        """Local minimum extent (x, y, z) relative to object origin."""
-        return self._format_output(self._min_point)
-
-    @property
-    def max_point(self) -> tuple[float, float, float] | torch.Tensor:
-        """Local maximum extent (x, y, z) relative to object origin."""
-        return self._format_output(self._max_point)
+    def max_point(self) -> torch.Tensor:
+        """Local maximum extent (x, y, z) relative to object origin. Shape (N, 3)."""
+        return self._max_point
 
     @property
     def num_envs(self) -> int:
@@ -72,24 +60,24 @@ class AxisAlignedBoundingBox:
         return self._min_point.shape[0]
 
     @property
-    def size(self) -> tuple[float, float, float] | torch.Tensor:
-        """Returns the size (width, depth, height) of the bounding box."""
-        return self._format_output(self._max_point - self._min_point)
+    def size(self) -> torch.Tensor:
+        """Returns the size (width, depth, height) of the bounding box. Shape (N, 3)."""
+        return self._max_point - self._min_point
 
     @property
-    def center(self) -> tuple[float, float, float] | torch.Tensor:
-        """Returns the center point of the bounding box."""
-        return self._format_output((self._min_point + self._max_point) * 0.5)
+    def center(self) -> torch.Tensor:
+        """Returns the center point of the bounding box. Shape (N, 3)."""
+        return (self._min_point + self._max_point) * 0.5
 
     @property
-    def top_surface_z(self) -> float | torch.Tensor:
-        """Returns the z-coordinate of the top surface."""
-        return self._format_scalar(self._max_point[:, 2])
+    def top_surface_z(self) -> torch.Tensor:
+        """Returns the z-coordinate of the top surface. Shape (N,)."""
+        return self._max_point[:, 2]
 
     @property
-    def bottom_surface_z(self) -> float | torch.Tensor:
-        """Returns the z-coordinate of the bottom surface."""
-        return self._format_scalar(self._min_point[:, 2])
+    def bottom_surface_z(self) -> torch.Tensor:
+        """Returns the z-coordinate of the bottom surface. Shape (N,)."""
+        return self._min_point[:, 2]
 
     def get_corners_at(self, pos: torch.Tensor | None = None) -> torch.Tensor:
         """Get 8 corners of this bounding box, optionally offset by position.
@@ -99,8 +87,7 @@ class AxisAlignedBoundingBox:
                  If None, returns corners in local/object frame.
 
         Returns:
-            Tensor of shape (8, 3) for N=1 or (N, 8, 3) for N>1,
-            with corners ordered: bottom 4, then top 4.
+            Tensor of shape (N, 8, 3) with corners ordered: bottom 4, then top 4.
         """
         min_pt, max_pt = self._min_point, self._max_point
         corners = torch.stack(
@@ -120,8 +107,6 @@ class AxisAlignedBoundingBox:
             if pos.dim() == 1:
                 pos = pos.unsqueeze(0)
             corners = corners + pos.unsqueeze(1)
-        if self._min_point.shape[0] == 1:
-            return corners.squeeze(0)
         return corners
 
     def scaled(self, scale: tuple[float, float, float] | torch.Tensor) -> "AxisAlignedBoundingBox":
@@ -160,7 +145,7 @@ class AxisAlignedBoundingBox:
         center = (self._min_point + self._max_point) * 0.5
         return AxisAlignedBoundingBox(min_point=self._min_point - center, max_point=self._max_point - center)
 
-    def overlaps(self, other: "AxisAlignedBoundingBox", margin: float = 0.0) -> bool | torch.Tensor:
+    def overlaps(self, other: "AxisAlignedBoundingBox", margin: float = 0.0) -> torch.Tensor:
         """Check if two AABBs overlap in 3D.
 
         Args:
@@ -169,9 +154,9 @@ class AxisAlignedBoundingBox:
                 rejects placements where the gap is smaller than margin.
 
         Returns:
-            bool when both are N=1, or (N,) bool tensor when batched.
+            Bool tensor of shape (N,). True where volumes overlap (or are closer than margin).
         """
-        result = (
+        return (
             (self._max_point[:, 0] + margin > other._min_point[:, 0])
             & (other._max_point[:, 0] + margin > self._min_point[:, 0])
             & (self._max_point[:, 1] + margin > other._min_point[:, 1])
@@ -179,9 +164,6 @@ class AxisAlignedBoundingBox:
             & (self._max_point[:, 2] + margin > other._min_point[:, 2])
             & (other._max_point[:, 2] + margin > self._min_point[:, 2])
         )
-        if result.numel() == 1:
-            return bool(result.item())
-        return result
 
     def rotated_90_around_z(self, quarters: int) -> "AxisAlignedBoundingBox":
         """Rotate AABB by quarters * 90° around Z axis.
@@ -268,12 +250,11 @@ def get_random_pose_within_bounding_box(bbox: AxisAlignedBoundingBox, seed: int 
     if seed is not None:
         torch.manual_seed(seed)
 
-    # Get workspace bounds
-    min_point = torch.tensor(bbox.min_point, dtype=torch.float32)
-    max_point = torch.tensor(bbox.max_point, dtype=torch.float32)
+    # Get workspace bounds as (3,) tensors from the first (and typically only) environment
+    min_point = bbox.min_point[0]
+    max_point = bbox.max_point[0]
 
     # Sample random position uniformly within workspace bounds
-    # random_position = min + (max - min) * rand
     random_position = min_point + (max_point - min_point) * torch.rand(3)
 
     pose = Pose(position_xyz=tuple(random_position.tolist()), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -35,6 +35,9 @@ class AxisAlignedBoundingBox:
         assert self._min_point.shape == self._max_point.shape
         assert self._min_point.shape[-1] == 3
 
+    def __repr__(self) -> str:
+        return f"AxisAlignedBoundingBox(min_point={self._min_point}, max_point={self._max_point})"
+
     @staticmethod
     def _to_batched_tensor(value: tuple[float, float, float] | torch.Tensor) -> torch.Tensor:
         """Convert tuple, 1-D tensor, or (N, 3) tensor to (N, 3) float32 tensor."""

--- a/isaaclab_arena/utils/isaac_sim_debug_draw.py
+++ b/isaaclab_arena/utils/isaac_sim_debug_draw.py
@@ -91,7 +91,7 @@ class IsaacSimDebugDraw:
             Tuple of (min_point, max_point) or None if extraction failed.
         """
         world_bbox = obj.get_world_bounding_box()
-        return world_bbox.min_point, world_bbox.max_point
+        return tuple(world_bbox.min_point[0].tolist()), tuple(world_bbox.max_point[0].tolist())
 
     def _draw_bbox_wireframe(
         self,

--- a/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
+++ b/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
@@ -9,7 +9,7 @@ On(table) and pairwise NoCollision (relation solver). Includes a robot (e.g. GR1
 No task — suitable for policy_runner with zero_action or any policy.
 
 Example:
-  python isaaclab_arena/evaluation/policy_runner.py --policy_type zero_action --num_steps 500 \\
+  python isaaclab_arena/evaluation/policy_runner.py --viz kit --policy_type zero_action --num_steps 500 \\
     --num_envs 1 --enable_cameras gr1_table_multi_object_no_collision --embodiment gr1_joint
 """
 

--- a/isaaclab_arena_examples/relations/relation_solver_visualization_notebook.py
+++ b/isaaclab_arena_examples/relations/relation_solver_visualization_notebook.py
@@ -93,7 +93,7 @@ def plot_loss_heatmap(X, Y, losses, parent, child, side, distance_m):
     parent_pose = parent.get_initial_pose()
     parent_bbox = parent.get_bounding_box()
     px, py, pz = parent_pose.position_xyz
-    pw, pd, ph = parent_bbox.size
+    pw, pd, ph = parent_bbox.size[0].tolist()
 
     # Draw parent bounding box
     parent_rect = Rectangle(
@@ -104,7 +104,7 @@ def plot_loss_heatmap(X, Y, losses, parent, child, side, distance_m):
 
     # Get child bounding box
     child_bbox = child.get_bounding_box()
-    cw, cd, ch = child_bbox.size
+    cw, cd, ch = child_bbox.size[0].tolist()
 
     # Mark ideal position
     if side == Side.POSITIVE_X:

--- a/isaaclab_arena_examples/relations/relation_solver_visualizer.py
+++ b/isaaclab_arena_examples/relations/relation_solver_visualizer.py
@@ -92,12 +92,14 @@ class RelationSolverVisualizer:
         # Compute world-space corners: world = position + local offset
         # This matches how the loss strategies compute world extents
         x, y, z = position
-        x_min = x + bbox.min_point[0]
-        x_max = x + bbox.max_point[0]
-        y_min = y + bbox.min_point[1]
-        y_max = y + bbox.max_point[1]
-        z_min = z + bbox.min_point[2]
-        z_max = z + bbox.max_point[2]
+        local_min = bbox.min_point[0].tolist()
+        local_max = bbox.max_point[0].tolist()
+        x_min = x + local_min[0]
+        x_max = x + local_max[0]
+        y_min = y + local_min[1]
+        y_max = y + local_max[1]
+        z_min = z + local_min[2]
+        z_max = z + local_max[2]
 
         # 8 corners of the box (same ordering as get_corners_at)
         corners = [
@@ -350,12 +352,14 @@ class RelationSolverVisualizer:
         """
         # Compute world-space corners: world = position + local offset
         x, y, z = position
-        x_min = x + bbox.min_point[0]
-        x_max = x + bbox.max_point[0]
-        y_min = y + bbox.min_point[1]
-        y_max = y + bbox.max_point[1]
-        z_min = z + bbox.min_point[2]
-        z_max = z + bbox.max_point[2]
+        local_min = bbox.min_point[0].tolist()
+        local_max = bbox.max_point[0].tolist()
+        x_min = x + local_min[0]
+        x_max = x + local_max[0]
+        y_min = y + local_min[1]
+        y_max = y + local_max[1]
+        z_min = z + local_min[2]
+        z_max = z + local_max[2]
 
         corners = [
             [x_min, y_min, z_min],
@@ -416,7 +420,7 @@ class RelationSolverVisualizer:
             for idx, obj in enumerate(self.objects):
                 pos = positions[idx]
                 bbox = obj.get_bounding_box()
-                half_size = [s / 2 for s in bbox.size]
+                half_size = (bbox.size[0] / 2).tolist()
                 all_x.extend([pos[0] - half_size[0], pos[0] + half_size[0]])
                 all_y.extend([pos[1] - half_size[1], pos[1] + half_size[1]])
                 all_z.extend([pos[2] - half_size[2], pos[2] + half_size[2]])


### PR DESCRIPTION
## Summary
Add batch dimension support to AxisAlignedBoundingBox

## Detailed description
- What was the reason for the change?
  - To support multi-environment batched placement, AxisAlignedBoundingBox needs to handle N bounding boxes simultaneously instead of only one.
- What has been changed?
  - Refactored AxisAlignedBoundingBox from a dataclass to a class with (N, 3) float32 tensor storage. Returns tuples/floats for N=1, tensors for N>1.
  - Fixed float32 rounding issue in `_validate_on_relations` Z boundary check.
  - Added `test_bounding_box.py` for single-env and multi-env coverage.
- What is the impact of this change?
  - No behavior change for existing code: backward compatible for single env (N=1).
  - Enables future multi-env batch support for the coming relation solver MR.