### PR TITLE
Add G1 loco-manip apple-to-plate workflow docs

### DIFF
--- a/docs/images/locomanip_arena_server_apple.png
+++ b/docs/images/locomanip_arena_server_apple.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d50a2b8f79a5075c05f4829cbf9d22a6c4bea8ffac4f455a0d8c32dcca11f18d
+size 602008

--- a/docs/pages/example_workflows/imitation_learning/index.rst
+++ b/docs/pages/example_workflows/imitation_learning/index.rst
@@ -8,6 +8,7 @@ closed-loop evaluation.
 Currently, the following imitation learning workflow examples are provided:
 
 * :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/index>`
+* :doc:`G1 Loco-Manipulation Apple-to-Plate Task <../locomanip_apple/index>`
 * :doc:`GR1 Open Microwave Door Task <../static_manipulation/index>`
 * :doc:`GR1 Sequential Pick & Place and Close Door Task <../sequential_static_manipulation/index>`
 
@@ -30,5 +31,6 @@ Not every step requires this container — the workflow pages will tell you when
    :maxdepth: 1
 
    ../locomanipulation/index
+   ../locomanip_apple/index
    ../static_manipulation/index
    ../sequential_static_manipulation/index

--- a/docs/pages/example_workflows/locomanip_apple/index.rst
+++ b/docs/pages/example_workflows/locomanip_apple/index.rst
@@ -8,7 +8,7 @@ This workflow mirrors the :doc:`G1 Loco-Manipulation Box Pick and Place Task <..
 Task Overview
 -------------
 
-**Task Name:** ``galileo_g1_locomanip_apple_to_plate``
+**Task Name:** ``galileo_g1_locomanip_pick_and_place``
 
 **Task Description:** The G1 humanoid robot navigates through a lab environment, picks up an apple
 from a shelf, and places it onto a plate on the table to the right of the shelf. This task requires

--- a/docs/pages/example_workflows/locomanip_apple/index.rst
+++ b/docs/pages/example_workflows/locomanip_apple/index.rst
@@ -41,9 +41,9 @@ flatter target.
    * - **Post-training**
      - Imitation Learning
    * - **Dataset**
-     - TBD (pre-recorded dataset will be published once trained checkpoints are available)
+     - Self-recorded (collect via Step 2)
    * - **Checkpoint**
-     - TBD
+     - Self-trained (post-train via Step 4)
    * - **Physics**
      - PhysX (200Hz @ 4 decimation)
    * - **Closed-loop**
@@ -51,21 +51,14 @@ flatter target.
    * - **Metrics**
      - Success rate
 
-.. note::
-
-   Pre-recorded datasets and trained checkpoints for this workflow are **not yet published**. Until they
-   are, the "download pre-recorded" dropdowns in the steps below serve as placeholders that will be
-   populated when the artifacts are released. In the meantime, the workflow is runnable end-to-end
-   starting from the teleoperation step (with or without an XR headset — see Step 2).
-
 
 Workflow
 --------
 
 This tutorial covers the pipeline between creating an environment, collecting teleoperation demonstrations, generating training data,
 fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop.
-A user can follow the whole pipeline, or can start at any intermediate step
-by downloading the pre-generated output of the preceding step(s) once those artifacts are published.
+Follow the steps in order from teleoperation through closed-loop evaluation; each step consumes the
+artifacts produced by the previous one.
 
 Prerequisites
 ^^^^^^^^^^^^^
@@ -73,12 +66,6 @@ Prerequisites
 Start the isaaclab docker container
 
 :docker_run_default:
-
-We store data on Hugging Face, so you'll need to log in to Hugging Face if you haven't already.
-
-.. code-block:: bash
-
-    hf auth login
 
 Create the folders for the data and models:
 

