### PR TITLE
Add GR00T remote closed-loop policy + base-container support

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -103,6 +103,13 @@ RUN if [ "$INSTALL_GROOT" = "true" ]; then \
   rm -f /tmp/install_cuda.sh
 # Copy GR00T
 COPY ./submodules/Isaac-GR00T ${WORKDIR}/submodules/Isaac-GR00T
+# Always make the `gr00t` package importable so the lightweight remote
+# PolicyClient (gr00t.policy.server_client) works in the base container.
+# The full GR00T runtime (torch + flash-attn + transformers + ...) is still
+# gated behind INSTALL_GROOT=true below.
+RUN /isaac-sim/python.sh -m pip install msgpack==1.1.0 msgpack-numpy==0.4.8 pyzmq==27.0.1 && \
+    /isaac-sim/python.sh -m pip install --no-deps --ignore-requires-python -e ${WORKDIR}/submodules/Isaac-GR00T/
+# TODO(xinjieyao, 2026-04-27): remove this after remote policy done refactoring
 # Copy GR00T dependencies installation script
 COPY docker/setup/install_gr00t_deps.sh /tmp/install_gr00t_deps.sh
 RUN chmod +x /tmp/install_gr00t_deps.sh

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -31,10 +31,7 @@ from isaaclab_arena_gr00t.policy.gr00t_core import (
     extract_obs_numpy_from_torch,
     load_gr00t_joint_configs,
 )
-from isaaclab_arena_gr00t.utils.io_utils import (
-    create_config_from_yaml,
-    load_gr00t_modality_config_from_file,
-)
+from isaaclab_arena_gr00t.utils.io_utils import create_config_from_yaml, load_gr00t_modality_config_from_file
 
 
 # TODO(xinjieyao, 2026-04-27): consider adding RemotePolicyArgs to inherit from BasePolicyArgs
@@ -122,9 +119,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
             strict=False,
         )
         if not self._client.ping():
