### PR TITLE
Add G1 AGILE recurrent student WBC policy

### DIFF
--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -138,7 +138,12 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
 
 @register_asset
 class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
-    """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control."""
+    """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control.
+
+    Like :class:`G1WBCAgileJointEmbodiment`, this overrides the leg/feet/waist actuator
+    gains to match the agile training-time values; without that override the policy's
+    joint targets get amplified by the Arena's stiffer default PD loop.
+    """
 
     name = "g1_wbc_agile_pink"
 
@@ -159,12 +164,21 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         self.camera_config._is_tiled_camera = use_tiled_camera
         self.camera_config._camera_offset = camera_offset
 
+        _override_actuator_gains_for_agile(self.scene_config.robot)
+
 
 @register_asset
 class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
     """Embodiment for the G1 robot with AGILE WBC policy and direct joint upperbody control.
 
     By default uses tiled camera for efficient parallel evaluation.
+
+    Overrides the leg/feet/waist actuator gains to match the agile training-time
+    values from ``unitree_g1_velocity_height_recurrent_student.yaml``. The Arena's
+    default G1 actuator stiffness is 2-4x higher than what the agile policy was
+    trained on; without this override the policy's joint targets get amplified
+    by the stiffer PD loop, manifesting as a slow yaw drift / postural twitch
+    even when the velocity command is zero.
     """
 
     name = "g1_wbc_agile_joint"
@@ -184,6 +198,108 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         self.event_config = G1WBCJointEventCfg()
         self.camera_config._is_tiled_camera = use_tiled_camera
         self.camera_config._camera_offset = camera_offset
+
+        _override_actuator_gains_for_agile(self.scene_config.robot)
+
+
+# Canonical PD gains and armature from the agile recurrent-student training YAML
+# (`agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.yaml`).
+# Keyed by the actuator group name in `G1SceneCfg.robot.actuators` and then by
+# *exact* joint name (no regex) to avoid the IsaacLab regex resolver complaining
+# about overlapping patterns (e.g. `.*_hip_.*` vs `.*_hip_pitch_joint`).
+_AGILE_GAINS_PER_GROUP: dict[str, dict[str, dict[str, float]]] = {
+    "legs": {
+        "left_hip_pitch_joint": {
+            "stiffness": 40.179237365722656,
+            "damping": 2.557889699935913,
+            "armature": 0.010177520103752613,
+        },
+        "right_hip_pitch_joint": {
+            "stiffness": 40.179237365722656,
+            "damping": 2.557889699935913,
+            "armature": 0.010177520103752613,
+        },
+        "left_hip_roll_joint": {
+            "stiffness": 99.09842681884766,
+            "damping": 6.308801651000977,
+            "armature": 0.025101924315094948,
+        },
+        "right_hip_roll_joint": {
+            "stiffness": 99.09842681884766,
+            "damping": 6.308801651000977,
+            "armature": 0.025101924315094948,
+        },
+        "left_hip_yaw_joint": {
+            "stiffness": 40.179237365722656,
+            "damping": 2.557889699935913,
+            "armature": 0.010177520103752613,
+        },
+        "right_hip_yaw_joint": {
+            "stiffness": 40.179237365722656,
+            "damping": 2.557889699935913,
+            "armature": 0.010177520103752613,
+        },
+        "left_knee_joint": {
+            "stiffness": 99.09842681884766,
+            "damping": 6.308801651000977,
+            "armature": 0.025101924315094948,
+        },
+        "right_knee_joint": {
+            "stiffness": 99.09842681884766,
+            "damping": 6.308801651000977,
+            "armature": 0.025101924315094948,
+        },
+    },
+    "feet": {
+        "left_ankle_pitch_joint": {
+            "stiffness": 28.501245498657227,
+            "damping": 1.8144457340240479,
+            "armature": 0.007219450082629919,
+        },
+        "right_ankle_pitch_joint": {
+            "stiffness": 28.501245498657227,
+            "damping": 1.8144457340240479,
+            "armature": 0.007219450082629919,
+        },
+        "left_ankle_roll_joint": {
+            "stiffness": 28.501245498657227,
+            "damping": 1.8144457340240479,
+            "armature": 0.007219450082629919,
+        },
+        "right_ankle_roll_joint": {
+            "stiffness": 28.501245498657227,
+            "damping": 1.8144457340240479,
+            "armature": 0.007219450082629919,
+        },
+    },
+    "waist": {
+        "waist_yaw_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
+        "waist_roll_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
+        "waist_pitch_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
+    },
+}
+
+
+def _override_actuator_gains_for_agile(robot_cfg: ArticulationCfg) -> None:
+    """Override the Arena G1 actuator stiffness/damping/armature in-place to match
+    the agile training-time values for joints the AGILE policy controls.
+
+    Replaces the actuator group's ``stiffness`` / ``damping`` / ``armature`` dicts
+    with exact-joint-name keys so the IsaacLab regex resolver doesn't see overlap
+    between e.g. the original ``.*_hip_.*`` armature key and the more specific
+    per-joint stiffness keys we add here.
+
+    Other parameters (``joint_names_expr``, ``effort_limit``, ``velocity_limit``,
+    ``friction``) keep their Arena defaults since they are physical limits or
+    joint-set definitions, not policy training inputs.
+    """
+    for group_name, per_joint_gains in _AGILE_GAINS_PER_GROUP.items():
+        if group_name not in robot_cfg.actuators:
+            continue
+        actuator_cfg = robot_cfg.actuators[group_name]
+        actuator_cfg.stiffness = {jn: g["stiffness"] for jn, g in per_joint_gains.items()}
+        actuator_cfg.damping = {jn: g["damping"] for jn, g in per_joint_gains.items()}
+        actuator_cfg.armature = {jn: g["armature"] for jn, g in per_joint_gains.items()}
 
 
 @configclass
@@ -665,9 +781,22 @@ class G1WBCPinkActionCfg:
 
 @configclass
 class G1WBCAgilePinkActionCfg:
-    """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body."""
+    """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body.
 
-    g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(asset_name="robot", joint_names=[".*"], wbc_version="agile")
+    The AGILE recurrent lower-body policy only drives the 12 leg joints (it does not
+    move waist_yaw/roll/pitch -- those slots stay at zero target from the WBC). To give
+    the upper-body PINK IK more reach, we extend its active joint set to include
+    ``waist_roll_joint`` and ``waist_pitch_joint`` (waist_yaw stays fixed because the
+    AGILE policy expects it at zero).
+    """
+
+    g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(
+        asset_name="robot",
+        joint_names=[".*"],
+        wbc_version="agile",
+        upperbody_active_joint_groups=["arms"],
+        upperbody_extra_active_joints=["waist_roll_joint", "waist_yaw_joint", "waist_pitch_joint"],
+    )
 
 
 @configclass

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import torch
 from collections.abc import Sequence
 from dataclasses import MISSING
@@ -140,9 +141,9 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
 class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
     """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control.
 
-    Like :class:`G1WBCAgileJointEmbodiment`, this overrides the leg/feet/waist actuator
-    gains to match the agile training-time values; without that override the policy's
-    joint targets get amplified by the Arena's stiffer default PD loop.
+    Uses :data:`G1_AGILE_CFG` so the leg/feet/waist actuator gains match the agile
+    training-time values; without that override the policy's joint targets get
+    amplified by the Arena's stiffer default PD loop.
     """
 
     name = "g1_wbc_agile_pink"
@@ -155,6 +156,7 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         use_tiled_camera: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
+        self.scene_config = G1AgileSceneCfg()
         self.action_config = G1WBCAgilePinkActionCfg()
         self.observation_config = G1WBCPinkObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
@@ -164,21 +166,17 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         self.camera_config._is_tiled_camera = use_tiled_camera
         self.camera_config._camera_offset = camera_offset
 
-        _override_actuator_gains_for_agile(self.scene_config.robot)
-
 
 @register_asset
 class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
     """Embodiment for the G1 robot with AGILE WBC policy and direct joint upperbody control.
 
-    By default uses tiled camera for efficient parallel evaluation.
-
-    Overrides the leg/feet/waist actuator gains to match the agile training-time
-    values from ``unitree_g1_velocity_height_recurrent_student.yaml``. The Arena's
-    default G1 actuator stiffness is 2-4x higher than what the agile policy was
-    trained on; without this override the policy's joint targets get amplified
-    by the stiffer PD loop, manifesting as a slow yaw drift / postural twitch
-    even when the velocity command is zero.
+    By default uses tiled camera for efficient parallel evaluation. Uses
+    :data:`G1_AGILE_CFG` so the leg/feet/waist actuator gains match the agile
+    training-time values; the Arena's default G1 actuator stiffness is 2-4x higher
+    than what the agile policy was trained on, which would amplify the policy's
+    joint targets through a stiffer PD loop and produce a slow yaw drift /
+    postural twitch even when the velocity command is zero.
     """
 
     name = "g1_wbc_agile_joint"
