### PR TITLE
Fix teleop doc bugs (#623)

### DIFF
--- a/docs/images/xr_start_button.png
+++ b/docs/images/xr_start_button.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ace30634352a22ed51c353631a9b1a35e7c0260beb2230b2b784a864e46019d6
+size 28978

--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -22,6 +22,17 @@ Step 1: Start the CloudXR Runtime
 
       python -m isaacteleop.cloudxr
 
+.. attention::
+
+   The first run will prompt users to accept the NVIDIA CloudXR License Agreement.
+   To accept the EULA, reply ``Yes`` when prompted with the below message:
+
+   .. code:: bash
+
+      NVIDIA CloudXR EULA must be accepted to run. View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+
+      Accept NVIDIA CloudXR EULA? [y/N]: Yes
+
 
 Step 2: Start Arena Teleop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -72,6 +72,18 @@ Step 1: Start the CloudXR Runtime
 
             python -m isaacteleop.cloudxr --cloudxr-env-config=avp.env
 
+.. attention::
+
+   The first run will prompt users to accept the NVIDIA CloudXR License Agreement.
+   To accept the EULA, reply ``Yes`` when prompted with the below message:
+
+   .. code:: bash
+
+      NVIDIA CloudXR EULA must be accepted to run. View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+
+      Accept NVIDIA CloudXR EULA? [y/N]: Yes
+
+
 Step 2: Start Recording
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -103,6 +115,13 @@ Step 2: Start Recording
         --object ranch_dressing_hope_robolab \
         --embodiment gr1_pink \
         --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+   .. figure:: ../../../images/xr_start_button.png
+      :width: 55%
+      :alt: Start XR button in the XR tab
+      :align: center
 
 
 Step 3: Connect XR Device and Record

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -72,6 +72,18 @@ Step 1: Start the CloudXR Runtime
 
             python -m isaacteleop.cloudxr --cloudxr-env-config=avp.env
 
+.. attention::
+
+   The first run will prompt users to accept the NVIDIA CloudXR License Agreement.
+   To accept the EULA, reply ``Yes`` when prompted with the below message:
+
+   .. code:: bash
+
+      NVIDIA CloudXR EULA must be accepted to run. View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+
+      Accept NVIDIA CloudXR EULA? [y/N]: Yes
+
+
 Step 2: Start Recording
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -101,6 +113,13 @@ Step 2: Start Recording
         --num_success_steps 2 \
         gr1_open_microwave \
         --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+   .. figure:: ../../../images/xr_start_button.png
+      :width: 55%
+      :alt: Start XR button in the XR tab
+      :align: center
 
 
 Step 3: Connect XR Device and Record

--- a/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
@@ -6,10 +6,9 @@ This workflow covers generating a new dataset using
 
 Note that this tutorial assumes that you've completed the
 :doc:`preceding step (Teleoperation Data Collection) <step_2_teleoperation>`.
-If you do not want to do the preceding step of recording demonstrations, you can jump to
-you can download the pre-generated dataset either in
+If you do not want to do the preceding step of recording demonstrations, you can jump to either
 :ref:`step_1_annotate_demonstrations` or :ref:`step_2_generate_augmented_dataset`
-below.
+below and download the pre-provided datasets.
 
 
 **Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)


### PR DESCRIPTION
## Summary
Fixes  bugs in the teleop docs:

1. Add a missing section on starting XR session for GR1 workflows
2. Add note to accept CloudXR EULA
3. Fix grammar mistake in static manip docs

(cherry picked from commit 8172896ef1be4b4c93c4d78f9c429e50ecfefd1c)