-            raise ConnectionError(
-                f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}"
-            )
+            raise ConnectionError(f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}")
 
         self.task_description: str | None = None
 

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GR00T remote closed-loop policy using GR00T's native PolicyClient.
+
+This policy connects to a GR00T policy server (launched via
+``gr00t/eval/run_gr00t_server.py``) and reuses the same observation/action
+translation pipeline as the local ``Gr00tClosedloopPolicy``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gymnasium as gym
+import torch
+from dataclasses import dataclass, field
+from typing import Any
+
+from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
+
+from isaaclab_arena.policy.action_chunking import ActionChunkingState
+from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
+from isaaclab_arena_gr00t.policy.gr00t_core import (
+    Gr00tBasePolicyArgs,
+    build_gr00t_action_tensor,
+    build_gr00t_policy_observations,
+    compute_action_dim,
+    extract_obs_numpy_from_torch,
+    load_gr00t_joint_configs,
+)
+from isaaclab_arena_gr00t.utils.io_utils import (
+    create_config_from_yaml,
+    load_gr00t_modality_config_from_file,
+)
+
+
+# TODO(xinjieyao, 2026-04-27): consider adding RemotePolicyArgs to inherit from BasePolicyArgs
+# and then having Gr00tRemoteClosedloopPolicyArgs inherit from RemotePolicyArgs
+@dataclass
+class Gr00tRemoteClosedloopPolicyArgs(Gr00tBasePolicyArgs):
+    """Configuration for Gr00tRemoteClosedloopPolicy.
+
+    Inherits policy_config_yaml_path and policy_device from Gr00tBasePolicyArgs,
+    and adds remote server connection parameters and num_envs.
+    """
+
+    num_envs: int = field(default=1, metadata={"help": "Number of environments to simulate"})
+    remote_host: str = field(default="localhost", metadata={"help": "GR00T policy server hostname"})
+    remote_port: int = field(default=5555, metadata={"help": "GR00T policy server port"})
+    remote_api_token: str | None = field(default=None, metadata={"help": "API token for the policy server"})
+
+    @classmethod
+    def from_cli_args(cls, args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicyArgs:
+        """Create configuration from parsed CLI arguments."""
+        return cls(
+            policy_config_yaml_path=args.policy_config_yaml_path,
+            policy_device=args.policy_device,
+            num_envs=args.num_envs,
+            remote_host=args.remote_host,
+            remote_port=args.remote_port,
+            remote_api_token=getattr(args, "remote_api_token", None),
+        )
+
+
+# TODO(xinjieyao, 2026-04-27): add policy registry
+class Gr00tRemoteClosedloopPolicy(PolicyBase):
+    """GR00T closed-loop policy that delegates inference to a remote GR00T server.
+
+    Uses GR00T's native ``PolicyClient`` (from ``gr00t.policy.server_client``)
+    to communicate with a GR00T policy server.
+    """
+
+    name = "gr00t_remote_closedloop"
+    config_class = Gr00tRemoteClosedloopPolicyArgs
+
+    def __init__(self, config: Gr00tRemoteClosedloopPolicyArgs):
+        super().__init__(config)
+
+        # Policy config (for obs/action translation — no model loading)
+        # TODO(xinjieyao, 2026-04-27): to be refactored
+        self.policy_config: Gr00tClosedloopPolicyConfig = create_config_from_yaml(
+            config.policy_config_yaml_path, Gr00tClosedloopPolicyConfig
+        )
+        self.num_envs = config.num_envs
+        self.device = config.policy_device
+        self.task_mode = TaskMode(self.policy_config.task_mode_name)
+
+        # Joint configs (for sim from/to policy joint space remapping)
+        (
+            self.policy_joints_config,
+            self.robot_action_joints_config,
+            self.robot_state_joints_config,
+        ) = load_gr00t_joint_configs(self.policy_config)
+
+        self.modality_configs = load_gr00t_modality_config_from_file(
+            self.policy_config.modality_config_path,
+            self.policy_config.embodiment_tag,
+        )
+
+        # Action / chunk shapes
+        self.action_dim = compute_action_dim(self.task_mode, self.robot_action_joints_config)
+        self.action_chunk_length = self.policy_config.action_chunk_length
+
+        # TODO(xinjieyao, 2026-04-27): consider adding & using ActionChunkingScheduler instead
+        self._chunking_state = ActionChunkingState(
+            num_envs=self.num_envs,
+            action_chunk_length=self.action_chunk_length,
+            action_horizon=self.policy_config.action_horizon,
+            action_dim=self.action_dim,
+            device=self.device,
+            dtype=torch.float,
+        )
+
+        # Connect to GR00T's native PolicyClient
+        self._client = Gr00tPolicyClient(
+            host=config.remote_host,
+            port=config.remote_port,
+            api_token=config.remote_api_token,
+            strict=False,
+        )
+        if not self._client.ping():
+            raise ConnectionError(
+                f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}"
+            )
+
+        self.task_description: str | None = None
+
+    # ---------------------- CLI helpers -------------------
+
+    @staticmethod
+    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        group = parser.add_argument_group(
+            "Gr00t Remote Closedloop Policy",
+            "Arguments for GR00T remote closed-loop policy evaluation.",
+        )
+        group.add_argument(
+            "--policy_config_yaml_path",
+            type=str,
+            required=True,
+            help="Path to the Gr00t closedloop policy config YAML file",
+        )
+        group.add_argument(
+            "--policy_device",
+            type=str,
+            default="cuda",
+            help="Device for Arena-side tensor operations (default: cuda)",
+        )
+        group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
+        group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
+        group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")
+        return parser
+
+    @staticmethod
+    def from_args(args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicy:
+        config = Gr00tRemoteClosedloopPolicyArgs.from_cli_args(args)
+        return Gr00tRemoteClosedloopPolicy(config)
+
+    # ---------------------- Policy interface -------------------
+
+    def set_task_description(self, task_description: str | None) -> str:
+        if task_description is None:
+            task_description = self.policy_config.language_instruction
+        if not task_description:
+            raise ValueError(
+                "No language instruction provided. Set 'language_instruction' in the job config, "
+                "pass --language_instruction on the CLI, or define 'task_description' on the task class."
+            )
+        self.task_description = task_description
+        return self.task_description
+
+    def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
+        def fetch_chunk() -> torch.Tensor:
+            return self._get_action_chunk(observation, self.policy_config.pov_cam_name_sim)
+
+        return self._chunking_state.get_action(fetch_chunk)
+
+    def _get_action_chunk(
+        self, observation: dict[str, Any], camera_names: list[str] | str = "robot_head_cam_rgb"
+    ) -> torch.Tensor:
+        """Get an action chunk from the remote GR00T server.
+
+        Calls GR00T's PolicyClient to get the action chunk.
+        """
+        if isinstance(camera_names, str):
+            camera_names = [camera_names]
+
+        # 1. Reuse the same obs translation as local policy
+        assert self.task_description is not None, "Task description is not set"
+        rgb_list_np, joint_pos_sim_np = extract_obs_numpy_from_torch(nested_obs=observation, camera_names=camera_names)
+        policy_observations = build_gr00t_policy_observations(
+            rgb_list_np=rgb_list_np,
+            joint_pos_sim_np=joint_pos_sim_np,
+            task_description=self.task_description,
+            policy_config=self.policy_config,
+            robot_state_joints_config=self.robot_state_joints_config,
+            policy_joints_config=self.policy_joints_config,
+            modality_configs=self.modality_configs,
+        )
+
+        # 2. Call GR00T's own client
+        robot_action_policy, _ = self._client.get_action(policy_observations)
+
+        # 3. Action translation from policy output to sim action tensor
+        action_tensor = build_gr00t_action_tensor(
+            robot_action_policy=robot_action_policy,
+            task_mode=self.task_mode,
+            policy_joints_config=self.policy_joints_config,
+            robot_action_joints_config=self.robot_action_joints_config,
+            device=self.device,
+            embodiment_tag=self.policy_config.embodiment_tag,
+        )
+
+        assert action_tensor.shape[0] == self.num_envs and action_tensor.shape[1] >= self.action_chunk_length
+        return action_tensor
+
+    def reset(self, env_ids: torch.Tensor | None = None):
+        if env_ids is None:
+            env_ids = slice(None)
+        self._client.reset()
+        self._chunking_state.reset(env_ids)

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -6,8 +6,7 @@
 """GR00T remote closed-loop policy using GR00T's native PolicyClient.
 
 This policy connects to a GR00T policy server (launched via
-``gr00t/eval/run_gr00t_server.py``) and reuses the same observation/action
-translation pipeline as the local ``Gr00tClosedloopPolicy``.
+``gr00t/eval/run_gr00t_server.py``) and uses its own observation/action translation pipeline.
 """
 
 from __future__ import annotations

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -142,6 +142,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
             default="cuda",
             help="Device for Arena-side tensor operations (default: cuda)",
         )
