### PR TITLE
Change rl_training_mode param type

### DIFF
--- a/docs/pages/example_workflows/reinforcement_learning/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/reinforcement_learning/step_1_environment_setup.rst
@@ -131,7 +131,7 @@ The task includes:
 - **Reward Terms**: Dense rewards for reaching, grasping, lifting, and achieving target poses
 - **Observation Space**: Robot state (joint positions, velocities), object state (pose, velocity), and goal commands
 - **Termination Conditions**: Object dropped or timeout
-- **Success Condition**: Object reaches target position (only active during evaluation when ``rl_training_mode=False``)
+- **Success Condition**: Object reaches target position (disabled by the ``--rl_training_mode`` flag for training)
 
 See :doc:`../../concepts/concept_tasks_design` for task creation details.
 
@@ -162,6 +162,7 @@ To validate the environment loads correctly, run one training iteration and chec
    python submodules/IsaacLab/scripts/reinforcement_learning/rsl_rl/train.py \
      --external_callback isaaclab_arena.environments.isaaclab_interop.environment_registration_callback \
      --task lift_object \
+     --rl_training_mode \
      --num_envs 64 \
      --max_iterations 1 \
      --headless

--- a/docs/pages/example_workflows/reinforcement_learning/step_2_policy_training.rst
+++ b/docs/pages/example_workflows/reinforcement_learning/step_2_policy_training.rst
@@ -17,6 +17,7 @@ builds the environment, and registers it with gym so IsaacLab's script can find 
    python submodules/IsaacLab/scripts/reinforcement_learning/rsl_rl/train.py \
      --external_callback isaaclab_arena.environments.isaaclab_interop.environment_registration_callback \
      --task lift_object \
+     --rl_training_mode \
      --num_envs 512 \
      --max_iterations 12000
 
@@ -53,6 +54,7 @@ For example, to train with relu activation and a higher learning rate:
    python submodules/IsaacLab/scripts/reinforcement_learning/rsl_rl/train.py \
      --external_callback isaaclab_arena.environments.isaaclab_interop.environment_registration_callback \
      --task lift_object \
+     --rl_training_mode \
      --num_envs 512 \
      --max_iterations 12000 \
      agent.policy.activation=relu \
@@ -109,6 +111,7 @@ Add ``--distributed`` to spread environments across all available GPUs:
    python submodules/IsaacLab/scripts/reinforcement_learning/rsl_rl/train.py \
      --external_callback isaaclab_arena.environments.isaaclab_interop.environment_registration_callback \
      --task lift_object \
+     --rl_training_mode \
      --num_envs 512 \
      --max_iterations 12000 \
      --headless \

--- a/docs/pages/example_workflows/reinforcement_learning/step_3_evaluation.rst
+++ b/docs/pages/example_workflows/reinforcement_learning/step_3_evaluation.rst
@@ -51,8 +51,7 @@ Method 1: Single Environment Evaluation
      --policy_type rsl_rl \
      --num_steps 1000 \
      --checkpoint_path logs/rsl_rl/generic_experiment/2026-01-28_17-26-10/model_11999.pt \
-     lift_object \
-     --rl_training_mode False
+     lift_object
 
 .. note::
 
@@ -60,8 +59,8 @@ Method 1: Single Environment Evaluation
    ``$MODELS_DIR/lift_object_checkpoint/model_11999.pt``
 
 Policy-specific arguments (``--policy_type``, ``--checkpoint_path``, etc.) must come **before** the
-environment name. Environment-specific arguments (``--rl_training_mode``, ``--object``, etc.) must
-come **after** it.
+environment name. Environment-specific arguments (``--object``, ``--embodiment``, etc.) must come
+**after** it.
 
 At the end of the run, metrics are printed to the console:
 
@@ -83,8 +82,7 @@ For more statistically significant results, run across many environments in para
      --num_envs 64 \
      --checkpoint_path logs/rsl_rl/generic_experiment/2026-01-28_17-26-10/model_11999.pt \
      --headless \
-     lift_object \
-     --rl_training_mode False
+     lift_object
 
 .. code-block:: text
 
@@ -112,17 +110,11 @@ Create a file ``eval_config.json``:
      "evaluations": [
        {
          "checkpoint_path": "logs/rsl_rl/generic_experiment/2026-01-28_17-26-10/model_5999.pt",
-         "environment": "lift_object",
-         "environment_args": {
-           "rl_training_mode": false
-         }
+         "environment": "lift_object"
        },
        {
          "checkpoint_path": "logs/rsl_rl/generic_experiment/2026-01-28_17-26-10/model_11999.pt",
-         "environment": "lift_object",
-         "environment_args": {
-           "rl_training_mode": false
-         }
+         "environment": "lift_object"
        }
      ]
    }
@@ -160,5 +152,6 @@ random seed, and hardware.
 
 .. note::
 
-   Always set ``--rl_training_mode False`` when evaluating. During training this flag is ``True``
-   to disable success termination; setting it to ``False`` re-enables it for proper evaluation.
+   For evaluation, omit ``--rl_training_mode`` (default): success termination stays enabled so
+   metrics such as success rate are meaningful. For RSL-RL training, pass ``--rl_training_mode`` to
+   disable success termination.

--- a/isaaclab_arena_environments/lift_object_environment.py
+++ b/isaaclab_arena_environments/lift_object_environment.py
@@ -79,4 +79,8 @@ class LiftObjectEnvironment(ExampleEnvironmentBase):
         # to be used in the record_demos.py script.
         parser.add_argument("--teleop_device", type=str, default=None)
         parser.add_argument("--embodiment", type=str, default="franka")
-        parser.add_argument("--rl_training_mode", type=bool, default=True)
+        parser.add_argument(
+            "--rl_training_mode",
+            action="store_true",
+            help="Disable success termination (use when training with RSL-RL). Omit for evaluation.",
+        )


### PR DESCRIPTION
## Summary
lift_object example CLI --rl_training_mode False doesn't work as expected, leading to eval always skipping success condition

## Detailed description
- What was the reason for the change?
With type=bool, any non-empty string becomes True, so the success condition is always skipped for lift_object eval
- What has been changed?
Change the rl_training_mode argument type to a flag, which needs to be set explicitly for training
- What is the impact of this change?
A bug for the lift_object example CLI is fixed. Commands for RL lift_object examples are changed.