@@ -191,6 +189,7 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         use_tiled_camera: bool = True,
     ):
         super().__init__(enable_cameras, initial_pose)
+        self.scene_config = G1AgileSceneCfg()
         self.action_config = G1WBCAgileJointActionCfg()
         self.observation_config = G1WBCJointObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
@@ -199,306 +198,278 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         self.camera_config._is_tiled_camera = use_tiled_camera
         self.camera_config._camera_offset = camera_offset
 
-        _override_actuator_gains_for_agile(self.scene_config.robot)
+
+# Default Arena G1 articulation config used by all non-AGILE G1 embodiments. Kept at
+# module level so AGILE-specific variants (see ``G1_AGILE_CFG``) can be expressed as
+# ``G1_CFG.copy()`` with targeted actuator overrides instead of mutating
+# ``scene_config`` in each embodiment constructor.
+G1_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=f"{ISAAC_NUCLEUS_DIR}/Samples/Groot/Robots/g1_29dof_with_hand_rev_1_0.usd",
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            retain_accelerations=False,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=1000.0,
+            max_depenetration_velocity=1.0,
+            solver_position_iteration_count=4,
+            solver_velocity_iteration_count=0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=False, solver_position_iteration_count=4, solver_velocity_iteration_count=0
+        ),
+    ),
+    prim_path="/World/envs/env_.*/Robot",
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.8, -1.38, 0.78),
+        rot=(0.0, 0.0, 1.0, 0.0),
+        joint_pos={
+            # target angles [rad]
+            "left_hip_pitch_joint": -0.1,
+            "left_hip_roll_joint": 0.0,
+            "left_hip_yaw_joint": 0.0,
+            "left_knee_joint": 0.3,
+            "left_ankle_pitch_joint": -0.2,
+            "left_ankle_roll_joint": 0.0,
+            "right_hip_pitch_joint": -0.1,
+            "right_hip_roll_joint": 0.0,
+            "right_hip_yaw_joint": 0.0,
+            "right_knee_joint": 0.3,
+            "right_ankle_pitch_joint": -0.2,
+            "right_ankle_roll_joint": 0.0,
+            "waist_yaw_joint": 0.0,
+            "waist_roll_joint": 0.0,
+            "waist_pitch_joint": 0.0,
+            "left_shoulder_pitch_joint": 0.0,
+            "left_shoulder_roll_joint": 0.0,
+            "left_shoulder_yaw_joint": 0.0,
+            "left_elbow_joint": 0.0,
+            "right_shoulder_pitch_joint": 0.0,
+            "right_shoulder_roll_joint": 0,
+            "right_shoulder_yaw_joint": 0.0,
+            "right_elbow_joint": 0.0,
+        },
+        joint_vel={".*": 0.0},
+    ),
+    actuators={
+        "legs": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_hip_yaw_joint",
+                ".*_hip_roll_joint",
+                ".*_hip_pitch_joint",
+                ".*_knee_joint",
+            ],
+            effort_limit={
+                ".*_hip_yaw_joint": 88.0,
+                ".*_hip_roll_joint": 88.0,
+                ".*_hip_pitch_joint": 88.0,
+                ".*_knee_joint": 139.0,
+            },
+            velocity_limit={
+                ".*_hip_yaw_joint": 32.0,
+                ".*_hip_roll_joint": 32.0,
+                ".*_hip_pitch_joint": 32.0,
+                ".*_knee_joint": 20.0,
+            },
+            stiffness={
+                ".*_hip_yaw_joint": 150.0,
+                ".*_hip_roll_joint": 150.0,
+                ".*_hip_pitch_joint": 150.0,
+                ".*_knee_joint": 300.0,
+            },
+            damping={
+                ".*_hip_yaw_joint": 2.0,
+                ".*_hip_roll_joint": 2.0,
+                ".*_hip_pitch_joint": 2.0,
+                ".*_knee_joint": 4.0,
+            },
+            armature={
+                ".*_hip_.*": 0.03,
+                ".*_knee_joint": 0.03,
+            },
+        ),
+        "feet": IdealPDActuatorCfg(
+            joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
+            stiffness={
+                ".*_ankle_pitch_joint": 40.0,
+                ".*_ankle_roll_joint": 40.0,
+            },
+            damping={
+                ".*_ankle_pitch_joint": 2,
+                ".*_ankle_roll_joint": 2,
+            },
+            effort_limit={
+                ".*_ankle_pitch_joint": 50.0,
+                ".*_ankle_roll_joint": 50.0,
+            },
+            velocity_limit={
+                ".*_ankle_pitch_joint": 37.0,
+                ".*_ankle_roll_joint": 37.0,
+            },
+            armature=0.03,
+            friction=0.03,
+        ),
+        "waist": IdealPDActuatorCfg(
+            joint_names_expr=[
+                "waist_.*_joint",
+            ],
+            effort_limit={
+                "waist_yaw_joint": 88.0,
+                "waist_roll_joint": 50.0,
+                "waist_pitch_joint": 50.0,
+            },
+            velocity_limit={
+                "waist_yaw_joint": 32.0,
+                "waist_roll_joint": 37.0,
+                "waist_pitch_joint": 37.0,
+            },
+            stiffness={
+                "waist_yaw_joint": 250.0,
+                "waist_roll_joint": 250.0,
+                "waist_pitch_joint": 250.0,
+            },
+            damping={
+                "waist_yaw_joint": 5.0,
+                "waist_roll_joint": 5.0,
+                "waist_pitch_joint": 5.0,
+            },
+            armature=0.03,
+            friction=0.03,
+        ),
+        "arms": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_shoulder_pitch_joint",
+                ".*_shoulder_roll_joint",
+                ".*_shoulder_yaw_joint",
+                ".*_elbow_joint",
+                ".*_wrist_.*_joint",
+            ],
+            effort_limit={
+                ".*_shoulder_pitch_joint": 25.0,
+                ".*_shoulder_roll_joint": 25.0,
+                ".*_shoulder_yaw_joint": 25.0,
+                ".*_elbow_joint": 25.0,
+                ".*_wrist_roll_joint": 25.0,
+                ".*_wrist_pitch_joint": 5.0,
+                ".*_wrist_yaw_joint": 5.0,
+            },
+            velocity_limit={
+                ".*_shoulder_pitch_joint": 37.0,
+                ".*_shoulder_roll_joint": 37.0,
+                ".*_shoulder_yaw_joint": 37.0,
+                ".*_elbow_joint": 37.0,
+                ".*_wrist_roll_joint": 37.0,
+                ".*_wrist_pitch_joint": 22.0,
+                ".*_wrist_yaw_joint": 22.0,
+            },
+            stiffness={
+                ".*_shoulder_pitch_joint": 100.0,
+                ".*_shoulder_roll_joint": 100.0,
+                ".*_shoulder_yaw_joint": 40.0,
+                ".*_elbow_joint": 40.0,
+                ".*_wrist_.*_joint": 20.0,
+            },
+            damping={
+                ".*_shoulder_pitch_joint": 5.0,
+                ".*_shoulder_roll_joint": 5.0,
+                ".*_shoulder_yaw_joint": 2.0,
+                ".*_elbow_joint": 2.0,
+                ".*_wrist_.*_joint": 2.0,
+            },
+            armature={".*_shoulder_.*": 0.03, ".*_elbow_.*": 0.03, ".*_wrist_.*_joint": 0.03},
+            friction=0.03,
+        ),
+        # NOTE(peterd, 9/25/2025): The follow hand joint values are tested and working with Leapmotion and Mimic
+        "hands": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_hand_.*",
+            ],
+            effort_limit=5.0,
+            velocity_limit=10.0,
+            stiffness=4.0,
+            damping=0.5,
+            armature=0.03,
+            friction=0.03,
+        ),
+    },
+)
 
 
-# Canonical PD gains and armature from the agile recurrent-student training YAML
-# (`agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.yaml`).
-# Keyed by the actuator group name in `G1SceneCfg.robot.actuators` and then by
-# *exact* joint name (no regex) to avoid the IsaacLab regex resolver complaining
-# about overlapping patterns (e.g. `.*_hip_.*` vs `.*_hip_pitch_joint`).
-_AGILE_GAINS_PER_GROUP: dict[str, dict[str, dict[str, float]]] = {
-    "legs": {
-        "left_hip_pitch_joint": {
-            "stiffness": 40.179237365722656,
-            "damping": 2.557889699935913,
-            "armature": 0.010177520103752613,
-        },
-        "right_hip_pitch_joint": {
-            "stiffness": 40.179237365722656,
-            "damping": 2.557889699935913,
-            "armature": 0.010177520103752613,
-        },
-        "left_hip_roll_joint": {
-            "stiffness": 99.09842681884766,
-            "damping": 6.308801651000977,
-            "armature": 0.025101924315094948,
-        },
-        "right_hip_roll_joint": {
-            "stiffness": 99.09842681884766,
-            "damping": 6.308801651000977,
-            "armature": 0.025101924315094948,
-        },
-        "left_hip_yaw_joint": {
-            "stiffness": 40.179237365722656,
-            "damping": 2.557889699935913,
-            "armature": 0.010177520103752613,
-        },
-        "right_hip_yaw_joint": {
-            "stiffness": 40.179237365722656,
-            "damping": 2.557889699935913,
-            "armature": 0.010177520103752613,
-        },
-        "left_knee_joint": {
-            "stiffness": 99.09842681884766,
-            "damping": 6.308801651000977,
-            "armature": 0.025101924315094948,
-        },
-        "right_knee_joint": {
-            "stiffness": 99.09842681884766,
-            "damping": 6.308801651000977,
-            "armature": 0.025101924315094948,
-        },
-    },
-    "feet": {
-        "left_ankle_pitch_joint": {
-            "stiffness": 28.501245498657227,
-            "damping": 1.8144457340240479,
-            "armature": 0.007219450082629919,
-        },
-        "right_ankle_pitch_joint": {
-            "stiffness": 28.501245498657227,
-            "damping": 1.8144457340240479,
-            "armature": 0.007219450082629919,
-        },
-        "left_ankle_roll_joint": {
-            "stiffness": 28.501245498657227,
-            "damping": 1.8144457340240479,
-            "armature": 0.007219450082629919,
-        },
-        "right_ankle_roll_joint": {
-            "stiffness": 28.501245498657227,
-            "damping": 1.8144457340240479,
-            "armature": 0.007219450082629919,
-        },
-    },
-    "waist": {
-        "waist_yaw_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
-        "waist_roll_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
-        "waist_pitch_joint": {"stiffness": 300.0, "damping": 5.0, "armature": 0.029999999329447746},
-    },
+# Motor model constants for the AGILE recurrent-student G1 policy. Naming and
+# values mirror ``agile/rl_env/assets/robots/unitree_g1.py`` so the AGILE source
+# of truth is greppable across repos. Stiffness/damping derive from the standard
+# second-order PD form (omega_n^2 * armature, 2 * zeta * omega_n * armature).
+_G1_AGILE_NATURAL_FREQ = 10.0 * 2.0 * math.pi  # 10 Hz
+_G1_AGILE_DAMPING_RATIO = 2.0
+_G1_AGILE_ARMATURE_7520_14 = 0.010177520
+_G1_AGILE_ARMATURE_7520_22 = 0.025101925
+_G1_AGILE_ARMATURE_5020 = 0.003609725
+_G1_AGILE_STIFFNESS_7520_14 = _G1_AGILE_ARMATURE_7520_14 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_STIFFNESS_7520_22 = _G1_AGILE_ARMATURE_7520_22 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_STIFFNESS_5020 = _G1_AGILE_ARMATURE_5020 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_DAMPING_7520_14 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_7520_14 * _G1_AGILE_NATURAL_FREQ
+_G1_AGILE_DAMPING_7520_22 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_7520_22 * _G1_AGILE_NATURAL_FREQ
+_G1_AGILE_DAMPING_5020 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_5020 * _G1_AGILE_NATURAL_FREQ
+
+
+# G1 articulation tuned to match the agile training-time PD/armature values from
+# ``unitree_g1_velocity_height_recurrent_student.yaml``. Arena's default G1 has
+# 2-4x higher leg/feet stiffness; without this override the policy's joint
+# targets get amplified by the stiffer PD loop, manifesting as a slow yaw drift
+# / postural twitch even when the velocity command is zero. ``effort_limit``,
+# ``velocity_limit``, ``friction``, spawn, init pose, hands, and arm gains keep
+# the Arena defaults since they are physical limits or joint-set definitions,
+# not policy training inputs.
+G1_AGILE_CFG = G1_CFG.copy()
+G1_AGILE_CFG.actuators["legs"].stiffness = {
+    ".*_hip_pitch_joint": _G1_AGILE_STIFFNESS_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_STIFFNESS_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_STIFFNESS_7520_14,
+    ".*_knee_joint": _G1_AGILE_STIFFNESS_7520_22,
 }
-
-
-def _override_actuator_gains_for_agile(robot_cfg: ArticulationCfg) -> None:
-    """Override the Arena G1 actuator stiffness/damping/armature in-place to match
-    the agile training-time values for joints the AGILE policy controls.
-
-    Replaces the actuator group's ``stiffness`` / ``damping`` / ``armature`` dicts
-    with exact-joint-name keys so the IsaacLab regex resolver doesn't see overlap
-    between e.g. the original ``.*_hip_.*`` armature key and the more specific
-    per-joint stiffness keys we add here.
-
-    Other parameters (``joint_names_expr``, ``effort_limit``, ``velocity_limit``,
-    ``friction``) keep their Arena defaults since they are physical limits or
-    joint-set definitions, not policy training inputs.
-    """
-    for group_name, per_joint_gains in _AGILE_GAINS_PER_GROUP.items():
-        if group_name not in robot_cfg.actuators:
-            continue
-        actuator_cfg = robot_cfg.actuators[group_name]
-        actuator_cfg.stiffness = {jn: g["stiffness"] for jn, g in per_joint_gains.items()}
-        actuator_cfg.damping = {jn: g["damping"] for jn, g in per_joint_gains.items()}
-        actuator_cfg.armature = {jn: g["armature"] for jn, g in per_joint_gains.items()}
+G1_AGILE_CFG.actuators["legs"].damping = {
+    ".*_hip_pitch_joint": _G1_AGILE_DAMPING_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_DAMPING_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_DAMPING_7520_14,
+    ".*_knee_joint": _G1_AGILE_DAMPING_7520_22,
+}
+G1_AGILE_CFG.actuators["legs"].armature = {
+    ".*_hip_pitch_joint": _G1_AGILE_ARMATURE_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_ARMATURE_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_ARMATURE_7520_14,
+    ".*_knee_joint": _G1_AGILE_ARMATURE_7520_22,
+}
+G1_AGILE_CFG.actuators["feet"].stiffness = 2.0 * _G1_AGILE_STIFFNESS_5020
+G1_AGILE_CFG.actuators["feet"].damping = 2.0 * _G1_AGILE_DAMPING_5020
+G1_AGILE_CFG.actuators["feet"].armature = 2.0 * _G1_AGILE_ARMATURE_5020
+# Waist gains come straight from the recurrent-student YAML; they don't fit
+# the (armature, omega_n, zeta) family above, so use the literal values.
+G1_AGILE_CFG.actuators["waist"].stiffness = {
+    "waist_yaw_joint": 300.0,
+    "waist_roll_joint": 300.0,
+    "waist_pitch_joint": 300.0,
+}
+G1_AGILE_CFG.actuators["waist"].damping = {
+    "waist_yaw_joint": 5.0,
+    "waist_roll_joint": 5.0,
+    "waist_pitch_joint": 5.0,
+}
+G1_AGILE_CFG.actuators["waist"].armature = 0.03
 
 
 @configclass
 class G1SceneCfg:
+    robot: ArticulationCfg = G1_CFG.copy()
 
-    # Gear'WBC G1 config, used in WBC training
-    robot: ArticulationCfg = ArticulationCfg(
-        spawn=sim_utils.UsdFileCfg(
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Samples/Groot/Robots/g1_29dof_with_hand_rev_1_0.usd",
-            activate_contact_sensors=True,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                disable_gravity=False,
-                retain_accelerations=False,
-                linear_damping=0.0,
-                angular_damping=0.0,
-                max_linear_velocity=1000.0,
-                max_angular_velocity=1000.0,
-                max_depenetration_velocity=1.0,
-                solver_position_iteration_count=4,
-                solver_velocity_iteration_count=0,
-            ),
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-                enabled_self_collisions=False, solver_position_iteration_count=4, solver_velocity_iteration_count=0
-            ),
-        ),
-        prim_path="/World/envs/env_.*/Robot",
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.8, -1.38, 0.78),
-            rot=(0.0, 0.0, 1.0, 0.0),
-            joint_pos={
-                # target angles [rad]
-                "left_hip_pitch_joint": -0.1,
-                "left_hip_roll_joint": 0.0,
-                "left_hip_yaw_joint": 0.0,
-                "left_knee_joint": 0.3,
-                "left_ankle_pitch_joint": -0.2,
-                "left_ankle_roll_joint": 0.0,
-                "right_hip_pitch_joint": -0.1,
-                "right_hip_roll_joint": 0.0,
-                "right_hip_yaw_joint": 0.0,
-                "right_knee_joint": 0.3,
-                "right_ankle_pitch_joint": -0.2,
-                "right_ankle_roll_joint": 0.0,
-                "waist_yaw_joint": 0.0,
-                "waist_roll_joint": 0.0,
-                "waist_pitch_joint": 0.0,
-                "left_shoulder_pitch_joint": 0.0,
-                "left_shoulder_roll_joint": 0.0,
-                "left_shoulder_yaw_joint": 0.0,
-                "left_elbow_joint": 0.0,
-                "right_shoulder_pitch_joint": 0.0,
-                "right_shoulder_roll_joint": 0,
-                "right_shoulder_yaw_joint": 0.0,
-                "right_elbow_joint": 0.0,
-            },
-            joint_vel={".*": 0.0},
-        ),
-        actuators={
-            "legs": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_hip_yaw_joint",
-                    ".*_hip_roll_joint",
-                    ".*_hip_pitch_joint",
-                    ".*_knee_joint",
-                ],
-                effort_limit={
-                    ".*_hip_yaw_joint": 88.0,
-                    ".*_hip_roll_joint": 88.0,
-                    ".*_hip_pitch_joint": 88.0,
-                    ".*_knee_joint": 139.0,
-                },
-                velocity_limit={
-                    ".*_hip_yaw_joint": 32.0,
-                    ".*_hip_roll_joint": 32.0,
-                    ".*_hip_pitch_joint": 32.0,
-                    ".*_knee_joint": 20.0,
-                },
-                stiffness={
-                    ".*_hip_yaw_joint": 150.0,
-                    ".*_hip_roll_joint": 150.0,
-                    ".*_hip_pitch_joint": 150.0,
-                    ".*_knee_joint": 300.0,
-                },
-                damping={
-                    ".*_hip_yaw_joint": 2.0,
-                    ".*_hip_roll_joint": 2.0,
-                    ".*_hip_pitch_joint": 2.0,
-                    ".*_knee_joint": 4.0,
-                },
-                armature={
-                    ".*_hip_.*": 0.03,
-                    ".*_knee_joint": 0.03,
-                },
-            ),
-            "feet": IdealPDActuatorCfg(
-                joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
-                stiffness={
-                    ".*_ankle_pitch_joint": 40.0,
-                    ".*_ankle_roll_joint": 40.0,
-                },
-                damping={
-                    ".*_ankle_pitch_joint": 2,
-                    ".*_ankle_roll_joint": 2,
-                },
-                effort_limit={
-                    ".*_ankle_pitch_joint": 50.0,
-                    ".*_ankle_roll_joint": 50.0,
-                },
-                velocity_limit={
-                    ".*_ankle_pitch_joint": 37.0,
-                    ".*_ankle_roll_joint": 37.0,
-                },
-                armature=0.03,
-                friction=0.03,
-            ),
-            "waist": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    "waist_.*_joint",
-                ],
-                effort_limit={
-                    "waist_yaw_joint": 88.0,
-                    "waist_roll_joint": 50.0,
-                    "waist_pitch_joint": 50.0,
-                },
-                velocity_limit={
-                    "waist_yaw_joint": 32.0,
-                    "waist_roll_joint": 37.0,
-                    "waist_pitch_joint": 37.0,
-                },
-                stiffness={
-                    "waist_yaw_joint": 250.0,
-                    "waist_roll_joint": 250.0,
-                    "waist_pitch_joint": 250.0,
-                },
-                damping={
-                    "waist_yaw_joint": 5.0,
-                    "waist_roll_joint": 5.0,
-                    "waist_pitch_joint": 5.0,
-                },
-                armature=0.03,
-                friction=0.03,
-            ),
-            "arms": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_shoulder_pitch_joint",
-                    ".*_shoulder_roll_joint",
-                    ".*_shoulder_yaw_joint",
-                    ".*_elbow_joint",
-                    ".*_wrist_.*_joint",
-                ],
-                effort_limit={
-                    ".*_shoulder_pitch_joint": 25.0,
-                    ".*_shoulder_roll_joint": 25.0,
-                    ".*_shoulder_yaw_joint": 25.0,
-                    ".*_elbow_joint": 25.0,
-                    ".*_wrist_roll_joint": 25.0,
-                    ".*_wrist_pitch_joint": 5.0,
-                    ".*_wrist_yaw_joint": 5.0,
-                },
-                velocity_limit={
-                    ".*_shoulder_pitch_joint": 37.0,
-                    ".*_shoulder_roll_joint": 37.0,
-                    ".*_shoulder_yaw_joint": 37.0,
-                    ".*_elbow_joint": 37.0,
-                    ".*_wrist_roll_joint": 37.0,
-                    ".*_wrist_pitch_joint": 22.0,
-                    ".*_wrist_yaw_joint": 22.0,
-                },
-                stiffness={
-                    ".*_shoulder_pitch_joint": 100.0,
-                    ".*_shoulder_roll_joint": 100.0,
-                    ".*_shoulder_yaw_joint": 40.0,
-                    ".*_elbow_joint": 40.0,
-                    ".*_wrist_.*_joint": 20.0,
-                },
-                damping={
-                    ".*_shoulder_pitch_joint": 5.0,
-                    ".*_shoulder_roll_joint": 5.0,
-                    ".*_shoulder_yaw_joint": 2.0,
-                    ".*_elbow_joint": 2.0,
-                    ".*_wrist_.*_joint": 2.0,
-                },
-                armature={".*_shoulder_.*": 0.03, ".*_elbow_.*": 0.03, ".*_wrist_.*_joint": 0.03},
-                friction=0.03,
-            ),
-            # NOTE(peterd, 9/25/2025): The follow hand joint values are tested and working with Leapmotion and Mimic
-            "hands": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_hand_.*",
-                ],
-                effort_limit=5.0,
-                velocity_limit=10.0,
-                stiffness=4.0,
-                damping=0.5,
-                armature=0.03,
-                friction=0.03,
-            ),
-        },
-    )
+
+@configclass
+class G1AgileSceneCfg(G1SceneCfg):
+    """G1 scene config with actuator gains tuned for the AGILE recurrent policy."""
+
+    robot: ArticulationCfg = G1_AGILE_CFG.copy()
 
 
 @configclass
