### PR TITLE
[DOC] Fix installation version and benchmark link

### DIFF
--- a/docs/pages/quickstart/installation.rst
+++ b/docs/pages/quickstart/installation.rst
@@ -6,10 +6,10 @@ This page describes how to install Isaac Lab Arena from source inside a Docker c
 Supported Systems
 -----------------
 
-Isaac Lab Arena runs on Isaac Sim ``5.1.0`` and Isaac Lab ``2.3.0``.
+Isaac Lab Arena runs on Isaac Sim ``6.0.0`` and Isaac Lab ``3.0.0``.
 The dependencies are installed automatically during the Docker build process.
 Hardware requirements for Isaac Lab Arena are shared with Isaac Sim, and are detailed in
-`Isaac Sim Requirements <https://docs.isaacsim.omniverse.nvidia.com/5.1.0/installation/requirements.html>`_.
+`Isaac Sim Requirements <https://docs.isaacsim.omniverse.nvidia.com/6.0.0/installation/requirements.html>`_.
 
 
 Installation via Docker

--- a/docs/pages/references/citing_us.rst
+++ b/docs/pages/references/citing_us.rst
@@ -13,18 +13,19 @@ We encourage the community to build and publish benchmarks on Isaac Lab-Arena. T
 2. **Reference your benchmark and Isaac Lab-Arena in publications.** When publishing on ArXiv or
    elsewhere, cite both your benchmark (by name, with a link to your repository) and Isaac Lab-Arena
    as the underlying evaluation framework.
+
+   You can cite Isaac Lab-Arena as follows:
+
+   .. code-block:: bibtex
+
+      @misc{isaaclab-arena2025,
+         title   = {Isaac Lab-Arena: Composable Environment Creation and Policy Evaluation for Robotics},
+         author  = {{NVIDIA Isaac Lab-Arena Contributors}},
+         year    = {2025},
+         url     = {https://github.com/isaac-sim/IsaacLab-Arena}
+      }
+
 3. **List it here.** Open a PR to add your benchmark to the
-   `Published Benchmarks <https://isaac-sim.github.io/IsaacLab-Arena/main/pages/references/published_benchmarks.html>`_
-   list above. This README serves as the single source of truth for the Arena benchmark ecosystem so that
+   `Published Benchmarks <https://github.com/isaac-sim/IsaacLab-Arena/tree/main#published-benchmarks>`_ list.
+   This list serves as the single source of truth for the Arena benchmark ecosystem so that
    the community can discover and reuse.
-
-If you use Isaac Lab-Arena in your research, please cite:
-
-.. code-block:: bibtex
-
-   @misc{isaaclab-arena2025,
-       title   = {Isaac Lab-Arena: Composable Environment Creation and Policy Evaluation for Robotics},
-       author  = {{NVIDIA Isaac Lab-Arena Contributors}},
-       year    = {2025},
-       url     = {https://github.com/isaac-sim/IsaacLab-Arena}
-   }


### PR DESCRIPTION
## Summary
Doc only, fix version tags in installation page and reference to published benchmarks.
Cherrypick #652 