### PR TITLE
Pluggable action schedulers for the GR00T remote policy

### DIFF
--- a/isaaclab_arena/policy/action_chunking.py
+++ b/isaaclab_arena/policy/action_chunking.py
@@ -11,7 +11,7 @@ import torch
 from collections.abc import Callable
 
 
-# TODO(xinjieyao, 2026-05-06): to be recycled
+# TODO(xinjieyao, 2026-05-06): Delete once all callers have migrated to action_scheduling.ActionChunkScheduler
 class ActionChunkingState:
     """Holds chunk buffer, per-env index, and refill flag; provides get_action(fetch_chunk_fn).
 

--- a/isaaclab_arena/policy/action_chunking.py
+++ b/isaaclab_arena/policy/action_chunking.py
@@ -11,6 +11,7 @@ import torch
 from collections.abc import Callable
 
 
+# TODO(xinjieyao, 2026-05-06): to be recycled
 class ActionChunkingState:
     """Holds chunk buffer, per-env index, and refill flag; provides get_action(fetch_chunk_fn).
 

--- a/isaaclab_arena/policy/action_chunking_client.py
+++ b/isaaclab_arena/policy/action_chunking_client.py
@@ -21,7 +21,7 @@ from isaaclab_arena.remote_policy.action_protocol import ChunkingActionProtocol
 from isaaclab_arena.remote_policy.remote_policy_config import RemotePolicyConfig
 
 
-# TODO(xinjieyao, 2026-05-06): to be recycled
+# TODO(xinjieyao, 2026-05-06): Delete once all callers have migrated to action_scheduling.ActionChunkScheduler
 class ActionChunkingClientSidePolicy(ClientSidePolicy):
     """Client-side policy that consumes fixed-length action chunks sequentially."""
 

--- a/isaaclab_arena/policy/action_chunking_client.py
+++ b/isaaclab_arena/policy/action_chunking_client.py
@@ -21,6 +21,7 @@ from isaaclab_arena.remote_policy.action_protocol import ChunkingActionProtocol
 from isaaclab_arena.remote_policy.remote_policy_config import RemotePolicyConfig
 
 
+# TODO(xinjieyao, 2026-05-06): to be recycled
 class ActionChunkingClientSidePolicy(ClientSidePolicy):
     """Client-side policy that consumes fixed-length action chunks sequentially."""
 

--- a/isaaclab_arena/policy/action_scheduling/__init__.py
+++ b/isaaclab_arena/policy/action_scheduling/__init__.py
@@ -5,3 +5,4 @@
 
 from .action_chunk_scheduler import ActionChunkScheduler
 from .action_scheduler import ActionScheduler
+from .synced_batch_action_scheduler import SyncedBatchActionScheduler

--- a/isaaclab_arena/policy/action_scheduling/__init__.py
+++ b/isaaclab_arena/policy/action_scheduling/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .action_chunk_scheduler import ActionChunkScheduler
+from .action_scheduler import ActionScheduler

--- a/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
@@ -51,12 +51,21 @@ class ActionChunkScheduler(ActionScheduler):
         self._total_envs_needed: int = 0
         self._per_env_fetch_count = torch.zeros(num_envs, dtype=torch.int64, device=device)
 