@@ -784,10 +755,10 @@ class G1WBCAgilePinkActionCfg:
     """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body.
 
     The AGILE recurrent lower-body policy only drives the 12 leg joints (it does not
-    move waist_yaw/roll/pitch -- those slots stay at zero target from the WBC). To give
-    the upper-body PINK IK more reach, we extend its active joint set to include
-    ``waist_roll_joint`` and ``waist_pitch_joint`` (waist_yaw stays fixed because the
-    AGILE policy expects it at zero).
+    move waist_yaw/roll/pitch). To give the upper-body PINK IK more reach, we extend
+    its active joint set to include ``waist_roll_joint`` and ``waist_pitch_joint``;
+    ``waist_yaw_joint`` is intentionally left out because the AGILE policy was trained
+    with waist_yaw held at zero.
     """
 
     g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 import torch
 import tqdm
+from gymnasium.wrappers import RecordVideo
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
@@ -167,9 +169,10 @@ def main():
             args_cli.distributed = True
             args_cli.device = f"cuda:{local_rank}"
 
-        # Build scene
+        # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
         arena_builder = get_arena_builder_from_cli(args_cli)
-        env, cfg = arena_builder.make_registered_and_return_cfg()
+        render_mode = "rgb_array" if args_cli.video else None
+        env, cfg = arena_builder.make_registered_and_return_cfg(render_mode=render_mode)
 
         # Per-rank seed when distributed so each process has a different seed
         seed = args_cli.seed
