### PR TITLE
Update IL GR00T training docs

### DIFF
--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -75,6 +75,7 @@ see :doc:`Policy Design <index>`.
 .. code-block:: bash
 
    python isaaclab_arena/evaluation/policy_runner.py \
+     -- viz kit \
      --policy_type <policy_type> \
      --num_steps 2000 \
      --num_envs 10 \
@@ -97,6 +98,7 @@ gets a randomly chosen object from the set. Some environments may require
 .. code-block:: bash
 
    python isaaclab_arena/evaluation/policy_runner.py \
+     --viz kit \
      --policy_type <policy_type> \
      --num_steps 2000 \
      --num_envs 4 \

--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -75,7 +75,7 @@ see :doc:`Policy Design <index>`.
 .. code-block:: bash
 
    python isaaclab_arena/evaluation/policy_runner.py \
-     -- viz kit \
+     --viz kit \
      --policy_type <policy_type> \
      --num_steps 2000 \
      --num_envs 10 \

--- a/docs/pages/example_workflows/imitation_learning/index.rst
+++ b/docs/pages/example_workflows/imitation_learning/index.rst
@@ -13,18 +13,20 @@ Currently, the following imitation learning workflow examples are provided:
 * :doc:`GR1 Sequential Pick & Place and Close Door Task <../sequential_static_manipulation/index>`
 
 
-GR00T Container
----------------
+GR00T Native Environment
+------------------------
 
-Some steps in these workflows (policy post-training and evaluation) require the **Base + GR00T**
-container, which includes the `GR00T model <https://github.com/NVIDIA/Isaac-GR00T/>`_ dependencies
-in addition to the standard Arena Base container. To launch it:
+Arena simulation, data conversion, and evaluation clients use the standard **Base** container:
 
 .. code-block:: bash
 
-   ./docker/run_docker.sh -g
+   ./docker/run_docker.sh
 
-Not every step requires this container — the workflow pages will tell you when to use it.
+GR00T finetuning and GR00T policy servers use the native Isaac-GR00T ``uv`` environment
+from ``submodules/Isaac-GR00T`` instead of Arena's Docker environment. Open another terminal
+outside the Arena Base Docker container, ``cd`` to the Isaac-GR00T checkout, and set up the
+environment by following the
+`GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_.
 
 
 .. toctree::

--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -4,9 +4,13 @@ Policy Post-Training
 This workflow covers post-training an example policy using the generated dataset,
 here we use `GR00T N1.6 <https://github.com/NVIDIA/Isaac-GR00T>`_ as the base model.
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+Use the Arena **Base** container for dataset download and LeRobot conversion. Run GR00T
+finetuning from the native Isaac-GR00T ``uv`` environment in ``submodules/Isaac-GR00T``,
+not from the Arena container.
 
-:docker_run_gr00t:
+**Docker Container for conversion**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -127,27 +131,33 @@ Training Configuration:
 - **Batch Size:** 96 (adjust based on GPU memory)
 - **Training Steps:** 20,000
 