--- a/docs/pages/example_workflows/locomanip_apple/index.rst
+++ b/docs/pages/example_workflows/locomanip_apple/index.rst
@@ -1,0 +1,113 @@
+G1 Loco-Manipulation Apple-to-Plate Task
+========================================
+
+This example demonstrates the complete workflow for the **G1 loco-manipulation apple-to-plate task** in Isaac Lab - Arena, covering environment setup and validation, teleoperation data collection (OpenXR with Meta Quest 3), data generation, policy post-training, and closed-loop evaluation.
+
+This workflow mirrors the :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/index>`, but replaces the brown box with a smaller, rounder object (an apple) and the blue bin with a flat plate. If you are new to Arena loco-manipulation, we recommend the box/bin workflow first since the manipulated objects are more forgiving.
+
+Task Overview
+-------------
+
+**Task Name:** ``galileo_g1_locomanip_apple_to_plate``
+
+**Task Description:** The G1 humanoid robot navigates through a lab environment, picks up an apple
+from a shelf, and places it onto a plate on the table to the right of the shelf. This task requires
+full-body coordination including lower body locomotion, squatting, and bimanual manipulation, with
+tighter end-effector control than the box pick-and-place due to the smaller, rounder object and
+flatter target.
+
+**Key Specifications:**
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Property
+     - Value
+   * - **Tags**
+     - Room-scale loco-manipulation
+   * - **Skills**
+     - Squat, Turn, Walk, Pick, Place
+   * - **Embodiment**
+     - Unitree G1 (29 DOF humanoid with Whole Body Controller)
+   * - **Interop**
+     - Isaac Lab Mimic
+   * - **Scene**
+     - Galileo Lab Environment
+   * - **Manipulated Object(s)**
+     - Apple (rigid body), Clay plate (destination)
+   * - **Policy**
+     - GR00T N1.6 (vision-language-action foundation model)
+   * - **Post-training**
+     - Imitation Learning
+   * - **Dataset**
+     - TBD (pre-recorded dataset will be published once trained checkpoints are available)
+   * - **Checkpoint**
+     - TBD
+   * - **Physics**
+     - PhysX (200Hz @ 4 decimation)
+   * - **Closed-loop**
+     - Yes (50Hz control)
+   * - **Metrics**
+     - Success rate
+
+.. note::
+
+   Pre-recorded datasets and trained checkpoints for this workflow are **not yet published**. Until they
+   are, the "download pre-recorded" dropdowns in the steps below serve as placeholders that will be
+   populated when the artifacts are released. In the meantime, the workflow is runnable end-to-end
+   starting from the teleoperation step (with or without an XR headset — see Step 2).
+
+
+Workflow
+--------
+
+This tutorial covers the pipeline between creating an environment, collecting teleoperation demonstrations, generating training data,
+fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop.
+A user can follow the whole pipeline, or can start at any intermediate step
+by downloading the pre-generated output of the preceding step(s) once those artifacts are published.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Start the isaaclab docker container
+
+:docker_run_default:
+
+We store data on Hugging Face, so you'll need to log in to Hugging Face if you haven't already.
+
+.. code-block:: bash
+
+    hf auth login
+
+Create the folders for the data and models:
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/locomanip_apple_tutorial
+    mkdir -p $DATASET_DIR
+    export MODELS_DIR=/models/isaaclab_arena/locomanip_apple_tutorial
+    mkdir -p $MODELS_DIR
+
+
+Workflow Steps
+^^^^^^^^^^^^^^
+
+Follow the following steps to complete the workflow:
+
+- :doc:`step_1_environment_setup`
+- :doc:`step_2_teleoperation`
+- :doc:`step_3_data_generation`
+- :doc:`step_4_policy_training`
+- :doc:`step_5_evaluation`
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   step_1_environment_setup
+   step_2_teleoperation
+   step_3_data_generation
+   step_4_policy_training
+   step_5_evaluation

--- a/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
@@ -1,0 +1,213 @@
+Environment Setup and Validation
+--------------------------------
+
+
+On this page we briefly describe the environment used in this example workflow
+and validate that we can load it in Isaac Lab.
+
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
+
+
+Environment Description
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. dropdown:: The Galileo G1 Loco-Manipulation Apple-to-Plate Environment
+   :animate: fade-in
+
+   .. code-block:: python
+
+       import math
+
+       class GalileoG1LocomanipAppleToPlateEnvironment(ExampleEnvironmentBase):
+
+           name: str = "galileo_g1_locomanip_apple_to_plate"
+
+           def get_env(self, args_cli: argparse.Namespace):
+               from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+               from isaaclab_arena.scene.scene import Scene
+               from isaaclab_arena.tasks.g1_locomanip_pick_and_place_task import G1LocomanipPickAndPlaceTask
+               from isaaclab_arena.utils.pose import Pose, PoseRange
+
+               background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+               # Objaverse assets are ~100x real-world scale; downscale to realistic size.
+               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=(0.01, 0.01, 0.01))
+               destination = self.asset_registry.get_asset_by_name(args_cli.destination)(scale=(0.5, 0.5, 0.5))
+               embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+
+               if args_cli.teleop_device is not None:
+                   teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+               else:
+                   teleop_device = None
+
+               XY_RANGE_M = 0.025
+               pick_up_object.set_initial_pose(
+                   PoseRange(
+                       position_xyz_min=(0.5785 - XY_RANGE_M, 0.18 - XY_RANGE_M, 0.0707),
+                       position_xyz_max=(0.5785 + XY_RANGE_M, 0.18 + XY_RANGE_M, 0.0707),
+                       rpy_min=(math.pi, 0.0, math.pi),
+                       rpy_max=(math.pi, 0.0, math.pi),
+                   )
+               )
+               destination.set_initial_pose(
+                   Pose(
+                       position_xyz=(-0.2450, -1.6272, -0.2641),
+                       rotation_xyzw=(0.0, 0.0, 1.0, 0.0),
+                   )
+               )
+               embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+               scene = Scene(assets=[background, pick_up_object, destination])
+               task = G1LocomanipPickAndPlaceTask(pick_up_object, destination, background)
+
+               isaaclab_arena_environment = IsaacLabArenaEnvironment(
+                   name=self.name,
+                   embodiment=embodiment,
+                   scene=scene,
+                   task=task,
+                   teleop_device=teleop_device,
+               )
+               return isaaclab_arena_environment
+
+
+Step-by-Step Breakdown
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**1. Interact with the Asset and Device Registry**
+
+.. code-block:: python
+
+    background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=(0.01, 0.01, 0.01))
+    destination = self.asset_registry.get_asset_by_name(args_cli.destination)(scale=(0.5, 0.5, 0.5))
+    embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+
+    if args_cli.teleop_device is not None:
+        teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+    else:
+        teleop_device = None
+
+The ``teleop_device`` is left as ``None`` when ``--teleop_device`` is not supplied so that scripts like
+``replay_demos.py`` and ``policy_runner.py`` (which don't need a teleop device) can launch the same
+environment without instantiating an XR runtime.
+
+Here, we're selecting the specific pieces we need for our loco-manipulation task: the Galileo arena as our background environment,
+an apple to pick up, a clay plate as our destination, and the G1 embodiment. The apple and plate are downscaled because the Objaverse
+and HOT3D assets are authored at larger-than-real-world scale — the specific factors (``0.01`` for the apple and ``0.5`` for the plate)
+were picked by eye so the objects look approximately right next to the G1.
+See :doc:`../../concepts/scene/concept_assets_design` for details on asset architecture.
+
+
+**2. Position the Objects**
+
+.. code-block:: python
+
+   XY_RANGE_M = 0.025
+   pick_up_object.set_initial_pose(
+       PoseRange(
+           position_xyz_min=(0.5785 - XY_RANGE_M, 0.18 - XY_RANGE_M, 0.0707),
+           position_xyz_max=(0.5785 + XY_RANGE_M, 0.18 + XY_RANGE_M, 0.0707),
+           rpy_min=(math.pi, 0.0, math.pi),
+           rpy_max=(math.pi, 0.0, math.pi),
+       )
+   )
+   destination.set_initial_pose(
+       Pose(
+           position_xyz=(-0.2450, -1.6272, -0.2641),
+           rotation_xyzw=(0.0, 0.0, 1.0, 0.0),
+       )
+   )
+
+The apple is placed on the shelf at a randomised pose within a small XY range, and the plate is placed on the
+table to the right of the shelf. The poses were carried over from the box/bin variant and validated visually
+in the simulator; if you adjust the apple or plate asset, you may need to retune the z-heights so the apple
+sits flush on the shelf and the plate sits flat on the table.
+
+
+**3. Compose the Scene**
+
+.. code-block:: python
+
+    scene = Scene(assets=[background, pick_up_object, destination])
+
+Now we bring everything together into an IsaacLab-Arena scene.
+See :doc:`../../concepts/scene/index` for scene composition details.
+
+
+**4. Create the Loco-Manipulation Pick and Place Task**
+
+.. code-block:: python
+
+    task = G1LocomanipPickAndPlaceTask(pick_up_object, destination, background)
+
+We reuse the same ``G1LocomanipPickAndPlaceTask`` as the box/bin workflow. The task takes the pick-up object and
+destination as constructor arguments, so swapping the apple and plate in for the box and bin works without
+any task-class changes. Internally, the task passes ``pick_up_object.name`` through to the Isaac Lab Mimic
+configuration so that data generation references the correct object frame.
+
+See :doc:`../../concepts/task/index` for task creation details.
+
+
+**5. Create the IsaacLab Arena Environment**
+
+.. code-block:: python
+
+    isaaclab_arena_environment = IsaacLabArenaEnvironment(
+        name=self.name,
+        embodiment=embodiment,
+        scene=scene,
+        task=task,
+        teleop_device=teleop_device,
+    )
+
+Finally, we assemble all the pieces into a complete, runnable environment. The ``IsaacLabArenaEnvironment`` is the
+top-level container that connects your embodiment (the robot), the scene (the world) and the task (the objective).
+See :doc:`../../concepts/concept_overview` for environment composition details.
+
+
+Step 1: Validate Environment with Automated Tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A dedicated pytest module covers the apple-to-plate environment: it asserts that the task does not
+terminate when the apple is at its initial pose, that the success termination fires when the apple is
+teleported onto the plate, and that the Isaac Lab Mimic config correctly references the apple asset
+across all subtask configurations.
+
+.. code-block:: bash
+
+   python -m pytest isaaclab_arena/tests/test_g1_locomanip_apple_to_plate.py -v
+
+You should see all three tests pass. The simulation-based tests
+(``test_initial_state_not_terminated`` and ``test_apple_on_plate_succeeds``) run headless with cameras
+enabled and take around a minute each. This is the fastest way to confirm the scene, task, and Mimic
+config are wired up correctly without requiring teleoperation hardware.
+
+
+Step 2: Validate Environment with Demo Replay (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a pre-recorded dataset is published for this workflow on Hugging Face, you can also validate the
+environment by replaying the dataset. The replay runs the environment with the recorded actions and no
+teleoperation device is needed, so this is a handy way to visually confirm the environment looks right
+without an XR headset:
+
+.. code-block:: bash
+
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
+     --viz kit \
+     --device cpu \
+     --enable_cameras \
+     --dataset_file ${DATASET_DIR}/arena_g1_locomanip_apple_dataset_generated.hdf5 \
+     galileo_g1_locomanip_apple_to_plate \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab \
+     --embodiment g1_wbc_pink
+
+.. note::
+
+   The downloaded dataset will be generated using CPU device physics, so the replay uses ``--device cpu``
+   to ensure reproducibility.
+
+You should see the G1 robot replaying the generated demonstrations, performing apple pick and place
+task in the Galileo lab environment.

--- a/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
@@ -172,8 +172,8 @@ top-level container that connects your embodiment (the robot), the scene (the wo
 See :doc:`../../concepts/concept_overview` for environment composition details.
 
 
-Step 1: Validate Environment with Automated Tests
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Validate Environment with Automated Tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A dedicated pytest module covers the apple-to-plate environment. It asserts that (i) the task does not
 terminate when the apple is at its initial pose, (ii) the success termination fires when the apple is
@@ -193,10 +193,6 @@ enabled and take around a minute each; the three Mimic config tests are lightwei
 few seconds. This is the fastest way to confirm the scene, task, and Mimic config are wired up
 correctly without requiring teleoperation hardware.
 
-
-Step 2: Validate Environment with Demo Replay (Optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 .. note::
 
    **First-run asset cache**: The Objaverse apple USD streams from an S3 staging bucket and
@@ -205,28 +201,3 @@ Step 2: Validate Environment with Demo Replay (Optional)
    tunnel through the shelf surface on the very first load. Subsequent runs read the cached
    USD from ``/tmp/Assets/`` and spawn correctly. If you see the apple fall through the shelf,
    just re-run the command once.
-
-Once a pre-recorded dataset is published for this workflow on Hugging Face, you can also validate the
-environment by replaying the dataset. The replay runs the environment with the recorded actions and no
-teleoperation device is needed, so this is a handy way to visually confirm the environment looks right
-without an XR headset:
-
-.. code-block:: bash
-
-   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
-     --viz kit \
-     --device cpu \
-     --enable_cameras \
-     --dataset_file ${DATASET_DIR}/arena_g1_locomanip_apple_dataset_generated.hdf5 \
-     galileo_g1_locomanip_pick_and_place \
-     --object apple_01_objaverse_robolab \
-     --destination clay_plates_hot3d_robolab \
-     --embodiment g1_wbc_pink
-
-.. note::
-
-   The downloaded dataset will be generated using CPU device physics, so the replay uses ``--device cpu``
-   to ensure reproducibility.
-
-You should see the G1 robot replaying the generated demonstrations, performing the apple pick and place
-task in the Galileo lab environment.

--- a/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
@@ -13,16 +13,21 @@ and validate that we can load it in Isaac Lab.
 Environment Description
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. dropdown:: The Galileo G1 Loco-Manipulation Apple-to-Plate Environment
+The apple-to-plate workflow reuses the ``GalileoG1LocomanipPickAndPlaceEnvironment`` (also used by the
+box-to-bin workflow) with a different pick-up object and destination. The environment exposes
+``--object`` and ``--destination`` CLI arguments, so switching between the two variants is just a
+matter of passing the right asset names — no separate environment class is needed.
+
+.. dropdown:: The Galileo G1 Loco-Manipulation Pick-and-Place Environment
    :animate: fade-in
 
    .. code-block:: python
 
        import math
 
-       class GalileoG1LocomanipAppleToPlateEnvironment(ExampleEnvironmentBase):
+       class GalileoG1LocomanipPickAndPlaceEnvironment(ExampleEnvironmentBase):
 
-           name: str = "galileo_g1_locomanip_apple_to_plate"
+           name: str = "galileo_g1_locomanip_pick_and_place"
 
            def get_env(self, args_cli: argparse.Namespace):
                from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
@@ -31,9 +36,8 @@ Environment Description
                from isaaclab_arena.utils.pose import Pose, PoseRange
 
                background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-               # Objaverse assets are ~100x real-world scale; downscale to realistic size.
-               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=(0.01, 0.01, 0.01))
-               destination = self.asset_registry.get_asset_by_name(args_cli.destination)(scale=(0.5, 0.5, 0.5))
+               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
+               destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
                embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
 
                if args_cli.teleop_device is not None:
@@ -79,8 +83,8 @@ Step-by-Step Breakdown
 .. code-block:: python
 
     background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=(0.01, 0.01, 0.01))
-    destination = self.asset_registry.get_asset_by_name(args_cli.destination)(scale=(0.5, 0.5, 0.5))
+    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
+    destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
     embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
 
     if args_cli.teleop_device is not None:
@@ -92,10 +96,11 @@ The ``teleop_device`` is left as ``None`` when ``--teleop_device`` is not suppli
 ``replay_demos.py`` and ``policy_runner.py`` (which don't need a teleop device) can launch the same
 environment without instantiating an XR runtime.
 
-Here, we're selecting the specific pieces we need for our loco-manipulation task: the Galileo arena as our background environment,
-an apple to pick up, a clay plate as our destination, and the G1 embodiment. The apple and plate are downscaled because the Objaverse
-and HOT3D assets are authored at larger-than-real-world scale — the specific factors (``0.01`` for the apple and ``0.5`` for the plate)
-were picked by eye so the objects look approximately right next to the G1.
+Here, we're selecting the specific pieces we need for our loco-manipulation task: the Galileo arena as
+our background environment, an apple to pick up, a clay plate as our destination, and the G1 embodiment.
+Each registered asset carries its own default scale — ``Apple01ObjaverseRobolab`` bakes in the
+``(0.01, 0.01, 0.01)`` factor that accounts for Objaverse assets being authored at ~100× real-world
+size, while the HOT3D plate is authored at real size (~30 cm diameter) and needs no rescaling.
 See :doc:`../../concepts/scene/concept_assets_design` for details on asset architecture.
 
 
@@ -121,8 +126,8 @@ See :doc:`../../concepts/scene/concept_assets_design` for details on asset archi
 
 The apple is placed on the shelf at a randomised pose within a small XY range, and the plate is placed on the
 table to the right of the shelf. The poses were carried over from the box/bin variant and validated visually
-in the simulator; if you adjust the apple or plate asset, you may need to retune the z-heights so the apple
-sits flush on the shelf and the plate sits flat on the table.
+in the simulator; if you swap in a different pick-up object or destination, you may need to tune the
+z-heights so the object sits flush on the shelf and the destination sits flat on the table.
 
 
 **3. Compose the Scene**
@@ -187,6 +192,15 @@ config are wired up correctly without requiring teleoperation hardware.
 Step 2: Validate Environment with Demo Replay (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+
+   **First-run asset cache**: The Objaverse apple USD streams from an S3 staging bucket and
+   PhysX re-cooks its collision mesh at the baked-in ``0.01x`` scale. On a fresh machine the
+   collision cook may land a frame after the first physics step, which can cause the apple to
+   tunnel through the shelf surface on the very first load. Subsequent runs read the cached
+   USD from ``/tmp/Assets/`` and spawn correctly. If you see the apple fall through the shelf,
+   just re-run the command once.
+
 Once a pre-recorded dataset is published for this workflow on Hugging Face, you can also validate the
 environment by replaying the dataset. The replay runs the environment with the recorded actions and no
 teleoperation device is needed, so this is a handy way to visually confirm the environment looks right
@@ -199,7 +213,7 @@ without an XR headset:
      --device cpu \
      --enable_cameras \
      --dataset_file ${DATASET_DIR}/arena_g1_locomanip_apple_dataset_generated.hdf5 \
-     galileo_g1_locomanip_apple_to_plate \
+     galileo_g1_locomanip_pick_and_place \
      --object apple_01_objaverse_robolab \
      --destination clay_plates_hot3d_robolab \
      --embodiment g1_wbc_pink
@@ -209,5 +223,5 @@ without an XR headset:
    The downloaded dataset will be generated using CPU device physics, so the replay uses ``--device cpu``
    to ensure reproducibility.
 
-You should see the G1 robot replaying the generated demonstrations, performing apple pick and place
+You should see the G1 robot replaying the generated demonstrations, performing the apple pick and place
 task in the Galileo lab environment.

--- a/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_1_environment_setup.rst
@@ -32,7 +32,7 @@ matter of passing the right asset names — no separate environment class is nee
            def get_env(self, args_cli: argparse.Namespace):
                from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
                from isaaclab_arena.scene.scene import Scene
-               from isaaclab_arena.tasks.g1_locomanip_pick_and_place_task import G1LocomanipPickAndPlaceTask
+               from isaaclab_arena.tasks.locomanip_pick_and_place_task import LocomanipPickAndPlaceTask
                from isaaclab_arena.utils.pose import Pose, PoseRange
 
                background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
@@ -63,7 +63,7 @@ matter of passing the right asset names — no separate environment class is nee
                embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
 
                scene = Scene(assets=[background, pick_up_object, destination])
-               task = G1LocomanipPickAndPlaceTask(pick_up_object, destination, background)
+               task = LocomanipPickAndPlaceTask(pick_up_object, destination, background)
 
                isaaclab_arena_environment = IsaacLabArenaEnvironment(
                    name=self.name,
@@ -144,12 +144,13 @@ See :doc:`../../concepts/scene/index` for scene composition details.
 
 .. code-block:: python
 
-    task = G1LocomanipPickAndPlaceTask(pick_up_object, destination, background)
+    task = LocomanipPickAndPlaceTask(pick_up_object, destination, background)
 
-We reuse the same ``G1LocomanipPickAndPlaceTask`` as the box/bin workflow. The task takes the pick-up object and
+We reuse the same ``LocomanipPickAndPlaceTask`` as the box/bin workflow. The task takes the pick-up object and
 destination as constructor arguments, so swapping the apple and plate in for the box and bin works without
-any task-class changes. Internally, the task passes ``pick_up_object.name`` through to the Isaac Lab Mimic
-configuration so that data generation references the correct object frame.
+any task-class changes. Internally, the task passes both ``pick_up_object.name`` and
+``destination_location.name`` through to the Isaac Lab Mimic configuration so that data generation references
+the correct object frame and resolves a unique ``datagen_config.name`` per ``(object, destination)`` pair.
 
 See :doc:`../../concepts/task/index` for task creation details.
 
@@ -174,19 +175,23 @@ See :doc:`../../concepts/concept_overview` for environment composition details.
 Step 1: Validate Environment with Automated Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A dedicated pytest module covers the apple-to-plate environment: it asserts that the task does not
-terminate when the apple is at its initial pose, that the success termination fires when the apple is
-teleported onto the plate, and that the Isaac Lab Mimic config correctly references the apple asset
-across all subtask configurations.
+A dedicated pytest module covers the apple-to-plate environment. It asserts that (i) the task does not
+terminate when the apple is at its initial pose, (ii) the success termination fires when the apple is
+teleported onto the plate, (iii) the Isaac Lab Mimic config correctly references both the apple object
+and plate destination across all subtask configurations and its datagen key, (iv) the legacy
+``(brown_box, blue_sorting_bin)`` pair still resolves to the preserved ``"locomanip_pick_and_place_D0"``
+datagen name, and (v) any non-legacy ``brown_box`` pair (e.g. ``brown_box`` + plate) is routed to a
+distinct templated datagen name so parallel Mimic runs cannot overwrite the box-to-bin dataset.
 
 .. code-block:: bash
 
    python -m pytest isaaclab_arena/tests/test_g1_locomanip_apple_to_plate.py -v
 
-You should see all three tests pass. The simulation-based tests
+You should see all five tests pass. The simulation-based tests
 (``test_initial_state_not_terminated`` and ``test_apple_on_plate_succeeds``) run headless with cameras
-enabled and take around a minute each. This is the fastest way to confirm the scene, task, and Mimic
-config are wired up correctly without requiring teleoperation hardware.
+enabled and take around a minute each; the three Mimic config tests are lightweight and complete in a
+few seconds. This is the fastest way to confirm the scene, task, and Mimic config are wired up
+correctly without requiring teleoperation hardware.
 
 
 Step 2: Validate Environment with Demo Replay (Optional)

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -7,27 +7,19 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation appl
    :class: tip
 
    The G1 loco-manipulation task needs bimanual end-effector control plus locomotion/squat
-   commands, which is not practical to drive from a keyboard or SpaceMouse. If you don't have an
-   XR headset, you have two headset-free options:
-
-   #. **Smoke-test the full pipeline with IWER.** Open
-      `<https://nvidia.github.io/IsaacTeleop/client>`_ in desktop Chrome (instead of the Quest
-      browser). The page auto-loads the `Immersive Web Emulator Runtime
-      <https://github.com/meta-quest/immersive-web-emulator>`_ and emulates a Quest 3 with your
-      mouse and keyboard, per the `IsaacTeleop Quick Start
-      <https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html>`_. Follow
-      Steps 1--4 below unchanged; the only difference is that Step 3 is done from a desktop
-      browser tab. This is enough to verify that CloudXR is reachable, the XR session starts,
-      actions flow into the env, and ``record_demos.py`` writes a valid HDF5 -- but driving a
-      bimanual loco-manip action space with a mouse is cumbersome, so IWER-recorded runs will
-      rarely complete the task. Treat it as a pipeline smoke test, not a data-collection path.
-
-   #. **Skip teleoperation entirely.** Jump to :doc:`step_3_data_generation`, where you can
-      download a pre-recorded dataset from Hugging Face and run the rest of the pipeline
-      (annotation, Mimic generation, policy training, closed-loop evaluation) without ever
-      touching teleoperation hardware. This is the same "emulation" path that the existing
-      :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/step_3_data_generation>`
-      workflow relies on.
+   commands, which is not practical to drive from a keyboard or SpaceMouse. If you don't have
+   an XR headset, you can still smoke-test the full pipeline with the
+   `Immersive Web Emulator Runtime (IWER)
+   <https://github.com/meta-quest/immersive-web-emulator>`_. Open
+   `<https://nvidia.github.io/IsaacTeleop/client>`_ in desktop Chrome (instead of the Quest
+   browser); the page auto-loads IWER and emulates a Quest 3 with your mouse and keyboard, per
+   the `IsaacTeleop Quick Start
+   <https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html>`_. Follow
+   Steps 1--4 below unchanged; the only difference is that Step 3 is done from a desktop
+   browser tab. This is enough to verify that CloudXR is reachable, the XR session starts,
+   actions flow into the env, and ``record_demos.py`` writes a valid HDF5 -- but driving a
+   bimanual loco-manip action space with a mouse is cumbersome, so IWER-recorded runs will
+   rarely complete the task. Treat it as a pipeline smoke test, not a data-collection path.
 
 
 Step 1: Start the CloudXR Runtime