@@ -196,6 +199,25 @@ def main():
                 print(f"[Rank {local_rank}/{world_size}] Simulation length: {num_episodes} episodes")
             else:
                 raise ValueError(f"[Rank {local_rank}/{world_size}] Either num_steps or num_episodes must be provided")
+
+        # Optionally wrap with RecordVideo. Mirrors the eval_runner.py wiring so the same
+        # mp4 layout works between policy_runner and eval_runner.
+        if args_cli.video:
+            os.makedirs(args_cli.video_dir, exist_ok=True)
+            if num_steps is not None:
+                video_length = num_steps
+            else:
+                # When num_episodes is set, capture exactly one episode's worth of frames.
+                # max_episode_length is in environment steps, which matches our rollout cadence.
+                video_length = num_episodes * env.unwrapped.max_episode_length
+            env = RecordVideo(
+                env,
+                video_folder=args_cli.video_dir,
+                step_trigger=lambda step: step == 0,
+                video_length=video_length,
+                disable_logger=True,
+            )
+            print(f"[Rank {local_rank}/{world_size}] Recording {video_length}-step video to: {args_cli.video_dir}")
 
         steps_str = f"{num_steps} steps" if num_steps is not None else f"{num_episodes} episodes"
         print(f"[Rank {local_rank}/{world_size}] Starting rollout ({steps_str})")

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -32,3 +32,16 @@ def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Language instruction for the policy. Takes precedence over the task's own description.",
     )