-To post-train the policy, run the following command
+To post-train the policy, open another terminal **outside** the Arena Base Docker container
+and ``cd`` to ``submodules/Isaac-GR00T``. Set up GR00T's native ``uv`` environment by following
+the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+then run the finetuning command below. The paths assume the default Arena Docker mounts
+(``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with custom
+mount directories.
 
 .. code-block:: bash
 
-   PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH python -m torch.distributed.run --nproc_per_node=8 --standalone submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
-   --dataset_path=$DATASET_DIR/arena_g1_loco_manipulation_dataset_generated/lerobot \
-   --output_dir=$MODELS_DIR \
-   --modality_config_path=isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py \
-   --global_batch_size=96 \
-   --max_steps=20000 \
-   --num_gpus=8 \
-   --save_steps=5000 \
-   --save_total_limit=5 \
-   --base_model_path=nvidia/GR00T-N1.6-3B \
-   --no_tune_llm \
-   --tune_visual \
-   --tune_projector \
-   --tune_diffusion_model \
-   --dataloader_num_workers=16 \
-   --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
-   --embodiment_tag=NEW_EMBODIMENT
+   uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
+     gr00t/experiment/launch_finetune.py \
+     --dataset-path ~/datasets/isaaclab_arena/locomanipulation_tutorial/arena_g1_loco_manipulation_dataset_generated/lerobot \
+     --output-dir ~/models/isaaclab_arena/locomanipulation_tutorial \
+     --modality-config-path ../../isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py \
+     --global-batch-size 96 \
+     --max-steps 20000 \
+     --num-gpus 8 \
+     --save-steps 5000 \
+     --save-total-limit 5 \
+     --base-model-path nvidia/GR00T-N1.6-3B \
+     --no-tune-llm \
+     --tune-visual \
+     --tune-projector \
+     --tune-diffusion-model \
+     --dataloader-num-workers 16 \
+     --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
+     --embodiment-tag NEW_EMBODIMENT
 
 
 If you have less powerful GPUs, please see the `GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_

--- a/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
@@ -5,9 +5,9 @@ This workflow demonstrates running the trained GR00T N1.6 policy in closed-loop
 and evaluating it in Arena G1 Loco Manipulation Task environment.
 
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
 
-:docker_run_gr00t:
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -68,11 +68,12 @@ The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/g1_loco
 
 **Prerequisite: launch the GR00T policy server**
 
-The closed-loop policy connects to a GR00T policy server. The server runs out of
+The Arena evaluation client runs in the Base container and connects to a GR00T policy server.
+The server runs out of
 the `Isaac-GR00T <https://github.com/NVIDIA/Isaac-GR00T/tree/e29d8fc50b0e4745120ae3fb72447986fe638aa6>`_
 submodule pinned at commit ``e29d8fc``; populate it with
 ``git submodule update --init submodules/Isaac-GR00T`` if it is not already
-checked out. Then, in a separate shell from the repo root:
+checked out. Then, in a separate shell with ``uv`` available from the repo root:
 
 .. todo::
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -5,9 +5,13 @@ This workflow covers post-training an example policy using the generated dataset
 here we use `GR00T N1.6 <https://github.com/NVIDIA/Isaac-GR00T>`_ as the base model.
 
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+Use the Arena **Base** container for dataset download and LeRobot conversion. Run GR00T
+finetuning from the native Isaac-GR00T ``uv`` environment in ``submodules/Isaac-GR00T``,
+not from the Arena container.
 
-:docker_run_gr00t:
+**Docker Container for conversion**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -143,28 +147,33 @@ We provide two post-training options:
       - **Global Batch Size:** 96 (adjust based on GPU memory)
       - **Training Steps:** 20,000
 
-      To post-train the policy, run the following command
+      To post-train the policy, open another terminal **outside** the Arena Base Docker container
+      and ``cd`` to ``submodules/Isaac-GR00T``. Set up GR00T's native ``uv`` environment by
+      following the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+      then run the finetuning command below. The paths assume the default Arena Docker mounts
+      (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
+      custom mount directories.
 
       .. code-block:: bash
 
-         PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH python -m torch.distributed.run --nproc_per_node=8 --standalone \
-         submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
-         --dataset_path=$DATASET_DIR/ranch_bottle_into_fridge_generated_100/lerobot \
-         --output_dir=$MODELS_DIR \
-         --modality_config_path=isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-         --global_batch_size=96 \
-         --max_steps=20000 \
-         --num_gpus=8 \
-         --save_steps=5000 \
-         --save_total_limit=5 \
-         --base_model_path=nvidia/GR00T-N1.6-3B \
-         --no_tune_llm \
-         --tune_visual \
-         --tune_projector \
-         --tune_diffusion_model \
-         --dataloader_num_workers=16 \
-         --embodiment_tag=GR1 \
-         --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
+         uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
+           gr00t/experiment/launch_finetune.py \
+           --dataset-path ~/datasets/isaaclab_arena/sequential_static_manipulation_tutorial/ranch_bottle_into_fridge_generated_100/lerobot \
+           --output-dir ~/models/isaaclab_arena/sequential_static_manipulation_tutorial \
+           --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
+           --global-batch-size 96 \
+           --max-steps 20000 \
+           --num-gpus 8 \
+           --save-steps 5000 \
+           --save-total-limit 5 \
+           --base-model-path nvidia/GR00T-N1.6-3B \
+           --no-tune-llm \
+           --tune-visual \
+           --tune-projector \
+           --tune-diffusion-model \
+           --dataloader-num-workers 16 \
+           --embodiment-tag GR1 \
+           --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
    .. tab-item:: Low Hardware Requirements
 
@@ -179,28 +188,32 @@ We provide two post-training options:
       - **Training Steps:** 30,000
       - **GPUs:** 1 (single-GPU training)
 
-      To post-train the policy, run the following command
+      To post-train the policy, open another terminal **outside** the Arena Base Docker container
+      and ``cd`` to ``submodules/Isaac-GR00T``. Set up GR00T's native ``uv`` environment by
+      following the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+      then run the finetuning command below. The paths assume the default Arena Docker mounts
+      (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
+      custom mount directories.
 
       .. code-block:: bash
 
-         PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH CUDA_VISIBLE_DEVICES=0 \
-         python submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
-         --dataset_path=$DATASET_DIR/ranch_bottle_into_fridge_generated_100/lerobot \
-         --output_dir=$MODELS_DIR \
-         --modality_config_path=isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-         --global_batch_size=16 \
-         --max_steps=30000 \
-         --num_gpus=1 \
-         --save_steps=5000 \
-         --base_model_path=nvidia/GR00T-N1.6-3B \
-         --no_tune_llm \
-         --tune_visual \
-         --tune_projector \
-         --tune_diffusion_model \
-         --dataloader_num_workers=4 \
-         --embodiment_tag=GR1 \
-         --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
-         --save_total_limit=5
+         CUDA_VISIBLE_DEVICES=0 uv run python gr00t/experiment/launch_finetune.py \
+           --dataset-path ~/datasets/isaaclab_arena/sequential_static_manipulation_tutorial/ranch_bottle_into_fridge_generated_100/lerobot \
+           --output-dir ~/models/isaaclab_arena/sequential_static_manipulation_tutorial \
+           --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
+           --global-batch-size 16 \
+           --max-steps 30000 \
+           --num-gpus 1 \
+           --save-steps 5000 \
+           --base-model-path nvidia/GR00T-N1.6-3B \
+           --no-tune-llm \
+           --tune-visual \
+           --tune-projector \
+           --tune-diffusion-model \
+           --dataloader-num-workers 4 \
+           --embodiment-tag GR1 \
+           --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
+           --save-total-limit 5
 
 see the `GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_
 for information on how to adjust the training configuration to your hardware, to achieve

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
@@ -4,9 +4,9 @@ Closed-Loop Policy Inference and Evaluation
 This workflow demonstrates running the trained GR00T N1.6 policy in closed-loop
 and evaluating it in the GR1 Sequential Pick & Place and Close Door Environment.
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
 
-:docker_run_gr00t:
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -72,11 +72,12 @@ The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/policy/
 
 **Prerequisite: launch the GR00T policy server**
 
-The closed-loop policy connects to a GR00T policy server. The server runs out of
+The Arena evaluation client runs in the Base container and connects to a GR00T policy server.
+The server runs out of
 the `Isaac-GR00T <https://github.com/NVIDIA/Isaac-GR00T/tree/e29d8fc50b0e4745120ae3fb72447986fe638aa6>`_
 submodule pinned at commit ``e29d8fc``; populate it with
 ``git submodule update --init submodules/Isaac-GR00T`` if it is not already
-checked out. Then, in a separate shell from the repo root:
+checked out. Then, in a separate shell with ``uv`` available from the repo root:
 
 .. todo::
 

--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -8,7 +8,7 @@ the GR00T submodule pinned inside Arena, and evaluation runs over Arena's
 **server-client (remote-policy) architecture**: the GR00T server hosts the finetuned checkpoint in
 its own venv, and Arena's client runs the simulation in the standard Arena container and queries the
 server over ZeroMQ. This decoupling means you can iterate on the model side without bumping Arena's
-submodule or rebuilding the GR00T-flavoured Arena container.
+submodule or rebuilding the Arena container.
 
 This workflow is the no-locomotion sibling of the :doc:`Unitree G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/index>`. The robot stands in place using the same Whole Body Controller (WBC) for balance, but the destination plate sits on the *same* shelf as the apple — within arm's reach — so the lower body never moves. If you want a tabletop manipulation surface for upper-body data collection without the complexity of full-body locomotion, this is the workflow to use.
 
@@ -100,15 +100,13 @@ Standalone Isaac-GR00T (N1.7) checkout (used in :doc:`step_3_policy_training` an
     export ISAAC_GR00T_DIR=/path/to/Isaac-GR00T
     cd $ISAAC_GR00T_DIR && git checkout 3df8b3825d67f755e69141446f4315f281b9b7e6
 
-    # Create the venv (uv-managed).
-    uv sync
-
-See the `Isaac-GR00T README <https://github.com/NVIDIA/Isaac-GR00T#readme>`_ for alternatives to
-``uv-managed`` environment.
+Open another terminal outside the Arena Base Docker container and set up the native GR00T
+``uv`` environment from ``$ISAAC_GR00T_DIR`` by following the
+`GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_.
 
 This venv is **separate** from Arena's container. Finetuning and the policy server both run from
 this standalone checkout so you can pick up new GR00T releases (e.g. N1.7 → next) without rebuilding
-Arena's GR00T-flavoured container or bumping ``submodules/Isaac-GR00T``.
+Arena's container or bumping ``submodules/Isaac-GR00T``.
 
 
 Workflow Steps

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -125,20 +125,22 @@ Training Configuration:
 - **Embodiment tag:** ``new_embodiment`` (case-insensitive; resolved to
   ``EmbodimentTag.NEW_EMBODIMENT`` by ``gr00t``)
 
-To post-train the policy, run the following command **from the standalone Isaac-GR00T checkout**.
-The launcher runs inside the standalone repo's ``uv``-managed venv. Replace
-``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone so the
-``--modality-config-path`` argument can register the WBC modality from Arena's source tree.
+To post-train the policy, open another terminal **outside** the Arena Base Docker container
+and ``cd`` to ``$ISAAC_GR00T_DIR``. Set up GR00T's native ``uv`` environment by following
+the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+then run the finetuning command below. Replace ``/path/to/IsaacLab-Arena`` with the absolute
+path to your Arena clone so the ``--modality-config-path`` argument can register the WBC
+modality from Arena's source tree. The dataset and output paths assume the default Arena Docker
+mounts (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
+custom mount directories.
 
 .. code-block:: bash
-
-   cd $ISAAC_GR00T_DIR
 
    uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
      gr00t/experiment/launch_finetune.py \
      --base-model-path nvidia/GR00T-N1.7-3B \
-     --dataset-path $DATASET_DIR/arena_g1_static_apple_dataset_recorded/lerobot \
-     --output-dir $MODELS_DIR/static_apple_n17_finetune \
+     --dataset-path ~/datasets/isaaclab_arena/static_apple_tutorial/arena_g1_static_apple_dataset_recorded/lerobot \
+     --output-dir ~/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune \
      --modality-config-path /path/to/IsaacLab-Arena/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py \
      --embodiment-tag new_embodiment \
      --global-batch-size 96 \

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -5,9 +5,13 @@ This workflow covers post-training an example policy using the generated dataset
 here we use `GR00T N1.6 <https://github.com/NVIDIA/Isaac-GR00T>`_ as the base model.
 
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+Use the Arena **Base** container for dataset download and LeRobot conversion. Run GR00T
+finetuning from the native Isaac-GR00T ``uv`` environment in ``submodules/Isaac-GR00T``,
+not from the Arena container.
 
-:docker_run_gr00t:
+**Docker Container for conversion**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -136,28 +140,33 @@ We provide two post-training options:
       - **Batch Size:** 24 (adjust based on GPU memory)
       - **Training Steps:** 20,000
 
-      To post-train the policy, run the following command
+      To post-train the policy, open another terminal **outside** the Arena Base Docker container
+      and ``cd`` to ``submodules/Isaac-GR00T``. Set up GR00T's native ``uv`` environment by
+      following the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+      then run the finetuning command below. The paths assume the default Arena Docker mounts
+      (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
+      custom mount directories.
 
       .. code-block:: bash
 
-         PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH python -m torch.distributed.run --nproc_per_node=8 --standalone \
-         submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
-         --dataset_path=$DATASET_DIR/arena_gr1_manipulation_dataset_generated/lerobot \
-         --output_dir=$MODELS_DIR \
-         --modality_config_path=isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-         --global_batch_size=24 \
-         --max_steps=20000 \
-         --num_gpus=8 \
-         --save_steps=5000 \
-         --save_total_limit=5 \
-         --base_model_path=nvidia/GR00T-N1.6-3B \
-         --no_tune_llm \
-         --tune_visual \
-         --tune_projector \
-         --tune_diffusion_model \
-         --dataloader_num_workers=16 \
-         --embodiment_tag=GR1 \
-         --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
+         uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
+           gr00t/experiment/launch_finetune.py \
+           --dataset-path ~/datasets/isaaclab_arena/static_manipulation_tutorial/arena_gr1_manipulation_dataset_generated/lerobot \
+           --output-dir ~/models/isaaclab_arena/static_manipulation_tutorial \
+           --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
+           --global-batch-size 24 \
+           --max-steps 20000 \
+           --num-gpus 8 \
+           --save-steps 5000 \
+           --save-total-limit 5 \
+           --base-model-path nvidia/GR00T-N1.6-3B \
+           --no-tune-llm \
+           --tune-visual \
+           --tune-projector \
+           --tune-diffusion-model \
+           --dataloader-num-workers 16 \
+           --embodiment-tag GR1 \
+           --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
 
    .. tab-item:: Low Hardware Requirements
 
@@ -172,28 +181,32 @@ We provide two post-training options:
       - **Training Steps:** 30,000
       - **GPUs:** 1 (single-GPU training)
 
-      To post-train the policy, run the following command
+      To post-train the policy, open another terminal **outside** the Arena Base Docker container
+      and ``cd`` to ``submodules/Isaac-GR00T``. Set up GR00T's native ``uv`` environment by
+      following the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
+      then run the finetuning command below. The paths assume the default Arena Docker mounts
+      (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
+      custom mount directories.
 
       .. code-block:: bash
 
-         PYTHONPATH=$GROOT_DEPS_DIR:$PYTHONPATH CUDA_VISIBLE_DEVICES=0 \
-         python submodules/Isaac-GR00T/gr00t/experiment/launch_finetune.py \
-         --dataset_path=$DATASET_DIR/arena_gr1_manipulation_dataset_generated/lerobot \
-         --output_dir=$MODELS_DIR \
-         --modality_config_path=isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-         --global_batch_size=16 \
-         --max_steps=30000 \
-         --num_gpus=1 \
-         --save_steps=5000 \
-         --base_model_path=nvidia/GR00T-N1.6-3B \
-         --no_tune_llm \
-         --tune_visual \
-         --tune_projector \
-         --tune_diffusion_model \
-         --dataloader_num_workers=4 \
-         --embodiment_tag=GR1 \
-         --color_jitter_params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
-         --save_total_limit=5
+         CUDA_VISIBLE_DEVICES=0 uv run python gr00t/experiment/launch_finetune.py \
+           --dataset-path ~/datasets/isaaclab_arena/static_manipulation_tutorial/arena_gr1_manipulation_dataset_generated/lerobot \
+           --output-dir ~/models/isaaclab_arena/static_manipulation_tutorial \
+           --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
+           --global-batch-size 16 \
+           --max-steps 30000 \
+           --num-gpus 1 \
+           --save-steps 5000 \
+           --base-model-path nvidia/GR00T-N1.6-3B \
+           --no-tune-llm \
+           --tune-visual \
+           --tune-projector \
+           --tune-diffusion-model \
+           --dataloader-num-workers 4 \
+           --embodiment-tag GR1 \
+           --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08 \
+           --save-total-limit 5
 
 
 see the `GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_

--- a/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
@@ -4,9 +4,9 @@ Closed-Loop Policy Inference and Evaluation
 This workflow demonstrates running the trained GR00T N1.6 policy in closed-loop
 and evaluating it in Arena GR1 Open Microwave Door Task environment.
 
-**Docker Container**: Base + GR00T (see :doc:`../imitation_learning/index` for more details)
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
 
-:docker_run_gr00t:
+:docker_run_default:
 
 Once inside the container, set the dataset and models directories.
 
@@ -67,11 +67,12 @@ The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/gr1_man
 
 **Prerequisite: launch the GR00T policy server**
 
-The closed-loop policy connects to a GR00T policy server. The server runs out of
+The Arena evaluation client runs in the Base container and connects to a GR00T policy server.
+The server runs out of
 the `Isaac-GR00T <https://github.com/NVIDIA/Isaac-GR00T/tree/e29d8fc50b0e4745120ae3fb72447986fe638aa6>`_
 submodule pinned at commit ``e29d8fc``; populate it with
 ``git submodule update --init submodules/Isaac-GR00T`` if it is not already
-checked out. Then, in a separate shell from the repo root:
+checked out. Then, in a separate shell with ``uv`` available from the repo root:
 
 .. todo::
 

--- a/isaaclab_arena_gr00t/tests/test_convert_hdf5_to_lerobot.py
+++ b/isaaclab_arena_gr00t/tests/test_convert_hdf5_to_lerobot.py
@@ -13,8 +13,7 @@ from isaaclab_arena_gr00t.lerobot.convert_hdf5_to_lerobot import convert_hdf5_to
 from isaaclab_arena_gr00t.tests.utils.constants import TestConstants
 from isaaclab_arena_gr00t.utils.io_utils import create_config_from_yaml
 
-pytestmark = pytest.mark.skip(reason="pyav is not installed in the base container")
-# TODO(xinjieyao, 2026-05-08): enable this test after pyav is installed in the base container
+pytestmark = pytest.mark.gr00t_policy
 
 
 def test_g1_convert_hdf5_to_lerobot():


### PR DESCRIPTION
## Summary
Update IL GR00T training docs

## Detailed description
- Reason: Clarify GR00T finetuning should use native GR00T uv deps outside Arena Base Docker.
- Changed: 
1. Policy training docs now link to the GR00T installation guide and show only finetuning launch commands.
2. Evaluation docs now consistently use Arena Base Docker while GR00T servers run from the GR00T uv environment.
- Impact: Users get a cleaner split between Arena simulation/evaluation and GR00T finetuning/server workflows.