+        group.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate")
         group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
         group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
         group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -142,7 +142,6 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
             default="cuda",
             help="Device for Arena-side tensor operations (default: cuda)",
         )
-        group.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate")
         group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
         group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
         group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for Gr00tRemoteClosedloopPolicy.
+
+Exercises the real obs/action translation pipeline and mocks only ``Gr00tPolicyClient`` -- the wire
+boundary to a remote GR00T server -- so no server is required.
+
+Verifies:
+- the obs dict sent to the server has the expected language/video/state structure;
+- the action dict returned by the server is converted to a tensor of the
+  expected (num_envs, action_chunk_length, action_dim) shape;
+- ``reset`` propagates to the client;
+- a failing ping during construction raises ``ConnectionError``.
+"""
+# TODO(xinjieyao, 2026-04-27):will be moved to base container test when removing deprecated local policy
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import yaml
+from typing import Any
+
+import pytest
+
+from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
+
+
+NUM_ENVS = 2
+ORIGINAL_HEIGHT = 480
+ORIGINAL_WIDTH = 640
+NUM_CHANNELS = 3
+NUM_SIM_JOINTS = 43  # G1 43-DoF
+ACTION_HORIZON = 50
+ACTION_CHUNK_LENGTH = 50
+EXPECTED_ACTION_DIM = 50  # 43 joints + 3 nav + 1 base height + 3 torso rpy
+
+# Joint group sizes from gr00t_43dof_joint_space.yaml (must match the YAML).
+POLICY_GROUP_SIZES = {
+    "left_leg": 6,
+    "right_leg": 6,
+    "waist": 3,
+    "left_arm": 7,
+    "left_hand": 7,
+    "right_arm": 7,
+    "right_hand": 7,
+}
+
+
+# ----------------------------- fixtures ------------------------------ #
+
+
+@pytest.fixture
+def policy_config_yaml(tmp_path):
+    """Write a copy of the g1 locomanip test config with model_path set to a
+    HuggingFace repo id so ``Gr00tClosedloopPolicyConfig.__post_init__`` passes
+    without a real checkpoint on disk (the remote policy never loads it)."""
+    src = (
+        Gr00tTestConstants.test_data_dir
+        + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
+    )
+    with open(src) as f:
+        cfg = yaml.safe_load(f)
+    cfg["model_path"] = "nvidia/GR00T-N1.6-3B"  # HF id passes _is_huggingface_model_id
+    dst = tmp_path / "remote_closedloop_config.yaml"
+    with open(dst, "w") as f:
+        yaml.dump(cfg, f)
+    return str(dst)
+
+
+@pytest.fixture
+def synthetic_observation():
+    """Env-shaped torch obs: one ego camera + 43 joint positions per env."""
+    rgb = torch.randint(
+        0, 255, (NUM_ENVS, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS), dtype=torch.uint8
+    )
+    joint_pos = torch.randn(NUM_ENVS, NUM_SIM_JOINTS, dtype=torch.float32)
+    return {
+        "camera_obs": {"robot_head_cam_rgb": rgb},
+        "policy": {"robot_joint_pos": joint_pos},
+    }
+
+
+def _make_action_response(num_envs: int, horizon: int) -> dict[str, np.ndarray]:
+    """Synthetic GR00T-server response in the format ``build_gr00t_action_np`` expects."""
+    response: dict[str, np.ndarray] = {}
+    for group, size in POLICY_GROUP_SIZES.items():
+        response[group] = np.random.randn(num_envs, horizon, size).astype(np.float32)
+    response["navigate_command"] = np.random.randn(num_envs, horizon, 3).astype(np.float32)
+    response["base_height_command"] = np.random.randn(num_envs, horizon, 1).astype(np.float32)
+    return response
+
+
+class _FakePolicyClient:
+    """Minimal stand-in for ``gr00t.policy.server_client.PolicyClient``."""
+
+    def __init__(self, *args, ping_ok: bool = True, **kwargs):
+        self.init_kwargs = kwargs
+        self._ping_ok = ping_ok
+        self.last_observation: dict[str, Any] | None = None
+        self.get_action_calls = 0
+        self.reset_called = False
+
+    def ping(self) -> bool:
+        return self._ping_ok
+
+    def get_action(self, observation: dict[str, Any]):
+        self.last_observation = observation
+        self.get_action_calls += 1
+        # Match the real PolicyClient return signature: (action_dict, latency_or_meta).
+        return _make_action_response(NUM_ENVS, ACTION_HORIZON), None
+
+    def reset(self):
+        self.reset_called = True
+
+
+@pytest.fixture
+def fake_client_factory(monkeypatch):
+    """Patch ``Gr00tPolicyClient`` in the policy module's namespace and return
+    a factory that gives access to the most recently constructed fake."""
+    from isaaclab_arena_gr00t.policy import gr00t_remote_closedloop_policy as mod
+
+    created: list[_FakePolicyClient] = []
+
+    def factory(ping_ok: bool = True):
+        def _ctor(*args, **kwargs):
+            client = _FakePolicyClient(*args, ping_ok=ping_ok, **kwargs)
+            created.append(client)
+            return client
+
+        monkeypatch.setattr(mod, "Gr00tPolicyClient", _ctor)
+        return created
+
+    return factory
+
+
+def _build_policy(policy_config_yaml: str):
+    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
+        Gr00tRemoteClosedloopPolicy,
+        Gr00tRemoteClosedloopPolicyArgs,
+    )
+
+    args = Gr00tRemoteClosedloopPolicyArgs(
+        policy_config_yaml_path=policy_config_yaml,
+        policy_device="cpu",  # keep the test portable; remote policy does no GPU compute
+        num_envs=NUM_ENVS,
+        remote_host="unused",
+        remote_port=0,
+        remote_api_token=None,
+    )
+    return Gr00tRemoteClosedloopPolicy(args)
+
+
+# ------------------------------- tests ------------------------------- #
+
+
+def test_observation_sent_to_server_has_expected_structure(
+    policy_config_yaml, synthetic_observation, fake_client_factory
+):
+    """The dict passed to ``PolicyClient.get_action`` matches GR00T's expected
+    language/video/state layout for the g1 sim WBC modality config."""
+    clients = fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    policy.set_task_description("pick up the brown box")
+
+    policy._get_action_chunk(synthetic_observation, ["robot_head_cam_rgb"])
+
+    assert len(clients) == 1
+    sent = clients[0].last_observation
+    assert sent is not None and clients[0].get_action_calls == 1
+
+    # language: one [task] entry per env
+    assert "language" in sent
+    lang = sent["language"]["annotation.human.task_description"]
+    assert lang == [["pick up the brown box"]] * NUM_ENVS
+
+    # video: one ego view, shaped (N, 1, H, W, C) and uint8
+    assert "video" in sent and "ego_view" in sent["video"]
+    ego = sent["video"]["ego_view"]
+    assert ego.shape == (NUM_ENVS, 1, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS)
+    assert ego.dtype == np.uint8
+
+    # state: one (N, 1, dof_in_group) entry per modality state key
+    expected_state_keys = {"left_arm", "right_arm", "left_hand", "right_hand", "waist"}
+    assert set(sent["state"].keys()) == expected_state_keys
+    for key in expected_state_keys:
+        arr = sent["state"][key]
+        assert arr.ndim == 3
+        assert arr.shape[0] == NUM_ENVS
+        assert arr.shape[1] == 1
+        assert arr.shape[2] == POLICY_GROUP_SIZES[key]
+
+
+def test_action_response_is_translated_to_correct_tensor_shape(
+    policy_config_yaml, synthetic_observation, fake_client_factory
+):
+    """Server's grouped joint dict is reassembled into a (N, chunk, action_dim) tensor."""
+    fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    policy.set_task_description("pick up the brown box")
+
+    action = policy._get_action_chunk(synthetic_observation, ["robot_head_cam_rgb"])
+
+    assert isinstance(action, torch.Tensor)
+    # _get_action_chunk asserts action_tensor.shape[1] >= action_chunk_length, but
+    # the full horizon is returned; pin both dims explicitly.
+    assert action.shape == (NUM_ENVS, ACTION_HORIZON, EXPECTED_ACTION_DIM)
+    assert action.device.type == "cpu"
+
+
+def test_reset_propagates_to_client(policy_config_yaml, fake_client_factory):
+    clients = fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    assert clients[0].reset_called is False
+    policy.reset()
+    assert clients[0].reset_called is True
+
+
+def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_client_factory):
+    fake_client_factory(ping_ok=False)
+    with pytest.raises(ConnectionError):
+        _build_policy(policy_config_yaml)

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -28,7 +28,6 @@ import pytest
 
 from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
 