+    parser.add_argument(
+        "--video",
+        action="store_true",
+        default=False,
+        help="Record an mp4 video of the rollout (uses gymnasium.wrappers.RecordVideo).",
+    )
+    parser.add_argument(
+        "--video_dir",
+        "--video-dir",
+        type=str,
+        default="/eval/videos",
+        help="Output directory for the recorded video. Created if missing. Used only with --video.",
+    )

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
@@ -88,11 +88,29 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         self._navigate_cmd = torch.zeros([self.num_envs, 3], device=self.device)
         self._torso_orientation_rpy_cmd = torch.zeros([self.num_envs, 3], device=self.device)
 
-        # Create the PINK IK controller
+        # Create the PINK IK controller. By default the IK only drives the "arms" group;
+        # the embodiment may extend this via `upperbody_extra_active_joints` (e.g. AGILE-pink
+        # adds waist_roll_joint and waist_pitch_joint).
         self.upperbody_controller = G1WBCUpperbodyController(
             robot_model=self.robot_model,
-            body_active_joint_groups=["arms"],
+            body_active_joint_groups=list(self.cfg.upperbody_active_joint_groups),
+            extra_active_joints=list(self.cfg.upperbody_extra_active_joints),
         )
+
+        # Map any extra (non-"upper_body"-group) IK-active joints to their sim-side joint
+        # indices so we can splice the IK solution back into ``_processed_actions`` after
+        # the WBC postprocess (which writes only ``upper_body`` and ``lower_body`` slots).
+        self._extra_active_joint_sim_indices: list[int] = []
+        self._extra_active_joint_full_indices: list[int] = []
+        sim_joint_names = self._asset.data.joint_names
+        full_joint_names = self.robot_model.joint_names
+        for jn in self.cfg.upperbody_extra_active_joints:
+            if jn not in sim_joint_names:
+                raise ValueError(f"Extra active joint '{jn}' not found in articulation joint_names")
+            if jn not in full_joint_names:
+                raise ValueError(f"Extra active joint '{jn}' not found in robot_model joint_names")
+            self._extra_active_joint_sim_indices.append(sim_joint_names.index(jn))
+            self._extra_active_joint_full_indices.append(full_joint_names.index(jn))
 
     # Properties.
     # """
@@ -244,6 +262,9 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         # Reformat the joint position tensor to the correct order for G1 upper body
         target_upper_body_joints = target_robot_joints[self.robot_model.get_joint_group_indices("upper_body")]
 
