### PR TITLE
 run subprocess-spawning tests in a separate pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
             --ignore=isaaclab_arena/tests/test_sequential_task_mimic_data_generation.py \
             isaaclab_arena/tests/
 
-      - name: Run tests with cameras
+      - name: Run pytest excluding policy-related tests. Now we run all tests with cameras.
         run: /isaac-sim/python.sh -m pytest -sv -m with_cameras isaaclab_arena/tests/
 
 


### PR DESCRIPTION
## Summary
To fix tests hang on CI

## Detailed description
Split the CI test step into two separate pytest invocations:

1. Run subprocess-spawning tests (test_policy_runner.py, test_sequential_task_mimic_data_generation.py) — each subprocess gets exclusive GPU access, runs, and exits cleanly
2. Run all remaining in-process tests with --ignore flags — these share the persistent SimulationApp as intended
