### PR TITLE
Extract Sequential Tasks section into dedicated concept page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -224,6 +224,7 @@ TABLE OF CONTENTS
    pages/concepts/concept_environment_design
    pages/concepts/concept_embodiment_design
    pages/concepts/concept_tasks_design
+   pages/concepts/concept_sequential_tasks_design
    pages/concepts/concept_scene_design
    pages/concepts/concept_metrics_design
    pages/concepts/concept_teleop_devices_design

--- a/docs/pages/concepts/concept_sequential_tasks_design.rst
+++ b/docs/pages/concepts/concept_sequential_tasks_design.rst
@@ -1,0 +1,23 @@
+Sequential Tasks Design
+=======================
+
+Tasks can be composed sequentially to form longer horizon, more complex tasks using the ``SequentialTaskBase`` class.
+``SequentialTaskBase`` takes a list of ``TaskBase`` instances and automatically composes them into a single task.
+The order of the tasks in the list determines the order in which subtasks must be completed.
+
+**Usage Example (Pick and Place Task and Close Door Task Composition)**
+
+.. code-block:: python
+
+    pick_object = asset_registry.get_asset_by_name("mustard_bottle")()
+    destination = ObjectReference("refrigerator_shelf", parent_asset=kitchen)
+    pick_and_place_task = PickAndPlaceTask(pick_object, destination, kitchen)
+
+    openable_object = OpenableObjectReference("refrigerator", parent_asset=kitchen, openable_joint_name="fridge_door_joint")
+    close_door_task = CloseDoorTask(openable_object, closedness_threshold=0.10)
+
+    sequential_task = SequentialTaskBase(subtasks=[pick_and_place_task, close_door_task])
+
+**Available Examples**
+
+- **PutAndCloseDoorTask**: Pick up and move an object to a destination location and then close a door (within **GR1PutAndCloseDoorEnvironment**).

--- a/docs/pages/concepts/concept_tasks_design.rst
+++ b/docs/pages/concepts/concept_tasks_design.rst
@@ -111,23 +111,5 @@ Usage Examples
 Sequential Tasks
 ----------------
 
-Tasks can be composed sequentially to form longer horizon, more complex tasks using the ``SequentialTaskBase`` class.
-``SequentialTaskBase`` takes a list of ``TaskBase`` instances and automatically composes them into a single task.
-The order of the tasks in the list determines the order in which subtasks must be completed.
-
-**Usage Example (Pick and Place Task and Close Door Task Composition)**
-
-.. code-block:: python
-
-    pick_object = asset_registry.get_asset_by_name("mustard_bottle")()
-    destination = ObjectReference("refrigerator_shelf", parent_asset=kitchen)
-    pick_and_place_task = PickAndPlaceTask(pick_object, destination, kitchen)
-
-    openable_object = OpenableObjectReference("refrigerator", parent_asset=kitchen, openable_joint_name="fridge_door_joint")
-    close_door_task = CloseDoorTask(openable_object, closedness_threshold=0.10)
-
-    sequential_task = SequentialTaskBase(subtasks=[pick_and_place_task, close_door_task])
-
-**Available Examples**
-
-- **PutAndCloseDoorTask**: Pick up and move an object to a destination location and then close a door (within **GR1PutAndCloseDoorEnvironment**).
+Tasks can be composed sequentially to form longer horizon, more complex tasks.
+See :doc:`./concept_sequential_tasks_design` for more details.


### PR DESCRIPTION
## Summary
Doc changes only, refactor task concept page.

## Detailed description
- Moved the Sequential Tasks section from concept_tasks_design.rst into a new standalone page concept_sequential_tasks_design.rst
- Replaced the original section with a brief summary and cross-reference link to the new page
- Registered the new page in the docs/index.rst toctree under the Concepts section