+        # Stash the IK solution for the post-WBC writeback of extra (non-upper_body) joints.
+        self._last_ik_target_robot_joints = target_robot_joints
+
         """
         **************************************************
         WBC closedloop
@@ -347,6 +368,16 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         self._processed_actions = postprocess_actions(
             wbc_action, self._asset.data, self.wbc_g1_joints_order, self.device
         )
+
+        # WBC writes only ``upper_body`` and ``lower_body`` slots; for joints that the IK
+        # actively drives but live outside ``upper_body`` (e.g. waist_roll/pitch for the
+        # AGILE-pink combo), splice the IK target back into ``_processed_actions`` so they
+        # actually get applied to the simulator instead of staying at the lower-body
+        # policy's default (zero) target.
+        if self._extra_active_joint_sim_indices:
+            ik_targets = self._last_ik_target_robot_joints
+            for sim_idx, full_idx in zip(self._extra_active_joint_sim_indices, self._extra_active_joint_full_indices):
+                self._processed_actions[:, sim_idx] = float(ik_targets[full_idx])
 
     def apply_actions(self):
         """Apply the computed joint positions based on the WBC solution."""

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
@@ -36,3 +36,11 @@ class G1DecoupledWBCPinkActionCfg(G1DecoupledWBCJointActionCfg):
 
     # Navigation Segment: Max navigation steps
     max_navigation_steps: int = 700
+
+    # Upper-body PINK IK active joint configuration. By default, only the "arms" joint group
+    # is moved by the IK. Extra individual joint names can be activated on top -- e.g. for
+    # the AGILE-pink combo we activate waist_roll_joint and waist_pitch_joint so the IK can
+    # use the torso (the AGILE recurrent lower-body policy doesn't drive these joints, so
+    # leaving them under PINK IK control gives the arms more reach).
+    upperbody_active_joint_groups: list[str] = ["arms"]
+    upperbody_extra_active_joints: list[str] = []

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
@@ -81,8 +81,10 @@ class AgileConfig(BaseConfig):
     wbc_version: Literal["agile"] = "agile"
     """Version of the whole body controller."""
 
+    # Pinned to a commit (rather than `main`) so upstream changes don't silently shift behavior.
+    # Bump to a new SHA / release tag when intentionally adopting a new policy export.
     wbc_model_path: str = (
-        "https://github.com/nvidia-isaac/WBC-AGILE/raw/v1.2/agile/data/policy/velocity_g1/unitree_g1_velocity_e2e.onnx"
+        "https://github.com/nvidia-isaac/WBC-AGILE/raw/7259792cf10803aab814d101134d493d24c8f22f/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx"
     )
     """Path to WBC model file (GitHub URL, resolved via retrieve_file_path)"""
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
@@ -81,10 +81,13 @@ class AgileConfig(BaseConfig):
     wbc_version: Literal["agile"] = "agile"
     """Version of the whole body controller."""
 
-    # Pinned to a commit (rather than `main`) so upstream changes don't silently shift behavior.
-    # Bump to a new SHA / release tag when intentionally adopting a new policy export.
+    # Locked to a specific commit SHA to prevent unintentional changes from upstream updates.
+    # Update to a new commit or release tag only when deliberately adopting a newer policy export.
+    # Currently set to a hotfix SHA; replace with an official tag once available.
+    COMMIT_HASH_FOR_WBC_AGILE_POLICY = "7259792cf10803aab814d101134d493d24c8f22f"
     wbc_model_path: str = (
-        "https://github.com/nvidia-isaac/WBC-AGILE/raw/7259792cf10803aab814d101134d493d24c8f22f/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx"
+        f"https://github.com/nvidia-isaac/WBC-AGILE/raw/{COMMIT_HASH_FOR_WBC_AGILE_POLICY}/"
+        "agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx"
     )
     """Path to WBC model file (GitHub URL, resolved via retrieve_file_path)"""
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_agile.yaml
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_agile.yaml
@@ -36,17 +36,17 @@ onnx_input_joint_names:
   - left_wrist_yaw_joint
   - right_wrist_yaw_joint
 
-# Joint ordering for ONNX model outputs (14 controlled joints in agile output order).
-# Must match the action_joint_pos element_names from unitree_g1_velocity_e2e.yaml.
+# Joint ordering for ONNX model outputs (12 leg joints in agile output order).
+# Recurrent student outputs JointPositionActionCfg(LEG_JOINT_NAMES); waist roll/pitch
+# are NOT controlled by this policy, so the leg-only ordering is the original 14-entry
+# list with waist_roll_joint and waist_pitch_joint removed.
 controlled_joint_names:
   - left_hip_pitch_joint
   - right_hip_pitch_joint
   - left_hip_roll_joint
   - right_hip_roll_joint
-  - waist_roll_joint
   - left_hip_yaw_joint
   - right_hip_yaw_joint
-  - waist_pitch_joint
   - left_knee_joint
   - right_knee_joint
   - left_ankle_pitch_joint
@@ -54,8 +54,45 @@ controlled_joint_names:
   - left_ankle_roll_joint
   - right_ankle_roll_joint
 
-num_actions: 14
+num_actions: 12
 num_body_joints: 29
 
-# Initial commands
-cmd_init: [0.0, 0.0, 0.0]
+# 4-channel velocity-height command [v_x, v_y, w_z, h]. Default pelvis height = 0.72 m
+# (matches the WBC standing-height default used by the zero-action baseline).
+cmd_init: [0.0, 0.0, 0.0, 0.72]
+
+# Matches `scale=0.1` on `joint_vel` in StudentVelocityPolicyCfg
+# (agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py).
+joint_vel_scale: 0.1
+
+# Per-joint action post-processing, mirrored from the agile training
+# JointPositionActionCfg (G1_ACTION_SCALE_LOWER, use_default_offset=True, clip=[-6, 6]).
+# Order matches `controlled_joint_names` above.
+# Final joint target = clip(raw_action, -6, 6) * action_scale + action_offset.
+action_clip: [-6.0, 6.0]
+action_scale:
+  - 0.5475464463233948  # left_hip_pitch_joint
+  - 0.5475464463233948  # right_hip_pitch_joint
+  - 0.3506614565849304  # left_hip_roll_joint
+  - 0.3506614565849304  # right_hip_roll_joint
+  - 0.5475464463233948  # left_hip_yaw_joint
+  - 0.5475464463233948  # right_hip_yaw_joint
+  - 0.3506614565849304  # left_knee_joint
+  - 0.3506614565849304  # right_knee_joint
+  - 0.4385773241519928  # left_ankle_pitch_joint
+  - 0.4385773241519928  # right_ankle_pitch_joint
+  - 0.4385773241519928  # left_ankle_roll_joint
+  - 0.4385773241519928  # right_ankle_roll_joint
+action_offset:
+  - -0.10  # left_hip_pitch_joint
+  - -0.10  # right_hip_pitch_joint
+  - 0.0    # left_hip_roll_joint
+  - 0.0    # right_hip_roll_joint
+  - 0.0    # left_hip_yaw_joint
+  - 0.0    # right_hip_yaw_joint
+  - 0.30   # left_knee_joint
+  - 0.30   # right_knee_joint
+  - -0.20  # left_ankle_pitch_joint
+  - -0.20  # right_ankle_pitch_joint
+  - 0.0    # left_ankle_roll_joint
+  - 0.0    # right_ankle_roll_joint

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
@@ -24,8 +24,16 @@ class G1BodyIKSolverSettings:
         self.posture_cost = 0.01
         self.posture_lm_damping = 1.0
         self.link_costs = {"hand": {"orientation_cost": 0.5, "position_cost": 1.0}}
+        # Per-joint posture-task weights (relative to the default of 1.0). Higher
+        # values make the IK resist deviating that joint from its rest pose.
+        # Both `waist_pitch` and `waist_roll` are set to 10.0 because, when these
+        # joints are in the IK's active set (e.g. AGILE-pink), the iterative
+        # integration of `pink.Configuration.q` accumulates small numerical drifts
+        # that, over hundreds of steps, manifest as a slow tilt; the strong
+        # posture weight pulls them back toward the default pose each step.
         self.posture_weight = {
             "waist_pitch": 10.0,
+            "waist_roll": 10.0,
             "shoulder_pitch": 4.0,
             "shoulder_roll": 3.0,
             "shoulder_yaw": 2.0,
@@ -202,10 +210,33 @@ class G1WBCUpperbodyController:
         self,
         robot_model: RobotModel,
         body_active_joint_groups: list[str] | None = None,
+        extra_active_joints: list[str] | None = None,
     ):
+        """Initialize the upperbody controller.
+
+        Args:
+            robot_model: Full robot model.
+            body_active_joint_groups: Joint group names whose joints stay active (driven by IK).
+                All other joints are fixed. If None and ``extra_active_joints`` is also None,
+                the full robot is used (no reduction).
+            extra_active_joints: Additional individual joint names to keep active on top of
+                ``body_active_joint_groups``. Useful when you want a partial group, e.g.
+                only ``waist_roll_joint`` and ``waist_pitch_joint`` from the ``waist`` group.
+        """
         # Initialize the body
-        if body_active_joint_groups is not None:
-            self.body = ReducedRobotModel.from_active_groups(robot_model, body_active_joint_groups)
+        active_groups = body_active_joint_groups
+        extra_joints = list(extra_active_joints) if extra_active_joints else []
+        if active_groups is not None or extra_joints:
+            # Compute the union of group joints + extra joints, then derive fixed joints.
+            active_joint_names: set[str] = set(extra_joints)
+            if active_groups is not None:
+                for group_name in active_groups:
+                    if group_name not in robot_model.supplemental_info.joint_groups:
+                        raise ValueError(f"Unknown joint group: {group_name}")
+                    group_indices = robot_model.get_joint_group_indices(group_name)
+                    active_joint_names.update(robot_model.joint_names[idx] for idx in group_indices)
+            fixed_joints = [name for name in robot_model.joint_names if name not in active_joint_names]
+            self.body = ReducedRobotModel(robot_model, fixed_joints)
             self.full_robot = self.body.full_robot
             self.using_reduced_robot_model = True
         else:

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
@@ -15,25 +15,29 @@ from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.base import WB
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.utils.homie_utils import load_config
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.utils.onnx_utils import OnnxInferenceSession
 
-# ONNX feedback state keys and their per-environment shapes (excluding batch dim).
-_STATE_KEYS_AND_SHAPES: dict[str, tuple[int, ...]] = {
-    "last_actions": (14,),
-    "base_ang_vel_history": (5, 3),
-    "projected_gravity_history": (5, 3),
-    "velocity_commands_history": (5, 3),
-    "controlled_joint_pos_history": (5, 14),
-    "controlled_joint_vel_history": (5, 14),
-    "actions_history": (5, 14),
-}
+# LSTM hidden state shape baked into the recurrent student ONNX.
+_LSTM_NUM_LAYERS = 1
+_LSTM_HIDDEN_SIZE = 256
 
 
 class G1AgilePolicy(WBCPolicy):
-    """G1 robot policy using the WBC-AGILE end-to-end neural network.
+    """G1 robot policy using the recurrent LSTM student exported from
+    ``agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py``.
 
-    This policy uses a single ONNX model that takes raw sensor inputs and
-    manages observation history internally via feedback connections. The model
-    outputs target joint positions along with per-joint Kp/Kd gains for 14
-    controlled joints (legs + waist_roll + waist_pitch).
+    The ONNX has three inputs: a flat ``obs`` vector and the LSTM hidden/cell
+    states ``h_in``/``c_in``. ``obs`` is laid out as::
+
+        [velocity_height_commands(4),  # [v_x, v_y, w_z, h]
+         base_ang_vel(3),
+         projected_gravity(3),
+         joint_pos_rel(29) = q - q_default,
+         joint_vel_rel(29) * joint_vel_scale,
+         last_action(num_actions=12)]
+
+    The 12 outputs are the leg target joint positions (no waist roll/pitch).
+
+    Note: the ONNX has a static batch dim of 1, so this policy only supports
+    ``num_envs == 1``. Re-export with dynamic axes if batched eval is needed.
     """
 
     def __init__(self, robot_model: RobotModel, config_path: str, model_path: str, num_envs: int = 1):
@@ -44,8 +48,14 @@ class G1AgilePolicy(WBCPolicy):
             config_path: Path to policy YAML configuration file (relative to wbc_policy dir).
             model_path: Path to the ONNX model file. Can be an S3/Nucleus URL
                 (resolved and cached by retrieve_file_path) or a local path.