-
 NUM_ENVS = 2
 ORIGINAL_HEIGHT = 480
 ORIGINAL_WIDTH = 640
@@ -58,10 +57,7 @@ def policy_config_yaml(tmp_path):
     """Write a copy of the g1 locomanip test config with model_path set to a
     HuggingFace repo id so ``Gr00tClosedloopPolicyConfig.__post_init__`` passes
     without a real checkpoint on disk (the remote policy never loads it)."""
-    src = (
-        Gr00tTestConstants.test_data_dir
-        + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
-    )
+    src = Gr00tTestConstants.test_data_dir + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
     with open(src) as f:
         cfg = yaml.safe_load(f)
     cfg["model_path"] = "nvidia/GR00T-N1.6-3B"  # HF id passes _is_huggingface_model_id
@@ -74,9 +70,7 @@ def policy_config_yaml(tmp_path):
 @pytest.fixture
 def synthetic_observation():
     """Env-shaped torch obs: one ego camera + 43 joint positions per env."""
-    rgb = torch.randint(
-        0, 255, (NUM_ENVS, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS), dtype=torch.uint8
-    )
+    rgb = torch.randint(0, 255, (NUM_ENVS, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS), dtype=torch.uint8)
     joint_pos = torch.randn(NUM_ENVS, NUM_SIM_JOINTS, dtype=torch.float32)
     return {
         "camera_obs": {"robot_head_cam_rgb": rgb},

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -206,11 +206,30 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
     """
     from gr00t.configs.data.embodiment_configs import MODALITY_CONFIGS
     from gr00t.data.embodiment_tags import EmbodimentTag
-    from gr00t.experiment.launch_finetune import load_modality_config
 
+    # TODO(xinjieyao, 2026-04-27): to be refactored after adding gr00t remote policy
     if modality_config_path:
-        # Import module for side-effect registration
-        load_modality_config(modality_config_path)
+        # Import the user's modality config module for its side-effect of
+        # registering entries into MODALITY_CONFIGS.
+        #
+        # Prefer GR00T's own helper when available (full GR00T container),
+        # but fall back to an inlined copy so the base container — which
+        # ships GR00T as source only and does not install training deps
+        # like tyro — still works.
+        try:
+            from gr00t.experiment.launch_finetune import load_modality_config
+
+            load_modality_config(modality_config_path)
+        except ImportError:
+            import importlib
+            import sys
+
+            path = Path(modality_config_path)
+            if path.exists() and path.suffix == ".py":
+                sys.path.append(str(path.parent))
+                importlib.import_module(path.stem)
+            else:
+                raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
 
     # Get the embodiment tag from policy config and convert to EmbodimentTag enum
     # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -221,15 +221,19 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
 
             load_modality_config(modality_config_path)
         except ImportError:
-            import importlib
-            import sys
+            import importlib.util
 
             path = Path(modality_config_path)
-            if path.exists() and path.suffix == ".py":
-                sys.path.append(str(path.parent))
-                importlib.import_module(path.stem)
-            else:
+            if not (path.exists() and path.suffix == ".py"):
                 raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
+            # Load by file location so we (a) don't mutate sys.path and (b) always
+            # execute the module body — register_modality_config() runs every call,
+            # rather than being skipped on a sys.modules cache hit.
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not load modality config from {path}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
 
     # Get the embodiment tag from policy config and convert to EmbodimentTag enum
     # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)


### PR DESCRIPTION
## Summary
Add GR00T remote closed-loop policy + base-container support

## Detailed description
- Why: Run GR00T closed-loop eval against a remote server from the base Arena container, without dragging in the full GR00T training stack (torch / flash-attn / transformers).
- What: 
- 
1. New `Gr00tRemoteClosedloopPolicy` that reuses the local obs/action pipeline but talks to GR00T's `PolicyClient` over zmq, plus mock-based unit tests
2. `io_utils.load_gr00t_modality_config_from_file` falls back to an inlined `load_modality_config` so it works without tyro
3. base Dockerfile now installs msgpack/msgpack-numpy/pyzmq and pip install --no-deps -e of the GR00T source.

- Impact: Remote GR00T eval now works in the base container

## TODO
- Action chunking
- Pi remote policy
- Refactor policy cfg class
- Remove existing gr00t imple