### PR TITLE
Add RAM req in doc for post-training

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ NIST Board 1, NVIDIA Isaac GR00T Industrial Benchmarks, NVIDIA DexBench, NVIDIA 
 
 We encourage the community to build and publish benchmarks on Isaac Lab-Arena. The recommended workflow:
 
-1. **Maintain your benchmark in your own repository.** Create a branch or package that integrates with Isaac Lab-Arena (e.g. an `IsaacLab-Arena` branch). See [RoboTwin](https://github.com/RoboTwin-Platform/RoboTwin/tree/IsaacLab-Arena) for a reference example.
+1. **Maintain your benchmark in your own repository.** Create a branch or package that integrates with Isaac Lab-Arena (e.g. an `IsaacLab-Arena` branch). See [RoboTwin](https://github.com/RoboTwin-Platform/RoboTwin/tree/IsaacLab-Arena) for a reference example. For detailed setup instructions — including repository layout, Dockerfile setup, and how to register custom environments/robots/tasks — see the [Arena in Your Repository](https://isaac-sim.github.io/IsaacLab-Arena/latest/pages/arena_in_your_repo/index.html) guide.
 2. **Reference your benchmark and Isaac Lab-Arena in publications.** When publishing on ArXiv or elsewhere, cite both your benchmark (by name, with a link to your repository) and Isaac Lab-Arena as the underlying evaluation framework.
 3. **List it here.** Open a PR to add your benchmark to the [Published Benchmarks](#published-benchmarks) list above. This README serves as the single source of truth for the Arena benchmark ecosystem so that community can discover and reuse.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ NIST Board 1, NVIDIA Isaac GR00T Industrial Benchmarks, NVIDIA DexBench, NVIDIA 
 
 We encourage the community to build and publish benchmarks on Isaac Lab-Arena. The recommended workflow:
 
-1. **Maintain your benchmark in your own repository.** Create a branch or package that integrates with Isaac Lab-Arena (e.g. an `IsaacLab-Arena` branch). See [RoboTwin](https://github.com/RoboTwin-Platform/RoboTwin/tree/IsaacLab-Arena) for a reference example. For detailed setup instructions — including repository layout, Dockerfile setup, and how to register custom environments/robots/tasks — see the [Arena in Your Repository](https://isaac-sim.github.io/IsaacLab-Arena/latest/pages/arena_in_your_repo/index.html) guide.
+1. **Maintain your benchmark in your own repository.** Create a branch or package that integrates with Isaac Lab-Arena (e.g. an `IsaacLab-Arena` branch). See [RoboTwin](https://github.com/RoboTwin-Platform/RoboTwin/tree/IsaacLab-Arena) for a reference example. For detailed setup instructions — including repository layout, Dockerfile setup, and how to register custom environments/robots/tasks — see the [Arena in Your Repository](https://isaac-sim.github.io/IsaacLab-Arena/main/pages/arena_in_your_repo/index.html) guide.
 2. **Reference your benchmark and Isaac Lab-Arena in publications.** When publishing on ArXiv or elsewhere, cite both your benchmark (by name, with a link to your repository) and Isaac Lab-Arena as the underlying evaluation framework.
 3. **List it here.** Open a PR to add your benchmark to the [Published Benchmarks](#published-benchmarks) list above. This README serves as the single source of truth for the Arena benchmark ecosystem so that community can discover and reuse.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -199,12 +199,10 @@ TABLE OF CONTENTS
    pages/quickstart/first_experiments/index
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Arena in Your Repo
 
-   pages/arena_in_your_repo/external_installation
-   pages/arena_in_your_repo/external_environments
-   pages/arena_in_your_repo/external_tasks_and_embodiments
+   pages/arena_in_your_repo/index
 
 .. toctree::
    :maxdepth: 1

--- a/docs/pages/arena_in_your_repo/index.rst
+++ b/docs/pages/arena_in_your_repo/index.rst
@@ -1,0 +1,13 @@
+Arena in Your Repository
+=======================
+
+This section explains how to integrate IsaacLab-Arena into your own repository — installing
+it as a submodule, defining custom environments, and registering your own tasks and
+embodiments.
+
+.. toctree::
+   :maxdepth: 1
+
+   external_installation
+   external_environments
+   external_tasks_and_embodiments

--- a/docs/pages/arena_in_your_repo/index.rst
+++ b/docs/pages/arena_in_your_repo/index.rst
@@ -1,5 +1,5 @@
 Arena in Your Repository
-=======================
+========================
 
 This section explains how to integrate IsaacLab-Arena into your own repository — installing
 it as a submodule, defining custom environments, and registering your own tasks and

--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -102,10 +102,16 @@ Step 2: Post-train Policy
 
 We post-train the GR00T N1.6 policy on the task.
 
-The GR00T N1.6 policy has 3 billion parameters so post-training is an an expensive operation.
-We provide one post-training option, 8 GPUs with 48GB memory, to achieve the best quality:
+The GR00T N1.6 policy has 3 billion parameters so post-training is an expensive operation.
+We provide one post-training option, 8 GPUs with 48GB memory, to achieve the best quality.
 
 Training takes approximately 4-8 hours on 8x L40s GPUs.
+
+Compute Requirements:
+
+- **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, GB200, etc.)
+- **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+  and multiple dataloader workers requires substantial host memory
 
 Training Configuration:
 
@@ -114,7 +120,6 @@ Training Configuration:
 - **Frozen Modules:** LLM (language model)
 - **Batch Size:** 96 (adjust based on GPU memory)
 - **Training Steps:** 20,000
-- **GPUs:** 8 (multi-GPU training)
 
 To post-train the policy, run the following command
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -110,8 +110,8 @@ Step 2: Post-train Policy
 
 We post-train the GR00T N1.6 policy on the task.
 
-The GR00T N1.6 policy has 3 billion parameters so post training is an an expensive operation.
-We provide three post-training options:
+The GR00T N1.6 policy has 3 billion parameters so post-training is an expensive operation.
+We provide two post-training options:
 
 * Best Quality: 8 GPUs with 48GB memory
 * Low Hardware Requirements: 1 GPU with 24GB memory
@@ -123,6 +123,12 @@ We provide three post-training options:
 
       Training takes approximately 4-8 hours on 8x L40s GPUs.
 
+      Compute Requirements:
+
+      - **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, A6000, A100)
+      - **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+        and multiple dataloader workers requires substantial host memory
+
       Training Configuration:
 
       - **Base Model:** GR00T-N1.6-3B (foundation model)
@@ -130,7 +136,6 @@ We provide three post-training options:
       - **Frozen Modules:** LLM (language model)
       - **Global Batch Size:** 96 (adjust based on GPU memory)
       - **Training Steps:** 20,000
-      - **GPUs:** 8 (multi-GPU training)
 
       To post-train the policy, run the following command
 

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -103,7 +103,7 @@ Step 2: Post-train Policy
 
 We post-train the GR00T N1.6 policy on the task.
 
-The GR00T N1.6 policy has 3 billion parameters so post training is an an expensive operation.
+The GR00T N1.6 policy has 3 billion parameters so post-training is an expensive operation.
 We provide two post-training options:
 
 * Best Quality: 8 GPUs with 48GB memory
@@ -116,6 +116,12 @@ We provide two post-training options:
 
       Training takes approximately 4-8 hours on 8x L40s GPUs.
 
+      Compute Requirements:
+
+      - **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, A6000, A100)
+      - **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+        and multiple dataloader workers requires substantial host memory
+
       Training Configuration:
 
       - **Base Model:** GR00T-N1.6-3B (foundation model)
@@ -123,7 +129,6 @@ We provide two post-training options:
       - **Frozen Modules:** LLM (language model)
       - **Batch Size:** 24 (adjust based on GPU memory)
       - **Training Steps:** 20,000
-      - **GPUs:** 8 (multi-GPU training)
 
       To post-train the policy, run the following command
 


### PR DESCRIPTION
## Summary
Doc fix to https://nvbugspro.nvidia.com/bug/6062848, Readme updates.

## Detailed description
- Policy training docs: Added a "Compute Requirements" section (GPU VRAM + system RAM guidance) to all three workflow tutorials (static_manipulation, sequential_static_manipulation, locomanipulation) and fixed the "an an" typo.
- Arena-in-your-repo docs: Created an index.rst landing page for the section and updated docs/index.rst to use it instead of listing the three sub-pages individually.
- README: Added a link to the "Installing IsaacLab-Arena in Your Repository" guide in the "Publishing Your Own Benchmark" section.