### PR TITLE
[Doc] Update training doc system requirements and defaults

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -110,8 +110,14 @@ Training takes approximately 4-8 hours on 8x L40s GPUs.
 Compute Requirements:
 
 - **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, GB200, etc.)
-- **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+- **System RAM:** 512 GB or more recommended — multi-GPU training with large batch sizes
   and multiple dataloader workers requires substantial host memory
+
+.. note::
+
+   If your system has less RAM or fewer GPUs, you can reduce ``global_batch_size`` and
+   ``dataloader_num_workers`` to fit your hardware. Training will still work but will take
+   longer to converge.
 
 Training Configuration:
 
@@ -139,7 +145,7 @@ To post-train the policy, run the following command
    --tune_visual \
    --tune_projector \
    --tune_diffusion_model \
-   --dataloader_num_workers=8 \
+   --dataloader_num_workers=16 \
    --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
    --embodiment_tag=NEW_EMBODIMENT
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -126,8 +126,14 @@ We provide two post-training options:
       Compute Requirements:
 
       - **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, A6000, A100)
-      - **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+      - **System RAM:** 512 GB or more recommended — multi-GPU training with large batch sizes
         and multiple dataloader workers requires substantial host memory
+
+      .. note::
+
+         If your system has less RAM or fewer GPUs, you can reduce ``global_batch_size`` and
+         ``dataloader_num_workers`` to fit your hardware. Training will still work but will take
+         longer to converge.
 
       Training Configuration:
 
@@ -156,7 +162,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=8 \
+         --dataloader_num_workers=16 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -191,7 +197,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=8 \
+         --dataloader_num_workers=16 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -197,7 +197,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=4 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -119,8 +119,14 @@ We provide two post-training options:
       Compute Requirements:
 
       - **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, A6000, A100)
-      - **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+      - **System RAM:** 512 GB or more recommended — multi-GPU training with large batch sizes
         and multiple dataloader workers requires substantial host memory
+
+      .. note::
+
+         If your system has less RAM or fewer GPUs, you can reduce ``global_batch_size`` and
+         ``dataloader_num_workers`` to fit your hardware. Training will still work but will take
+         longer to converge.
 
       Training Configuration:
 
@@ -149,7 +155,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=8 \
+         --dataloader_num_workers=16 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
@@ -184,7 +190,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=8 \
+         --dataloader_num_workers=16 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -190,7 +190,7 @@ We provide two post-training options:
          --tune_visual \
          --tune_projector \
          --tune_diffusion_model \
-         --dataloader_num_workers=16 \
+         --dataloader_num_workers=4 \
          --embodiment_tag=GR1 \
          --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
          --save_total_limit=5


### PR DESCRIPTION
## Summary
Address https://nvbugspro.nvidia.com/bug/6084606. Update training doc system requirements and defaults

## Detailed description
Across all three workflow docs (locomanipulation, static_manipulation, sequential_static_manipulation):

- Increased recommended system RAM from 256 GB to 512 GB
- Changed --dataloader_num_workers from 8 to 16 in all training commands
- Added a .. note:: explaining that global_batch_size and dataloader_num_workers can be reduced on less powerful hardware at the cost of longer training time
