### PR TITLE
Deactivate all tests except for the subprocess tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,20 +140,20 @@ jobs:
       # - All subprocess-spawning tests (each spawns their own SimulationApp)
       #
       # To restore sanity here is a goal for Isaac Lab Arena v0.3.
-      - name: Run in-process Newton tests
-        run: |
-          /isaac-sim/python.sh -m pytest -sv -m with_newton \
-            isaaclab_arena/tests/
+      # - name: Run in-process Newton tests
+      #   run: |
+      #     /isaac-sim/python.sh -m pytest -sv -m with_newton \
+      #       isaaclab_arena/tests/
 
-      - name: Run in-process PhysX tests without cameras
-        run: |
-          /isaac-sim/python.sh -m pytest -sv -m "not with_cameras and not with_subprocess and not with_newton" \
-            isaaclab_arena/tests/
+      # - name: Run in-process PhysX tests without cameras
+      #   run: |
+      #     /isaac-sim/python.sh -m pytest -sv -m "not with_cameras and not with_subprocess and not with_newton" \
+      #       isaaclab_arena/tests/
 
-      - name: Run in-process PhysX tests with cameras
-        run: |
-          /isaac-sim/python.sh -m pytest -sv -m "with_cameras and not with_subprocess and not with_newton" \
-            isaaclab_arena/tests/
+      # - name: Run in-process PhysX tests with cameras
+      #   run: |
+      #     /isaac-sim/python.sh -m pytest -sv -m "with_cameras and not with_subprocess and not with_newton" \
+      #       isaaclab_arena/tests/
 
       - name: Run subprocess-spawning  PhysX tests
         run: |


### PR DESCRIPTION
## Summary
Tests if we still get stalls when only running the subprocess-spawning tests (without the in-process tests).

