### PR TITLE
Correct the CloudXR config for Quest handtracking

### DIFF
--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -29,7 +29,7 @@ Step 1: Start the CloudXR Runtime
 
       .. code-block:: bash
 
-         echo "NV_DEVICE_PROFILE=auto-native" > handtracking.env
+         echo "NV_CXR_ENABLE_PUSH_DEVICES=0" > handtracking.env
 
 
       Start the CloudXR runtime with the customized config file:

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -28,7 +28,7 @@ Step 1: Start the CloudXR Runtime
 
       .. code-block:: bash
 
-         echo "NV_DEVICE_PROFILE=auto-native" > handtracking.env
+         echo "NV_CXR_ENABLE_PUSH_DEVICES=0" > handtracking.env
 
 
       Start the CloudXR runtime with the customized config file:


### PR DESCRIPTION
## Summary
The config in the doc is mistakenly set for AVP instead of for Quest/Pico handtracking. Correcting the doc.
This fixes issue reported from https://nvbugspro.nvidia.com/bug/6076546
