### PR TITLE
Force isaaclab newton specified mujoco version (#629)

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -52,6 +52,15 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 # Install Isaac Teleop Python APIs (retargeters, device I/O, OpenXR bindings)
 RUN /isaac-sim/python.sh -m pip install isaacteleop~=1.1.0 --extra-index-url https://pypi.nvidia.com
 
+# Install isaaclab_newton's [all] extra so its pinned mujoco / mujoco-warp / newton
+# versions take effect. The earlier `isaaclab*` loop above and `isaaclab.sh -i`
+# install with `--no-deps` and without the extra, so the pins in
+# `isaaclab_newton/setup.py::EXTRAS_REQUIRE["all"]` are otherwise ignored,
+# and `isaaclab` pulls `mujoco-warp>=3.5` which resolves to 3.7.x — where
+# `geom_dataid` is 2D and breaks the pinned Newton's SolverMuJoCo kernels.
+RUN /isaac-sim/python.sh -m pip install -e \
+      "${WORKDIR}/submodules/IsaacLab/source/isaaclab_newton[all]"
+
 # Upgrade pip ahead of the editable install
 RUN /isaac-sim/python.sh -m pip install --upgrade pip
 


### PR DESCRIPTION
## Summary
This fixes the isaaclab newton training crashing from arena docker bug https://nvbugspro.nvidia.com/bug/6100149

## Detailed description
- What was the reason for the change? isaaclab source/isaaclab_newton/setup.py specified EXTRAS_REQUIRE to ping the mujoco/newton dep versions to "mujoco==3.5.0" / "newton @ git+https://github.com/newton-physics/newton.git@2684d75bfa4bb8b058a93b81c458a74b7701c997"

however, arena docker installs the isaaclab dependencies through isaaclab.sh which only specifies "mujoco>=3.5" in isaaclab source/isaaclab/setup.py

Result: the arena container ends up with mujoco-warp==3.7.0.1 + newton==1.1.0, from recent updates, which crashes with the arena submodule version of isaaclab.

- What has been changed? Update the arena dockerfile to force
submodules/IsaacLab/source/isaaclab_newton[all] specifically.

- What is the impact of this change? 
Fixes the newton training example crash
