### PR TITLE
Reduce to minimum policy runner tests.

### DIFF
--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -56,64 +56,34 @@ def run_policy_runner(
 
 
 @pytest.mark.with_subprocess
-def test_zero_action_policy_press_button():
-    run_policy_runner(
-        policy_type="zero_action",
-        example_environment="press_button",
-        num_steps=NUM_STEPS,
-    )
-
-
-@pytest.mark.with_subprocess
-@pytest.mark.parametrize("embodiment", ["franka_ik", "gr1_pink", "gr1_joint"])
-@pytest.mark.parametrize("object_name", ["cracker_box", "tomato_soup_can"])
-def test_zero_action_policy_kitchen_pick_and_place(embodiment, object_name):
-    # TODO(alexmillane, 2025.07.29): Get an exhaustive list of all scenes and embodiments
-    # from a registry when we have one.
+def test_zero_action_policy():
     run_policy_runner(
         policy_type="zero_action",
         example_environment="kitchen_pick_and_place",
-        embodiment=embodiment,
-        object_name=object_name,
+        embodiment="franka_ik",
+        object_name="cracker_box",
         num_steps=NUM_STEPS,
     )
 
 
 @pytest.mark.with_subprocess
-def test_zero_action_policy_galileo_pick_and_place():
-    # TODO(alexmillane, 2025.07.29): Get an exhaustive list of all scenes and embodiments
-    # from a registry when we have one.
-    # NOTE(alexmillane, 2025.09.04): Only test one configuration here to keep
-    # the test fast.
-    run_policy_runner(
-        policy_type="zero_action",
-        example_environment="galileo_pick_and_place",
-        embodiment="gr1_pink",
-        object_name="power_drill",
-        num_steps=NUM_STEPS,
-    )
-
-
-@pytest.mark.with_subprocess
-@pytest.mark.parametrize("object_name", ["cracker_box", "tomato_soup_can", "mustard_bottle"])
-def test_zero_action_policy_gr1_open_microwave(object_name):
-    # TODO(alexmillane, 2025.07.29): Get an exhaustive list of all scenes and embodiments
-    # from a registry when we have one.
-    run_policy_runner(
-        policy_type="zero_action",
-        example_environment="gr1_open_microwave",
-        embodiment="gr1_pink",
-        object_name=object_name,
-        num_steps=NUM_STEPS,
-    )
-
-
-@pytest.mark.with_subprocess
-def test_replay_policy_gr1_open_microwave():
+def test_replay_policy():
     run_policy_runner(
         policy_type="replay",
         replay_file_path=TestConstants.test_data_dir + "/test_demo_gr1_open_microwave.hdf5",
         example_environment="gr1_open_microwave",
         embodiment="gr1_pink",
+        num_steps=NUM_STEPS,
+    )
+
+
+@pytest.mark.with_subprocess
+@pytest.mark.parametrize("object_name", ["cracker_box", "tomato_soup_can"])
+def test_zero_action_policy_with_objects(object_name):
+    run_policy_runner(
+        policy_type="zero_action",
+        example_environment="gr1_open_microwave",
+        embodiment="gr1_pink",
+        object_name=object_name,
         num_steps=NUM_STEPS,
     )


### PR DESCRIPTION
## Summary
Reduce to a minimum number of policy runner tests.

## Detailed description
- These tests are slow and flaky
- Reduce to a minimal number to try to speed up CI and decrease the probability it stalls.

## Not done
- This reduces our test coverage on our environments (which was already very low)
- I will try, in a follow up MR, to add complete coverage of the environments **in process**, so that they're fast to run.