-            num_envs: Number of environments.
+            num_envs: Number of environments. Must be 1 for the static-batch ONNX.
         """
+        assert num_envs == 1, (
+            "G1AgilePolicy uses a recurrent LSTM ONNX with static batch=1; "
+            f"got num_envs={num_envs}. Re-export the ONNX with dynamic batch axis "
+            "to support num_envs > 1."
+        )
+
         parent_dir = pathlib.Path(__file__).parent.parent
         self.config = load_config(str(parent_dir / config_path))
         self.robot_model = robot_model
@@ -58,10 +68,10 @@ class G1AgilePolicy(WBCPolicy):
         model_full_path = parent_dir / model_local_path
         self.session = OnnxInferenceSession(str(model_full_path))
 
-        # Build joint index mappings between WBC order and agile ONNX order
+        # Build joint index mappings between WBC order and agile ONNX order.
         self._build_joint_mappings()
 
-        # Initialize state
+        # Initialize state.
         self._init_state()
 
     def _build_joint_mappings(self):
@@ -73,7 +83,7 @@ class G1AgilePolicy(WBCPolicy):
         onnx_input_names = self.config["onnx_input_joint_names"]
         self.wbc_to_agile_input = np.array([wbc_order[name] for name in onnx_input_names])
 
-        # Mapping for ONNX output: for each of the 14 agile output joints, the
+        # Mapping for ONNX output: for each of the 12 agile output joints, the
         # position in the 15-element lower_body array to write to.
         controlled_names = self.config["controlled_joint_names"]
         lower_body_indices = self.robot_model.get_joint_group_indices("lower_body")
@@ -82,16 +92,47 @@ class G1AgilePolicy(WBCPolicy):
         )
 
         self.num_lower_body = len(lower_body_indices)
+        self.num_actions = int(self.config["num_actions"])
 
     def _init_state(self):
         """Initialize all per-environment state variables."""
         self.observation = None
-        self.cmd = np.tile(self.config["cmd_init"], (self.num_envs, 1))
 
-        # Batched ONNX feedback state: each array has shape (num_envs, ...).
-        self.state = {
-            key: np.zeros((self.num_envs, *shape), dtype=np.float32) for key, shape in _STATE_KEYS_AND_SHAPES.items()
-        }
+        # 4-dim command: [v_x, v_y, w_z, h].
+        self._cmd_init = np.array(self.config["cmd_init"], dtype=np.float32)
+        assert self._cmd_init.shape == (4,), f"cmd_init must be 4-dim, got {self._cmd_init.shape}"
+        self.cmd = np.tile(self._cmd_init, (self.num_envs, 1))
+
+        # LSTM feedback state.
+        self.h_state = np.zeros((_LSTM_NUM_LAYERS, self.num_envs, _LSTM_HIDDEN_SIZE), dtype=np.float32)
+        self.c_state = np.zeros_like(self.h_state)
+
+        # Previous action fed back as part of obs.
+        self.last_action = np.zeros((self.num_envs, self.num_actions), dtype=np.float32)
+
+        self.joint_vel_scale = float(self.config.get("joint_vel_scale", 0.1))
+
+        # Action post-processing (matches agile JointPositionActionCfg):
+        #   target_q = clip(raw_action, action_clip) * action_scale + action_offset
+        action_clip = self.config.get("action_clip")
+        if action_clip is not None:
+            self._action_clip_min = float(action_clip[0])
+            self._action_clip_max = float(action_clip[1])
+        else:
+            self._action_clip_min = -np.inf
+            self._action_clip_max = np.inf
+        action_scale = self.config.get("action_scale", [1.0] * self.num_actions)
+        action_offset = self.config.get("action_offset", [0.0] * self.num_actions)
+        self._action_scale = np.array(action_scale, dtype=np.float32).reshape(1, -1)
+        self._action_offset = np.array(action_offset, dtype=np.float32).reshape(1, -1)
+        assert self._action_scale.shape == (
+            1,
+            self.num_actions,
+        ), f"action_scale must have {self.num_actions} entries, got {self._action_scale.shape}"
+        assert self._action_offset.shape == (
+            1,
+            self.num_actions,
+        ), f"action_offset must have {self.num_actions} entries, got {self._action_offset.shape}"
 
     def reset(self, env_ids: torch.Tensor):
         """Reset the policy state for the given environment ids.
@@ -99,10 +140,11 @@ class G1AgilePolicy(WBCPolicy):
         Args:
             env_ids: The environment ids to reset.
         """
-        idx = env_ids.cpu().numpy()
-        for key, shape in _STATE_KEYS_AND_SHAPES.items():
-            self.state[key][idx] = np.zeros(shape, dtype=np.float32)
-        self.cmd[idx] = self.config["cmd_init"]
+        idx = env_ids.cpu().numpy() if isinstance(env_ids, torch.Tensor) else np.asarray(env_ids)
+        self.h_state[:, idx, :] = 0.0
+        self.c_state[:, idx, :] = 0.0
+        self.last_action[idx] = 0.0
+        self.cmd[idx] = self._cmd_init
 
     def set_observation(self, observation: dict[str, Any]):
         """Store the current observation for the next get_action call.
@@ -118,9 +160,12 @@ class G1AgilePolicy(WBCPolicy):
         Args:
             goal: Dictionary containing goals. Supported keys:
                 - "navigate_cmd": velocity command array of shape (num_envs, 3)
+                - "base_height_command": height command of shape (num_envs, 1)
         """
-        if "navigate_cmd" in goal:
-            self.cmd = goal["navigate_cmd"]
+        nav = goal.get("navigate_cmd")
+        height = goal.get("base_height_command")
+        if nav is not None and height is not None:
+            self.cmd = np.concatenate([nav, height], axis=1).astype(np.float32)
 
     def get_action(self, time: float | None = None) -> dict[str, Any]:
         """Compute and return the next action based on current observation.
@@ -134,26 +179,38 @@ class G1AgilePolicy(WBCPolicy):
 
         obs = self.observation
 
-        # Build batched ONNX inputs (all envs at once)
-        ort_inputs = {
-            "root_link_quat_w": obs["floating_base_pose"][:, 3:7].astype(np.float32),
-            "root_ang_vel_b": obs["floating_base_vel"][:, 3:6].astype(np.float32),
-            "velocity_commands": self.cmd.astype(np.float32),
-            "joint_pos": obs["q"][:, self.wbc_to_agile_input].astype(np.float32),
-            "joint_vel": obs["dq"][:, self.wbc_to_agile_input].astype(np.float32),
-            **{key: self.state[key] for key in _STATE_KEYS_AND_SHAPES},
-        }
+        # Use root_ang_vel_b (COM frame) to match `mdp.base_ang_vel` from training.
+        ang_vel_b = obs["root_ang_vel_b"].astype(np.float32)
+        proj_grav = obs["projected_gravity_b"].astype(np.float32)
 
-        # Run batched inference
-        result = self.session.run(ort_inputs)
+        # Reorder WBC-ordered q/dq/default_q into the agile training order.
+        q_agile = obs["q"][:, self.wbc_to_agile_input].astype(np.float32)
+        dq_agile = obs["dq"][:, self.wbc_to_agile_input].astype(np.float32)
+        q_default_agile = obs["default_q"][:, self.wbc_to_agile_input].astype(np.float32)
 
-        # Update feedback state for next step
-        for key in _STATE_KEYS_AND_SHAPES:
-            self.state[key] = result[f"{key}_out"]
+        joint_pos_rel = q_agile - q_default_agile
+        joint_vel_rel = dq_agile * self.joint_vel_scale
 
-        # Map 14 agile output joints to the 15-joint lower_body array.
-        # waist_yaw (not controlled by agile) stays at 0.0.
+        flat_obs = np.concatenate(
+            [self.cmd, ang_vel_b, proj_grav, joint_pos_rel, joint_vel_rel, self.last_action],
+            axis=1,
+        )
+
+        result = self.session.run({"obs": flat_obs.astype(np.float32), "h_in": self.h_state, "c_in": self.c_state})
+
+        actions = result["actions"].astype(np.float32)  # (N, num_actions)
+        self.h_state = result["h_out"]
+        self.c_state = result["c_out"]
+
+        # Feed back the *raw* (pre-processed) action: this matches mdp.last_action
+        # which returns env.action_manager.action (the policy output before scale/offset).
+        self.last_action = actions
+
+        # Match the agile training JointPositionActionCfg post-processing:
+        #   target_q = clip(raw_action, clip_min, clip_max) * scale + offset
+        target_q = np.clip(actions, self._action_clip_min, self._action_clip_max)
+        target_q = target_q * self._action_scale + self._action_offset
+
         body_action = np.zeros((self.num_envs, self.num_lower_body), dtype=np.float32)
-        body_action[:, self.agile_idx_to_lower_body_idx] = result["action_joint_pos"]
-
+        body_action[:, self.agile_idx_to_lower_body_idx] = target_q
         return {"body_action": body_action}

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
@@ -84,7 +84,9 @@ class G1AgilePolicy(WBCPolicy):
         self.wbc_to_agile_input = np.array([wbc_order[name] for name in onnx_input_names])
 
         # Mapping for ONNX output: for each of the 12 agile output joints, the