@@ -149,7 +141,10 @@ Step 4: Record with Quest 3
 Step 5: Replay Recorded Demos (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To replay the recorded demos:
+Replay the recorded HDF5 to confirm the demos look correct end-to-end. This doubles as a no-XR
+sanity check on the environment: it drives the env from the recorded actions and needs no
+teleoperation device, so you can visually verify the scene, embodiment and asset placements
+without launching CloudXR.
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -6,15 +6,28 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation appl
 .. admonition:: No teleoperation hardware?
    :class: tip
 
-   The G1 loco-manipulation task needs bimanual end-effector control plus locomotion/squat commands,
-   which is not practical to drive from a keyboard or SpaceMouse. If you don't have an XR headset,
-   **skip this step** and jump to :doc:`step_3_data_generation`, where you can download a
-   pre-recorded dataset from Hugging Face and run the rest of the pipeline (annotation, Mimic
-   generation, policy training, closed-loop evaluation) without ever touching teleoperation hardware.
+   The G1 loco-manipulation task needs bimanual end-effector control plus locomotion/squat
+   commands, which is not practical to drive from a keyboard or SpaceMouse. If you don't have an
+   XR headset, you have two headset-free options:
 
-   This is the same "emulation" path that the existing
-   :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/step_3_data_generation>`
-   workflow relies on.
+   #. **Smoke-test the full pipeline with IWER.** Open
+      `<https://nvidia.github.io/IsaacTeleop/client>`_ in desktop Chrome (instead of the Quest
+      browser). The page auto-loads the `Immersive Web Emulator Runtime
+      <https://github.com/meta-quest/immersive-web-emulator>`_ and emulates a Quest 3 with your
+      mouse and keyboard, per the `IsaacTeleop Quick Start
+      <https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html>`_. Follow
+      Steps 1--4 below unchanged; the only difference is that Step 3 is done from a desktop
+      browser tab. This is enough to verify that CloudXR is reachable, the XR session starts,
+      actions flow into the env, and ``record_demos.py`` writes a valid HDF5 -- but driving a
+      bimanual loco-manip action space with a mouse is cumbersome, so IWER-recorded runs will
+      rarely complete the task. Treat it as a pipeline smoke test, not a data-collection path.
+
+   #. **Skip teleoperation entirely.** Jump to :doc:`step_3_data_generation`, where you can
+      download a pre-recorded dataset from Hugging Face and run the rest of the pipeline
+      (annotation, Mimic generation, policy training, closed-loop evaluation) without ever
+      touching teleoperation hardware. This is the same "emulation" path that the existing
+      :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/step_3_data_generation>`
+      workflow relies on.
 
 
 Step 1: Start the CloudXR Runtime

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -25,43 +25,72 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation appl
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On the host machine, configure the firewall to allow CloudXR traffic. The required ports depend on the client type.
+#. On the host machine, configure the firewall to allow CloudXR traffic. The required ports depend on the client type.
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   sudo ufw allow 49100/tcp   # Signaling
-   sudo ufw allow 47998/udp   # Media stream
-   sudo ufw allow 48322/tcp   # Proxy (HTTPS mode only)
+      sudo ufw allow 49100/tcp   # Signaling
+      sudo ufw allow 47998/udp   # Media stream
+      sudo ufw allow 48322/tcp   # Proxy (HTTPS mode only)
 
 
-Start the CloudXR runtime from the Arena Docker container:
+#. Start the CloudXR runtime from the Arena Docker container:
 
-:docker_run_default:
+   :docker_run_default:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-   python -m isaacteleop.cloudxr
+      python -m isaacteleop.cloudxr
+
+.. attention::
+
+   The first run will prompt users to accept the NVIDIA CloudXR License Agreement.
+   To accept the EULA, reply ``Yes`` when prompted with the below message:
+
+   .. code:: bash
+
+      NVIDIA CloudXR EULA must be accepted to run. View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+
+      Accept NVIDIA CloudXR EULA? [y/N]: Yes
 
 
 Step 2: Start Arena Teleop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In another terminal, start the Arena Docker container and launch the teleop session to verify the pipeline:
+#. In another terminal, start the Arena Docker container and launch the teleop session to verify the pipeline:
 
-:docker_run_default:
+   :docker_run_default:
 
-.. code-block:: bash
+#. Run the following command to activate IsaacTeleop CloudXR environment settings:
 
-   source ~/.cloudxr/run/cloudxr.env
-   python isaaclab_arena/scripts/imitation_learning/teleop.py \
-     --viz kit \
-     --device cpu \
-     galileo_g1_locomanip_pick_and_place \
-     --object apple_01_objaverse_robolab \
-     --destination clay_plates_hot3d_robolab \
-     --teleop_device openxr
+   .. code-block:: bash
 
-Start the session from the **XR** tab in the application window.
+      source ~/.cloudxr/run/cloudxr.env
+
+   .. important::
+      **Order matters.** In the terminal where you will run Arena, ``source ~/.cloudxr/run/cloudxr.env`` *after* the CloudXR runtime from Step 1 is already running,
+      and *before* you start the Arena app. The Arena app must inherit the IsaacTeleop CloudXR environment variables.
+
+#. Run the teleop script:
+
+   .. code-block:: bash
+
+      python isaaclab_arena/scripts/imitation_learning/teleop.py \
+      --viz kit \
+      --device cpu \
+      galileo_g1_locomanip_pick_and_place \
+      --object apple_01_objaverse_robolab \
+      --destination clay_plates_hot3d_robolab \
+      --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+   .. figure:: ../../../images/locomanip_arena_server_apple.png
+      :width: 100%
+      :alt: Arena teleop with XR running (stereoscopic view and OpenXR settings)
+      :align: center
+
+      Arena teleop session with XR running. Stereoscopic view (left) and OpenXR settings in the XR tab (right).
 
 
 Step 3: Connect from Meta Quest 3
@@ -79,7 +108,20 @@ A strong wireless connection is essential for a high-quality streaming experienc
    Accept the certificate in the new page that opens, then navigate back to the
    CloudXR.js client page.
 
-#. Click Connect to begin teleoperation.
+#. Click **Connect** to begin teleoperation.
+
+   .. note::
+      Once you press **Connect** in the web browser, you should see the following control panel. Press **Play** to start teleoperation.
+      You can also reset the scene by pressing the **Reset** button.
+
+      If the control panel is not visible (for example, behind a solid wall in the simulated environment), you can put the headset on
+      before clicking **Start XR** in the Isaac Lab Arena application, and drag the control panel to a better location.
+
+      .. figure:: ../../../images/react-isaac-sample-controls-start.jpg
+         :width: 40%
+         :alt: IsaacSim view
+         :align: center
+
 
 #. **Teleoperation Controls**:
 
@@ -92,9 +134,24 @@ A strong wireless connection is essential for a high-quality streaming experienc
 
    If the simulation runs at too low FPS and makes the teleoperation feel laggy, you can try to reduce the XR resolution from the XR tab / Advanced Settings / Render Resolution.
 
+   .. figure:: ../../../images/xr_resolution.png
+      :width: 40%
+      :alt: XR resolution panel
+      :align: center
+
+      Reducing render resolution from 1 (default) to 0.2.
+
 
 Step 4: Record with Quest 3
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   Run the following command to activate IsaacTeleop CloudXR environment settings again if you are starting the recording app from a different terminal.
+
+   .. code-block:: bash
+
+      source ~/.cloudxr/run/cloudxr.env
 
 #. **Recording**: When ready to collect data, run the recording script from the Arena container:
 
@@ -114,6 +171,10 @@ Step 4: Record with Quest 3
         --object apple_01_objaverse_robolab \
         --destination clay_plates_hot3d_robolab \
         --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+#. Follow Step 3 to connect the Quest 3 headset again.
 
 #. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
 
@@ -136,6 +197,14 @@ Step 4: Record with Quest 3
    Releasing a small round object onto a flat plate is noticeably harder than dropping a box into a
    bin. Keep the release height low and the orientation stable — successful demonstrations make
    Isaac Lab Mimic's job much easier in :doc:`step_3_data_generation`.
+
+.. warning::
+
+   **Known issue:** the squat height does not reset correctly between demos. As a
+   workaround, after each completed demo:
+
+   #. Use the **right joystick** (up) to stand the robot back up.
+   #. Use the CloudXR control panel to **Reset**, then **Play** to start the next demo.
 
 
 Step 5: Replay Recorded Demos (Optional)

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -52,6 +52,8 @@ In another terminal, start the Arena Docker container and launch the teleop sess
      --viz kit \
      --device cpu \
      galileo_g1_locomanip_pick_and_place \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab \
      --teleop_device openxr
 
 Start the session from the **XR** tab in the application window.
@@ -104,6 +106,8 @@ Step 4: Record with Quest 3
         --num_demos 10 \
         --num_success_steps 2 \
         galileo_g1_locomanip_pick_and_place \
+        --object apple_01_objaverse_robolab \
+        --destination clay_plates_hot3d_robolab \
         --teleop_device openxr
 
 #. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
@@ -141,4 +145,6 @@ To replay the recorded demos:
      --viz kit \
      --device cpu \
      --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
-     galileo_g1_locomanip_pick_and_place
+     galileo_g1_locomanip_pick_and_place \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -1,0 +1,144 @@
+Teleoperation Data Collection
+-----------------------------
+
+This workflow covers collecting demonstrations for the G1 loco-manipulation apple-to-plate task using **Meta Quest 3** supported by `Nvidia IsaacTeleop <https://github.com/NVIDIA/IsaacTeleop>`_.
+
+.. admonition:: No teleoperation hardware?
+   :class: tip
+
+   The G1 loco-manipulation task needs bimanual end-effector control plus locomotion/squat commands,
+   which is not practical to drive from a keyboard or SpaceMouse. If you don't have an XR headset,
+   **skip this step** and jump to :doc:`step_3_data_generation`, where you can download a
+   pre-recorded dataset from Hugging Face and run the rest of the pipeline (annotation, Mimic
+   generation, policy training, closed-loop evaluation) without ever touching teleoperation hardware.
+
+   This is the same "emulation" path that the existing
+   :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/step_3_data_generation>`
+   workflow relies on.
+
+
+Step 1: Start the CloudXR Runtime
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On the host machine, configure the firewall to allow CloudXR traffic. The required ports depend on the client type.
+
+.. code-block:: bash
+
+   sudo ufw allow 49100/tcp   # Signaling
+   sudo ufw allow 47998/udp   # Media stream
+   sudo ufw allow 48322/tcp   # Proxy (HTTPS mode only)
+
+
+Start the CloudXR runtime from the Arena Docker container:
+
+:docker_run_default:
+
+.. code-block:: bash
+
+   python -m isaacteleop.cloudxr
+
+
+Step 2: Start Arena Teleop
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In another terminal, start the Arena Docker container and launch the teleop session to verify the pipeline:
+
+:docker_run_default:
+
+.. code-block:: bash
+
+   source ~/.cloudxr/run/cloudxr.env
+   python isaaclab_arena/scripts/imitation_learning/teleop.py \
+     --viz kit \
+     --device cpu \
+     galileo_g1_locomanip_apple_to_plate \
+     --teleop_device openxr
+
+Start the session from the **XR** tab in the application window.
+
+
+Step 3: Connect from Meta Quest 3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For detailed instructions please refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_:
+
+A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
+
+#. Open the browser on your headset and navigate to `<https://nvidia.github.io/IsaacTeleop/client>`_.
+
+#. Enter the IP address of your Isaac Lab host machine in the **Server IP** field.
+
+#. Click the **Click https://<ip>:48322/ to accept cert** link that appears on the page.
+   Accept the certificate in the new page that opens, then navigate back to the
+   CloudXR.js client page.
+
+#. Click Connect to begin teleoperation.
+
+#. **Teleoperation Controls**:
+
+* **Left joystick**: Move the body forward/backward/left/right.
+* **Right joystick**: Squat (down), rotate torso (left/right).
+* **Controllers**: Move end-effector (EE) targets for the arms.
+
+
+.. note::
+
+   If the simulation runs at too low FPS and makes the teleoperation feel laggy, you can try to reduce the XR resolution from the XR tab / Advanced Settings / Render Resolution.
+
+
+Step 4: Record with Quest 3
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. **Recording**: When ready to collect data, run the recording script from the Arena container:
+
+   .. code-block:: bash
+
+      export DATASET_DIR=/datasets/isaaclab_arena/locomanip_apple_tutorial
+      mkdir -p $DATASET_DIR
+
+      # Record demonstrations with OpenXR teleop
+      python isaaclab_arena/scripts/imitation_learning/record_demos.py \
+        --viz kit \
+        --device cpu \
+        --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
+        --num_demos 10 \
+        --num_success_steps 2 \
+        galileo_g1_locomanip_apple_to_plate \
+        --teleop_device openxr
+
+#. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
+
+.. hint::
+
+   Suggested sequence for the task:
+
+   #. Align your body with the robot.
+   #. Walk forward (left joystick forward) toward the shelf.
+   #. Pinch-grasp the apple with a fingertip grip (controllers) — the apple is small and round,
+      so approach it from above and squeeze gently.
+   #. Walk backward (left joystick back) away from the shelf.
+   #. Turn toward the plate on the table (right joystick).
+   #. Walk forward to the table.
+   #. Squat (right joystick down) so the apple hovers just over the plate.
+   #. Open the gripper to release the apple onto the plate (controllers).
+
+.. note::
+
+   Releasing a small round object onto a flat plate is noticeably harder than dropping a box into a
+   bin. Keep the release height low and the orientation stable — successful demonstrations make
+   Isaac Lab Mimic's job much easier in :doc:`step_3_data_generation`.
+
+
+Step 5: Replay Recorded Demos (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To replay the recorded demos:
+
+.. code-block:: bash
+
+   # Replay from the recorded HDF5 dataset
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
+     --viz kit \
+     --device cpu \
+     --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
+     galileo_g1_locomanip_apple_to_plate

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -51,7 +51,7 @@ In another terminal, start the Arena Docker container and launch the teleop sess
    python isaaclab_arena/scripts/imitation_learning/teleop.py \
      --viz kit \
      --device cpu \
-     galileo_g1_locomanip_apple_to_plate \
+     galileo_g1_locomanip_pick_and_place \
      --teleop_device openxr
 
 Start the session from the **XR** tab in the application window.
@@ -103,7 +103,7 @@ Step 4: Record with Quest 3
         --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
         --num_demos 10 \
         --num_success_steps 2 \
-        galileo_g1_locomanip_apple_to_plate \
+        galileo_g1_locomanip_pick_and_place \
         --teleop_device openxr
 
 #. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
@@ -141,4 +141,4 @@ To replay the recorded demos:
      --viz kit \
      --device cpu \
      --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
-     galileo_g1_locomanip_apple_to_plate
+     galileo_g1_locomanip_pick_and_place

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -78,9 +78,9 @@ A strong wireless connection is essential for a high-quality streaming experienc
 
 #. **Teleoperation Controls**:
 
-* **Left joystick**: Move the body forward/backward/left/right.
-* **Right joystick**: Squat (down), rotate torso (left/right).
-* **Controllers**: Move end-effector (EE) targets for the arms.
+   * **Left joystick**: Move the body forward/backward/left/right.
+   * **Right joystick**: Squat (down), rotate torso (left/right).
+   * **Controllers**: Move end-effector (EE) targets for the arms.
 
 
 .. note::

--- a/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_2_teleoperation.rst
@@ -166,7 +166,7 @@ Step 4: Record with Quest 3
         --device cpu \
         --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
         --num_demos 10 \
-        --num_success_steps 2 \
+        --num_success_steps 10 \
         galileo_g1_locomanip_pick_and_place \
         --object apple_01_objaverse_robolab \
         --destination clay_plates_hot3d_robolab \

--- a/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
@@ -109,11 +109,15 @@ You can remove ``--headless`` and add ``--viz kit``
 
 .. note::
 
-   Mimic relies on the ``pick_up_object_name`` field of ``G1LocomanipPickPlaceMimicEnvCfg`` to know
-   which object frame to use in its subtask configuration. The loco-manip task plumbs
-   ``pick_up_object.name`` through to the Mimic config automatically, so the same ``generate_dataset.py``
-   command that works for the brown-box workflow works here — just with ``apple_01_objaverse_robolab``
-   instead of ``brown_box``.
+   Mimic relies on the ``pick_up_object_name`` and ``destination_name`` fields of
+   ``LocomanipPickAndPlaceMimicEnvCfg`` to know which object and destination frames to use in its
+   subtask configuration, and to derive a unique ``datagen_config.name`` per
+   ``(object, destination)`` pair. The loco-manip task plumbs ``pick_up_object.name`` and
+   ``destination_location.name`` through to the Mimic config automatically, so the same
+   ``generate_dataset.py`` command that works for the brown-box + blue-bin workflow works here — just
+   with ``apple_01_objaverse_robolab`` and ``clay_plates_hot3d_robolab``. The apple-to-plate dataset
+   is written under a distinct templated datagen key, so it does not overwrite the brown-box dataset
+   that keeps the preserved ``"locomanip_pick_and_place_D0"`` name.
 
 
 Step 3: Validate Generated Dataset (Optional)

--- a/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
@@ -1,0 +1,140 @@
+Data Generation
+---------------
+
+This workflow covers annotating and generating the demonstration dataset using
+`Isaac Lab Mimic <https://isaac-sim.github.io/IsaacLab/main/source/overview/imitation-learning/teleop_imitation.html>`_.
+
+
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
+
+.. note::
+
+   If you skipped :doc:`step_2_teleoperation` because you don't have teleoperation hardware, this is
+   the step where you rejoin the pipeline. Use the "Download Pre-annotated Dataset" dropdown below to
+   fetch a ready-to-generate annotated HDF5 file (once published) and continue to Step 2 on this page.
+
+
+Step 1: Annotate Demonstrations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This step describes how to annotate the demonstrations recorded in the preceding step
+so they can be used by Isaac Lab Mimic. For more details on Mimic annotation, see the
+`Isaac Lab Mimic documentation <https://isaac-sim.github.io/IsaacLab/main/source/overview/imitation-learning/teleop_imitation.html#annotate-the-demonstrationsl>`_.
+
+To skip this step, you can download the pre-annotated dataset from Hugging Face as described below.
+
+.. dropdown:: Download Pre-annotated Dataset (skip annotation step)
+   :animate: fade-in
+
+   These commands can be used to download the pre-annotated dataset,
+   such that the annotation step can be skipped.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
+         arena_g1_locomanip_apple_dataset_annotated.hdf5 \
+         --repo-type dataset \
+         --local-dir $DATASET_DIR
+
+   .. note::
+
+      The ``nvidia/Arena-G1-Loco-Manipulation-Apple-Task`` dataset repository is a placeholder — it
+      will be populated once apple-to-plate demonstrations are collected and annotated. Until then,
+      you will need to record demonstrations yourself via :doc:`step_2_teleoperation`.
+
+To start the annotation process, run the following command:
+
+.. code-block:: bash
+
+   python isaaclab_arena/scripts/imitation_learning/annotate_demos.py \
+     --viz kit \
+     --device cpu \
+     --input_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
+     --output_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_annotated.hdf5 \
+     --mimic \
+     galileo_g1_locomanip_apple_to_plate
+
+Follow the instructions described on the CLI to complete the annotation.
+
+
+
+Step 2: Generate Augmented Dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Isaac Lab Mimic generates additional demonstrations from the annotated demonstrations
+by applying object and trajectory transformations to introduce data variations.
+
+This step can be skipped by downloading the pre-generated dataset from Hugging Face as described below.
+
+.. dropdown:: Download Pre-generated Dataset (skip data generation step)
+   :animate: fade-in
+
+   These commands can be used to download the pre-generated dataset,
+   such that the data generation step can be skipped.
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
+         arena_g1_locomanip_apple_dataset_generated.hdf5 \
+         --repo-type dataset \
+         --local-dir $DATASET_DIR
+
+Generate the dataset:
+
+.. code-block:: bash
+
+   # Generate 100 demonstrations
+   python isaaclab_arena/scripts/imitation_learning/generate_dataset.py \
+     --headless \
+     --enable_cameras \
+     --mimic \
+     --input_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_annotated.hdf5 \
+     --output_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated.hdf5 \
+     --generation_num_trials 100 \
+     --device cpu \
+     galileo_g1_locomanip_apple_to_plate \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab \
+     --embodiment g1_wbc_pink
+
+Data generation takes 1-4 hours depending on your CPU/GPU.
+You can remove ``--headless`` and add ``--viz kit``
+(before specifying the task name ``galileo_g1_locomanip_apple_to_plate``) to visualize during data generation.
+
+.. note::
+
+   Mimic relies on the ``pick_up_object_name`` field of ``G1LocomanipPickPlaceMimicEnvCfg`` to know
+   which object frame to use in its subtask configuration. The loco-manip task plumbs
+   ``pick_up_object.name`` through to the Mimic config automatically, so the same ``generate_dataset.py``
+   command that works for the brown-box workflow works here — just with ``apple_01_objaverse_robolab``
+   instead of ``brown_box``.
+
+
+Step 3: Validate Generated Dataset (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To visualize the data produced, you can replay the dataset using the following command:
+
+.. code-block:: bash
+
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
+     --viz kit \
+     --device cpu \
+     --enable_cameras \
+     --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated.hdf5 \
+     galileo_g1_locomanip_apple_to_plate \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab \
+     --embodiment g1_wbc_pink
+
+You should see the robot successfully perform the task.
+
+.. note::
+
+   The dataset was generated using CPU device physics, therefore the replay uses ``--device cpu`` to ensure reproducibility.

--- a/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
@@ -21,7 +21,7 @@ Step 1: Annotate Demonstrations
 
 This step describes how to annotate the demonstrations recorded in the preceding step
 so they can be used by Isaac Lab Mimic. For more details on Mimic annotation, see the
-`Isaac Lab Mimic documentation <https://isaac-sim.github.io/IsaacLab/main/source/overview/imitation-learning/teleop_imitation.html#annotate-the-demonstrationsl>`_.
+`Isaac Lab Mimic documentation <https://isaac-sim.github.io/IsaacLab/main/source/overview/imitation-learning/teleop_imitation.html#annotate-the-demonstrations>`_.
 
 To skip this step, you can download the pre-annotated dataset from Hugging Face as described below.
 
@@ -57,7 +57,9 @@ To start the annotation process, run the following command:
      --input_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
      --output_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_annotated.hdf5 \
      --mimic \
-     galileo_g1_locomanip_pick_and_place
+     galileo_g1_locomanip_pick_and_place \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab
 
 Follow the instructions described on the CLI to complete the annotation.
 

--- a/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
@@ -57,7 +57,7 @@ To start the annotation process, run the following command:
      --input_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_recorded.hdf5 \
      --output_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_annotated.hdf5 \
      --mimic \
-     galileo_g1_locomanip_apple_to_plate
+     galileo_g1_locomanip_pick_and_place
 
 Follow the instructions described on the CLI to complete the annotation.
 
@@ -98,14 +98,14 @@ Generate the dataset:
      --output_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated.hdf5 \
      --generation_num_trials 100 \
      --device cpu \
-     galileo_g1_locomanip_apple_to_plate \
+     galileo_g1_locomanip_pick_and_place \
      --object apple_01_objaverse_robolab \
      --destination clay_plates_hot3d_robolab \
      --embodiment g1_wbc_pink
 
 Data generation takes 1-4 hours depending on your CPU/GPU.
 You can remove ``--headless`` and add ``--viz kit``
-(before specifying the task name ``galileo_g1_locomanip_apple_to_plate``) to visualize during data generation.
+(before specifying the task name ``galileo_g1_locomanip_pick_and_place``) to visualize during data generation.
 
 .. note::
 
@@ -128,7 +128,7 @@ To visualize the data produced, you can replay the dataset using the following c
      --device cpu \
      --enable_cameras \
      --dataset_file $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated.hdf5 \
-     galileo_g1_locomanip_apple_to_plate \
+     galileo_g1_locomanip_pick_and_place \
      --object apple_01_objaverse_robolab \
      --destination clay_plates_hot3d_robolab \
      --embodiment g1_wbc_pink

--- a/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_3_data_generation.rst
@@ -9,12 +9,6 @@ This workflow covers annotating and generating the demonstration dataset using
 
 :docker_run_default:
 
-.. note::
-
-   If you skipped :doc:`step_2_teleoperation` because you don't have teleoperation hardware, this is
-   the step where you rejoin the pipeline. Use the "Download Pre-annotated Dataset" dropdown below to
-   fetch a ready-to-generate annotated HDF5 file (once published) and continue to Step 2 on this page.
-
 
 Step 1: Annotate Demonstrations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,30 +16,6 @@ Step 1: Annotate Demonstrations
 This step describes how to annotate the demonstrations recorded in the preceding step
 so they can be used by Isaac Lab Mimic. For more details on Mimic annotation, see the
 `Isaac Lab Mimic documentation <https://isaac-sim.github.io/IsaacLab/main/source/overview/imitation-learning/teleop_imitation.html#annotate-the-demonstrations>`_.
-
-To skip this step, you can download the pre-annotated dataset from Hugging Face as described below.
-
-.. dropdown:: Download Pre-annotated Dataset (skip annotation step)
-   :animate: fade-in
-
-   These commands can be used to download the pre-annotated dataset,
-   such that the annotation step can be skipped.
-
-   To download run:
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
-         arena_g1_locomanip_apple_dataset_annotated.hdf5 \
-         --repo-type dataset \
-         --local-dir $DATASET_DIR
-
-   .. note::
-
-      The ``nvidia/Arena-G1-Loco-Manipulation-Apple-Task`` dataset repository is a placeholder — it
-      will be populated once apple-to-plate demonstrations are collected and annotated. Until then,
-      you will need to record demonstrations yourself via :doc:`step_2_teleoperation`.
 
 To start the annotation process, run the following command:
 
@@ -70,22 +40,6 @@ Step 2: Generate Augmented Dataset
 
 Isaac Lab Mimic generates additional demonstrations from the annotated demonstrations
 by applying object and trajectory transformations to introduce data variations.
-
-This step can be skipped by downloading the pre-generated dataset from Hugging Face as described below.
-
-.. dropdown:: Download Pre-generated Dataset (skip data generation step)
-   :animate: fade-in
-
-   These commands can be used to download the pre-generated dataset,
-   such that the data generation step can be skipped.
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
-         arena_g1_locomanip_apple_dataset_generated.hdf5 \
-         --repo-type dataset \
-         --local-dir $DATASET_DIR
 
 Generate the dataset:
 

--- a/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
@@ -78,16 +78,20 @@ The converter is controlled by a config file at ``isaaclab_arena_gr00t/lerobot/c
 
    .. code-block:: yaml
 
+      # Input/Output paths
       data_root: /datasets/isaaclab_arena/locomanip_apple_tutorial
       hdf5_name: "arena_g1_locomanip_apple_dataset_generated.hdf5"
 
+      # Task description
       language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
       task_index: 2
 
+      # Data field mappings
       state_name_sim: "robot_joint_pos"
       action_name_sim: "processed_actions"
       pov_cam_name_sim: "robot_head_cam_rgb"
 
+      # Output configuration
       fps: 50
       chunks_size: 1000
 

--- a/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
@@ -1,0 +1,147 @@
+Policy Post-Training
+--------------------
+
+This workflow covers post-training an example policy using the generated dataset,
+here we use `GR00T N1.6 <https://github.com/NVIDIA/Isaac-GR00T>`_ as the base model.
+
+**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+
+:docker_run_gr00t:
+
+Once inside the container, set the dataset and models directories.
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/locomanip_apple_tutorial
+    export MODELS_DIR=/models/isaaclab_arena/locomanip_apple_tutorial
+
+Note that this tutorial assumes that you've completed the
+:doc:`preceding step (Data Generation) <step_3_data_generation>` or downloaded the pre-generated dataset.
+
+.. dropdown:: Download Pre-generated Dataset (skip preceding steps)
+   :animate: fade-in
+
+   These commands can be used to download the mimic-generated HDF5 dataset ready for policy post-training,
+   such that the preceding steps can be skipped.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
+         arena_g1_locomanip_apple_dataset_generated.hdf5 \
+         --repo-type dataset \
+         --local-dir $DATASET_DIR
+
+
+Step 1: Convert to LeRobot Format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+GR00T N1.6 requires the dataset to be in LeRobot format.
+We provide a script to convert from the IsaacLab Mimic generated HDF5 dataset to LeRobot format.
+Note that this conversion step can be skipped by downloading the pre-converted LeRobot format dataset.
+
+.. dropdown:: Download Pre-converted LeRobot Dataset (skip conversion step)
+   :animate: fade-in
+
+   These commands can be used to download the pre-converted LeRobot format dataset,
+   such that the conversion step can be skipped.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
+         --include lerobot/* \
+         --repo-type dataset \
+         --local-dir $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated
+
+   If you download this dataset, you can skip the conversion step below and continue to the next step.
+
+Convert the HDF5 dataset to LeRobot format for policy post-training:
+
+.. code-block:: bash
+
+   python isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py \
+     --yaml_file isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml
+
+
+This creates a folder ``$DATASET_DIR/arena_g1_locomanip_apple_dataset_generated/lerobot`` containing parquet files with states/actions,
+MP4 camera recordings, and dataset metadata.
+
+The converter is controlled by a config file at ``isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml``.
+
+.. dropdown:: Configuration file (``g1_locomanip_apple_config.yaml``)
+   :animate: fade-in
+
+   .. code-block:: yaml
+
+      data_root: /datasets/isaaclab_arena/locomanip_apple_tutorial
+      hdf5_name: "arena_g1_locomanip_apple_dataset_generated.hdf5"
+
+      language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
+      task_index: 2
+
+      state_name_sim: "robot_joint_pos"
+      action_name_sim: "processed_actions"
+      pov_cam_name_sim: "robot_head_cam_rgb"
+
+      fps: 50
+      chunks_size: 1000
+
+The main differences from the brown-box config are the ``data_root`` / ``hdf5_name`` pointing at the
+apple-to-plate dataset and the ``language_instruction`` describing the apple-and-plate variant.
+
+
+Step 2: Post-train Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We post-train the GR00T N1.6 policy on the task.
+
+The GR00T N1.6 policy has 3 billion parameters so post-training is an expensive operation.
+We provide one post-training option, 8 GPUs with 48GB memory, to achieve the best quality.
+
+Training takes approximately 4-8 hours on 8x L40s GPUs.
+
+Compute Requirements:
+
+- **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, GB200, etc.)
+- **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+  and multiple dataloader workers requires substantial host memory
+
+Training Configuration:
+
+- **Base Model:** GR00T-N1.6-3B (foundation model)
+- **Tuned Modules:** Visual backbone, projector, diffusion model
+- **Frozen Modules:** LLM (language model)
+- **Batch Size:** 96 (adjust based on GPU memory)
+- **Training Steps:** 20,000
+
+To post-train the policy, run the following command
+
+.. code-block:: bash
+
+   PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH python -m torch.distributed.run --nproc_per_node=8 --standalone submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
+   --dataset_path=$DATASET_DIR/arena_g1_locomanip_apple_dataset_generated/lerobot \
+   --output_dir=$MODELS_DIR \
+   --modality_config_path=isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py \
+   --global_batch_size=96 \
+   --max_steps=20000 \
+   --num_gpus=8 \
+   --save_steps=5000 \
+   --save_total_limit=5 \
+   --base_model_path=nvidia/GR00T-N1.6-3B \
+   --no_tune_llm \
+   --tune_visual \
+   --tune_projector \
+   --tune_diffusion_model \
+   --dataloader_num_workers=8 \
+   --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
+   --embodiment_tag=NEW_EMBODIMENT
+
+
+If you have less powerful GPUs, please see the `GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_
+for information on how to adjust the training configuration to your hardware, to achieve
+the best results. We recommend fine-tuning the visual backbone, projector, and diffusion model for better results.

--- a/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_4_policy_training.rst
@@ -16,23 +16,7 @@ Once inside the container, set the dataset and models directories.
     export MODELS_DIR=/models/isaaclab_arena/locomanip_apple_tutorial
 
 Note that this tutorial assumes that you've completed the
-:doc:`preceding step (Data Generation) <step_3_data_generation>` or downloaded the pre-generated dataset.
-
-.. dropdown:: Download Pre-generated Dataset (skip preceding steps)
-   :animate: fade-in
-
-   These commands can be used to download the mimic-generated HDF5 dataset ready for policy post-training,
-   such that the preceding steps can be skipped.
-
-   To download run:
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
-         arena_g1_locomanip_apple_dataset_generated.hdf5 \
-         --repo-type dataset \
-         --local-dir $DATASET_DIR
+:doc:`preceding step (Data Generation) <step_3_data_generation>`.
 
 
 Step 1: Convert to LeRobot Format
@@ -40,25 +24,6 @@ Step 1: Convert to LeRobot Format
 
 GR00T N1.6 requires the dataset to be in LeRobot format.
 We provide a script to convert from the IsaacLab Mimic generated HDF5 dataset to LeRobot format.
-Note that this conversion step can be skipped by downloading the pre-converted LeRobot format dataset.
-
-.. dropdown:: Download Pre-converted LeRobot Dataset (skip conversion step)
-   :animate: fade-in
-
-   These commands can be used to download the pre-converted LeRobot format dataset,
-   such that the conversion step can be skipped.
-
-   To download run:
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/Arena-G1-Loco-Manipulation-Apple-Task \
-         --include lerobot/* \
-         --repo-type dataset \
-         --local-dir $DATASET_DIR/arena_g1_locomanip_apple_dataset_generated
-
-   If you download this dataset, you can skip the conversion step below and continue to the next step.
 
 Convert the HDF5 dataset to LeRobot format for policy post-training:
 

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -81,7 +81,7 @@ Test the policy in a single environment with visualization via the GUI run:
      --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
      --num_steps 1500 \
      --enable_cameras \
-     galileo_g1_locomanip_apple_to_plate \
+     galileo_g1_locomanip_pick_and_place \
      --object apple_01_objaverse_robolab \
      --destination clay_plates_hot3d_robolab \
      --embodiment g1_wbc_joint
@@ -118,7 +118,7 @@ Parallel evaluation of the policy in multiple parallel environments is also supp
            --enable_cameras \
            --device cuda \
            --policy_device cuda  \
-           galileo_g1_locomanip_apple_to_plate \
+           galileo_g1_locomanip_pick_and_place \
            --object apple_01_objaverse_robolab \
            --destination clay_plates_hot3d_robolab \
            --embodiment g1_wbc_joint
@@ -139,7 +139,7 @@ Parallel evaluation of the policy in multiple parallel environments is also supp
            --policy_device cuda  \
            --distributed \
            --headless \
-           galileo_g1_locomanip_apple_to_plate \
+           galileo_g1_locomanip_pick_and_place \
            --object apple_01_objaverse_robolab \
            --destination clay_plates_hot3d_robolab \
            --embodiment g1_wbc_joint

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -80,6 +80,7 @@ Test the policy in a single environment with visualization via the GUI run:
      --policy_type isaaclab_arena_gr00t.policy.gr00t_closedloop_policy.Gr00tClosedloopPolicy \
      --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
      --num_steps 1500 \
+     --device cpu \
      --enable_cameras \
      galileo_g1_locomanip_pick_and_place \
      --object apple_01_objaverse_robolab \

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -17,30 +17,7 @@ Once inside the container, set the dataset and models directories.
     export MODELS_DIR=/models/isaaclab_arena/locomanip_apple_tutorial
 
 Note that this tutorial assumes that you've completed the
-:doc:`preceding step (Policy Training) <step_4_policy_training>` or downloaded the
-pre-trained model checkpoint below:
-
-.. dropdown:: Download Pre-trained Model (skip preceding steps)
-   :animate: fade-in
-
-   These commands can be used to download the pre-trained GR00T N1.6 policy checkpoint,
-   such that the preceding steps can be skipped.
-   This step requires the Hugging Face CLI, which can be installed by following the
-   `official instructions <https://huggingface.co/docs/huggingface_hub/installation>`_.
-
-   To download run:
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/GN1x-Tuned-Arena-G1-Locomanip-Apple \
-         --local-dir $MODELS_DIR/checkpoint-20000
-
-   .. note::
-
-      The ``nvidia/GN1x-Tuned-Arena-G1-Locomanip-Apple`` checkpoint is a placeholder — it will be
-      populated once apple-to-plate demonstrations have been collected and the policy has been
-      post-trained. Until then, train your own checkpoint via :doc:`step_4_policy_training`.
+:doc:`preceding step (Policy Training) <step_4_policy_training>`.
 
 
 Step 1: Run Single Environment Evaluation

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -130,7 +130,7 @@ Parallel evaluation of the policy in multiple parallel environments is also supp
 
       .. code-block:: bash
 
-         python -m torch.distributed.run --nnode=1 --nproc_per_node=2 isaaclab_arena/evaluation/policy_runner.py \
+         python -m torch.distributed.run --nnodes=1 --nproc_per_node=2 isaaclab_arena/evaluation/policy_runner.py \
            --policy_type isaaclab_arena_gr00t.policy.gr00t_closedloop_policy.Gr00tClosedloopPolicy \
            --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
            --num_steps 1200 \

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -178,13 +178,11 @@ and the number of episodes is more than the single environment evaluation becaus
 
 .. note::
 
-   Because the apple is smaller and rounder than the brown box, and the plate is flat rather than a
-   deep bin, the apple-to-plate task is typically harder than the box-to-bin task. The environment
-   passes a tighter 10 cm Euclidean ``success_proximity_max_distance`` around the plate for the
-   apple-on-plate success condition; the box-to-bin default (contact-sensor-only, i.e.
-   ``success_proximity_max_distance=0.0``) is too permissive for a ~30 cm plate footprint.
-   If you need to tune this for a different apple/plate combination, see the
-   ``_SUCCESS_PROXIMITY_OVERRIDES_M`` dict in
-   ``isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py``, which maps
-   ``(--object, --destination)`` pairs to the ``success_proximity_max_distance`` scalar that the
-   environment forwards to ``LocomanipPickAndPlaceTask``.
+   The apple-to-plate task is typically harder than the brown-box-to-blue-bin task: the apple is
+   smaller and rounder (easier to nudge or roll off the edge), and a ~30 cm flat plate leaves far
+   less drop margin than the deep blue bin. Both variants share the same contact-sensor success
+   termination (``force_threshold=0.5 N``, ``velocity_threshold=0.1 m/s``), filtered to contacts
+   with the ``--destination`` asset. The thresholds are set on ``LocomanipPickAndPlaceTask`` in
+   ``isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py``; tune them
+   on the task constructor if you need a different success criterion for a new apple/plate
+   combination.

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -179,7 +179,9 @@ and the number of episodes is more than the single environment evaluation becaus
 .. note::
 
    Because the apple is smaller and rounder than the brown box, and the plate is flat rather than a
-   deep bin, the apple-to-plate task is typically harder than the box-to-bin task. Expect success rate
-   to be somewhat lower until the task's success thresholds have been tuned for the new assets —
-   see the ``max_z_separation`` and related values in
-   ``isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py``.
+   deep bin, the apple-to-plate task is typically harder than the box-to-bin task. The environment
+   passes tighter 10 cm proximity thresholds on all three axes for the apple-on-plate success
+   condition, since the box-to-bin defaults (26 cm along x) are too loose for a ~30 cm plate.
+   If you need to override these for a different apple/plate combination, see the
+   ``max_x_separation`` / ``max_y_separation`` / ``max_z_separation`` kwargs on
+   ``G1LocomanipPickAndPlaceTask`` in ``isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py``.

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -182,7 +182,7 @@ and the number of episodes is more than the single environment evaluation becaus
    smaller and rounder (easier to nudge or roll off the edge), and a ~30 cm flat plate leaves far
    less drop margin than the deep blue bin. Both variants share the same contact-sensor success
    termination (``force_threshold=0.5 N``, ``velocity_threshold=0.1 m/s``), filtered to contacts
-   with the ``--destination`` asset. The thresholds are set on ``LocomanipPickAndPlaceTask`` in
-   ``isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py``; tune them
-   on the task constructor if you need a different success criterion for a new apple/plate
-   combination.
+   with the ``--destination`` asset. Both values are passed to ``LocomanipPickAndPlaceTask`` from
+   ``isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py``; edit the
+   ``force_threshold`` / ``velocity_threshold`` kwargs there if you need a different success
+   criterion for a new apple/plate combination.

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -72,7 +72,7 @@ by the quality of post-trained policy, the quality of the dataset, and number of
 
 .. code-block:: text
 
-   Metrics: {success_rate: 1.0, num_episodes: 1}
+   [Rank 0/1] Metrics: {'success_rate': 1.0, 'num_episodes': 1}
 
 Step 2: Run Parallel Environments Evaluation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ and the number of episodes is more than the single environment evaluation becaus
 
 .. code-block:: text
 
-   Metrics: {'success_rate': 1.0, 'num_episodes': 4}
+   [Rank 0/1] Metrics: {'success_rate': 1.0, 'num_episodes': 4}
 
 .. note::
 
@@ -151,8 +151,14 @@ and the number of episodes is more than the single environment evaluation becaus
 
 .. note::
 
-   The policy was trained on datasets generated using CPU-based physics, therefore the evaluation uses ``--device cpu`` to ensure physics reproducibility.
-   If you have GPU-generated datasets, you can switch to using GPU-based physics for evaluation by providing the ``--device cuda`` flag.
+   The example policy was trained on datasets generated with CPU-based physics, so the
+   single-environment command above uses ``--device cpu`` to keep evaluation physics aligned
+   with training and give per-episode reproducibility. The parallel commands instead use
+   ``--device cuda`` for throughput -- this swaps the physics backend, so individual episodes
+   are no longer bit-for-bit reproducible against the CPU-trained policy, but aggregate
+   success-rate metrics over many episodes remain informative. If your dataset was generated on
+   GPU physics, prefer ``--device cuda`` for both single and parallel runs to keep evaluation
+   physics aligned with training.
 
 .. note::
 

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -180,8 +180,11 @@ and the number of episodes is more than the single environment evaluation becaus
 
    Because the apple is smaller and rounder than the brown box, and the plate is flat rather than a
    deep bin, the apple-to-plate task is typically harder than the box-to-bin task. The environment
-   passes tighter 10 cm proximity thresholds on all three axes for the apple-on-plate success
-   condition, since the box-to-bin defaults (26 cm along x) are too loose for a ~30 cm plate.
-   If you need to override these for a different apple/plate combination, see the
-   ``max_x_separation`` / ``max_y_separation`` / ``max_z_separation`` kwargs on
-   ``G1LocomanipPickAndPlaceTask`` in ``isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py``.
+   passes a tighter 10 cm Euclidean ``success_proximity_max_distance`` around the plate for the
+   apple-on-plate success condition; the box-to-bin default (contact-sensor-only, i.e.
+   ``success_proximity_max_distance=0.0``) is too permissive for a ~30 cm plate footprint.
+   If you need to tune this for a different apple/plate combination, see the
+   ``_SUCCESS_PROXIMITY_OVERRIDES_M`` dict in
+   ``isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py``, which maps
+   ``(--object, --destination)`` pairs to the ``success_proximity_max_distance`` scalar that the
+   environment forwards to ``LocomanipPickAndPlaceTask``.

--- a/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanip_apple/step_5_evaluation.rst
@@ -1,0 +1,185 @@
+Closed-Loop Policy Inference and Evaluation
+-------------------------------------------
+
+This workflow demonstrates running the trained GR00T N1.6 policy in closed-loop
+and evaluating it in the Arena G1 Loco-Manipulation Apple-to-Plate Task environment.
+
+
+**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+
+:docker_run_gr00t:
+
+Once inside the container, set the dataset and models directories.
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/locomanip_apple_tutorial
+    export MODELS_DIR=/models/isaaclab_arena/locomanip_apple_tutorial
+
+Note that this tutorial assumes that you've completed the
+:doc:`preceding step (Policy Training) <step_4_policy_training>` or downloaded the
+pre-trained model checkpoint below:
+
+.. dropdown:: Download Pre-trained Model (skip preceding steps)
+   :animate: fade-in
+
+   These commands can be used to download the pre-trained GR00T N1.6 policy checkpoint,
+   such that the preceding steps can be skipped.
+   This step requires the Hugging Face CLI, which can be installed by following the
+   `official instructions <https://huggingface.co/docs/huggingface_hub/installation>`_.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/GN1x-Tuned-Arena-G1-Locomanip-Apple \
+         --local-dir $MODELS_DIR/checkpoint-20000
+
+   .. note::
+
+      The ``nvidia/GN1x-Tuned-Arena-G1-Locomanip-Apple`` checkpoint is a placeholder — it will be
+      populated once apple-to-plate demonstrations have been collected and the policy has been
+      post-trained. Until then, train your own checkpoint via :doc:`step_4_policy_training`.
+
+
+Step 1: Run Single Environment Evaluation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We first run the policy in a single environment with visualization via the GUI.
+
+The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml``.
+
+.. dropdown:: Configuration file (``g1_locomanip_apple_gr00t_closedloop_config.yaml``):
+   :animate: fade-in
+
+   .. code-block:: yaml
+
+      model_path: /models/isaaclab_arena/locomanip_apple_tutorial/checkpoint-20000
+      language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
+      action_horizon: 50
+      embodiment_tag: NEW_EMBODIMENT
+      video_backend: decord
+      modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+      policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+      action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+      state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+      action_chunk_length: 50
+      pov_cam_name_sim: "robot_head_cam_rgb"
+
+      task_mode_name: g1_locomanipulation
+
+Test the policy in a single environment with visualization via the GUI run:
+
+.. code-block:: bash
+
+   python isaaclab_arena/evaluation/policy_runner.py \
+     --viz kit \
+     --policy_type isaaclab_arena_gr00t.policy.gr00t_closedloop_policy.Gr00tClosedloopPolicy \
+     --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
+     --num_steps 1500 \
+     --enable_cameras \
+     galileo_g1_locomanip_apple_to_plate \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab \
+     --embodiment g1_wbc_joint
+
+The evaluation should produce the following output on the console at the end of the evaluation.
+You should see similar metrics.
+
+Note that all these metrics are computed over the entire evaluation process, and are affected
+by the quality of post-trained policy, the quality of the dataset, and number of steps in the evaluation.
+
+.. code-block:: text
+
+   Metrics: {success_rate: 1.0, num_episodes: 1}
+
+Step 2: Run Parallel Environments Evaluation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Parallel evaluation of the policy in multiple parallel environments is also supported by the policy runner.
+
+.. tab-set::
+
+   .. tab-item:: Single GPU Evaluation
+
+      Test the policy in 5 parallel environments with visualization via the GUI run:
+
+      .. code-block:: bash
+
+         python isaaclab_arena/evaluation/policy_runner.py \
+           --viz kit \
+           --policy_type isaaclab_arena_gr00t.policy.gr00t_closedloop_policy.Gr00tClosedloopPolicy \
+           --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
+           --num_steps 1200 \
+           --num_envs 5 \
+           --enable_cameras \
+           --device cuda \
+           --policy_device cuda  \
+           galileo_g1_locomanip_apple_to_plate \
+           --object apple_01_objaverse_robolab \
+           --destination clay_plates_hot3d_robolab \
+           --embodiment g1_wbc_joint
+
+   .. tab-item:: Distribute Multi-GPU Evaluation
+
+      Test the policy in 5 parallel environments on each GPU with 2 GPUs total run:
+
+      .. code-block:: bash
+
+         python -m torch.distributed.run --nnode=1 --nproc_per_node=2 isaaclab_arena/evaluation/policy_runner.py \
+           --policy_type isaaclab_arena_gr00t.policy.gr00t_closedloop_policy.Gr00tClosedloopPolicy \
+           --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml \
+           --num_steps 1200 \
+           --num_envs 5 \
+           --enable_cameras \
+           --device cuda \
+           --policy_device cuda  \
+           --distributed \
+           --headless \
+           galileo_g1_locomanip_apple_to_plate \
+           --object apple_01_objaverse_robolab \
+           --destination clay_plates_hot3d_robolab \
+           --embodiment g1_wbc_joint
+
+
+And during the evaluation, you should see the following output on the console at the end of the evaluation
+indicating which environments are terminated (task-specific conditions like the apple is placed onto the plate,
+or the episode length is exceeded by 30 seconds),
+or truncated (if timeouts are enabled, like the maximum episode length is exceeded).
+
+.. code-block:: text
+
+   Resetting policy for terminated env_ids: tensor([3], device='cuda:0') and truncated env_ids: tensor([], device='cuda:0', dtype=torch.int64)
+
+At the end of the evaluation, you should see the following output on the console indicating the metrics.
+You can see that the success rate might not be 1.0 as more trials are being evaluated and randomizations are being introduced,
+and the number of episodes is more than the single environment evaluation because of the parallelization.
+
+.. code-block:: text
+
+   Metrics: {'success_rate': 1.0, 'num_episodes': 4}
+
+.. note::
+
+   Note that the embodiment used in closed-loop policy inference is ``g1_wbc_joint``, which is different
+   from ``g1_wbc_pink`` used in data generation.
+   This is because during tele-operation, the upper body is controlled via target end-effector poses,
+   which are realized by using the PINK IK controller, and the lower body is controlled via a WBC policy.
+   GR00T N1.6 policy is trained on upper body joint positions and lower body WBC policy inputs, so we use
+   ``g1_wbc_joint`` for closed-loop policy inference.
+
+.. note::
+
+   The policy was trained on datasets generated using CPU-based physics, therefore the evaluation uses ``--device cpu`` to ensure physics reproducibility.
+   If you have GPU-generated datasets, you can switch to using GPU-based physics for evaluation by providing the ``--device cuda`` flag.
+
+.. note::
+
+   Because the apple is smaller and rounder than the brown box, and the plate is flat rather than a
+   deep bin, the apple-to-plate task is typically harder than the box-to-bin task. Expect success rate
+   to be somewhat lower until the task's success thresholds have been tuned for the new assets —
+   see the ``max_z_separation`` and related values in
+   ``isaaclab_arena/tasks/g1_locomanip_pick_and_place_task.py``.

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -117,7 +117,7 @@ class GalileoLocomanipBackground(LibraryBackground):
     tags = ["background"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/background_library/galileo_locomanip/galileo_locomanip.usd"
     initial_pose = Pose(position_xyz=(4.420, 1.408, -0.795), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
-    object_min_z = -0.2
+    object_min_z = -0.3
 
     def __init__(self):
         super().__init__()

--- a/isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml
+++ b/isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Gr00tDatasetConfig Example Configuration
+# This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
+# Example for G1 loco-manipulation apple-to-plate task
+
+data_root: "/datasets/isaaclab_arena/locomanip_apple_tutorial"
+
+language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
+task_index: 2
+
+hdf5_name: "arena_g1_locomanip_apple_dataset_generated.hdf5"
+
+state_name_sim: "robot_joint_pos"
+left_eef_pos_name_sim: "left_eef_pos"
+left_eef_quat_name_sim: "left_eef_quat"
+right_eef_pos_name_sim: "right_eef_pos"
+right_eef_quat_name_sim: "right_eef_quat"
+teleop_base_height_command_name_sim: "base_height_cmd"
+teleop_navigate_command_name_sim: "navigate_cmd"
+teleop_torso_orientation_rpy_command_name_sim: "torso_orientation_rpy_cmd"
+action_name_sim: "processed_actions"
+pov_cam_name_sim: "robot_head_cam_rgb"
+
+state_name_lerobot: "observation.state"
+action_name_lerobot: "action"
+action_eef_name_sim: "action.eef"
+video_name_lerobot: "observation.images.ego_view"
+task_description_lerobot: "annotation.human.task_description"
+
+chunks_size: 1000
+
+fps: 50
+
+data_path: "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
+video_path: "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4"
+
+modality_template_path: "isaaclab_arena_gr00t/embodiments/g1/modality.json"
+modality_fname: "modality.json"
+episodes_fname: "episodes.jsonl"
+tasks_fname: "tasks.jsonl"
+info_template_path: "isaaclab_arena_gr00t/embodiments/g1/info.json"
+info_fname: "info.json"
+
+policy_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml"
+robot_type: "unitree_g1"
+
+action_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
+state_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
+
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]

--- a/isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml
+++ b/isaaclab_arena_gr00t/lerobot/config/g1_locomanip_apple_config.yaml
@@ -7,13 +7,17 @@
 # This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
 # Example for G1 loco-manipulation apple-to-plate task
 
+# Root directory for all data storage
 data_root: "/datasets/isaaclab_arena/locomanip_apple_tutorial"
 
+# Instruction given to the policy in natural language
 language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
 task_index: 2
 
+# Name of the HDF5 file to use for the dataset
 hdf5_name: "arena_g1_locomanip_apple_dataset_generated.hdf5"
 
+# Mimic-generated HDF5 datafield names
 state_name_sim: "robot_joint_pos"
 left_eef_pos_name_sim: "left_eef_pos"
 left_eef_quat_name_sim: "left_eef_quat"
@@ -25,19 +29,24 @@ teleop_torso_orientation_rpy_command_name_sim: "torso_orientation_rpy_cmd"
 action_name_sim: "processed_actions"
 pov_cam_name_sim: "robot_head_cam_rgb"
 
+# Gr00t-LeRobot datafield names
 state_name_lerobot: "observation.state"
 action_name_lerobot: "action"
 action_eef_name_sim: "action.eef"
 video_name_lerobot: "observation.images.ego_view"
 task_description_lerobot: "annotation.human.task_description"
 
+# Parquet configuration
 chunks_size: 1000
 
+# Video configuration
 fps: 50
 
+# File path templates
 data_path: "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
 video_path: "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4"
 
+# Configuration file paths
 modality_template_path: "isaaclab_arena_gr00t/embodiments/g1/modality.json"
 modality_fname: "modality.json"
 episodes_fname: "episodes.jsonl"
@@ -45,11 +54,14 @@ tasks_fname: "tasks.jsonl"
 info_template_path: "isaaclab_arena_gr00t/embodiments/g1/info.json"
 info_fname: "info.json"
 
+# policy specific parameters (gr00t demonstration data stored in lerobot format)
 policy_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml"
 robot_type: "unitree_g1"
 
+# Robot simulation specific parameters
 action_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
 state_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
 
+# Image configuration (height, width, channels)
 original_image_size: [480, 640, 3]
 target_image_size: [480, 640, 3]

--- a/isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/g1_locomanip_apple_gr00t_closedloop_config.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This file shows how to configure the Gr00tClosedloopPolicy class for G1 loco-manipulation apple-to-plate task
+model_path: /models/isaaclab_arena/locomanip_apple_tutorial/checkpoint-20000
+language_instruction: "Pick up the apple from the shelf, and place it onto the plate on the table located at the right of the shelf."
+action_horizon: 50
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 50
+pov_cam_name_sim: "robot_head_cam_rgb"
+
+task_mode_name: g1_locomanipulation


### PR DESCRIPTION
## Summary
Document the end-to-end imitation learning pipeline for the new galileo_g1_locomanip_apple_to_plate environment, mirroring the existing box-to-bin loco-manipulation workflow.

## Detailed description
- Add overview (index) and five step pages: environment setup, teleoperation, data generation, policy post-training, and closed-loop evaluation.
- Register the new workflow in docs/pages/example_workflows/ imitation_learning/index.rst.
- Add LeRobot conversion config (g1_locomanip_apple_config.yaml) and GR00T closed-loop inference config (g1_locomanip_apple_gr00t_closedloop_config.yaml).