### PR TITLE
Remove use-wandb in doc

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -140,7 +140,6 @@ To post-train the policy, run the following command
    --tune_projector \
    --tune_diffusion_model \
    --dataloader_num_workers=16 \
-   --use-wandb \
    --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
    --embodiment_tag=NEW_EMBODIMENT
 

--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -139,7 +139,7 @@ To post-train the policy, run the following command
    --tune_visual \
    --tune_projector \
    --tune_diffusion_model \
-   --dataloader_num_workers=16 \
+   --dataloader_num_workers=8 \
    --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
    --embodiment_tag=NEW_EMBODIMENT
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -157,7 +157,6 @@ We provide two post-training options:
          --tune_projector \
          --tune_diffusion_model \
          --dataloader_num_workers=16 \
-         --use-wandb \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -193,7 +192,6 @@ We provide two post-training options:
          --tune_projector \
          --tune_diffusion_model \
          --dataloader_num_workers=16 \
-         --use-wandb \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -156,7 +156,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=8 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -191,7 +191,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=8 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -151,7 +151,6 @@ We provide two post-training options:
          --tune_diffusion_model \
          --no-resume \
          --dataloader_num_workers=16 \
-         --no_use_wandb \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -151,7 +151,7 @@ We provide two post-training options:
          --tune_diffusion_model \
          --no-resume \
          --dataloader_num_workers=16 \
-         --use-wandb \
+         --no_use_wandb \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -187,7 +187,6 @@ We provide two post-training options:
          --tune_projector \
          --tune_diffusion_model \
          --dataloader_num_workers=16 \
-         --use-wandb \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -149,8 +149,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --no-resume \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=8 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -185,7 +184,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=8 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5


### PR DESCRIPTION
## Summary
Address https://nvbugspro.nvidia.com/bug/6062848

## Detailed description
In a multi-GPU setup, the standard output (stdout) buffer gets flooded with logs from secondary GPUs. As a result, the wandb prompt requesting user input gets buried in the output. Because the prompt goes unanswered, the data loading process stalls, eventually leading to a timeout