-    def get_action(self, fetch_action_tensor_fn: Callable[[], torch.Tensor]) -> torch.Tensor:
+    def get_action(
+        self,
+        fetch_action_tensor_fn: Callable[[], torch.Tensor],
+        hold_action: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """Return one action per env, refilling the chunk when needed.
 
         fetch_action_tensor_fn() must return a tensor of shape (num_envs, horizon, action_dim)
         with horizon >= action_horizon.
+
+        ``hold_action`` is part of the base ``ActionScheduler`` API for schedulers that
+        need a fallback for waiting envs (e.g. ``SyncedBatchActionScheduler``); this
+        scheduler doesn't have a waiting state so the argument is accepted and ignored.
         """
+        del hold_action
         assert self.current_action_index.min() >= 0, "At least one env's action index is less than 0"
         assert (
             self.current_action_index.max() < self.action_chunk_length

--- a/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
@@ -62,10 +62,22 @@ class ActionChunkScheduler(ActionScheduler):
         with horizon >= action_horizon.
 
         ``hold_action`` is part of the base ``ActionScheduler`` API for schedulers that
-        need a fallback for waiting envs (e.g. ``SyncedBatchActionScheduler``); this
-        scheduler doesn't have a waiting state so the argument is accepted and ignored.
+        need a fallback for waiting envs; this scheduler doesn't have a waiting state
+        so the argument is accepted and ignored.
         """
         del hold_action
+        if self.env_requires_new_chunk.any():
+            new_chunk = fetch_action_tensor_fn()
+            mask = self.env_requires_new_chunk
+            self.current_action_chunk[mask] = new_chunk[mask]
+            self.current_action_index[mask] = 0
+            self.env_requires_new_chunk[mask] = False
+
+            self._n_fetch_calls += 1
+            n_needed = int(mask.sum().item())
+            self._total_envs_needed += n_needed
+            self._per_env_fetch_count[mask] += 1
+
         assert self.current_action_index.min() >= 0, "At least one env's action index is less than 0"
         assert (
             self.current_action_index.max() < self.action_chunk_length

--- a/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/action_chunk_scheduler.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ActionChunkScheduler: buffer an action chunk and step through it sequentially."""
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Callable
+
+from isaaclab_arena.policy.action_scheduling.action_scheduler import ActionScheduler
+
+
+class ActionChunkScheduler(ActionScheduler):
+    """Buffers one action chunk and replays it one step at a time.
+
+    Fetches a new action tensor from the policy only when the current one is exhausted.
+    Per-env tracking allows environments to refetch independently.
+    """
+
+    def __init__(
+        self,
+        num_envs: int,
+        action_chunk_length: int,
+        action_horizon: int,
+        action_dim: int,
+        device: str | torch.device,
+        dtype: torch.dtype = torch.float32,
+    ) -> None:
+        self.num_envs = num_envs
+        self.action_chunk_length = action_chunk_length
+        self.action_horizon = action_horizon
+        self.action_dim = action_dim
+        self.device = device
+
+        self.current_action_chunk = torch.zeros(
+            (num_envs, action_horizon, action_dim),
+            dtype=dtype,
+            device=device,
+        )
+        # Use a bool list to indicate that the action chunk is not yet computed for each env
+        # True means the action chunk is not yet computed, False means the action
+        self.current_action_index = torch.zeros(num_envs, dtype=torch.int32, device=device)
+        self.env_requires_new_chunk = torch.ones(num_envs, dtype=torch.bool, device=device)
+
+        # Fetch-efficiency tracking: how many times each env triggered a chunk fetch,
+        # and how many envs actually needed the fetch vs. total (wasted compute detection).
+        self._n_fetch_calls: int = 0
+        self._total_envs_needed: int = 0
+        self._per_env_fetch_count = torch.zeros(num_envs, dtype=torch.int64, device=device)
+
+    def get_action(self, fetch_action_tensor_fn: Callable[[], torch.Tensor]) -> torch.Tensor:
+        """Return one action per env, refilling the chunk when needed.
+
+        fetch_action_tensor_fn() must return a tensor of shape (num_envs, horizon, action_dim)
+        with horizon >= action_horizon.
+        """
+        assert self.current_action_index.min() >= 0, "At least one env's action index is less than 0"
+        assert (
+            self.current_action_index.max() < self.action_chunk_length
+        ), "At least one env's action index is greater than the action chunk length"
+
+        # Take one action per env at the current index (before incrementing)
+        batch_idx = torch.arange(self.num_envs, device=self.device)
+        action = self.current_action_chunk[batch_idx, self.current_action_index]
+        assert action.shape == (
+            self.num_envs,
+            self.action_dim,
+        ), f"{action.shape=} != ({self.num_envs}, {self.action_dim})"
+
+        self.current_action_index += 1
+        reset_env_ids = self.current_action_index == self.action_chunk_length
+        self.current_action_chunk[reset_env_ids] = 0.0
+        self.env_requires_new_chunk = self.current_action_index >= self.action_chunk_length
+        self.current_action_index[reset_env_ids] = -1
+
+        return action
+
+    def reset(self, env_ids: torch.Tensor | slice | None = None) -> None:
+        """Reset chunking state for the given envs (all if None)."""
+        if env_ids is None:
+            env_ids = slice(None)
+        self.current_action_chunk[env_ids] = 0.0
+        self.current_action_index[env_ids] = -1
+        self.env_requires_new_chunk[env_ids] = True

--- a/isaaclab_arena/policy/action_scheduling/action_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/action_scheduler.py
@@ -21,11 +21,18 @@ class ActionScheduler(ABC):
     """
 
     @abstractmethod
-    def get_action(self, fetch_action_tensor_fn: Callable[[], torch.Tensor]) -> torch.Tensor:
+    def get_action(
+        self,
+        fetch_action_tensor_fn: Callable[[], torch.Tensor],
+        hold_action: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         """Return one action per env for the current timestep.
 
         Args:
             fetch_action_tensor_fn: Callable that queries the action and returns an action tensor.
+            hold_action: Optional ``(num_envs, action_dim)`` tensor used by schedulers
+                that need a fallback action for envs waiting on others. Schedulers that don't
+                need it accept ``None`` and ignore the argument so callers can use a uniform call site.
 
         Returns:
             Per-step action tensor of shape ``(num_envs, action_dim)``.

--- a/isaaclab_arena/policy/action_scheduling/action_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/action_scheduler.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Abstract base class for action scheduling strategies."""
+
+from __future__ import annotations
+
+import torch
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+
+
+class ActionScheduler(ABC):
+    """Translates raw action outputs into per-step actions.
+
+    The policy calls ``get_action(fetch_action_fn)`` at every environment step.
+    The scheduler controls when to query the action and how to derive a single
+    action from one or more action outputs.
+    """
+
+    @abstractmethod
+    def get_action(self, fetch_action_tensor_fn: Callable[[], torch.Tensor]) -> torch.Tensor:
+        """Return one action per env for the current timestep.
+
+        Args:
+            fetch_action_tensor_fn: Callable that queries the action and returns an action tensor.
+
+        Returns:
+            Per-step action tensor of shape ``(num_envs, action_dim)``.
+        """
+        ...

--- a/isaaclab_arena/policy/action_scheduling/synced_batch_action_scheduler.py
+++ b/isaaclab_arena/policy/action_scheduling/synced_batch_action_scheduler.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SyncedBatchActionScheduler: hold per-env state until every env needs a new chunk."""
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Callable
+
+from isaaclab_arena.policy.action_scheduling.action_chunk_scheduler import ActionChunkScheduler
+
+
+class SyncedBatchActionScheduler(ActionChunkScheduler):
+    """ActionChunkScheduler that waits until ALL envs need a new chunk before calling inference.
+
+    Envs that exhaust their chunk early hold their current robot state until every env is ready.
+    Only then is one full-batch inference call made for all envs together.
+
+    Tradeoff vs ActionChunkScheduler:
+    - Action tensor batch is always full (N envs, never wasted)
+    - Envs that reset early hold their post-reset state for up to
+      (action_chunk_length - 1) steps before receiving a fresh action tensor
+    """
+
+    def get_action(
+        self,
+        fetch_action_tensor_fn: Callable[[], torch.Tensor],
+        hold_action: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return one action per env, fetching only when all envs need a new chunk.
+
+        Args:
+            fetch_action_tensor_fn: Callable that queries the action and returns an action tensor.
+            hold_action: (num_envs, action_dim) current robot joint state; applied
+                to envs that are waiting for others to catch up. Required for this
+                scheduler — defaulted to ``None`` only to match the base API.
+        """
+        if hold_action is None:
+            raise ValueError("SyncedBatchActionScheduler.get_action requires a hold_action tensor")
+        if self.env_requires_new_chunk.all():
+            self._n_fetch_calls += 1
+            self._total_envs_needed += self.num_envs
+            self._per_env_fetch_count += 1
+
+            new_chunk = fetch_action_tensor_fn()
+            self.current_action_chunk[:] = new_chunk
+            self.current_action_index[:] = 0
+            self.env_requires_new_chunk[:] = False
+
+        waiting = self.env_requires_new_chunk
+        batch_idx = torch.arange(self.num_envs, device=self.device)
+        action = self.current_action_chunk[batch_idx, self.current_action_index.clamp(min=0)]
+        action[waiting] = hold_action[waiting]
+
+        self.current_action_index[~waiting] += 1
+        exhausted = (~waiting) & (self.current_action_index >= self.action_chunk_length)
+        self.current_action_chunk[exhausted] = 0.0
+        self.current_action_index[exhausted] = -1
+        self.env_requires_new_chunk[exhausted] = True
+
+        return action

--- a/isaaclab_arena/tests/test_action_scheduling.py
+++ b/isaaclab_arena/tests/test_action_scheduling.py
@@ -26,22 +26,14 @@ def _make_chunk() -> torch.Tensor:
     )
 
 
-def _load_chunk(scheduler, chunk: torch.Tensor) -> None:
-    """Manually seed the scheduler's buffer (ActionChunkScheduler.get_action steps but does not fetch)."""
-    scheduler.current_action_chunk[:] = chunk
-    scheduler.current_action_index[:] = 0
-    scheduler.env_requires_new_chunk[:] = False
-
-
 # ----------------------------- ActionChunkScheduler ------------------------------
 
 
-def test_action_chunk_scheduler_steps_through_loaded_chunk():
+def test_action_chunk_scheduler_steps_through_chunk_and_refetches_when_exhausted():
     from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
 
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     chunk = _make_chunk()
-    _load_chunk(scheduler, chunk)
 
     fetch_calls = 0
 
@@ -50,20 +42,42 @@ def test_action_chunk_scheduler_steps_through_loaded_chunk():
         fetch_calls += 1
         return chunk
 
-    for k in range(ACTION_CHUNK_LENGTH):
+    # First call: every env needs a chunk → exactly one fetch, action is slot 0.
+    a0 = scheduler.get_action(fetch)
+    assert fetch_calls == 1
+    assert a0.shape == (NUM_ENVS, ACTION_DIM)
+    torch.testing.assert_close(a0, chunk[:, 0])
+
+    # Subsequent calls within the chunk step without re-fetching.
+    for k in range(1, ACTION_CHUNK_LENGTH):
         action = scheduler.get_action(fetch)
-        assert action.shape == (NUM_ENVS, ACTION_DIM)
         torch.testing.assert_close(action, chunk[:, k])
+    assert fetch_calls == 1
 
     # After draining the chunk, every env should be flagged as needing a new one.
     assert scheduler.env_requires_new_chunk.all()
+
+    # Next call triggers a new fetch.
+    scheduler.get_action(fetch)
+    assert fetch_calls == 2
 
 
 def test_action_chunk_scheduler_reset_marks_all_envs_for_refetch():
     from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
 
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
-    _load_chunk(scheduler, _make_chunk())
+    chunk = _make_chunk()
+
+    fetch_calls = 0
+
+    def fetch() -> torch.Tensor:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return chunk
+
+    # Drive one step so the buffer is populated and indices have advanced.
+    scheduler.get_action(fetch)
+    assert fetch_calls == 1
     assert not scheduler.env_requires_new_chunk.any()
 
     scheduler.reset()
@@ -72,17 +86,39 @@ def test_action_chunk_scheduler_reset_marks_all_envs_for_refetch():
     assert (scheduler.current_action_index == -1).all()
     assert (scheduler.current_action_chunk == 0.0).all()
 
+    # Next get_action must trigger a refetch.
+    scheduler.get_action(fetch)
+    assert fetch_calls == 2
+
 
 def test_action_chunk_scheduler_reset_per_env_only_touches_selected_envs():
     from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
 
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
-    _load_chunk(scheduler, _make_chunk())
+    chunk = _make_chunk()
+
+    fetch_calls = 0
+
+    def fetch() -> torch.Tensor:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return chunk
+
+    # Populate both envs through a normal fetch+step.
+    scheduler.get_action(fetch)
+    assert fetch_calls == 1
 
     scheduler.reset(torch.tensor([1]))
 
+    # env 0 keeps its (advanced) state; env 1 is flagged for refetch.
     assert scheduler.env_requires_new_chunk.tolist() == [False, True]
-    assert scheduler.current_action_index.tolist() == [0, -1]
+    assert scheduler.current_action_index.tolist() == [1, -1]
+
+    # Next call refetches because env 1 needs a chunk; env 0 must not be overwritten.
+    env0_buffer_before = scheduler.current_action_chunk[0].clone()
+    scheduler.get_action(fetch)
+    assert fetch_calls == 2
+    torch.testing.assert_close(scheduler.current_action_chunk[0], env0_buffer_before)
 
 
 # --------------------------- SyncedBatchActionScheduler --------------------------

--- a/isaaclab_arena/tests/test_action_scheduling.py
+++ b/isaaclab_arena/tests/test_action_scheduling.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 import torch
 
-from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, SyncedBatchActionScheduler
-
 NUM_ENVS = 2
 ACTION_CHUNK_LENGTH = 4
 ACTION_HORIZON = 4
@@ -28,7 +26,7 @@ def _make_chunk() -> torch.Tensor:
     )
 
 
-def _load_chunk(scheduler: ActionChunkScheduler, chunk: torch.Tensor) -> None:
+def _load_chunk(scheduler, chunk: torch.Tensor) -> None:
     """Manually seed the scheduler's buffer (ActionChunkScheduler.get_action steps but does not fetch)."""
     scheduler.current_action_chunk[:] = chunk
     scheduler.current_action_index[:] = 0
@@ -39,6 +37,8 @@ def _load_chunk(scheduler: ActionChunkScheduler, chunk: torch.Tensor) -> None:
 
 
 def test_action_chunk_scheduler_steps_through_loaded_chunk():
+    from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
+
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     chunk = _make_chunk()
     _load_chunk(scheduler, chunk)
@@ -60,6 +60,8 @@ def test_action_chunk_scheduler_steps_through_loaded_chunk():
 
 
 def test_action_chunk_scheduler_reset_marks_all_envs_for_refetch():
+    from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
+
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     _load_chunk(scheduler, _make_chunk())
     assert not scheduler.env_requires_new_chunk.any()
@@ -72,6 +74,8 @@ def test_action_chunk_scheduler_reset_marks_all_envs_for_refetch():
 
 
 def test_action_chunk_scheduler_reset_per_env_only_touches_selected_envs():
+    from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
+
     scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     _load_chunk(scheduler, _make_chunk())
 
@@ -85,6 +89,8 @@ def test_action_chunk_scheduler_reset_per_env_only_touches_selected_envs():
 
 
 def test_synced_batch_scheduler_fetches_only_when_all_envs_need_a_chunk():
+    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
+
     scheduler = SyncedBatchActionScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     chunk = _make_chunk()
     hold = torch.full((NUM_ENVS, ACTION_DIM), -1.0)
@@ -113,6 +119,8 @@ def test_synced_batch_scheduler_fetches_only_when_all_envs_need_a_chunk():
 
 
 def test_synced_batch_scheduler_holds_waiting_envs_after_partial_reset():
+    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
+
     scheduler = SyncedBatchActionScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
     chunk = _make_chunk()
     hold = torch.tensor([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])

--- a/isaaclab_arena/tests/test_action_scheduling.py
+++ b/isaaclab_arena/tests/test_action_scheduling.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the ActionChunkScheduler and SyncedBatchActionScheduler.
+
+Pure torch — no Isaac Sim, no remote server. Verifies the per-env stepping,
+reset semantics, and (for the synced variant) the hold-on-wait behavior.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, SyncedBatchActionScheduler
+
+NUM_ENVS = 2
+ACTION_CHUNK_LENGTH = 4
+ACTION_HORIZON = 4
+ACTION_DIM = 3
+
+
+def _make_chunk() -> torch.Tensor:
+    """Deterministic (NUM_ENVS, ACTION_HORIZON, ACTION_DIM) tensor with unique values per slot."""
+    return torch.arange(NUM_ENVS * ACTION_HORIZON * ACTION_DIM, dtype=torch.float).reshape(
+        NUM_ENVS, ACTION_HORIZON, ACTION_DIM
+    )
+
+
+def _load_chunk(scheduler: ActionChunkScheduler, chunk: torch.Tensor) -> None:
+    """Manually seed the scheduler's buffer (ActionChunkScheduler.get_action steps but does not fetch)."""
+    scheduler.current_action_chunk[:] = chunk
+    scheduler.current_action_index[:] = 0
+    scheduler.env_requires_new_chunk[:] = False
+
+
+# ----------------------------- ActionChunkScheduler ------------------------------
+
+
+def test_action_chunk_scheduler_steps_through_loaded_chunk():
+    scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
+    chunk = _make_chunk()
+    _load_chunk(scheduler, chunk)
+
+    fetch_calls = 0
+
+    def fetch() -> torch.Tensor:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return chunk
+
+    for k in range(ACTION_CHUNK_LENGTH):
+        action = scheduler.get_action(fetch)
+        assert action.shape == (NUM_ENVS, ACTION_DIM)
+        torch.testing.assert_close(action, chunk[:, k])
+
+    # After draining the chunk, every env should be flagged as needing a new one.
+    assert scheduler.env_requires_new_chunk.all()
+
+
+def test_action_chunk_scheduler_reset_marks_all_envs_for_refetch():
+    scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
+    _load_chunk(scheduler, _make_chunk())
+    assert not scheduler.env_requires_new_chunk.any()
+
+    scheduler.reset()
+
+    assert scheduler.env_requires_new_chunk.all()
+    assert (scheduler.current_action_index == -1).all()
+    assert (scheduler.current_action_chunk == 0.0).all()
+
+
+def test_action_chunk_scheduler_reset_per_env_only_touches_selected_envs():
+    scheduler = ActionChunkScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
+    _load_chunk(scheduler, _make_chunk())
+
+    scheduler.reset(torch.tensor([1]))
+
+    assert scheduler.env_requires_new_chunk.tolist() == [False, True]
+    assert scheduler.current_action_index.tolist() == [0, -1]
+
+
+# --------------------------- SyncedBatchActionScheduler --------------------------
+
+
+def test_synced_batch_scheduler_fetches_only_when_all_envs_need_a_chunk():
+    scheduler = SyncedBatchActionScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
+    chunk = _make_chunk()
+    hold = torch.full((NUM_ENVS, ACTION_DIM), -1.0)
+
+    fetch_calls = 0
+
+    def fetch() -> torch.Tensor:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return chunk
+
+    # First call: every env needs a chunk → exactly one fetch.
+    a0 = scheduler.get_action(fetch, hold)
+    assert fetch_calls == 1
+    torch.testing.assert_close(a0, chunk[:, 0])
+
+    # Subsequent calls within the chunk: no further fetches, just stepping.
+    for k in range(1, ACTION_CHUNK_LENGTH):
+        a = scheduler.get_action(fetch, hold)
+        torch.testing.assert_close(a, chunk[:, k])
+    assert fetch_calls == 1
+
+    # Chunk exhausted → next call triggers a new fetch.
+    scheduler.get_action(fetch, hold)
+    assert fetch_calls == 2
+
+
+def test_synced_batch_scheduler_holds_waiting_envs_after_partial_reset():
+    scheduler = SyncedBatchActionScheduler(NUM_ENVS, ACTION_CHUNK_LENGTH, ACTION_HORIZON, ACTION_DIM, device="cpu")
+    chunk = _make_chunk()
+    hold = torch.tensor([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+
+    fetch_calls = 0
+
+    def fetch() -> torch.Tensor:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return chunk
+
+    # Bring everyone in sync, take one step.
+    scheduler.get_action(fetch, hold)  # fetch happens here
+    assert fetch_calls == 1
+
+    # Reset env 1; env 0 still has chunk to play.
+    scheduler.reset(torch.tensor([1]))
+
+    a = scheduler.get_action(fetch, hold)
+    # No new fetch — env 0 is not yet exhausted, so .all() is False.
+    assert fetch_calls == 1
+    # env 0 advances to chunk[0, 1]; env 1 is waiting and gets the hold action.
+    torch.testing.assert_close(a[0], chunk[0, 1])
+    torch.testing.assert_close(a[1], hold[1])

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
 
-from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
+from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, ActionScheduler, SyncedBatchActionScheduler
 from isaaclab_arena.policy.policy_base import PolicyBase
 from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
 from isaaclab_arena_gr00t.policy.gr00t_core import (
@@ -72,7 +72,11 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
     name = "gr00t_remote_closedloop"
     config_class = Gr00tRemoteClosedloopPolicyArgs
 
-    def __init__(self, config: Gr00tRemoteClosedloopPolicyArgs):
+    def __init__(
+        self,
+        config: Gr00tRemoteClosedloopPolicyArgs,
+        action_scheduler_cls: type[ActionScheduler] = ActionChunkScheduler,
+    ):
         super().__init__(config)
 
         # Policy config (for obs/action translation — no model loading)
@@ -100,7 +104,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         self.action_dim = compute_action_dim(self.task_mode, self.robot_action_joints_config)
         self.action_chunk_length = self.policy_config.action_chunk_length
 
-        self._chunking_state = ActionChunkScheduler(
+        self._chunking_state = action_scheduler_cls(
             num_envs=self.num_envs,
             action_chunk_length=self.action_chunk_length,
             action_horizon=self.policy_config.action_horizon,
@@ -144,12 +148,28 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
         group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
         group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")
+        group.add_argument(
+            "--scheduler",
+            type=str,
+            default="chunk",
+            choices=["chunk", "synced_batch"],
+            help=(
+                "Action scheduler: 'chunk' fetches a new chunk for any env that needs one;"
+                " 'synced_batch' waits until ALL envs need a new chunk and then issues a single"
+                " full-batch inference call (envs that finish early hold their current robot state)."
+            ),
+        )
         return parser
 
     @staticmethod
     def from_args(args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicy:
         config = Gr00tRemoteClosedloopPolicyArgs.from_cli_args(args)
-        return Gr00tRemoteClosedloopPolicy(config)
+        scheduler_cls: type[ActionScheduler] = (
+            SyncedBatchActionScheduler
+            if getattr(args, "scheduler", "chunk") == "synced_batch"
+            else ActionChunkScheduler
+        )
+        return Gr00tRemoteClosedloopPolicy(config, action_scheduler_cls=scheduler_cls)
 
     # ---------------------- Policy interface -------------------
 
@@ -168,7 +188,21 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         def fetch_chunk() -> torch.Tensor:
             return self._get_action_chunk(observation, self.policy_config.pov_cam_name_sim)
 
-        return self._chunking_state.get_action(fetch_chunk)
+        return self._chunking_state.get_action(
+            fetch_chunk,
+            hold_action=self._extract_hold_action(observation),
+        )
+
+    def _extract_hold_action(self, observation: dict[str, Any]) -> torch.Tensor:
+        """Build the action vector that waiting envs should hold: their current sim joint positions
+        copied into the action slots that share a joint name with the state config."""
+        joint_pos_sim = observation["policy"]["robot_joint_pos"].to(device=self.device, dtype=torch.float)
+        hold_action = torch.zeros((self.num_envs, self.action_dim), dtype=torch.float, device=self.device)
+        for joint_name, action_idx in self.robot_action_joints_config.items():
+            state_idx = self.robot_state_joints_config.get(joint_name)
+            if state_idx is not None:
+                hold_action[:, action_idx] = joint_pos_sim[:, state_idx]
+        return hold_action
 
     def _get_action_chunk(
         self, observation: dict[str, Any], camera_names: list[str] | str = "robot_head_cam_rgb"

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -142,6 +142,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
             default="cuda",
             help="Device for Arena-side tensor operations (default: cuda)",
         )
+        group.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate")
         group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
         group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
         group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -142,7 +142,6 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
             default="cuda",
             help="Device for Arena-side tensor operations (default: cuda)",
         )
-        group.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate")
         group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
         group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
         group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
 
-from isaaclab_arena.policy.action_chunking import ActionChunkingState
+from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
 from isaaclab_arena.policy.policy_base import PolicyBase
 from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
 from isaaclab_arena_gr00t.policy.gr00t_core import (
@@ -100,8 +100,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         self.action_dim = compute_action_dim(self.task_mode, self.robot_action_joints_config)
         self.action_chunk_length = self.policy_config.action_chunk_length
 
-        # TODO(xinjieyao, 2026-04-27): consider adding & using ActionChunkingScheduler instead
-        self._chunking_state = ActionChunkingState(
+        self._chunking_state = ActionChunkScheduler(
             num_envs=self.num_envs,
             action_chunk_length=self.action_chunk_length,
             action_horizon=self.policy_config.action_horizon,

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import pytest
 
+from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, SyncedBatchActionScheduler
 from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
 
 NUM_ENVS = 2
@@ -131,7 +132,7 @@ def fake_client_factory(monkeypatch):
     return factory
 
 
-def _build_policy(policy_config_yaml: str):
+def _build_policy(policy_config_yaml: str, action_scheduler_cls=ActionChunkScheduler):
     from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
         Gr00tRemoteClosedloopPolicy,
         Gr00tRemoteClosedloopPolicyArgs,
@@ -145,7 +146,7 @@ def _build_policy(policy_config_yaml: str):
         remote_port=0,
         remote_api_token=None,
     )
-    return Gr00tRemoteClosedloopPolicy(args)
+    return Gr00tRemoteClosedloopPolicy(args, action_scheduler_cls=action_scheduler_cls)
 
 
 # ------------------------------- tests ------------------------------- #
@@ -217,3 +218,47 @@ def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_cli
     fake_client_factory(ping_ok=False)
     with pytest.raises(ConnectionError):
         _build_policy(policy_config_yaml)
+
+
+# ---------------- scheduler-switch tests ---------------- #
+
+
+@pytest.mark.parametrize("scheduler_cls", [ActionChunkScheduler, SyncedBatchActionScheduler])
+def test_get_action_returns_correct_shape_for_each_scheduler(
+    policy_config_yaml, synthetic_observation, fake_client_factory, scheduler_cls
+):
+    """Both ActionChunkScheduler and SyncedBatchActionScheduler should drive the policy
+    end-to-end and produce one (num_envs, action_dim) action per get_action call."""
+    fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml, action_scheduler_cls=scheduler_cls)
+    assert isinstance(policy._chunking_state, scheduler_cls)
+    policy.set_task_description("pick up the brown box")
+
+    action = policy.get_action(env=None, observation=synthetic_observation)
+
+    assert isinstance(action, torch.Tensor)
+    assert action.shape == (NUM_ENVS, EXPECTED_ACTION_DIM)
+    assert action.device.type == "cpu"
+
+
+def test_synced_batch_holds_joint_position_for_env_after_partial_reset(
+    policy_config_yaml, synthetic_observation, fake_client_factory
+):
+    """After resetting a single env, SyncedBatchActionScheduler should hold that env on
+    the joint-position-derived hold_action while the others continue stepping their chunk."""
+    clients = fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml, action_scheduler_cls=SyncedBatchActionScheduler)
+    policy.set_task_description("pick up the brown box")
+
+    # Step 1: every env needs a chunk → exactly one fetch.
+    policy.get_action(env=None, observation=synthetic_observation)
+    assert clients[0].get_action_calls == 1
+
+    # Reset env 1 only; env 0 still has its chunk.
+    policy.reset(env_ids=torch.tensor([1]))
+
+    action = policy.get_action(env=None, observation=synthetic_observation)
+    # No new chunk fetched (env 0 not yet exhausted, so .all() is False).
+    assert clients[0].get_action_calls == 1
+    expected_hold = policy._extract_hold_action(synthetic_observation)
+    torch.testing.assert_close(action[1], expected_hold[1])

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -26,7 +26,13 @@ from typing import Any
 
 import pytest
 
-from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, SyncedBatchActionScheduler
+# NOTE: ``isaaclab_arena.policy.action_scheduling`` is imported lazily inside
+# tests/helpers (mirrors ``test_action_scheduling.py``). Importing it at module
+# top level pulls in ``isaaclab_arena.policy.__init__`` which star-imports
+# policies that load isaaclab/pxr — that pre-loads pxr at pytest collection
+# time and trips Kit's ``omni.kit.usd.mdl`` extension when a sibling test later
+# instantiates SimulationApp (CI gr00t docker has GROOT_DEPS_DIR set, which
+# makes the ordering fatal).
 from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
 
 NUM_ENVS = 2
@@ -132,11 +138,16 @@ def fake_client_factory(monkeypatch):
     return factory
 
 
-def _build_policy(policy_config_yaml: str, action_scheduler_cls=ActionChunkScheduler):
+def _build_policy(policy_config_yaml: str, action_scheduler_cls=None):
     from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
         Gr00tRemoteClosedloopPolicy,
         Gr00tRemoteClosedloopPolicyArgs,
     )
+
+    if action_scheduler_cls is None:
+        from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
+
+        action_scheduler_cls = ActionChunkScheduler
 
     args = Gr00tRemoteClosedloopPolicyArgs(
         policy_config_yaml_path=policy_config_yaml,
@@ -223,12 +234,16 @@ def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_cli
 # ---------------- scheduler-switch tests ---------------- #
 
 
-@pytest.mark.parametrize("scheduler_cls", [ActionChunkScheduler, SyncedBatchActionScheduler])
+@pytest.mark.parametrize("scheduler_cls_name", ["ActionChunkScheduler", "SyncedBatchActionScheduler"])
 def test_get_action_returns_correct_shape_for_each_scheduler(
-    policy_config_yaml, synthetic_observation, fake_client_factory, scheduler_cls
+    policy_config_yaml, synthetic_observation, fake_client_factory, scheduler_cls_name
 ):
     """Both ActionChunkScheduler and SyncedBatchActionScheduler should drive the policy
     end-to-end and produce one (num_envs, action_dim) action per get_action call."""
+    from isaaclab_arena.policy import action_scheduling
+
+    scheduler_cls = getattr(action_scheduling, scheduler_cls_name)
+
     fake_client_factory(ping_ok=True)
     policy = _build_policy(policy_config_yaml, action_scheduler_cls=scheduler_cls)
     assert isinstance(policy._chunking_state, scheduler_cls)
@@ -246,6 +261,8 @@ def test_synced_batch_holds_joint_position_for_env_after_partial_reset(
 ):
     """After resetting a single env, SyncedBatchActionScheduler should hold that env on
     the joint-position-derived hold_action while the others continue stepping their chunk."""
+    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
+
     clients = fake_client_factory(ping_ok=True)
     policy = _build_policy(policy_config_yaml, action_scheduler_cls=SyncedBatchActionScheduler)
     policy.set_task_description("pick up the brown box")

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -207,8 +207,22 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
     from gr00t.configs.data.embodiment_configs import MODALITY_CONFIGS
     from gr00t.data.embodiment_tags import EmbodimentTag
 
+    # Resolve the embodiment tag first so we can short-circuit if the registration
+    # for this tag has already happened — re-executing the user module would re-trigger
+    # register_modality_config(), which asserts on duplicate registration.
+    try:
+        embodiment_tag_enum = EmbodimentTag[embodiment_tag.upper()]
+    except KeyError:
+        embodiment_tag_str = embodiment_tag.upper()
+        matching_tags = [tag for tag in EmbodimentTag if tag.name == embodiment_tag_str]
+        if not matching_tags:
+            available_tags = [tag.name for tag in EmbodimentTag]
+            raise ValueError(f"Invalid embodiment tag '{embodiment_tag}'. Available tags: {available_tags}")
+        embodiment_tag_enum = matching_tags[0]
+    embodiment_tag_key = embodiment_tag_enum.value
+
     # TODO(xinjieyao, 2026-04-27): to be refactored after adding gr00t remote policy
-    if modality_config_path:
+    if modality_config_path and embodiment_tag_key not in MODALITY_CONFIGS:
         # Import the user's modality config module for its side-effect of
         # registering entries into MODALITY_CONFIGS.
         #
@@ -226,29 +240,13 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
             path = Path(modality_config_path)
             if not (path.exists() and path.suffix == ".py"):
                 raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
-            # Load by file location so we (a) don't mutate sys.path and (b) always
-            # execute the module body — register_modality_config() runs every call,
-            # rather than being skipped on a sys.modules cache hit.
+            # Load by file location so we don't mutate sys.path and the module body
+            # always executes when we choose to call this branch (we just decided we need to).
             spec = importlib.util.spec_from_file_location(path.stem, path)
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not load modality config from {path}")
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
-
-    # Get the embodiment tag from policy config and convert to EmbodimentTag enum
-    # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)
-    try:
-        embodiment_tag_enum = EmbodimentTag[embodiment_tag.upper()]
-    except KeyError:
-        embodiment_tag_str = embodiment_tag.upper()
-        matching_tags = [tag for tag in EmbodimentTag if tag.name == embodiment_tag_str]
-        if not matching_tags:
-            available_tags = [tag.name for tag in EmbodimentTag]
-            raise ValueError(f"Invalid embodiment tag '{embodiment_tag}'. Available tags: {available_tags}")
-        embodiment_tag_enum = matching_tags[0]
-
-    # Use the enum's value (lowercase string) to look up in MODALITY_CONFIGS
-    embodiment_tag_key = embodiment_tag_enum.value
 
     if embodiment_tag_key not in MODALITY_CONFIGS:
         raise ValueError(

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -221,19 +221,15 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
 
             load_modality_config(modality_config_path)
         except ImportError:
-            import importlib.util
+            import importlib
+            import sys
 
             path = Path(modality_config_path)
-            if not (path.exists() and path.suffix == ".py"):
+            if path.exists() and path.suffix == ".py":
+                sys.path.append(str(path.parent))
+                importlib.import_module(path.stem)
+            else:
                 raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
-            # Load by file location so we (a) don't mutate sys.path and (b) always
-            # execute the module body — register_modality_config() runs every call,
-            # rather than being skipped on a sys.modules cache hit.
-            spec = importlib.util.spec_from_file_location(path.stem, path)
-            if spec is None or spec.loader is None:
-                raise ImportError(f"Could not load modality config from {path}")
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
 
     # Get the embodiment tag from policy config and convert to EmbodimentTag enum
     # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -207,22 +207,8 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
     from gr00t.configs.data.embodiment_configs import MODALITY_CONFIGS
     from gr00t.data.embodiment_tags import EmbodimentTag
 
-    # Resolve the embodiment tag first so we can short-circuit if the registration
-    # for this tag has already happened — re-executing the user module would re-trigger
-    # register_modality_config(), which asserts on duplicate registration.
-    try:
-        embodiment_tag_enum = EmbodimentTag[embodiment_tag.upper()]
-    except KeyError:
-        embodiment_tag_str = embodiment_tag.upper()
-        matching_tags = [tag for tag in EmbodimentTag if tag.name == embodiment_tag_str]
-        if not matching_tags:
-            available_tags = [tag.name for tag in EmbodimentTag]
-            raise ValueError(f"Invalid embodiment tag '{embodiment_tag}'. Available tags: {available_tags}")
-        embodiment_tag_enum = matching_tags[0]
-    embodiment_tag_key = embodiment_tag_enum.value
-
     # TODO(xinjieyao, 2026-04-27): to be refactored after adding gr00t remote policy
-    if modality_config_path and embodiment_tag_key not in MODALITY_CONFIGS:
+    if modality_config_path:
         # Import the user's modality config module for its side-effect of
         # registering entries into MODALITY_CONFIGS.
         #
@@ -240,13 +226,29 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
             path = Path(modality_config_path)
             if not (path.exists() and path.suffix == ".py"):
                 raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
-            # Load by file location so we don't mutate sys.path and the module body
-            # always executes when we choose to call this branch (we just decided we need to).
+            # Load by file location so we (a) don't mutate sys.path and (b) always
+            # execute the module body — register_modality_config() runs every call,
+            # rather than being skipped on a sys.modules cache hit.
             spec = importlib.util.spec_from_file_location(path.stem, path)
             if spec is None or spec.loader is None:
                 raise ImportError(f"Could not load modality config from {path}")
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
+
+    # Get the embodiment tag from policy config and convert to EmbodimentTag enum
+    # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)
+    try:
+        embodiment_tag_enum = EmbodimentTag[embodiment_tag.upper()]
+    except KeyError:
+        embodiment_tag_str = embodiment_tag.upper()
+        matching_tags = [tag for tag in EmbodimentTag if tag.name == embodiment_tag_str]
+        if not matching_tags:
+            available_tags = [tag.name for tag in EmbodimentTag]
+            raise ValueError(f"Invalid embodiment tag '{embodiment_tag}'. Available tags: {available_tags}")
+        embodiment_tag_enum = matching_tags[0]
+
+    # Use the enum's value (lowercase string) to look up in MODALITY_CONFIGS
+    embodiment_tag_key = embodiment_tag_enum.value
 
     if embodiment_tag_key not in MODALITY_CONFIGS:
         raise ValueError(

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -221,15 +221,19 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
 
             load_modality_config(modality_config_path)
         except ImportError:
-            import importlib
-            import sys
+            import importlib.util
 
             path = Path(modality_config_path)
-            if path.exists() and path.suffix == ".py":
-                sys.path.append(str(path.parent))
-                importlib.import_module(path.stem)
-            else:
+            if not (path.exists() and path.suffix == ".py"):
                 raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
+            # Load by file location so we (a) don't mutate sys.path and (b) always
+            # execute the module body — register_modality_config() runs every call,
+            # rather than being skipped on a sys.modules cache hit.
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not load modality config from {path}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
 
     # Get the embodiment tag from policy config and convert to EmbodimentTag enum
     # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)


### PR DESCRIPTION
## Summary
Pluggable action schedulers for the GR00T remote policy

## Detailed description
- Why: Let the remote GR00T policy choose between per-env chunk fetching and a synchronized full-batch mode for higher GR00T-server utilization, and lift the fetch/play logic out of the policy class.
- What: New `isaaclab_arena/policy/action_scheduling/` package with `ActionScheduler` (abstract), `ActionChunkScheduler` (per-env), and `SyncedBatchActionScheduler` (waits for all envs, holds waiting envs at their current state); pure-torch tests; `Gr00tRemoteClosedloopPolicy` rewired to take a pluggable scheduler with a new `--scheduler chunk|synced_batch` CLI flag and a _extract_hold_action helper func.
- Impact: Default behavior unchanged (chunked); opt-in --scheduler synced_batch for batched inference; no new deps.
