### PR TITLE
Add teleop reset known issue and workaround to doc (#631)

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -159,6 +159,14 @@ Step 4: Record with Quest 3
    :align: center
    :height: 400px
 
+.. warning::
+
+   **Known issue:** the squat height does not reset correctly between demos. As a
+   workaround, after each completed demo:
+
+   #. Use the **right joystick** (up) to stand the robot back up.
+   #. Use the control panel to **Reset**, then **Play** to start the next demo.
+
 
 Step 5: Replay Recorded Demos (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
Current isaacteleop version has buggy reset (squat height is wrong). Won't be able to fix it in 0.2 release (requires isaaclab / isaacteleop version update which is too risky). Add this known issue ans work around instruction to doc.
This is for bug https://nvbugspro.nvidia.com/bug/6103425

## Summary
Short description of the change (max 50 chars)

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
