### PR TITLE
fix stale cache

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -70,7 +70,7 @@ ENV LW_API_ENDPOINT="https://api-dev.lightwheel.net"
 # HuggingFace CLI for downloading datasets and models.
 # Use pipx so the hf binary gets an isolated venv with all its deps (e.g. requests),
 # without touching system Python packages.
-RUN apt-get install -y pipx && \
+RUN apt-get update && apt-get install -y pipx && \
     PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install \
     "huggingface-hub[cli]" \


### PR DESCRIPTION
## Summary

- When installing pipx, the base image's apt cache is stale, so the specific .deb URL for python3.12-venv (a dependency of pipx) 404s on the Ubuntu mirror. 
- It is eported by VDR and reproducible on a fresh built locally.
- Adding apt-get update before the install refreshes the package index so it resolves the current URLs.

