### PR TITLE
Fix sphinx numpy connection

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ todo_include_todos = True
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "numpy": ("http://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("http://numpy.org/doc/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Summary
The URL used in Sphinx's mapping (docs.scipy.org/doc/numpy/) is legacy. NumPy moved its documentation to its own domain. Updated conf.py.
