### PR TITLE
Stop G1 asset force download

### DIFF
--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
@@ -54,7 +54,7 @@ class G1AgilePolicy(WBCPolicy):
         # Resolve model path via OV asset API (handles S3 download + local caching).
         # Same pattern as G1HomiePolicyV2: retrieve_file_path returns a local path
         # (absolute for S3 cache, relative for local files), then join with parent_dir.
-        model_local_path = retrieve_file_path(model_path, force_download=True)
+        model_local_path = retrieve_file_path(model_path)
         model_full_path = parent_dir / model_local_path
         self.session = OnnxInferenceSession(str(model_full_path))
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
@@ -54,7 +54,7 @@ class G1AgilePolicy(WBCPolicy):
         # Resolve model path via OV asset API (handles S3 download + local caching).
         # Same pattern as G1HomiePolicyV2: retrieve_file_path returns a local path
         # (absolute for S3 cache, relative for local files), then join with parent_dir.
-        model_local_path = retrieve_file_path(model_path)
+        model_local_path = retrieve_file_path(model_path, force_download=False)
         model_full_path = parent_dir / model_local_path
         self.session = OnnxInferenceSession(str(model_full_path))
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
@@ -34,8 +34,8 @@ class G1HomiePolicyV2(WBCPolicy):
         self.num_envs = num_envs
 
         model_path_1, model_path_2 = model_path.split(",")
-        model_path_1_local = retrieve_file_path(model_path_1, force_download=True)
-        model_path_2_local = retrieve_file_path(model_path_2, force_download=True)
+        model_path_1_local = retrieve_file_path(model_path_1)
+        model_path_2_local = retrieve_file_path(model_path_2)
 
         self.policy_1 = OnnxInferenceSession(str(parent_dir / model_path_1_local))
         self.policy_2 = OnnxInferenceSession(str(parent_dir / model_path_2_local))

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_homie_policy.py
@@ -34,8 +34,8 @@ class G1HomiePolicyV2(WBCPolicy):
         self.num_envs = num_envs
 
         model_path_1, model_path_2 = model_path.split(",")
-        model_path_1_local = retrieve_file_path(model_path_1)
-        model_path_2_local = retrieve_file_path(model_path_2)
+        model_path_1_local = retrieve_file_path(model_path_1, force_download=False)
+        model_path_2_local = retrieve_file_path(model_path_2, force_download=False)
 
         self.policy_1 = OnnxInferenceSession(str(parent_dir / model_path_1_local))
         self.policy_2 = OnnxInferenceSession(str(parent_dir / model_path_2_local))

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
@@ -36,8 +36,8 @@ def instantiate_g1_robot_model(
         "urdf_path": f"{ISAACLAB_NUCLEUS_DIR}/Arena/wbc_policy/robot_model/g1/g1_29dof_with_hand.urdf",
     }
 
-    asset_path_local = retrieve_file_path(robot_model_config["asset_path"], force_download=True)
-    urdf_path_local = retrieve_file_path(robot_model_config["urdf_path"], force_download=True)
+    asset_path_local = retrieve_file_path(robot_model_config["asset_path"])
+    urdf_path_local = retrieve_file_path(robot_model_config["urdf_path"])
 
     assert waist_location in [
         "lower_body",

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/utils/g1.py
@@ -36,8 +36,8 @@ def instantiate_g1_robot_model(
         "urdf_path": f"{ISAACLAB_NUCLEUS_DIR}/Arena/wbc_policy/robot_model/g1/g1_29dof_with_hand.urdf",
     }
 
-    asset_path_local = retrieve_file_path(robot_model_config["asset_path"])
-    urdf_path_local = retrieve_file_path(robot_model_config["urdf_path"])
+    asset_path_local = retrieve_file_path(robot_model_config["asset_path"], force_download=False)
+    urdf_path_local = retrieve_file_path(robot_model_config["urdf_path"], force_download=False)
 
     assert waist_location in [
         "lower_body",


### PR DESCRIPTION
## Summary
Stop force-redownloading G1 WBC assets on every run. Following slack discussion [thread](https://nvidia.slack.com/archives/C097CP8FG67/p1778087187243489).

## Detailed description
- Why: The G1 WBC policy and robot-model loading were calling retrieve_file_path(..., force_download=True), re-fetching the same ONNX/USD/URDF files from Nucleus on every startup — slow and unnecessary once the local cache is warm.
- What: Drop `force_download=True` from four call sites: `model_path_1` / `model_path_2` in `G1HomiePolicyV2.__init__` (`g1_homie_policy.py`) and `asset_path` / `urdf_path` in `instantiate_g1_robot_model` (`utils/g1.py`).
- Impact: Cached files are reused; first run on a fresh machine still downloads as before. No behavioral change in the policy itself.
