### PR TITLE
Install missing arena package into NGC docker.

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -98,6 +98,7 @@ COPY isaaclab_arena ${WORKDIR}/isaaclab_arena
 COPY isaaclab_arena_g1 ${WORKDIR}/isaaclab_arena_g1
 COPY isaaclab_arena_gr00t ${WORKDIR}/isaaclab_arena_gr00t
 COPY isaaclab_arena_environments ${WORKDIR}/isaaclab_arena_environments
+COPY isaaclab_arena_examples ${WORKDIR}/isaaclab_arena_examples
 COPY docs ${WORKDIR}/docs
 
 # Install IsaacLab Arena (runtime + dev deps declared in setup.py)


### PR DESCRIPTION
## Summary
Install missing arena package into NGC docker.

## Detailed description
- We forgot to install our new package `isaaclab_arena_examples` into the docker image.
- This was masked in CI due to mounting a branch and correctly installing there.

