### PR TITLE
Remove self hosted assets due to prim path not found

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -803,7 +803,7 @@ class RedCube(LibraryObject):
     name = "red_cube"
     tags = ["object"]
 
-    usd_path =f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/red_block.usd"
+    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/red_block.usd"
 
     object_type = ObjectType.RIGID
     default_prim_path = "{ENV_REGEX_NS}/RedCube"


### PR DESCRIPTION
## Summary
The requirement of RigidBodyAP at root level of prim path has been relaxed.
Fall back to the source object path.