-        # position in the 15-element lower_body array to write to.
+        # position in the 15-slot ``lower_body`` array (12 legs + 3 waist; see
+        # ``G1SupplementalInfo.joint_groups`` in ``g1_supplemental_info.py``).
+        # AGILE only drives the 12 leg slots; the 3 waist slots stay at zero.
         controlled_names = self.config["controlled_joint_names"]
         lower_body_indices = self.robot_model.get_joint_group_indices("lower_body")
         self.agile_idx_to_lower_body_idx = np.array(
@@ -157,15 +159,34 @@ class G1AgilePolicy(WBCPolicy):
     def set_goal(self, goal: dict[str, Any]):
         """Set the goal for the policy.
 
+        ``self.cmd`` is a 4-wide buffer ``[v_x, v_y, w_z, h]`` initialized from
+        ``cmd_init``. Each key below updates only its own slice, so callers that
+        provide one without the other (e.g. a velocity-only navigation override)
+        leave the height channel at its previous value rather than silently
+        no-op'ing.
+
         Args:
             goal: Dictionary containing goals. Supported keys:
                 - "navigate_cmd": velocity command array of shape (num_envs, 3)
                 - "base_height_command": height command of shape (num_envs, 1)
         """
         nav = goal.get("navigate_cmd")
+        if nav is not None:
+            nav = np.asarray(nav, dtype=np.float32)
+            assert nav.shape == (
+                self.num_envs,
+                3,
+            ), f"navigate_cmd must have shape ({self.num_envs}, 3), got {nav.shape}"
+            self.cmd[:, :3] = nav
+
         height = goal.get("base_height_command")
-        if nav is not None and height is not None:
-            self.cmd = np.concatenate([nav, height], axis=1).astype(np.float32)
+        if height is not None:
+            height = np.asarray(height, dtype=np.float32)
+            assert height.shape == (
+                self.num_envs,
+                1,
+            ), f"base_height_command must have shape ({self.num_envs}, 1), got {height.shape}"
+            self.cmd[:, 3:4] = height
 
     def get_action(self, time: float | None = None) -> dict[str, Any]:
         """Compute and return the next action based on current observation.

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
@@ -64,6 +64,7 @@ def prepare_observations(
     # Get robot joint observations
     sim_joint_pos = wp.to_torch(robot_data.joint_pos).cpu().numpy()
     sim_joint_vel = wp.to_torch(robot_data.joint_vel).cpu().numpy()
+    sim_default_joint_pos = wp.to_torch(robot_data.default_joint_pos).cpu().numpy()
     num_joints = len(robot_data.joint_names)
 
     # Convert joints data from Lab's order to GR00T's order saved in config yaml
@@ -72,6 +73,9 @@ def prepare_observations(
     wbc_joint_acc = np.zeros((num_envs, num_joints))
     wbc_joint_pos = convert_sim_joint_to_wbc_joint(sim_joint_pos, robot_data.joint_names, wbc_joints_order)
     wbc_joint_vel = convert_sim_joint_to_wbc_joint(sim_joint_vel, robot_data.joint_names, wbc_joints_order)
+    wbc_default_joint_pos = convert_sim_joint_to_wbc_joint(
+        sim_default_joint_pos, robot_data.joint_names, wbc_joints_order
+    )
 
     # Prepare obs dict for WBC policy input to G1DecoupledWholeBodyPolicy class
     assert wbc_joint_pos.shape == wbc_joint_vel.shape == wbc_joint_acc.shape == (num_envs, num_joints)
@@ -92,15 +96,24 @@ def prepare_observations(
 
     torso_link_ang_vel_b = math_utils.quat_apply_inverse(torso_link_quat_w_xyzw, torso_link_ang_vel_w)
 
+    projected_gravity_b = wp.to_torch(robot_data.projected_gravity_b).cpu().numpy()
+    # `mdp.base_ang_vel` returns `root_ang_vel_b` (COM frame). The AGILE recurrent policy
+    # was trained with this exact quantity, so expose it separately from the link-frame
+    # `floating_base_vel` that other WBC policies consume.
+    root_ang_vel_b = wp.to_torch(robot_data.root_ang_vel_b).cpu().numpy()
+
     # Prepare obs tmers
     wbc_obs = {
         "q": wbc_joint_pos,
         "dq": wbc_joint_vel,
+        "default_q": wbc_default_joint_pos,
         "ddq": np.zeros((num_envs, num_joints)),  # Not used by Standing Waist Height Policy
         "tau_est": np.zeros((num_envs, num_joints)),  # Not used by Standing Waist Height Policy
         "floating_base_pose": base_pose_w,  # wrt world frame, used to project gravity vector to local frame
-        "floating_base_vel": base_vel_b,  # wrt body frame
+        "floating_base_vel": base_vel_b,  # root_link_*_vel_b (link frame), used by Homie WBC
         "floating_base_acc": np.zeros((num_envs, 6)),  # Not used by Standing Waist Height Policy
+        "projected_gravity_b": projected_gravity_b,  # gravity projected into base frame, used by AGILE recurrent
+        "root_ang_vel_b": root_ang_vel_b,  # COM-frame angular velocity, used by AGILE recurrent
         "torso_quat": torso_link_quat_w_wxyz.cpu().numpy(),
         "torso_ang_vel": torso_link_ang_vel_b.cpu().numpy(),
     }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                       
  Switch G1 AGILE WBC to recurrent LSTM student          
                                                                                                                                                                                                                   
  ## Detailed description
                                                                                                                                                                                                                   
  **What was the reason for the change?**                

  The previous AGILE WBC used a velocity-only end-to-end ONNX (`unitree_g1_velocity_e2e.onnx`) that did not expose a base-height command and tended to drift in yaw under the Arena's stiffer default actuator     
  gains. We want to drive the lower body with the recurrent LSTM student trained from `agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py`, which (a) supports a 4-dim `[v_x, v_y, w_z, h]`
  command, (b) has a leaner action set (12 leg joints), and (c) frees waist_roll / waist_pitch from policy control so the upper-body PINK IK can use them for arm reach.                                           
                                                         
  **What has been changed?**

  - *Policy* — `G1AgilePolicy` rewritten for the LSTM ONNX: builds the flat obs vector (`cmd`, `base_ang_vel`, `projected_gravity`, `joint_pos_rel`, `joint_vel_rel`, `last_action`), manages `(h, c)` LSTM state, 
  and applies the training-time `clip → scale → offset` post-processing so the runtime matches `JointPositionActionCfg` exactly. `last_action` is fed back as the raw pre-processed action to match
  `mdp.last_action`.                                                                                                                                                                                               
  - *Config* — `g1_agile.yaml` now declares `num_actions: 12`, the leg-only `controlled_joint_names`, the 4-dim `cmd_init`, `joint_vel_scale`, and per-joint `action_clip / action_scale / action_offset` mirrored
  from the agile training cfg. `AgileConfig.wbc_model_path` points at the recurrent-student ONNX pinned to an upstream commit SHA (rather than a tag) so behavior cannot drift silently.                           
  - *Upper-body IK* — `G1WBCUpperbodyController` accepts extra individual active joints on top of joint groups; `G1DecoupledWBCPinkAction` splices those IK targets back into `_processed_actions` after the WBC
  postprocess (which only writes `upper_body` / `lower_body` slots). `waist_roll` posture weight added (10.0, alongside `waist_pitch`) to suppress slow numerical drift from `pink.Configuration.q` integration.   
  - *Embodiment* — `G1WBCAgilePinkEmbodiment` and `G1WBCAgileJointEmbodiment` override leg / feet / waist actuator stiffness, damping, and armature to match the agile training YAML (Arena defaults were 2–4×
  stiffer). `G1WBCAgilePinkActionCfg` activates `waist_roll / waist_yaw / waist_pitch` in the upper-body IK. Default G1 spawn `z` bumped to `0.9` for stand-up margin.                                             
  - *Observations* — `run_policy.prepare_observations` exposes `default_q`, `projected_gravity_b`, and `root_ang_vel_b` (COM frame) so the runtime obs match the `mdp.*` terms the student was trained against.
  - *Policy runner* — Adds `--video` / `--video_dir` to `policy_runner.py` (gymnasium `RecordVideo`), mirroring `eval_runner.py`'s mp4 capture so the two entry points produce the same output layout.             
                                                                                                                                                                                                                   
  **What is the impact of this change?**                                                                                                                                                                           
                                                                                                                                                                                                                   
  - AGILE WBC now exposes a base-height channel (default 0.72 m) and runs the recurrent student end-to-end; locomotion is more stable under the Arena's PD loop and waist drift is gone.                           
  - AGILE-pink combo gains arm reach because the IK can use `waist_roll / waist_pitch`.
  - Existing AGILE callers must supply a 4-channel command (`navigate_cmd` + `base_height_command`) instead of just 3-channel `navigate_cmd`; older 3-channel callers will hit the goal-shape guard in `set_goal`. 
  - `policy_runner` callers can now record mp4s directly without dropping into `eval_runner`.