### PR TITLE
Update newton example doc to clearly state failure using physx eval

### DIFF
--- a/docs/pages/example_workflows/dexsuite_lift/step_3_evaluation.rst
+++ b/docs/pages/example_workflows/dexsuite_lift/step_3_evaluation.rst
@@ -78,7 +78,9 @@ At the end of the run, metrics are printed to the console:
         dexsuite_lift
 
    However, the model behaviour may differ significantly when training and
-   evaluation use different physics backends.
+   evaluation use different physics backends. The above model, which was
+   trained with Newton, fails to grasp or lift the cube completely when
+   evaluated with PhysX.
 
 
 Parallel Environment Evaluation


### PR DESCRIPTION
## Summary
This is a doc change requested by QA in https://nvbugspro.nvidia.com/bug/6063011
It clarifies that evaluated newton trained model using physx is expected to completely fail the dexsuite task. 

