### PR TITLE
Remove Isaac Sim warmup to cache.

### DIFF
--- a/.github/actions/setup-isaac-sim-kit-cache/action.yml
+++ b/.github/actions/setup-isaac-sim-kit-cache/action.yml
@@ -34,8 +34,3 @@ runs:
       with:
         path: /isaac-sim/kit/cache
         key: isaac-kit-cache-${{ steps.read_version.outputs.isaac_sim_version }}
-
-    - name: Warmup shader cache if cache missed
-      if: steps.isaac_sim_cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: /isaac-sim/warmup.sh


### PR DESCRIPTION
## Summary
Calling the isaac sim warmup script appears to stall things. Removing.
