### PR TITLE
Cherrypick for 0.2.1: G1 static apple-to-plate workflow + AGILE pink checkpoint

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install -y \
   git-lfs \
   cmake \
   sudo \
+  jq \
+  ffmpeg \
   python3-pip
 
 ################################
@@ -63,6 +65,9 @@ RUN /isaac-sim/python.sh -m pip install -e \
 
 # Upgrade pip ahead of the editable install
 RUN /isaac-sim/python.sh -m pip install --upgrade pip
+
+# PyAV: video read/write backend used by isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py
+RUN /isaac-sim/python.sh -m pip install av
 
 # Lightwheel server
 ENV LW_API_ENDPOINT="https://api-dev.lightwheel.net"

--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -96,6 +96,13 @@ RUN if [ "$INSTALL_GROOT" = "true" ]; then \
   rm -f /tmp/install_cuda.sh
 # Copy GR00T
 COPY ./submodules/Isaac-GR00T ${WORKDIR}/submodules/Isaac-GR00T
+# Always make the `gr00t` package importable so the lightweight remote
+# PolicyClient (gr00t.policy.server_client) works in the base container.
+# The full GR00T runtime (torch + flash-attn + transformers + ...) is still
+# gated behind INSTALL_GROOT=true below.
+RUN /isaac-sim/python.sh -m pip install msgpack==1.1.0 msgpack-numpy==0.4.8 pyzmq==27.0.1 && \
+    /isaac-sim/python.sh -m pip install --no-deps --ignore-requires-python -e ${WORKDIR}/submodules/Isaac-GR00T/
+# TODO(xinjieyao, 2026-04-27): remove this after remote policy done refactoring
 # Copy GR00T dependencies installation script
 COPY docker/setup/install_gr00t_deps.sh /tmp/install_gr00t_deps.sh
 RUN chmod +x /tmp/install_gr00t_deps.sh

--- a/docs/images/static_apple_scene.png
+++ b/docs/images/static_apple_scene.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a2cd8041dc173b420a8d24f5dd11a4b30a76bbbbe5319050e8334bdd8730939
+size 724995

--- a/docs/pages/example_workflows/imitation_learning/index.rst
+++ b/docs/pages/example_workflows/imitation_learning/index.rst
@@ -8,6 +8,7 @@ closed-loop evaluation.
 Currently, the following imitation learning workflow examples are provided:
 
 * :doc:`G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/index>`
+* :doc:`G1 Static Apple-to-Plate Task <../static_apple/index>`
 * :doc:`GR1 Open Microwave Door Task <../static_manipulation/index>`
 * :doc:`GR1 Sequential Pick & Place and Close Door Task <../sequential_static_manipulation/index>`
 
@@ -30,5 +31,6 @@ Not every step requires this container — the workflow pages will tell you when
    :maxdepth: 1
 
    ../locomanipulation/index
+   ../static_apple/index
    ../static_manipulation/index
    ../sequential_static_manipulation/index

--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -1,0 +1,132 @@
+Unitree G1 Static Apple-to-Plate Task
+=====================================
+
+This example demonstrates the complete workflow for the **Unitree G1 static (no-locomotion) apple-to-plate task** in Isaac Lab - Arena, covering environment setup and validation, teleoperation data collection (OpenXR with Meta Quest 3 or Pico 4 Ultra), policy post-training directly on the recorded teleop demonstrations, and closed-loop evaluation.
+
+The training step uses a **standalone clone of NVIDIA's Isaac-GR00T (N1.7) repository** rather than
+the GR00T submodule pinned inside Arena, and evaluation runs over Arena's
+**server-client (remote-policy) architecture**: the GR00T server hosts the finetuned checkpoint in
+its own venv, and Arena's client runs the simulation in the standard Arena container and queries the
+server over ZeroMQ. This decoupling means you can iterate on the model side without bumping Arena's
+submodule or rebuilding the GR00T-flavoured Arena container.
+
+This workflow is the no-locomotion sibling of the :doc:`Unitree G1 Loco-Manipulation Box Pick and Place Task <../locomanipulation/index>`. The robot stands in place using the same Whole Body Controller (WBC) for balance, but the destination plate sits on the *same* shelf as the apple — within arm's reach — so the lower body never moves. If you want a tabletop manipulation surface for upper-body data collection without the complexity of full-body locomotion, this is the workflow to use.
+
+Task Overview
+-------------
+
+**Task Name:** ``galileo_g1_static_pick_and_place``
+
+**Task Description:** The Unitree G1 humanoid robot stands in front of a shelf and uses its arms to pick up
+an apple and place it onto a plate sitting on the same shelf, within arm's reach. WBC actively
+balances the standing pose (no locomotion, no squat), and PinkIK drives the upper body via the same
+23-D action layout used by the loco-manipulation variant.
+
+**Key Specifications:**
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Property
+     - Value
+   * - **Tags**
+     - Tabletop manipulation, no locomotion
+   * - **Skills**
+     - Pick, Place (no walk / squat / turn)
+   * - **Embodiment**
+     - Unitree G1 (29 DOF humanoid with Whole Body Controller, balance only)
+   * - **Interop**
+     - LeRobot dataset format (direct from teleop HDF5)
+   * - **Scene**
+     - Galileo Lab Environment (single shelf, no second table)
+   * - **Manipulated Object(s)**
+     - Apple (rigid body), Clay plate (destination, same-shelf placement)
+   * - **Policy**
+     - GR00T N1.7 (vision-language-action foundation model, finetuned via standalone Isaac-GR00T)
+   * - **Post-training**
+     - Imitation Learning
+   * - **Dataset**
+     - Self-recorded (collect via Step 2)
+   * - **Checkpoint**
+     - Self-trained (post-train via Step 4)
+   * - **Physics**
+     - PhysX (200Hz @ 4 decimation)
+   * - **Closed-loop**
+     - Yes (50Hz control)
+   * - **Metrics**
+     - Success rate
+
+
+Workflow
+--------
+
+This tutorial covers the pipeline between creating an environment, collecting teleoperation
+demonstrations, fine-tuning a policy (GR00T N1.7, from a standalone Isaac-GR00T checkout) directly
+on the recorded HDF5, and evaluating the policy in closed-loop over Arena's server-client
+architecture. Follow the steps in order from environment setup through closed-loop evaluation;
+each step consumes the artifacts produced by the previous one.
+
+.. note::
+
+   This workflow trains directly from teleop recordings. The recorded HDF5 from
+   :doc:`step_2_teleoperation` is converted to LeRobot format and
+   fed straight into post-training in :doc:`step_3_policy_training`.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Start the Isaac Lab Docker container:
+
+:docker_run_default:
+
+Create the folders for the data and models:
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
+    mkdir -p $DATASET_DIR
+    export MODELS_DIR=/models/isaaclab_arena/static_apple_tutorial
+    mkdir -p $MODELS_DIR
+
+Standalone Isaac-GR00T (N1.7) checkout (used in :doc:`step_3_policy_training` and
+:doc:`step_4_evaluation`):
+
+.. code:: bash
+
+    # Clone wherever you want; the docs below refer to it as $ISAAC_GR00T_DIR.
+    # Pin to the commit this workflow was validated against.
+    git clone https://github.com/NVIDIA/Isaac-GR00T.git /path/to/Isaac-GR00T
+    export ISAAC_GR00T_DIR=/path/to/Isaac-GR00T
+    cd $ISAAC_GR00T_DIR && git checkout 3df8b3825d67f755e69141446f4315f281b9b7e6
+
+    # Create the venv (uv-managed).
+    uv sync
+
+See the `Isaac-GR00T README <https://github.com/NVIDIA/Isaac-GR00T#readme>`_ for alternatives to
+``uv-managed`` environment.
+
+This venv is **separate** from Arena's container. Finetuning and the policy server both run from
+this standalone checkout so you can pick up new GR00T releases (e.g. N1.7 → next) without rebuilding
+Arena's GR00T-flavoured container or bumping ``submodules/Isaac-GR00T``.
+
+
+Workflow Steps
+^^^^^^^^^^^^^^
+
+Follow the following steps to complete the workflow:
+
+- :doc:`step_1_environment_setup`
+- :doc:`step_2_teleoperation`
+- :doc:`step_3_policy_training`
+- :doc:`step_4_evaluation`
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   step_1_environment_setup
+   step_2_teleoperation
+   step_3_policy_training
+   step_4_evaluation

--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -47,9 +47,9 @@ balances the standing pose (no locomotion, no squat), and PinkIK drives the uppe
    * - **Post-training**
      - Imitation Learning
    * - **Dataset**
-     - Self-recorded (collect via Step 2)
+     - `Arena-G1-Static-PickNPlace-Task <https://huggingface.co/datasets/nvidia/Arena-G1-Static-PickNPlace-Task>`_
    * - **Checkpoint**
-     - Self-trained (post-train via Step 4)
+     - `GN1x-Tuned-Arena-G1-Static-PickNPlace <https://huggingface.co/nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace>`_
    * - **Physics**
      - PhysX (200Hz @ 4 decimation)
    * - **Closed-loop**

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -1,0 +1,227 @@
+Environment Setup and Validation
+--------------------------------
+
+
+On this page we briefly describe the environment used in this example workflow
+and validate that we can load it in Isaac Lab.
+
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
+
+
+Environment Description
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The static apple-to-plate workflow ships its own ``GalileoG1StaticPickAndPlaceEnvironment`` registered
+under ``galileo_g1_static_pick_and_place``. It reuses the same ``galileo_locomanip`` background USD
+and the same OpenXR retargeter as the loco-manipulation apple-to-plate environment, but defaults to
+the ``g1_wbc_agile_pink`` embodiment (AGILE end-to-end velocity policy) instead of ``g1_wbc_pink``
+(HOMIE stand+walk pair). The static task never walks, so AGILE's single-policy backend is a better
+fit than HOMIE's stand/walk model split — both share the same 23-D action layout and OpenXR
+retargeter pipeline, so only the lower-body ONNX backend changes. Both the apple and the destination
+plate are placed on the *same* shelf so the robot never needs to drive its base anywhere — WBC just
+holds the standing pose. The ``g1_wbc_pink`` embodiment is still accepted as an override for users
+who specifically want HOMIE.
+
+.. note::
+
+   **Recording vs. evaluation embodiment.** Teleoperation in :doc:`step_2_teleoperation` uses the
+   default ``g1_wbc_agile_pink`` (PinkIK + AGILE), while closed-loop policy evaluation in
+   :doc:`step_4_evaluation` uses ``g1_wbc_agile_joint`` (direct joint control + AGILE). Both share
+   the same AGILE lower-body backend; the ``_joint`` twin just bypasses PinkIK at inference because
+   the policy is trained on the joint-space targets that PinkIK *produced* during recording. This
+   matters for finetuning: see :doc:`step_3_policy_training` for the rationale.
+
+.. dropdown:: The Galileo G1 Static Pick-and-Place Environment
+   :animate: fade-in
+
+   .. code-block:: python
+
+       from isaaclab_arena.assets.register import register_environment
+       from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+       SHELF_SURFACE_Z = -0.030
+       SHELF_AIRGAP = 0.005
+       PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
+       DESTINATION_SPAWN_XY = (0.5785, -0.06)
+
+       _USD_ORIGIN_ABOVE_BOTTOM_M = {
+           "apple_01_objaverse_robolab": 0.019,
+           "clay_plates_hot3d_robolab": 0.0,
+       }
+
+       TUNED_PICK_UP_OBJECT_NAME = "apple_01_objaverse_robolab"
+       TUNED_DESTINATION_NAME = "clay_plates_hot3d_robolab"
+
+
+       @register_environment
+       class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
+
+           name: str = "galileo_g1_static_pick_and_place"
+
+           def get_env(self, args_cli):
+               from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+               from isaaclab_arena.scene.scene import Scene
+               from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+               from isaaclab_arena.utils.pose import Pose
+
+               background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
+               destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
+               embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
+                   enable_cameras=args_cli.enable_cameras
+               )
+
+               teleop_device = (
+                   self.device_registry.get_device_by_name(args_cli.teleop_device)()
+                   if args_cli.teleop_device is not None else None
+               )
+
+               embodiment.set_initial_pose(
+                   Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+               )
+               px, py = PICK_UP_OBJECT_SPAWN_XY
+               dx, dy = DESTINATION_SPAWN_XY
+               pick_up_object.set_initial_pose(
+                   Pose(position_xyz=(px, py, _shelf_spawn_z(args_cli.object)),
+                        rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+               )
+               destination.set_initial_pose(
+                   Pose(position_xyz=(dx, dy, _shelf_spawn_z(args_cli.destination)),
+                        rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+               )
+
+               scene = Scene(assets=[background, pick_up_object, destination])
+               return IsaacLabArenaEnvironment(
+                   name=self.name,
+                   embodiment=embodiment,
+                   scene=scene,
+                   task=PickAndPlaceTask(
+                       pick_up_object=pick_up_object,
+                       destination_location=destination,
+                       background_scene=background,
+                       force_threshold=0.5,
+                       velocity_threshold=0.1,
+                   ),
+                   teleop_device=teleop_device,
+               )
+
+
+Step-by-Step Breakdown
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**1. Interact with the Asset and Device Registry**
+
+.. code-block:: python
+
+    background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
+    destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
+    embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
+        enable_cameras=args_cli.enable_cameras
+    )
+
+The static workflow shares the ``galileo_locomanip`` background with the loco-manipulation variant
+on purpose: the lighting, shelf geometry and 23-D action layout are already tuned, so the only
+thing that changes is *where* the destination sits and which lower-body WBC backend balances the
+robot. The default ``g1_wbc_agile_pink`` embodiment swaps HOMIE's stand+walk pair for AGILE's
+single end-to-end velocity policy, which is a better fit for a no-locomotion task; ``g1_wbc_pink`` is
+accepted as an override for users who want HOMIE behaviour. ``teleop_device`` is left as ``None``
+when ``--teleop_device`` is not supplied so that scripts like ``replay_demos.py`` and
+``policy_runner.py`` can launch the same environment without instantiating an XR runtime.
+
+
+**2. Position the Objects**
+
+.. code-block:: python
+
+   embodiment.set_initial_pose(
+       Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+   )
+   pick_up_object.set_initial_pose(
+       Pose(position_xyz=(0.5785, 0.18, _shelf_spawn_z(args_cli.object)),
+            rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+   )
+   destination.set_initial_pose(
+       Pose(position_xyz=(0.5785, -0.06, _shelf_spawn_z(args_cli.destination)),
+            rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+   )
+
+The robot pose mirrors the loco-manipulation env exactly so the WBC controller stands the robot up
+in the same shelf-relative spot. The apple is placed at a measured on-shelf X/Y, and the plate is
+offset 24 cm in -Y so its 30 cm footprint clears the apple without collision. ``_shelf_spawn_z``
+consults a per-asset USD-origin table so each asset's *bottom face* — not its USD origin — lands
+flush on the shelf surface; assets not in the table fall back to ``SHELF_SURFACE_Z + SHELF_AIRGAP``
+and emit a warning so you know to verify the spawn pose visually before recording demonstrations.
+
+
+**3. Compose the Scene**
+
+.. code-block:: python
+
+    scene = Scene(assets=[background, pick_up_object, destination])
+
+The static env uses a single shelf-anchored background plus the pick-up object and the destination;
+no second table is needed because the destination plate sits on the same shelf as the apple.
+See :doc:`../../concepts/scene/index` for scene composition details.
+
+
+**4. Create the Pick and Place Task**
+
+.. code-block:: python
+
+    task = PickAndPlaceTask(
+        pick_up_object=pick_up_object,
+        destination_location=destination,
+        background_scene=background,
+        force_threshold=0.5,
+        velocity_threshold=0.1,
+    )
+
+The static env uses ``PickAndPlaceTask`` directly. The task wires the apple,
+plate, and background into the standard pick-and-place termination logic;
+``force_threshold`` / ``velocity_threshold`` mirror the locomanip env so success
+metrics are directly comparable.
+
+See :doc:`../../concepts/task/index` for task creation details.
+
+
+**5. Create the IsaacLab Arena Environment**
+
+.. code-block:: python
+
+    isaaclab_arena_environment = IsaacLabArenaEnvironment(
+        name=self.name,
+        embodiment=embodiment,
+        scene=scene,
+        task=task,
+        teleop_device=teleop_device,
+    )
+
+Finally, we assemble all the pieces into a complete, runnable environment.
+See :doc:`../../concepts/concept_overview` for environment composition details.
+
+
+Validate Environment with Automated Tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A dedicated pytest module covers the static apple-to-plate environment. It asserts that
+(i) the task does not terminate when the apple is at its initial pose, and (ii) the success
+termination fires after the apple is teleported above the plate and allowed to settle.
+
+.. code-block:: bash
+
+   python -m pytest isaaclab_arena/tests/test_g1_static_pick_and_place.py -v
+
+You should see both tests pass. They run headless with cameras enabled and take around a
+minute each. This is the fastest way to confirm the scene, task, and termination logic are
+wired up correctly without requiring teleoperation hardware.
+
+.. note::
+
+   **First-run asset cache**: The Objaverse apple USD streams from an S3 staging bucket and PhysX
+   re-cooks its collision mesh at the baked-in ``0.01x`` scale. On a fresh machine the collision cook
+   may land a frame after the first physics step, which can cause the apple to tunnel through the
+   shelf surface on the very first load. Subsequent runs read the cached USD from ``/tmp/Assets/``
+   and spawn correctly. If you see the apple fall through the shelf, just re-run the command once.

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -223,22 +223,3 @@ wired up correctly without requiring teleoperation hardware.
    may land a frame after the first physics step, which can cause the apple to tunnel through the
    shelf surface on the very first load. Subsequent runs read the cached USD from ``/tmp/Assets/``
    and spawn correctly. If you see the apple fall through the shelf, just re-run the command once.
-
-
-Download a pre-recorded teleop dataset (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you want to skip teleoperation hardware setup (:doc:`step_2_teleoperation`) and just validate the
-pipeline end-to-end, you can download a pre-recorded teleop HDF5 from Hugging Face and feed it
-straight into :doc:`step_3_policy_training`:
-
-.. code-block:: bash
-
-   hf download \
-       nvidia/Arena-G1-Static-PickNPlace-Task \
-       arena_g1_static_apple_dataset_recorded.hdf5 \
-       --repo-type dataset \
-       --local-dir $DATASET_DIR
-
-The HDF5 follows the same format ``record_demos.py`` produces locally, so the rest of the workflow
-(replay, LeRobot conversion, finetuning, eval) runs unchanged against it.

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -38,7 +38,6 @@ who specifically want HOMIE.
 
    .. code-block:: python
 
-       from isaaclab_arena.assets.register import register_environment
        from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
 
        SHELF_SURFACE_Z = -0.030
@@ -55,7 +54,6 @@ who specifically want HOMIE.
        TUNED_DESTINATION_NAME = "clay_plates_hot3d_robolab"
 
 
-       @register_environment
        class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
 
            name: str = "galileo_g1_static_pick_and_place"
@@ -225,3 +223,22 @@ wired up correctly without requiring teleoperation hardware.
    may land a frame after the first physics step, which can cause the apple to tunnel through the
    shelf surface on the very first load. Subsequent runs read the cached USD from ``/tmp/Assets/``
    and spawn correctly. If you see the apple fall through the shelf, just re-run the command once.
+
+
+Download a pre-recorded teleop dataset (optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to skip teleoperation hardware setup (:doc:`step_2_teleoperation`) and just validate the
+pipeline end-to-end, you can download a pre-recorded teleop HDF5 from Hugging Face and feed it
+straight into :doc:`step_3_policy_training`:
+
+.. code-block:: bash
+
+   hf download \
+       nvidia/Arena-G1-Static-PickNPlace-Task \
+       arena_g1_static_apple_dataset_recorded.hdf5 \
+       --repo-type dataset \
+       --local-dir $DATASET_DIR
+
+The HDF5 follows the same format ``record_demos.py`` produces locally, so the rest of the workflow
+(replay, LeRobot conversion, finetuning, eval) runs unchanged against it.

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -1,0 +1,221 @@
+Teleoperation Data Collection
+-----------------------------
+
+This workflow covers collecting demonstrations for the Unitree G1 static apple-to-plate task using **Meta Quest 3** or **Pico 4 Ultra** supported by `Nvidia IsaacTeleop <https://github.com/NVIDIA/IsaacTeleop>`_.
+
+.. admonition:: No teleoperation hardware?
+   :class: tip
+
+   The static task drops the locomotion / squat / turn channels but still needs bimanual end-effector
+   control, so a keyboard or SpaceMouse is not practical. If you don't have an XR headset, you can
+   still smoke-test the pipeline with the
+   `Immersive Web Emulator Runtime (IWER)
+   <https://github.com/meta-quest/immersive-web-emulator>`_. Open
+   `<https://nvidia.github.io/IsaacTeleop/client>`_ in desktop Chrome (instead of the Quest browser);
+   the page auto-loads IWER and emulates a Quest 3 with your mouse and keyboard, per the
+   `IsaacTeleop Quick Start
+   <https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html>`_. Follow Steps 1--4
+   below unchanged; the only difference is that Step 3 is done from a desktop browser tab. Because
+   the static task is upper-body-only, IWER drives it noticeably better than the loco-manipulation
+   variant — you can plausibly complete a few demos with just mouse + keyboard, though a real Quest
+   3 still gives much smoother demonstrations.
+
+
+Step 1: Start the CloudXR Runtime
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. On the host machine, configure the firewall to allow CloudXR traffic. The required ports depend on the client type. The example below uses ``ufw`` (Ubuntu); on other distributions use the equivalent firewall tooling (e.g. ``firewalld`` on Fedora/RHEL, ``pf`` on macOS).
+
+   .. code-block:: bash
+
+      sudo ufw allow 49100/tcp   # Signaling
+      sudo ufw allow 47998/udp   # Media stream
+      sudo ufw allow 48322/tcp   # Proxy (HTTPS mode only)
+
+
+#. Start the CloudXR runtime from the Arena Docker container:
+
+   :docker_run_default:
+
+   .. code-block:: bash
+
+      python -m isaacteleop.cloudxr
+
+.. attention::
+
+   The first run will prompt users to accept the NVIDIA CloudXR License Agreement.
+   To accept the EULA, reply ``Yes`` when prompted with the below message:
+
+   .. code:: bash
+
+      NVIDIA CloudXR EULA must be accepted to run. View: https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE
+
+      Accept NVIDIA CloudXR EULA? [y/N]: Yes
+
+
+Step 2: Start Arena Teleop
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. In another terminal, start the Arena Docker container and launch the teleop session to verify the pipeline:
+
+   :docker_run_default:
+
+#. Run the following command to activate IsaacTeleop CloudXR environment settings:
+
+   .. code-block:: bash
+
+      source ~/.cloudxr/run/cloudxr.env
+
+   .. important::
+      **Order matters.** In the terminal where you will run Arena, ``source ~/.cloudxr/run/cloudxr.env`` *after* the CloudXR runtime from Step 1 is already running,
+      and *before* you start the Arena app. The Arena app must inherit the IsaacTeleop CloudXR environment variables.
+
+#. Run the teleop script:
+
+   .. code-block:: bash
+
+      python isaaclab_arena/scripts/imitation_learning/teleop.py \
+      --viz kit \
+      --device cpu \
+      galileo_g1_static_pick_and_place \
+      --object apple_01_objaverse_robolab \
+      --destination clay_plates_hot3d_robolab \
+      --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+   .. figure:: ../../../images/static_apple_scene.png
+      :width: 100%
+      :alt: Arena teleop with XR running (stereoscopic view and OpenXR settings)
+      :align: center
+
+      Arena teleop session with XR running. Stereoscopic view (left) and OpenXR settings in the XR tab (right).
+
+
+Step 3: Connect from the headset device
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For detailed instructions please refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_:
+
+A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
+
+#. Open the browser on your headset and navigate to `<https://nvidia.github.io/IsaacTeleop/client>`_.
+
+#. Enter the IP address of your Isaac Lab host machine in the **Server IP** field.
+
+#. Click the **Click https://<ip>:48322/ to accept cert** link that appears on the page.
+   Accept the certificate in the new page that opens, then navigate back to the
+   CloudXR.js client page.
+
+#. Click **Connect** to begin teleoperation.
+
+   .. note::
+      Once you press **Connect** in the web browser, you should see the following control panel. Press **Play** to start teleoperation.
+      You can also reset the scene by pressing the **Reset** button.
+
+      If the control panel is not visible (for example, behind a solid wall in the simulated environment), you can put the headset on
+      before clicking **Start XR** in the Isaac Lab Arena application, and drag the control panel to a better location.
+
+      .. figure:: ../../../images/react-isaac-sample-controls-start.jpg
+         :width: 40%
+         :alt: IsaacSim view
+         :align: center
+
+#. **Teleoperation Controls**:
+
+   * **Left joystick**: Move the body forward/backward/left/right.
+   * **Right joystick**: Squat (down), rotate torso (left/right).
+   * **Controllers**: Move end-effector (EE) targets for the arms.
+
+
+.. note::
+
+   If the simulation runs at too low FPS and makes the teleoperation feel laggy, you can try to reduce the XR resolution from the XR tab / Advanced Settings / Render Resolution.
+
+   .. figure:: ../../../images/xr_resolution.png
+      :width: 40%
+      :alt: XR resolution panel
+      :align: center
+
+      Reducing render resolution from 1 (default) to 0.2.
+
+Step 4: Record with the headset device
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   Run the following command to activate IsaacTeleop CloudXR environment settings again if you are starting the recording app from a different terminal.
+
+   .. code-block:: bash
+
+      source ~/.cloudxr/run/cloudxr.env
+
+#. **Recording**: When ready to collect data, run the recording script from the Arena container:
+
+   .. code-block:: bash
+
+      export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
+      mkdir -p $DATASET_DIR
+
+   .. code-block:: bash
+
+      # Record demonstrations with OpenXR teleop
+      python isaaclab_arena/scripts/imitation_learning/record_demos.py \
+        --viz kit \
+        --device cpu \
+        --enable_cameras \
+        --dataset_file $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
+        --num_demos 10 \
+        --num_success_steps 10 \
+        galileo_g1_static_pick_and_place \
+        --object apple_01_objaverse_robolab \
+        --destination clay_plates_hot3d_robolab \
+        --teleop_device openxr
+
+#. In the running application, start the session from the **XR** tab in the application window.
+
+#. Follow Step 3 to connect the headset again.
+
+#. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
+
+.. hint::
+
+   Suggested sequence for the task:
+
+   #. Reach toward the apple with one controller — the apple is small and round, so approach it
+      from above and pinch-grasp with a fingertip grip.
+   #. Lift it 5--10 cm above the shelf to clear the plate's rim.
+   #. Move it laterally over the plate.
+   #. Open the gripper to release the apple onto the plate.
+
+   Demos for this task should be noticeably shorter than the loco-manipulation variant (no walk / turn /
+   squat phases), so you can collect 10 successful demos in around 5--10 minutes once the pipeline is
+   running.
+
+
+.. note::
+
+   Releasing a small round object onto a flat plate is noticeably harder than dropping a box into a
+   bin. Keep the release height low and the orientation stable — these recordings are fed directly
+   into LeRobot conversion and policy post-training (see :doc:`step_3_policy_training`), so demo
+   quality is what the policy learns from.
+
+
+Step 5: Replay Recorded Demos (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Replay the recorded HDF5 to confirm the demos look correct end-to-end. This doubles as a no-XR
+sanity check on the environment: it drives the env from the recorded actions and needs no
+teleoperation device, so you can visually verify the scene, embodiment and asset placements
+without launching CloudXR.
+
+.. code-block:: bash
+
+   # Replay from the recorded HDF5 dataset
+   python isaaclab_arena/scripts/imitation_learning/replay_demos.py \
+     --viz kit \
+     --device cpu \
+     --dataset_file $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
+     galileo_g1_static_pick_and_place \
+     --object apple_01_objaverse_robolab \
+     --destination clay_plates_hot3d_robolab

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -215,11 +215,12 @@ whether the finetuned policy actually works in the AGILE-joint runtime:
    between training and serving.
 
 #. **Pick** ``action_horizon`` **deliberately.** The default (40) gives an 800 ms inference chunk at
-   50 Hz, which trades responsiveness against compute. For static apple-to-plate (~600 step
-   episodes) 40 is a good default. Going lower (e.g., 20) gives more responsive closed-loop control
-   at the cost of more frequent policy queries; going higher (e.g., 60) gives a longer inference
-   horizon at the cost of more compute per step. Whichever value you pick, **keep the modality
-   config and the server YAML in sync** (see the caution above).
+   50 Hz, which trades responsiveness against compute, and is the maximum supported by the released
+   GR00T N1.7 base model (``max_action_horizon = 40`` is baked into the checkpoint). For static
+   apple-to-plate (~600 step episodes) 40 is a good default. You can go lower (e.g., 20) for more
+   responsive closed-loop control at the cost of more frequent policy queries; you cannot go higher
+   without retraining the base model. Whichever value you pick, **keep the modality config and the
+   server YAML in sync** (see the caution above).
 
 If you adjust any of these and the resulting checkpoint behaves badly at evaluation, the most
 common culprits in order are: (i) too few or low-quality demonstrations, (ii) modality config /

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -1,0 +1,227 @@
+Policy Post-Training (GR00T N1.7)
+---------------------------------
+
+This workflow covers post-training a `GR00T N1.7 <https://github.com/NVIDIA/Isaac-GR00T>`_ policy
+directly on the **teleoperated demonstrations** exported in HDF5 from :doc:`step_2_teleoperation`.
+The recorded HDF5 is converted to LeRobot format inside the Arena container, then handed off to a
+**standalone Isaac-GR00T checkout** (``$ISAAC_GR00T_DIR`` from :doc:`index`) for finetuning. The
+finetuned checkpoint is later served back to Arena over the server-client architecture in
+:doc:`step_4_evaluation`.
+
+The N1.7 finetune script lives in the standalone Isaac-GR00T repo, not in Arena's pinned
+``submodules/Isaac-GR00T``. This lets you train on the latest GR00T release without bumping the
+Arena submodule.
+
+This page assumes you have a successful recording at
+``$DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5`` from
+:doc:`step_2_teleoperation`.
+
+
+Step 1: Convert to LeRobot Format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+GR00T N1.7 consumes datasets in LeRobot format. The conversion runs inside the standard
+**Base** Arena container.
+
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
+
+Once inside the container, set the dataset directory:
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
+
+.. caution::
+
+   ``isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py`` expects each episode to include
+   ego RGB under ``observations/camera_obs/robot_head_cam_rgb`` (see ``pov_cam_name_sim`` in the
+   conversion config). Before bulk collection, run the conversion once on a short recording to
+   confirm the layout matches.
+
+Edit ``isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml`` so ``hdf5_name`` matches
+your recorded file (``arena_g1_static_apple_dataset_recorded.hdf5``) and ``data_root`` matches
+``$DATASET_DIR``.
+
+Convert the HDF5 dataset to LeRobot format for policy post-training:
+
+.. code-block:: bash
+
+   python isaaclab_arena_gr00t/lerobot/convert_hdf5_to_lerobot.py \
+     --yaml_file isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml
+
+
+This creates a folder ``$DATASET_DIR/arena_g1_static_apple_dataset_recorded/lerobot`` containing
+parquet files with states/actions, MP4 camera recordings, and dataset metadata.
+
+The converter is controlled by a config file at
+``isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml``.
+
+.. dropdown:: Configuration file (``g1_static_apple_config.yaml``)
+   :animate: fade-in
+
+   .. code-block:: yaml
+
+      # Input/Output paths
+      data_root: /datasets/isaaclab_arena/static_apple_tutorial
+      hdf5_name: "arena_g1_static_apple_dataset_recorded.hdf5"
+
+      # Task description
+      language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+      task_index: 3
+
+      # Data field mappings
+      state_name_sim: "robot_joint_pos"
+      action_name_sim: "processed_actions"
+      pov_cam_name_sim: "robot_head_cam_rgb"
+
+      # Output configuration
+      fps: 50
+      chunks_size: 1000
+
+The main differences from the loco-manipulation box config (``g1_locomanip_config.yaml``) are the
+``data_root`` / ``hdf5_name`` pointing at the static apple-to-plate dataset and the
+``language_instruction`` describing the same-shelf placement (no walking, no second table).
+The 43-DoF action layout, embodiment tag, modality template and joint-space configurations are all
+shared with the loco-manipulation variant — the static workflow does not need its own GR00T embodiment
+config because the upper-body action channels and observation modalities are identical; only the
+recorded body channel happens to stay at zero throughout each demo.
+
+.. note::
+
+   The recorder's ``processed_actions`` field already contains the 43-DoF joint-space targets
+   that PinkIK produced during teleoperation. That is why the doc tells you to record with
+   ``g1_wbc_agile_pink`` and evaluate with ``g1_wbc_agile_joint`` — the policy never sees the
+   end-effector pose targets PinkIK consumed; it only sees the joint targets PinkIK *produced*.
+
+
+Step 2: Post-train Policy (standalone Isaac-GR00T venv)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We post-train the GR00T N1.7 policy on the task using the **standalone Isaac-GR00T checkout** from
+:doc:`index` (referenced as ``$ISAAC_GR00T_DIR``). This step runs **outside the Arena container** so
+GR00T's dependencies do not have to coexist with the Arena/Isaac Sim ones.
+
+The GR00T N1.7 policy has 3 billion parameters so post-training is an expensive operation.
+We provide one post-training option, 8 GPUs with 48 GB memory, to achieve the best quality.
+
+Training takes approximately 4-8 hours on 8x L40s GPUs.
+
+Compute Requirements:
+
+- **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, GB200, etc.)
+- **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
+  and multiple dataloader workers requires substantial host memory
+
+Training Configuration:
+
+- **Base Model:** GR00T-N1.7-3B (foundation model, downloaded from Hugging Face on first run)
+- **Tuned Modules:** Visual backbone, projector, diffusion model
+- **Frozen Modules:** LLM (language model)
+- **Batch Size:** 96 (adjust based on GPU memory)
+- **Training Steps:** 20,000
+- **Action horizon:** 40 (must match the diffusion head value used at evaluation; see note below)
+- **Embodiment tag:** ``new_embodiment`` (case-insensitive; resolved to
+  ``EmbodimentTag.NEW_EMBODIMENT`` by ``gr00t``)
+
+To post-train the policy, run the following command **from the standalone Isaac-GR00T checkout**.
+The launcher runs inside the standalone repo's ``uv``-managed venv. Replace
+``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone so the
+``--modality-config-path`` argument can register the WBC modality from Arena's source tree.
+
+.. code-block:: bash
+
+   cd $ISAAC_GR00T_DIR
+
+   uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
+     gr00t/experiment/launch_finetune.py \
+     --base-model-path nvidia/GR00T-N1.7-3B \
+     --dataset-path $DATASET_DIR/arena_g1_static_apple_dataset_recorded/lerobot \
+     --output-dir $MODELS_DIR/static_apple_n17_finetune \
+     --modality-config-path /path/to/IsaacLab-Arena/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py \
+     --embodiment-tag new_embodiment \
+     --global-batch-size 96 \
+     --max-steps 20000 \
+     --num-gpus 8 \
+     --save-steps 5000 \
+     --save-total-limit 5 \
+     --no-tune-llm \
+     --tune-visual \
+     --tune-projector \
+     --tune-diffusion-model \
+     --dataloader-num-workers 8 \
+     --color-jitter-params brightness 0.3 contrast 0.4 saturation 0.5 hue 0.08
+
+.. note::
+
+   **N1.7 CLI vs N1.6 CLI.** The N1.7 ``launch_finetune.py`` is built on `tyro
+   <https://brentyi.github.io/tyro/>`_, so flags are kebab-case (``--base-model-path``, not
+   ``--base_model_path``) and booleans use the ``--flag`` / ``--no-flag`` pair (``--no-tune-llm``).
+   ``--color-jitter-params`` takes alternating ``key value`` pairs, not a JSON string. Run
+   ``uv run python gr00t/experiment/launch_finetune.py --help`` from ``$ISAAC_GR00T_DIR`` to
+   inspect the full argument set for the version you have checked out.
+
+.. note::
+
+   The ``--modality-config-path`` argument points to Arena's
+   ``isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py`` so that
+   ``register_modality_config(...)`` runs and ``new_embodiment`` resolves to the WBC modality
+   layout (5 state keys + 7 action keys). This is the **same file** the server consumes at
+   evaluation time, so it is the single source of truth for the modality layout.
+
+.. caution::
+
+   **Action horizon must match between training and serving.** ``action_horizon`` is baked into the
+   diffusion head at training time and cannot be changed at inference. The Arena server YAML
+   used in :doc:`step_4_evaluation` ships with ``action_horizon: 40`` to match the value that this
+   step trains. If you want a different horizon, change **both**:
+
+   1. ``delta_indices=list(range(N))`` in
+      ``isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py`` for the action
+      modality (controls what the LeRobot loader feeds the model during training).
+   2. ``action_horizon: N`` and ``action_chunk_length: N`` (≤ ``action_horizon``) in the
+      server-side YAML at
+      ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml``.
+
+If you have less powerful GPUs, please see the
+`GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_ for
+information on how to adjust the training configuration to your hardware. We recommend fine-tuning
+the visual backbone, projector, and diffusion model for better results.
+
+
+Recommendations for finetuning that works with AGILE on apple-to-plate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The static apple-to-plate environment runs the AGILE Whole Body Controller (lower-body) and either
+PinkIK (recording) or direct joint control (evaluation). The following choices materially affect
+whether the finetuned policy actually works in the AGILE-joint runtime:
+
+#. **Record with AGILE, not HOMIE.** Keep the default ``--embodiment g1_wbc_agile_pink`` during
+   teleoperation. AGILE's WBC is a single end-to-end velocity policy; HOMIE is a stand+walk pair.
+   The lower-body joint targets PinkIK plus the WBC produce are systematically different between
+   the two, so a HOMIE-trained policy will be off-distribution when served against the AGILE-joint
+   eval embodiment.
+
+#. **Don't record with the joint embodiment.** Use ``g1_wbc_agile_pink`` (PinkIK on top of AGILE),
+   not ``g1_wbc_agile_joint``. The recorder writes the **joint-space output of PinkIK** as
+   ``processed_actions``, which is what the policy needs to learn. Recording with
+   ``g1_wbc_agile_joint`` would force the human teleoperator to drive 43 joint targets directly,
+   which is impractical and not what eval uses anyway.
+
+#. **Use Arena's** ``g1_sim_wbc_data_gr00t_n_1_7_config.py`` **for** ``--modality-config-path``\ **.**
+   This registers the modality with ``NEW_EMBODIMENT`` (40-step action horizon for N1.7) and is the
+   same file the Arena server consumes at eval. Keeping a single source of truth prevents skew
+   between training and serving.
+
+#. **Pick** ``action_horizon`` **deliberately.** The default (40) gives an 800 ms inference chunk at
+   50 Hz, which trades responsiveness against compute. For static apple-to-plate (~600 step
+   episodes) 40 is a good default. Going lower (e.g., 20) gives more responsive closed-loop control
+   at the cost of more frequent policy queries; going higher (e.g., 60) gives a longer inference
+   horizon at the cost of more compute per step. Whichever value you pick, **keep the modality
+   config and the server YAML in sync** (see the caution above).
+
+If you adjust any of these and the resulting checkpoint behaves badly at evaluation, the most
+common culprits in order are: (i) too few or low-quality demonstrations, (ii) modality config /
+``action_horizon`` mismatch between training and server YAML, (iii) recording with the wrong
+embodiment.

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -2,9 +2,10 @@ Closed-Loop Policy Inference and Evaluation
 -------------------------------------------
 
 This workflow demonstrates running the finetuned GR00T N1.7 policy in closed-loop and evaluating it
-in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **server-client (remote-policy)
-architecture**. The server hosts the finetuned checkpoint outside the Arena container; the Arena
-container runs the simulation and queries the server over ZeroMQ.
+in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **server-client
+(remote-policy) architecture**. The GR00T policy server, which hosts the finetuned checkpoint, runs
+outside the Arena container. The Arena container itself runs only the simulation and a thin GR00T
+client that queries the server for actions.
 
 Note that this tutorial assumes that you've completed the
 :doc:`preceding step (Policy Training) <step_3_policy_training>` or downloaded the

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -1,0 +1,203 @@
+Closed-Loop Policy Inference and Evaluation
+-------------------------------------------
+
+This workflow demonstrates running the finetuned GR00T N1.7 policy in closed-loop and evaluating it
+in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **server-client (remote-policy)
+architecture**. The server hosts the finetuned checkpoint outside the Arena container; the Arena
+container runs the simulation and queries the server over ZeroMQ.
+
+Note that this tutorial assumes that you've completed the
+:doc:`preceding step (Policy Training) <step_3_policy_training>`.
+
+
+Step 1: Start the GR00T policy server
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The server runs GR00T's stock ``run_gr00t_server.py`` from the standalone Isaac-GR00T (N1.7) checkout.
+Start it **before** launching the client; the client will connect on first inference. Run the
+server **outside Docker** in the standalone Isaac-GR00T venv created in :doc:`index`.
+
+The server takes all of its configuration from CLI flags (model checkpoint, embodiment tag, the
+modality config from Arena's source tree, and bind host/port). Replace
+``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone and ``${MODEL_PATH}`` with
+the finetuned checkpoint directory from :doc:`step_3_policy_training`.
+
+.. code-block:: bash
+
+   cd $ISAAC_GR00T_DIR
+
+   uv run python gr00t/eval/run_gr00t_server.py \
+      --modality-config-path /path/to/IsaacLab-Arena/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py \
+      --model-path ${MODEL_PATH} \
+      --embodiment-tag NEW_EMBODIMENT \
+      --device cuda \
+      --host 0.0.0.0 \
+      --port 5555
+
+The server prints ``Server Ready and listening on 0.0.0.0:5555`` once it is ready for clients.
+
+
+Step 2: Run Single Environment Evaluation (Arena container)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the server from Step 1 running, launch the Arena client. The client side does not need any
+GR00T dependencies — it talks to the server over ZeroMQ — so it runs in the standard **Base**
+Arena container. ``Gr00tRemoteClosedloopPolicy`` is Arena's client wrapper around the remote GR00T server.
+
+**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+
+:docker_run_default:
+
+Once inside the container, set the dataset and models directories.
+
+.. code:: bash
+
+    export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
+    export MODELS_DIR=/models/isaaclab_arena/static_apple_tutorial
+
+We first run the policy in a single environment with visualization via the GUI. Replace
+``<SERVER_HOST>`` below with the IP of the host running Step 1 (or ``localhost`` if it is the
+same machine).
+
+.. caution::
+
+   Before running, edit ``model_path`` in
+   ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml`` to point at
+   the finetuned checkpoint directory you produced in :doc:`step_3_policy_training` (for example,
+   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000``).
+   It must match the ``--model-path`` you passed to ``run_gr00t_server.py`` in Step 1.
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \
+      --viz kit \
+      --policy_type isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy \
+      --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml \
+      --remote_host <SERVER_HOST> --remote_port 5555 \
+      --num_steps 600 \
+      --enable_cameras \
+      galileo_g1_static_pick_and_place \
+      --object apple_01_objaverse_robolab \
+      --destination clay_plates_hot3d_robolab \
+      --embodiment g1_wbc_agile_joint
+
+Note the lower ``--num_steps`` (600 instead of 1500): with no walking phase, a successful
+static apple-to-plate episode runs for roughly half as long as the loco-manipulation variant.
+
+The evaluation should produce the following output on the console at the end of the evaluation.
+You should see similar metrics.
+
+Note that all these metrics are computed over the entire evaluation process, and are affected
+by the quality of post-trained policy, the quality of the dataset, and number of steps in the evaluation.
+
+.. code-block:: text
+
+   [Rank 0/1] Metrics: {'success_rate': 1.0, 'object_moved_rate': 1.0, 'num_episodes': 1}
+
+
+Run Parallel Environments Evaluation (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Parallel evaluation of the policy in multiple parallel environments is also supported by the policy
+runner. The command below assumes the server from Step 1 is still running.
+
+Test the policy in 5 parallel environments with visualization via the GUI:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \
+      --viz kit \
+      --policy_type isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy \
+      --remote_host <SERVER_HOST> \
+      --remote_port 5555 \
+      --num_steps 500 \
+      --num_envs 5 \
+      --enable_cameras \
+      galileo_g1_static_pick_and_place \
+      --object apple_01_objaverse_robolab \
+      --destination clay_plates_hot3d_robolab \
+      --embodiment g1_wbc_agile_joint
+
+.. note::
+
+   With the server-client architecture, the policy device is a server-side concern: the server
+   places the policy on its own GPU via the ``--device`` flag passed to ``run_gr00t_server.py``
+   in Step 1. The client's ``--device`` flag (above) controls Arena's physics backend, not the
+   policy.
+
+.. note::
+
+   The parallel command uses ``ActionChunkingClientSidePolicy`` instead of
+   ``Gr00tRemoteClosedloopPolicy`` (the single-environment client) because parallel evaluation
+   needs the action-chunking buffer lifted out of the per-env policy and shared across envs.
+   Single-env evaluation works with either client; the parallel command requires this one.
+
+And during the evaluation, you should see the following output on the console at the end of the evaluation
+indicating which environments are terminated (task-specific conditions like the apple is placed onto the plate,
+or the episode length is exceeded by 30 seconds),
+or truncated (if timeouts are enabled, like the maximum episode length is exceeded).
+
+.. code-block:: text
+
+   Resetting policy for terminated env_ids: tensor([3], device='cuda:0') and truncated env_ids: tensor([], device='cuda:0', dtype=torch.int64)
+
+At the end of the evaluation, you should see the following output on the console indicating the metrics.
+You can see that the success rate might not be 1.0 as more trials are being evaluated and randomizations are being introduced,
+and the number of episodes is more than the single environment evaluation because of the parallelization.
+
+.. code-block:: text
+
+   [Rank 0/1] Metrics: {'success_rate': 1.0, 'num_episodes': 4}
+
+.. note::
+
+   Note that the embodiment used in closed-loop policy inference is ``g1_wbc_agile_joint``, which is
+   different from ``g1_wbc_agile_pink`` used during teleoperation recording.
+   This is because during tele-operation, the upper body is controlled via target end-effector poses,
+   which are realized by using the PINK IK controller, and the lower body is controlled via the AGILE
+   WBC policy. The GR00T N1.7 policy is trained on upper body joint positions and lower body WBC
+   policy inputs, so we use the joint-control twin (``g1_wbc_agile_joint``) for closed-loop policy
+   inference -- it shares the AGILE lower-body backend with the recording embodiment, just bypasses
+   PinkIK.
+
+.. note::
+
+   The single-environment command above does not pass ``--device``, so Arena defaults to its
+   built-in physics backend. The parallel command explicitly sets ``--device cuda`` for
+   throughput. If your dataset was recorded on GPU physics, prefer ``--device cuda`` for both
+   single and parallel runs to keep evaluation physics aligned with training; if it was recorded
+   on CPU physics, add ``--device cpu`` to the single-environment command for per-episode
+   reproducibility (parallel throughput becomes the trade-off for CPU-trained policies).
+
+.. note::
+
+   The same-shelf placement makes the static variant slightly easier than the loco-manipulation
+   apple-to-plate task: the destination plate is always within arm's reach so the policy
+   never has to recover from a mistimed approach, and there are no intermediate locomotion
+   phases that can drift off-course. The success criterion is the same contact-sensor
+   termination used by the loco-manipulation variant (``force_threshold=0.5 N``,
+   ``velocity_threshold=0.1 m/s``), filtered to contacts with the ``--destination`` asset.
+   Both values are passed to ``PickAndPlaceTask`` from
+   ``isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py``; edit the
+   ``force_threshold`` / ``velocity_threshold`` kwargs there if you need a different success
+   criterion for a new pick-up object or destination.
+
+.. note::
+
+   **Common server-client failure modes.**
+
+   - ``ValueError: Invalid action shape, expected: 23, received: 50.`` — the client's embodiment
+     expects a 23-D PinkIK action, but the server is returning a 43-DoF joint chunk. Make sure the
+     client uses ``--embodiment g1_wbc_agile_joint`` (joint twin), not
+     ``g1_wbc_agile_pink`` (PinkIK twin).
+   - ``ModuleNotFoundError`` on the client side — the client's ``--policy_type`` is wrong. The
+     two valid client classes for this workflow are
+     ``isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy``
+     (single env, takes ``--policy_config_yaml_path``) and
+     ``isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy`` (parallel,
+     no YAML).
+   - Action shape mismatch on the server (e.g., ``Action key 'left_arm''s horizon must be 40.
+     Got 50``) — the action modality registered at training time disagrees with the modality
+     loaded by the server. Re-finetune at the same horizon or update the
+     ``--modality-config-path`` you pass to ``run_gr00t_server.py`` to match the checkpoint (see
+     the caution in :doc:`step_3_policy_training`).

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -112,61 +112,6 @@ by the quality of post-trained policy, the quality of the dataset, and number of
 
    [Rank 0/1] Metrics: {'success_rate': 1.0, 'object_moved_rate': 1.0, 'num_episodes': 1}
 
-
-Run Parallel Environments Evaluation (Optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Parallel evaluation of the policy in multiple parallel environments is also supported by the policy
-runner. The command below assumes the server from Step 1 is still running.
-
-Test the policy in 5 parallel environments with visualization via the GUI:
-
-.. code-block:: bash
-
-   /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \
-      --viz kit \
-      --policy_type isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy \
-      --remote_host <SERVER_HOST> \
-      --remote_port 5555 \
-      --num_steps 500 \
-      --num_envs 5 \
-      --enable_cameras \
-      galileo_g1_static_pick_and_place \
-      --object apple_01_objaverse_robolab \
-      --destination clay_plates_hot3d_robolab \
-      --embodiment g1_wbc_agile_joint
-
-.. note::
-
-   With the server-client architecture, the policy device is a server-side concern: the server
-   places the policy on its own GPU via the ``--device`` flag passed to ``run_gr00t_server.py``
-   in Step 1. The client's ``--device`` flag (above) controls Arena's physics backend, not the
-   policy.
-
-.. note::
-
-   The parallel command uses ``ActionChunkingClientSidePolicy`` instead of
-   ``Gr00tRemoteClosedloopPolicy`` (the single-environment client) because parallel evaluation
-   needs the action-chunking buffer lifted out of the per-env policy and shared across envs.
-   Single-env evaluation works with either client; the parallel command requires this one.
-
-And during the evaluation, you should see the following output on the console at the end of the evaluation
-indicating which environments are terminated (task-specific conditions like the apple is placed onto the plate,
-or the episode length is exceeded by 30 seconds),
-or truncated (if timeouts are enabled, like the maximum episode length is exceeded).
-
-.. code-block:: text
-
-   Resetting policy for terminated env_ids: tensor([3], device='cuda:0') and truncated env_ids: tensor([], device='cuda:0', dtype=torch.int64)
-
-At the end of the evaluation, you should see the following output on the console indicating the metrics.
-You can see that the success rate might not be 1.0 as more trials are being evaluated and randomizations are being introduced,
-and the number of episodes is more than the single environment evaluation because of the parallelization.
-
-.. code-block:: text
-
-   [Rank 0/1] Metrics: {'success_rate': 1.0, 'num_episodes': 4}
-
 .. note::
 
    Note that the embodiment used in closed-loop policy inference is ``g1_wbc_agile_joint``, which is
@@ -177,15 +122,6 @@ and the number of episodes is more than the single environment evaluation becaus
    policy inputs, so we use the joint-control twin (``g1_wbc_agile_joint``) for closed-loop policy
    inference -- it shares the AGILE lower-body backend with the recording embodiment, just bypasses
    PinkIK.
-
-.. note::
-
-   The single-environment command above does not pass ``--device``, so Arena defaults to its
-   built-in physics backend. The parallel command explicitly sets ``--device cuda`` for
-   throughput. If your dataset was recorded on GPU physics, prefer ``--device cuda`` for both
-   single and parallel runs to keep evaluation physics aligned with training; if it was recorded
-   on CPU physics, add ``--device cpu`` to the single-environment command for per-episode
-   reproducibility (parallel throughput becomes the trade-off for CPU-trained policies).
 
 .. note::
 
@@ -209,11 +145,9 @@ and the number of episodes is more than the single environment evaluation becaus
      client uses ``--embodiment g1_wbc_agile_joint`` (joint twin), not
      ``g1_wbc_agile_pink`` (PinkIK twin).
    - ``ModuleNotFoundError`` on the client side — the client's ``--policy_type`` is wrong. The
-     two valid client classes for this workflow are
-     ``isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy``
-     (single env, takes ``--policy_config_yaml_path``) and
-     ``isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy`` (parallel,
-     no YAML).
+     valid client class for this workflow is
+     ``isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy``,
+     which takes ``--policy_config_yaml_path``.
    - Action shape mismatch on the server (e.g., ``Action key 'left_arm''s horizon must be 40.
      Got 50``) — the action modality registered at training time disagrees with the modality
      loaded by the server. Re-finetune at the same horizon or update the

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -7,7 +7,24 @@ architecture**. The server hosts the finetuned checkpoint outside the Arena cont
 container runs the simulation and queries the server over ZeroMQ.
 
 Note that this tutorial assumes that you've completed the
-:doc:`preceding step (Policy Training) <step_3_policy_training>`.
+:doc:`preceding step (Policy Training) <step_3_policy_training>` or downloaded the
+pre-trained model checkpoint below:
+
+.. dropdown:: Download Pre-trained Model (skip preceding steps)
+   :animate: fade-in
+
+   These commands can be used to download the pre-trained GR00T N1.7 policy checkpoint,
+   such that the preceding steps can be skipped.
+   This step requires the Hugging Face CLI, which can be installed by following the
+   `official instructions <https://huggingface.co/docs/huggingface_hub/installation>`_.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace \
+         --local-dir $MODELS_DIR/checkpoint-20000
 
 
 Step 1: Start the GR00T policy server

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -7,26 +7,8 @@ in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **s
 outside the Arena container. The Arena container itself runs only the simulation and a thin GR00T
 client that queries the server for actions.
 
-Note that this tutorial assumes that you've completed the
-:doc:`preceding step (Policy Training) <step_3_policy_training>` or downloaded the
-pre-trained model checkpoint below:
-
-.. dropdown:: Download Pre-trained Model (skip preceding steps)
-   :animate: fade-in
-
-   These commands can be used to download the pre-trained GR00T N1.7 policy checkpoint,
-   such that the preceding steps can be skipped.
-   This step requires the Hugging Face CLI, which can be installed by following the
-   `official instructions <https://huggingface.co/docs/huggingface_hub/installation>`_.
-
-   To download run:
-
-   .. code-block:: bash
-
-      hf download \
-         nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace \
-         --local-dir $MODELS_DIR/checkpoint-20000
-
+This tutorial uses the dataset you collected in :doc:`step_2_teleoperation` and the model
+you trained in :doc:`step_3_policy_training`.
 
 Step 1: Start the GR00T policy server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/isaaclab_arena/assets/retargeter_library.py
+++ b/isaaclab_arena/assets/retargeter_library.py
@@ -73,6 +73,22 @@ class G1WbcPinkIsaacTeleopRetargeter(RetargetterBase):
 
 
 @register_retargeter
+class G1WbcAgilePinkIsaacTeleopRetargeter(RetargetterBase):
+    """Isaac Teleop pipeline builder for G1 WBC AGILE with Pink IK."""
+
+    device = "openxr"
+    embodiment = "g1_wbc_agile_pink"
+
+    def __init__(self):
+        pass
+
+    def get_pipeline_builder(self, embodiment: object) -> Callable:
+        from isaaclab_arena_g1.teleop.g1_pink_locomanipulation_pipeline import _build_g1_pink_locomanipulation_pipeline
+
+        return _build_g1_pink_locomanipulation_pipeline
+
+
+@register_retargeter
 class FrankaKeyboardRetargeter(RetargetterBase):
     device = "keyboard"
     embodiment = "franka_ik"

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -137,6 +137,30 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
 
 
 @register_asset
+class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
+    """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control."""
+
+    name = "g1_wbc_agile_pink"
+
+    def __init__(
+        self,
+        enable_cameras: bool = False,
+        initial_pose: Pose | None = None,
+        camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
+        use_tiled_camera: bool = False,
+    ):
+        super().__init__(enable_cameras, initial_pose)
+        self.action_config = G1WBCAgilePinkActionCfg()
+        self.observation_config = G1WBCPinkObservationsCfg()
+        self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
+        self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
+        self.observation_config.action.concatenate_terms = self.concatenate_observation_terms
+        self.event_config = G1WBCPinkEventCfg()
+        self.camera_config._is_tiled_camera = use_tiled_camera
+        self.camera_config._camera_offset = camera_offset
+
+
+@register_asset
 class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
     """Embodiment for the G1 robot with AGILE WBC policy and direct joint upperbody control.
 
@@ -637,6 +661,13 @@ class G1WBCPinkActionCfg:
     """Action specifications for the MDP, for G1 WBC action."""
 
     g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(asset_name="robot", joint_names=[".*"])
+
+
+@configclass
+class G1WBCAgilePinkActionCfg:
+    """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body."""
+
+    g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(asset_name="robot", joint_names=[".*"], wbc_version="agile")
 
 
 @configclass

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import torch
 from collections.abc import Sequence
 from dataclasses import MISSING
@@ -138,7 +139,12 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
 
 @register_asset
 class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
-    """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control."""
+    """Embodiment for the G1 robot with AGILE WBC policy and PINK IK upperbody control.
+
+    Uses :data:`G1_AGILE_CFG` so the leg/feet/waist actuator gains match the agile
+    training-time values; without that override the policy's joint targets get
+    amplified by the Arena's stiffer default PD loop.
+    """
 
     name = "g1_wbc_agile_pink"
 
@@ -150,6 +156,7 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         use_tiled_camera: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
+        self.scene_config = G1AgileSceneCfg()
         self.action_config = G1WBCAgilePinkActionCfg()
         self.observation_config = G1WBCPinkObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
@@ -164,7 +171,12 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
 class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
     """Embodiment for the G1 robot with AGILE WBC policy and direct joint upperbody control.
 
-    By default uses tiled camera for efficient parallel evaluation.
+    By default uses tiled camera for efficient parallel evaluation. Uses
+    :data:`G1_AGILE_CFG` so the leg/feet/waist actuator gains match the agile
+    training-time values; the Arena's default G1 actuator stiffness is 2-4x higher
+    than what the agile policy was trained on, which would amplify the policy's
+    joint targets through a stiffer PD loop and produce a slow yaw drift /
+    postural twitch even when the velocity command is zero.
     """
 
     name = "g1_wbc_agile_joint"
@@ -177,6 +189,7 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         use_tiled_camera: bool = True,
     ):
         super().__init__(enable_cameras, initial_pose)
+        self.scene_config = G1AgileSceneCfg()
         self.action_config = G1WBCAgileJointActionCfg()
         self.observation_config = G1WBCJointObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
@@ -186,203 +199,277 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         self.camera_config._camera_offset = camera_offset
 
 
+# Default Arena G1 articulation config used by all non-AGILE G1 embodiments. Kept at
+# module level so AGILE-specific variants (see ``G1_AGILE_CFG``) can be expressed as
+# ``G1_CFG.copy()`` with targeted actuator overrides instead of mutating
+# ``scene_config`` in each embodiment constructor.
+G1_CFG = ArticulationCfg(
+    spawn=sim_utils.UsdFileCfg(
+        usd_path=f"{ISAAC_NUCLEUS_DIR}/Samples/Groot/Robots/g1_29dof_with_hand_rev_1_0.usd",
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            retain_accelerations=False,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=1000.0,
+            max_depenetration_velocity=1.0,
+            solver_position_iteration_count=4,
+            solver_velocity_iteration_count=0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=False, solver_position_iteration_count=4, solver_velocity_iteration_count=0
+        ),
+    ),
+    prim_path="/World/envs/env_.*/Robot",
+    init_state=ArticulationCfg.InitialStateCfg(
+        pos=(0.8, -1.38, 0.78),
+        rot=(0.0, 0.0, 1.0, 0.0),
+        joint_pos={
+            # target angles [rad]
+            "left_hip_pitch_joint": -0.1,
+            "left_hip_roll_joint": 0.0,
+            "left_hip_yaw_joint": 0.0,
+            "left_knee_joint": 0.3,
+            "left_ankle_pitch_joint": -0.2,
+            "left_ankle_roll_joint": 0.0,
+            "right_hip_pitch_joint": -0.1,
+            "right_hip_roll_joint": 0.0,
+            "right_hip_yaw_joint": 0.0,
+            "right_knee_joint": 0.3,
+            "right_ankle_pitch_joint": -0.2,
+            "right_ankle_roll_joint": 0.0,
+            "waist_yaw_joint": 0.0,
+            "waist_roll_joint": 0.0,
+            "waist_pitch_joint": 0.0,
+            "left_shoulder_pitch_joint": 0.0,
+            "left_shoulder_roll_joint": 0.0,
+            "left_shoulder_yaw_joint": 0.0,
+            "left_elbow_joint": 0.0,
+            "right_shoulder_pitch_joint": 0.0,
+            "right_shoulder_roll_joint": 0,
+            "right_shoulder_yaw_joint": 0.0,
+            "right_elbow_joint": 0.0,
+        },
+        joint_vel={".*": 0.0},
+    ),
+    actuators={
+        "legs": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_hip_yaw_joint",
+                ".*_hip_roll_joint",
+                ".*_hip_pitch_joint",
+                ".*_knee_joint",
+            ],
+            effort_limit={
+                ".*_hip_yaw_joint": 88.0,
+                ".*_hip_roll_joint": 88.0,
+                ".*_hip_pitch_joint": 88.0,
+                ".*_knee_joint": 139.0,
+            },
+            velocity_limit={
+                ".*_hip_yaw_joint": 32.0,
+                ".*_hip_roll_joint": 32.0,
+                ".*_hip_pitch_joint": 32.0,
+                ".*_knee_joint": 20.0,
+            },
+            stiffness={
+                ".*_hip_yaw_joint": 150.0,
+                ".*_hip_roll_joint": 150.0,
+                ".*_hip_pitch_joint": 150.0,
+                ".*_knee_joint": 300.0,
+            },
+            damping={
+                ".*_hip_yaw_joint": 2.0,
+                ".*_hip_roll_joint": 2.0,
+                ".*_hip_pitch_joint": 2.0,
+                ".*_knee_joint": 4.0,
+            },
+            armature={
+                ".*_hip_.*": 0.03,
+                ".*_knee_joint": 0.03,
+            },
+        ),
+        "feet": IdealPDActuatorCfg(
+            joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
+            stiffness={
+                ".*_ankle_pitch_joint": 40.0,
+                ".*_ankle_roll_joint": 40.0,
+            },
+            damping={
+                ".*_ankle_pitch_joint": 2,
+                ".*_ankle_roll_joint": 2,
+            },
+            effort_limit={
+                ".*_ankle_pitch_joint": 50.0,
+                ".*_ankle_roll_joint": 50.0,
+            },
+            velocity_limit={
+                ".*_ankle_pitch_joint": 37.0,
+                ".*_ankle_roll_joint": 37.0,
+            },
+            armature=0.03,
+            friction=0.03,
+        ),
+        "waist": IdealPDActuatorCfg(
+            joint_names_expr=[
+                "waist_.*_joint",
+            ],
+            effort_limit={
+                "waist_yaw_joint": 88.0,
+                "waist_roll_joint": 50.0,
+                "waist_pitch_joint": 50.0,
+            },
+            velocity_limit={
+                "waist_yaw_joint": 32.0,
+                "waist_roll_joint": 37.0,
+                "waist_pitch_joint": 37.0,
+            },
+            stiffness={
+                "waist_yaw_joint": 250.0,
+                "waist_roll_joint": 250.0,
+                "waist_pitch_joint": 250.0,
+            },
+            damping={
+                "waist_yaw_joint": 5.0,
+                "waist_roll_joint": 5.0,
+                "waist_pitch_joint": 5.0,
+            },
+            armature=0.03,
+            friction=0.03,
+        ),
+        "arms": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_shoulder_pitch_joint",
+                ".*_shoulder_roll_joint",
+                ".*_shoulder_yaw_joint",
+                ".*_elbow_joint",
+                ".*_wrist_.*_joint",
+            ],
+            effort_limit={
+                ".*_shoulder_pitch_joint": 25.0,
+                ".*_shoulder_roll_joint": 25.0,
+                ".*_shoulder_yaw_joint": 25.0,
+                ".*_elbow_joint": 25.0,
+                ".*_wrist_roll_joint": 25.0,
+                ".*_wrist_pitch_joint": 5.0,
+                ".*_wrist_yaw_joint": 5.0,
+            },
+            velocity_limit={
+                ".*_shoulder_pitch_joint": 37.0,
+                ".*_shoulder_roll_joint": 37.0,
+                ".*_shoulder_yaw_joint": 37.0,
+                ".*_elbow_joint": 37.0,
+                ".*_wrist_roll_joint": 37.0,
+                ".*_wrist_pitch_joint": 22.0,
+                ".*_wrist_yaw_joint": 22.0,
+            },
+            stiffness={
+                ".*_shoulder_pitch_joint": 100.0,
+                ".*_shoulder_roll_joint": 100.0,
+                ".*_shoulder_yaw_joint": 40.0,
+                ".*_elbow_joint": 40.0,
+                ".*_wrist_.*_joint": 20.0,
+            },
+            damping={
+                ".*_shoulder_pitch_joint": 5.0,
+                ".*_shoulder_roll_joint": 5.0,
+                ".*_shoulder_yaw_joint": 2.0,
+                ".*_elbow_joint": 2.0,
+                ".*_wrist_.*_joint": 2.0,
+            },
+            armature={".*_shoulder_.*": 0.03, ".*_elbow_.*": 0.03, ".*_wrist_.*_joint": 0.03},
+            friction=0.03,
+        ),
+        # NOTE(peterd, 9/25/2025): The follow hand joint values are tested and working with Leapmotion and Mimic
+        "hands": IdealPDActuatorCfg(
+            joint_names_expr=[
+                ".*_hand_.*",
+            ],
+            effort_limit=5.0,
+            velocity_limit=10.0,
+            stiffness=4.0,
+            damping=0.5,
+            armature=0.03,
+            friction=0.03,
+        ),
+    },
+)
+
+
+# Motor model constants for the AGILE recurrent-student G1 policy. Naming and
+# values mirror ``agile/rl_env/assets/robots/unitree_g1.py`` so the AGILE source
+# of truth is greppable across repos. Stiffness/damping derive from the standard
+# second-order PD form (omega_n^2 * armature, 2 * zeta * omega_n * armature).
+_G1_AGILE_NATURAL_FREQ = 10.0 * 2.0 * math.pi  # 10 Hz
+_G1_AGILE_DAMPING_RATIO = 2.0
+_G1_AGILE_ARMATURE_7520_14 = 0.010177520
+_G1_AGILE_ARMATURE_7520_22 = 0.025101925
+_G1_AGILE_ARMATURE_5020 = 0.003609725
+_G1_AGILE_STIFFNESS_7520_14 = _G1_AGILE_ARMATURE_7520_14 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_STIFFNESS_7520_22 = _G1_AGILE_ARMATURE_7520_22 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_STIFFNESS_5020 = _G1_AGILE_ARMATURE_5020 * _G1_AGILE_NATURAL_FREQ**2
+_G1_AGILE_DAMPING_7520_14 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_7520_14 * _G1_AGILE_NATURAL_FREQ
+_G1_AGILE_DAMPING_7520_22 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_7520_22 * _G1_AGILE_NATURAL_FREQ
+_G1_AGILE_DAMPING_5020 = 2.0 * _G1_AGILE_DAMPING_RATIO * _G1_AGILE_ARMATURE_5020 * _G1_AGILE_NATURAL_FREQ
+
+
+# G1 articulation tuned to match the agile training-time PD/armature values from
+# ``unitree_g1_velocity_height_recurrent_student.yaml``. Arena's default G1 has
+# 2-4x higher leg/feet stiffness; without this override the policy's joint
+# targets get amplified by the stiffer PD loop, manifesting as a slow yaw drift
+# / postural twitch even when the velocity command is zero. ``effort_limit``,
+# ``velocity_limit``, ``friction``, spawn, init pose, hands, and arm gains keep
+# the Arena defaults since they are physical limits or joint-set definitions,
+# not policy training inputs.
+G1_AGILE_CFG = G1_CFG.copy()
+G1_AGILE_CFG.actuators["legs"].stiffness = {
+    ".*_hip_pitch_joint": _G1_AGILE_STIFFNESS_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_STIFFNESS_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_STIFFNESS_7520_14,
+    ".*_knee_joint": _G1_AGILE_STIFFNESS_7520_22,
+}
+G1_AGILE_CFG.actuators["legs"].damping = {
+    ".*_hip_pitch_joint": _G1_AGILE_DAMPING_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_DAMPING_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_DAMPING_7520_14,
+    ".*_knee_joint": _G1_AGILE_DAMPING_7520_22,
+}
+G1_AGILE_CFG.actuators["legs"].armature = {
+    ".*_hip_pitch_joint": _G1_AGILE_ARMATURE_7520_14,
+    ".*_hip_roll_joint": _G1_AGILE_ARMATURE_7520_22,
+    ".*_hip_yaw_joint": _G1_AGILE_ARMATURE_7520_14,
+    ".*_knee_joint": _G1_AGILE_ARMATURE_7520_22,
+}
+G1_AGILE_CFG.actuators["feet"].stiffness = 2.0 * _G1_AGILE_STIFFNESS_5020
+G1_AGILE_CFG.actuators["feet"].damping = 2.0 * _G1_AGILE_DAMPING_5020
+G1_AGILE_CFG.actuators["feet"].armature = 2.0 * _G1_AGILE_ARMATURE_5020
+# Waist gains come straight from the recurrent-student YAML; they don't fit
+# the (armature, omega_n, zeta) family above, so use the literal values.
+G1_AGILE_CFG.actuators["waist"].stiffness = {
+    "waist_yaw_joint": 300.0,
+    "waist_roll_joint": 300.0,
+    "waist_pitch_joint": 300.0,
+}
+G1_AGILE_CFG.actuators["waist"].damping = {
+    "waist_yaw_joint": 5.0,
+    "waist_roll_joint": 5.0,
+    "waist_pitch_joint": 5.0,
+}
+G1_AGILE_CFG.actuators["waist"].armature = 0.03
+
+
 @configclass
 class G1SceneCfg:
+    robot: ArticulationCfg = G1_CFG.copy()
 
-    # Gear'WBC G1 config, used in WBC training
-    robot: ArticulationCfg = ArticulationCfg(
-        spawn=sim_utils.UsdFileCfg(
-            usd_path=f"{ISAAC_NUCLEUS_DIR}/Samples/Groot/Robots/g1_29dof_with_hand_rev_1_0.usd",
-            activate_contact_sensors=True,
-            rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                disable_gravity=False,
-                retain_accelerations=False,
-                linear_damping=0.0,
-                angular_damping=0.0,
-                max_linear_velocity=1000.0,
-                max_angular_velocity=1000.0,
-                max_depenetration_velocity=1.0,
-                solver_position_iteration_count=4,
-                solver_velocity_iteration_count=0,
-            ),
-            articulation_props=sim_utils.ArticulationRootPropertiesCfg(
-                enabled_self_collisions=False, solver_position_iteration_count=4, solver_velocity_iteration_count=0
-            ),
-        ),
-        prim_path="/World/envs/env_.*/Robot",
-        init_state=ArticulationCfg.InitialStateCfg(
-            pos=(0.8, -1.38, 0.78),
-            rot=(0.0, 0.0, 1.0, 0.0),
-            joint_pos={
-                # target angles [rad]
-                "left_hip_pitch_joint": -0.1,
-                "left_hip_roll_joint": 0.0,
-                "left_hip_yaw_joint": 0.0,
-                "left_knee_joint": 0.3,
-                "left_ankle_pitch_joint": -0.2,
-                "left_ankle_roll_joint": 0.0,
-                "right_hip_pitch_joint": -0.1,
-                "right_hip_roll_joint": 0.0,
-                "right_hip_yaw_joint": 0.0,
-                "right_knee_joint": 0.3,
-                "right_ankle_pitch_joint": -0.2,
-                "right_ankle_roll_joint": 0.0,
-                "waist_yaw_joint": 0.0,
-                "waist_roll_joint": 0.0,
-                "waist_pitch_joint": 0.0,
-                "left_shoulder_pitch_joint": 0.0,
-                "left_shoulder_roll_joint": 0.0,
-                "left_shoulder_yaw_joint": 0.0,
-                "left_elbow_joint": 0.0,
-                "right_shoulder_pitch_joint": 0.0,
-                "right_shoulder_roll_joint": 0,
-                "right_shoulder_yaw_joint": 0.0,
-                "right_elbow_joint": 0.0,
-            },
-            joint_vel={".*": 0.0},
-        ),
-        actuators={
-            "legs": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_hip_yaw_joint",
-                    ".*_hip_roll_joint",
-                    ".*_hip_pitch_joint",
-                    ".*_knee_joint",
-                ],
-                effort_limit={
-                    ".*_hip_yaw_joint": 88.0,
-                    ".*_hip_roll_joint": 88.0,
-                    ".*_hip_pitch_joint": 88.0,
-                    ".*_knee_joint": 139.0,
-                },
-                velocity_limit={
-                    ".*_hip_yaw_joint": 32.0,
-                    ".*_hip_roll_joint": 32.0,
-                    ".*_hip_pitch_joint": 32.0,
-                    ".*_knee_joint": 20.0,
-                },
-                stiffness={
-                    ".*_hip_yaw_joint": 150.0,
-                    ".*_hip_roll_joint": 150.0,
-                    ".*_hip_pitch_joint": 150.0,
-                    ".*_knee_joint": 300.0,
-                },
-                damping={
-                    ".*_hip_yaw_joint": 2.0,
-                    ".*_hip_roll_joint": 2.0,
-                    ".*_hip_pitch_joint": 2.0,
-                    ".*_knee_joint": 4.0,
-                },
-                armature={
-                    ".*_hip_.*": 0.03,
-                    ".*_knee_joint": 0.03,
-                },
-            ),
-            "feet": IdealPDActuatorCfg(
-                joint_names_expr=[".*_ankle_pitch_joint", ".*_ankle_roll_joint"],
-                stiffness={
-                    ".*_ankle_pitch_joint": 40.0,
-                    ".*_ankle_roll_joint": 40.0,
-                },
-                damping={
-                    ".*_ankle_pitch_joint": 2,
-                    ".*_ankle_roll_joint": 2,
-                },
-                effort_limit={
-                    ".*_ankle_pitch_joint": 50.0,
-                    ".*_ankle_roll_joint": 50.0,
-                },
-                velocity_limit={
-                    ".*_ankle_pitch_joint": 37.0,
-                    ".*_ankle_roll_joint": 37.0,
-                },
-                armature=0.03,
-                friction=0.03,
-            ),
-            "waist": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    "waist_.*_joint",
-                ],
-                effort_limit={
-                    "waist_yaw_joint": 88.0,
-                    "waist_roll_joint": 50.0,
-                    "waist_pitch_joint": 50.0,
-                },
-                velocity_limit={
-                    "waist_yaw_joint": 32.0,
-                    "waist_roll_joint": 37.0,
-                    "waist_pitch_joint": 37.0,
-                },
-                stiffness={
-                    "waist_yaw_joint": 250.0,
-                    "waist_roll_joint": 250.0,
-                    "waist_pitch_joint": 250.0,
-                },
-                damping={
-                    "waist_yaw_joint": 5.0,
-                    "waist_roll_joint": 5.0,
-                    "waist_pitch_joint": 5.0,
-                },
-                armature=0.03,
-                friction=0.03,
-            ),
-            "arms": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_shoulder_pitch_joint",
-                    ".*_shoulder_roll_joint",
-                    ".*_shoulder_yaw_joint",
-                    ".*_elbow_joint",
-                    ".*_wrist_.*_joint",
-                ],
-                effort_limit={
-                    ".*_shoulder_pitch_joint": 25.0,
-                    ".*_shoulder_roll_joint": 25.0,
-                    ".*_shoulder_yaw_joint": 25.0,
-                    ".*_elbow_joint": 25.0,
-                    ".*_wrist_roll_joint": 25.0,
-                    ".*_wrist_pitch_joint": 5.0,
-                    ".*_wrist_yaw_joint": 5.0,
-                },
-                velocity_limit={
-                    ".*_shoulder_pitch_joint": 37.0,
-                    ".*_shoulder_roll_joint": 37.0,
-                    ".*_shoulder_yaw_joint": 37.0,
-                    ".*_elbow_joint": 37.0,
-                    ".*_wrist_roll_joint": 37.0,
-                    ".*_wrist_pitch_joint": 22.0,
-                    ".*_wrist_yaw_joint": 22.0,
-                },
-                stiffness={
-                    ".*_shoulder_pitch_joint": 100.0,
-                    ".*_shoulder_roll_joint": 100.0,
-                    ".*_shoulder_yaw_joint": 40.0,
-                    ".*_elbow_joint": 40.0,
-                    ".*_wrist_.*_joint": 20.0,
-                },
-                damping={
-                    ".*_shoulder_pitch_joint": 5.0,
-                    ".*_shoulder_roll_joint": 5.0,
-                    ".*_shoulder_yaw_joint": 2.0,
-                    ".*_elbow_joint": 2.0,
-                    ".*_wrist_.*_joint": 2.0,
-                },
-                armature={".*_shoulder_.*": 0.03, ".*_elbow_.*": 0.03, ".*_wrist_.*_joint": 0.03},
-                friction=0.03,
-            ),
-            # NOTE(peterd, 9/25/2025): The follow hand joint values are tested and working with Leapmotion and Mimic
-            "hands": IdealPDActuatorCfg(
-                joint_names_expr=[
-                    ".*_hand_.*",
-                ],
-                effort_limit=5.0,
-                velocity_limit=10.0,
-                stiffness=4.0,
-                damping=0.5,
-                armature=0.03,
-                friction=0.03,
-            ),
-        },
-    )
+
+@configclass
+class G1AgileSceneCfg(G1SceneCfg):
+    """G1 scene config with actuator gains tuned for the AGILE recurrent policy."""
+
+    robot: ArticulationCfg = G1_AGILE_CFG.copy()
 
 
 @configclass
@@ -665,9 +752,22 @@ class G1WBCPinkActionCfg:
 
 @configclass
 class G1WBCAgilePinkActionCfg:
-    """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body."""
+    """Action specifications for the MDP, for G1 AGILE WBC with PINK IK upper body.
 
-    g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(asset_name="robot", joint_names=[".*"], wbc_version="agile")
+    The AGILE recurrent lower-body policy only drives the 12 leg joints (it does not
+    move waist_yaw/roll/pitch). To give the upper-body PINK IK more reach, we extend
+    its active joint set to include ``waist_roll_joint`` and ``waist_pitch_joint``;
+    ``waist_yaw_joint`` is intentionally left out because the AGILE policy was trained
+    with waist_yaw held at zero.
+    """
+
+    g1_action: ActionTermCfg = G1DecoupledWBCPinkActionCfg(
+        asset_name="robot",
+        joint_names=[".*"],
+        wbc_version="agile",
+        upperbody_active_joint_groups=["arms"],
+        upperbody_extra_active_joints=["waist_roll_joint", "waist_yaw_joint", "waist_pitch_joint"],
+    )
 
 
 @configclass

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -4,8 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 import torch
 import tqdm
+from gymnasium.wrappers import RecordVideo
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
@@ -167,9 +169,10 @@ def main():
             args_cli.distributed = True
             args_cli.device = f"cuda:{local_rank}"
 
-        # Build scene
+        # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
         arena_builder = get_arena_builder_from_cli(args_cli)
-        env, cfg = arena_builder.make_registered_and_return_cfg()
+        render_mode = "rgb_array" if args_cli.video else None
+        env, cfg = arena_builder.make_registered_and_return_cfg(render_mode=render_mode)
 
         # Per-rank seed when distributed so each process has a different seed
         seed = args_cli.seed
@@ -196,6 +199,25 @@ def main():
                 print(f"[Rank {local_rank}/{world_size}] Simulation length: {num_episodes} episodes")
             else:
                 raise ValueError(f"[Rank {local_rank}/{world_size}] Either num_steps or num_episodes must be provided")
+
+        # Optionally wrap with RecordVideo. Mirrors the eval_runner.py wiring so the same
+        # mp4 layout works between policy_runner and eval_runner.
+        if args_cli.video:
+            os.makedirs(args_cli.video_dir, exist_ok=True)
+            if num_steps is not None:
+                video_length = num_steps
+            else:
+                # When num_episodes is set, capture exactly one episode's worth of frames.
+                # max_episode_length is in environment steps, which matches our rollout cadence.
+                video_length = num_episodes * env.unwrapped.max_episode_length
+            env = RecordVideo(
+                env,
+                video_folder=args_cli.video_dir,
+                step_trigger=lambda step: step == 0,
+                video_length=video_length,
+                disable_logger=True,
+            )
+            print(f"[Rank {local_rank}/{world_size}] Recording {video_length}-step video to: {args_cli.video_dir}")
 
         steps_str = f"{num_steps} steps" if num_steps is not None else f"{num_episodes} episodes"
         print(f"[Rank {local_rank}/{world_size}] Starting rollout ({steps_str})")

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -32,3 +32,16 @@ def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default=None,
         help="Language instruction for the policy. Takes precedence over the task's own description.",
     )
+    parser.add_argument(
+        "--video",
+        action="store_true",
+        default=False,
+        help="Record an mp4 video of the rollout (uses gymnasium.wrappers.RecordVideo).",
+    )
+    parser.add_argument(
+        "--video_dir",
+        "--video-dir",
+        type=str,
+        default="/eval/videos",
+        help="Output directory for the recorded video. Created if missing. Used only with --video.",
+    )

--- a/isaaclab_arena/scripts/imitation_learning/generate_dataset.py
+++ b/isaaclab_arena/scripts/imitation_learning/generate_dataset.py
@@ -69,34 +69,14 @@ import isaaclab_mimic.envs  # noqa: F401
 import isaaclab_tasks  # noqa: F401
 from isaaclab.envs import ManagerBasedRLMimicEnv
 from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
-from isaaclab.managers import DatasetExportMode, RecorderTerm, RecorderTermCfg
-from isaaclab.utils import configclass
+from isaaclab.managers import DatasetExportMode
 from isaaclab_mimic.datagen.generation import env_loop, setup_async_generation
 from isaaclab_mimic.datagen.utils import setup_output_paths
 
+from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
+
 # start logger
 logger = logging.getLogger(__name__)
-
-
-class PreStepFlatCameraObservationsRecorder(RecorderTerm):
-    """Recorder term that records the camera observations in each step."""
-
-    def record_pre_step(self):
-        return "camera_obs", self._env.obs_buf["camera_obs"]
-
-
-@configclass
-class PreStepFlatCameraObservationsRecorderCfg(RecorderTermCfg):
-    """Configuration for the camera observation recorder term."""
-
-    class_type: type[RecorderTerm] = PreStepFlatCameraObservationsRecorder
-
-
-@configclass
-class ArenaEnvRecorderManagerCfg(ActionStateRecorderManagerCfg):
-    """Add the camera observation recorder term."""
-
-    record_pre_step_flat_camera_observations = PreStepFlatCameraObservationsRecorderCfg()
 
 
 def setup_env_config(

--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -69,6 +69,13 @@ if "openxr" in args_cli.teleop_device.lower():
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
+# Patch isaaclab_physx's RTX render-update helper so the first frame's annotator
+# buffers are populated before the teleop loop renders. Without this the initial
+# pre-step render emerges black under the visualizer that record_demos.py uses.
+from isaaclab_arena.utils.isaaclab_utils.isaac_rtx_renderer_patch import patch_isaac_rtx_renderer
+
+patch_isaac_rtx_renderer()
+
 """Rest everything follows."""
 
 
@@ -94,6 +101,8 @@ from isaaclab.envs.ui import EmptyWindow
 from isaaclab.managers import DatasetExportMode
 from isaaclab_mimic.ui.instruction_display import InstructionDisplay, show_subtask_instructions
 from isaaclab_teleop import IsaacTeleopCfg, create_isaac_teleop_device, remove_camera_configs
+
+from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
 
 # Imports have to follow simulation startup.
 
@@ -205,7 +214,10 @@ def create_environment_config(
     env_cfg.terminations.time_out = None
     env_cfg.observations.policy.concatenate_terms = False
 
-    env_cfg.recorders: ActionStateRecorderManagerCfg = ActionStateRecorderManagerCfg()
+    if args_cli.enable_cameras:
+        env_cfg.recorders = ArenaEnvRecorderManagerCfg()
+    else:
+        env_cfg.recorders = ActionStateRecorderManagerCfg()
     env_cfg.recorders.dataset_export_dir_path = output_dir
     env_cfg.recorders.dataset_filename = output_file_name
     env_cfg.recorders.dataset_export_mode = DatasetExportMode.EXPORT_SUCCEEDED_ONLY

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -34,6 +34,8 @@ class PickAndPlaceTask(TaskBase):
         destination_object: Asset | None = None,
         episode_length_s: float | None = None,
         task_description: str | None = None,
+        force_threshold: float = 1.0,
+        velocity_threshold: float = 0.1,
     ):
         super().__init__(episode_length_s=episode_length_s)
         self.pick_up_object = pick_up_object
@@ -45,6 +47,8 @@ class PickAndPlaceTask(TaskBase):
                 contact_against_prim_paths=[self.destination_location.get_prim_path()],
             ),
         )
+        self.force_threshold = force_threshold
+        self.velocity_threshold = velocity_threshold
         self.events_cfg = None
         self.termination_cfg = self.make_termination_cfg()
         self.task_description = (
@@ -65,8 +69,8 @@ class PickAndPlaceTask(TaskBase):
             params={
                 "object_cfg": SceneEntityCfg(self.pick_up_object.name),
                 "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
-                "force_threshold": 1.0,
-                "velocity_threshold": 0.1,
+                "force_threshold": self.force_threshold,
+                "velocity_threshold": self.velocity_threshold,
             },
         )
         object_dropped = TerminationTermCfg(

--- a/isaaclab_arena/tasks/terminations.py
+++ b/isaaclab_arena/tasks/terminations.py
@@ -241,7 +241,9 @@ def goal_pose_task_termination(
 
 
 def root_height_below_minimum_multi_objects(
-    env: ManagerBasedRLEnv, minimum_height: float, asset_cfg_list: list[SceneEntityCfg] = [SceneEntityCfg("robot")]
+    env: ManagerBasedRLEnv,
+    minimum_height: float,
+    asset_cfg_list: list[SceneEntityCfg] = [SceneEntityCfg("robot")],
 ) -> torch.Tensor:
     """Terminate when any asset's root height is below the minimum height.
 

--- a/isaaclab_arena/tests/test_g1_static_pick_and_place.py
+++ b/isaaclab_arena/tests/test_g1_static_pick_and_place.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for ``galileo_g1_static_pick_and_place`` (WBC-balanced G1, no nav).
+
+Mirrors ``test_g1_locomanip_apple_to_plate.py`` (same 23-D action layout, same
+standing-pose hold actions during warmup) but uses the AGILE WBC backend
+(``G1WBCAgileJointEmbodiment``) -- production env defaults to ``g1_wbc_agile_pink``,
+so the joint twin keeps the test honest to the deployed stack while still skipping the
+PinkIK forward solve for speed.
+"""
+
+import torch
+import traceback
+
+import pytest
+import warp as wp
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+NUM_STEPS = 10
+WARMUP_STEPS = 50
+# Steps allowed for the once-teleported apple to fall + settle into stable contact with
+# the plate (force > force_threshold AND velocity < velocity_threshold). Tuned empirically:
+# a 0.02 m fall takes ~64 ms (~3 env steps @ 20 ms / step), then PhysX needs a handful of
+# extra contact-resolution steps for the apple to come to rest. 50 steps = 1 s of sim time.
+APPLE_SETTLE_STEPS = 50
+HEADLESS = True
+ENABLE_CAMERAS = True
+
+APPLE_INITIAL_POSITION_M = (0.15, 0.15, 0.05)
+PLATE_INITIAL_POSITION_M = (0.15, -0.40, 0.02)
+# Drop height for the success-case teleport. Kept small so the apple has a short, contained
+# fall onto the plate -- larger offsets risk the apple bouncing off a thin plate edge before
+# settling into stable contact.
+APPLE_ABOVE_PLATE_OFFSET_M = 0.02
+
+
+def get_test_environment(num_envs: int):
+    """Build a simplified G1 static apple-to-plate environment for testing.
+
+    Uses a plain ``table`` background (instead of the production ``galileo_locomanip``
+    scene) to isolate task-termination logic and keep the test fast. Mirrors the locomanip
+    test's structure -- same standing-action pattern, same termination semantics -- so
+    test failures here can be cleanly attributed to the static-task plumbing rather than
+    the WBC stack itself.
+    """
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.g1.g1 import G1WBCAgileJointEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+    from isaaclab_arena.utils.pose import Pose
+
+    asset_registry = AssetRegistry()
+    background = asset_registry.get_asset_by_name("table")()
+    apple = asset_registry.get_asset_by_name("apple_01_objaverse_robolab")()
+    plate = asset_registry.get_asset_by_name("clay_plates_hot3d_robolab")()
+
+    apple.set_initial_pose(Pose(position_xyz=APPLE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    plate.set_initial_pose(Pose(position_xyz=PLATE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+    # Use the joint-control AGILE WBC variant in tests: the production env defaults to
+    # ``g1_wbc_agile_pink`` (AGILE end-to-end velocity policy + PinkIK upper body), so
+    # the joint twin matches the deployed WBC backend while skipping the PinkIK forward
+    # solve on every step -- this test exercises task termination semantics, not the IK
+    # stack. The zero-norm wrist quat bootstrapping fix in
+    # ``g1_decoupled_wbc_pink_action._identity_if_zero_norm_xyzw`` makes the pink variant
+    # safe to use here too, but the joint variant remains a deliberate speed optimization.
+    embodiment = G1WBCAgileJointEmbodiment(enable_cameras=ENABLE_CAMERAS)
+    embodiment.set_initial_pose(Pose(position_xyz=(-0.4, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+    scene = Scene(assets=[background, apple, plate])
+    # Construct ``PickAndPlaceTask`` with parent default termination thresholds: this test
+    # exercises termination semantics, not threshold tuning. The production env keeps the
+    # locomanip-tightened pair (0.5, 0.1) for comparable metrics; any drift in the parent
+    # defaults is caught by the parent's own tests.
+    task = PickAndPlaceTask(
+        pick_up_object=apple,
+        destination_location=plate,
+        background_scene=background,
+        episode_length_s=30.0,
+        task_description="Pick up the apple from the table and place it onto the plate.",
+    )
+
+    isaaclab_arena_environment = IsaacLabArenaEnvironment(
+        name="test_g1_static_pick_and_place",
+        embodiment=embodiment,
+        scene=scene,
+        task=task,
+    )
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", str(num_envs)])
+    env_builder = ArenaEnvBuilder(isaaclab_arena_environment, args_cli)
+    env = env_builder.make_registered()
+    env.reset()
+
+    return env, apple, plate
+
+
+def _step_with_standing_actions(env, num_steps: int) -> list[bool]:
+    """Step the env with standing-idle actions and return termination flags per step.
+
+    Mirrors the locomanip test: zero actions everywhere except the hip-height channel
+    (``actions[:, -4] = 0.75``), which tells WBC to hold standing height instead of
+    interpreting the zero as "squat to floor". Identical action layout to the locomanip
+    env because both pink variants and both joint variants share the same 23-D
+    ``G1DecoupledWBCJointActionCfg`` -- only the lower-body ONNX backend (HOMIE vs AGILE)
+    differs, and that does not change the action vector layout.
+    """
+    terminated_list = []
+    for _ in range(num_steps):
+        with torch.inference_mode():
+            actions = _zero_actions(env)
+            actions[:, -4] = 0.75
+            _, _, terminated, _, _ = env.step(actions)
+            terminated_list.append(terminated.item())
+    return terminated_list
+
+
+def _zero_actions(env) -> torch.Tensor:
+    """Return a ``(num_envs, action_dim)``-shaped zero action tensor on the env's device.
+
+    Uses ``single_action_space.shape`` instead of ``action_space.shape`` so the result
+    has the correct rank regardless of how the wrapper exposes the vectorized action
+    space (some wrappers prepend the batch dim, some don't).
+    """
+    return torch.zeros((env.unwrapped.num_envs,) + env.unwrapped.single_action_space.shape, device=env.unwrapped.device)
+
+
+def _teleport_apple(env, apple, position_xyz: tuple[float, float, float]) -> None:
+    """Teleport ``apple`` to ``position_xyz`` (env-local frame), identity rotation, zero velocity."""
+    from isaaclab_arena.utils.pose import Pose
+
+    with torch.inference_mode():
+        apple.set_object_pose(env, Pose(position_xyz=position_xyz, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+
+def _test_initial_state_not_terminated(simulation_app) -> bool:
+    """Apple starts away from the plate -- task must not be terminated."""
+
+    env, apple, _ = get_test_environment(num_envs=1)
+
+    try:
+        # Warmup: let the WBC controller settle the standing pose before checking
+        # termination. Same rationale as the locomanip test.
+        _step_with_standing_actions(env, WARMUP_STEPS)
+        _teleport_apple(env, apple, APPLE_INITIAL_POSITION_M)
+
+        terminated_list = _step_with_standing_actions(env, NUM_STEPS)
+        for step, terminated in enumerate(terminated_list):
+            assert not terminated, f"Task terminated unexpectedly at post-warmup step {step}/{NUM_STEPS}"
+    except Exception as e:
+        print(f"Error: {e}")
+        traceback.print_exc()
+        return False
+    finally:
+        env.close()
+
+    return True
+
+
+def _test_apple_on_plate_succeeds(simulation_app) -> bool:
+    """Teleporting the apple just above the plate once should trigger success termination as it settles.
+
+    Single-teleport + settle pattern: the apple falls a small distance under gravity,
+    rests on the plate, and the contact force + low velocity reliably trigger the
+    termination within ``APPLE_SETTLE_STEPS``.
+    """
+
+    from isaaclab.assets import RigidObject
+
+    env, apple, plate = get_test_environment(num_envs=1)
+
+    try:
+        _step_with_standing_actions(env, WARMUP_STEPS)
+
+        plate_object: RigidObject = env.unwrapped.scene[plate.name]
+        plate_pos_world = wp.to_torch(plate_object.data.root_pos_w)[0]
+        env_origin = env.unwrapped.scene.env_origins[0]
+        # ``wp.to_torch`` may return a tensor on a different device than ``env_origins``
+        # (warp-managed vs torch-managed); explicitly align before subtracting.
+        plate_pos_local = plate_pos_world.to(env_origin.device) - env_origin
+        apple_target = (
+            float(plate_pos_local[0]),
+            float(plate_pos_local[1]),
+            float(plate_pos_local[2]) + APPLE_ABOVE_PLATE_OFFSET_M,
+        )
+
+        # One-shot teleport: drop the apple above the plate, then run physics until it
+        # settles into stable contact (or we hit APPLE_SETTLE_STEPS).
+        _teleport_apple(env, apple, apple_target)
+
+        terminated_list = _step_with_standing_actions(env, APPLE_SETTLE_STEPS)
+        terminated_ever = any(terminated_list)
+
+        assert terminated_ever, (
+            "Task should terminate after apple is placed on plate; got terminated_list="
+            f"{terminated_list[:10]}... (showing first 10 of {len(terminated_list)})"
+        )
+        print(f"Success: apple-on-plate termination detected (fired at step {terminated_list.index(True)})")
+
+    except Exception as e:
+        print(f"Error: {e}")
+        traceback.print_exc()
+        return False
+
+    finally:
+        env.close()
+
+    return True
+
+
+@pytest.mark.with_cameras
+def test_initial_state_not_terminated():
+    result = run_simulation_app_function(
+        _test_initial_state_not_terminated,
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+    )
+    assert result, f"Test {_test_initial_state_not_terminated.__name__} failed"
+
+
+@pytest.mark.with_cameras
+def test_apple_on_plate_succeeds():
+    result = run_simulation_app_function(
+        _test_apple_on_plate_succeeds,
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+    )
+    assert result, f"Test {_test_apple_on_plate_succeeds.__name__} failed"
+
+
+if __name__ == "__main__":
+    test_initial_state_not_terminated()
+    test_apple_on_plate_succeeds()

--- a/isaaclab_arena/tests/test_g1_static_pick_and_place.py
+++ b/isaaclab_arena/tests/test_g1_static_pick_and_place.py
@@ -30,6 +30,8 @@ APPLE_SETTLE_STEPS = 50
 HEADLESS = True
 ENABLE_CAMERAS = True
 
+APPLE_SCALE = (0.009, 0.009, 0.009)
+PLATE_SCALE = (0.5, 0.5, 0.5)
 APPLE_INITIAL_POSITION_M = (0.15, 0.15, 0.05)
 PLATE_INITIAL_POSITION_M = (0.15, -0.40, 0.02)
 # Drop height for the success-case teleport. Kept small so the apple has a short, contained
@@ -48,7 +50,7 @@ def get_test_environment(num_envs: int):
     the WBC stack itself.
     """
 
-    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.assets.asset_registry import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.embodiments.g1.g1 import G1WBCAgileJointEmbodiment
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
@@ -59,8 +61,8 @@ def get_test_environment(num_envs: int):
 
     asset_registry = AssetRegistry()
     background = asset_registry.get_asset_by_name("table")()
-    apple = asset_registry.get_asset_by_name("apple_01_objaverse_robolab")()
-    plate = asset_registry.get_asset_by_name("clay_plates_hot3d_robolab")()
+    apple = asset_registry.get_asset_by_name("apple_01_objaverse_robolab")(scale=APPLE_SCALE)
+    plate = asset_registry.get_asset_by_name("clay_plates_hot3d_robolab")(scale=PLATE_SCALE)
 
     apple.set_initial_pose(Pose(position_xyz=APPLE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
     plate.set_initial_pose(Pose(position_xyz=PLATE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))

--- a/isaaclab_arena/utils/isaaclab_utils/isaac_rtx_renderer_patch.py
+++ b/isaaclab_arena/utils/isaaclab_utils/isaac_rtx_renderer_patch.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime patch for ``isaaclab_physx.renderers.isaac_rtx_renderer_utils.ensure_isaac_rtx_render_update``.
+
+Lab's stock implementation early-returns whenever any visualizer reports
+``viz.pumps_app_update() == True``. On the first call for a fresh
+``SimulationContext`` the visualizer hasn't actually pumped yet (``sim.render()``
+has not been called), so skipping the pump leaves annotator buffers empty and
+produces a black first frame in scripts that rely on a populated frame before
+the first ``env.step()`` (notably ``record_demos.py``).
+
+Apply by calling :func:`patch_isaac_rtx_renderer` once, after ``AppLauncher``
+has initialized Kit and before any camera/renderer is constructed.
+"""
+
+
+def patch_isaac_rtx_renderer() -> None:
+    """Replace ``ensure_isaac_rtx_render_update`` with a version that performs
+    the initial ``app.update()`` itself when called for the first time on a new
+    ``SimulationContext``, instead of deferring to a visualizer that has not
+    yet had a chance to pump.
+
+    Patches both the canonical module (``isaac_rtx_renderer_utils``) and the
+    importing module (``isaac_rtx_renderer``), since the latter does
+    ``from .isaac_rtx_renderer_utils import ensure_isaac_rtx_render_update`` at
+    load time and holds its own binding.
+    """
+    import isaaclab.sim as sim_utils
+    import isaaclab_physx.renderers.isaac_rtx_renderer as rtx_renderer
+    import isaaclab_physx.renderers.isaac_rtx_renderer_utils as rtx_utils
+
+    def patched_ensure_isaac_rtx_render_update() -> None:
+        sim = sim_utils.SimulationContext.instance()
+        if sim is None:
+            return
+
+        key = (id(sim), sim._physics_step_count)
+        if rtx_utils._last_render_update_key == key:
+            return
+
+        if key[0] != rtx_utils._last_render_update_key[0]:
+            rtx_utils._streaming_is_busy = False
+            rtx_utils._streaming_subscribed = False
+            rtx_utils._streaming_subscription = None
+
+        # On the very first call for a new SimulationContext the visualizer has
+        # not had a chance to pump (sim.render() was never called), so we must
+        # perform the initial app.update() ourselves to populate annotator
+        # buffers. Subsequent calls defer to the visualizer.
+        first_call_for_sim = rtx_utils._last_render_update_key[0] != id(sim)
+        if not first_call_for_sim and any(viz.pumps_app_update() for viz in sim.visualizers):
+            rtx_utils._last_render_update_key = key
+            return
+
+        if not sim.is_rendering:
+            return
+
+        rtx_utils._ensure_streaming_subscription()
+        sim.physics_manager.forward()
+
+        import omni.kit.app
+
+        sim.set_setting("/app/player/playSimulations", False)
+        omni.kit.app.get_app().update()
+
+        if rtx_utils._streaming_is_busy:
+            rtx_utils._wait_for_streaming_complete()
+
+        sim.set_setting("/app/player/playSimulations", True)
+
+        rtx_utils._last_render_update_key = key
+
+    rtx_utils.ensure_isaac_rtx_render_update = patched_ensure_isaac_rtx_render_update
+    rtx_renderer.ensure_isaac_rtx_render_update = patched_ensure_isaac_rtx_render_update
+
+    print("Patched isaaclab_physx.renderers.isaac_rtx_renderer_utils.ensure_isaac_rtx_render_update")

--- a/isaaclab_arena/utils/isaaclab_utils/recorders.py
+++ b/isaaclab_arena/utils/isaaclab_utils/recorders.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
+from isaaclab.managers import RecorderTerm, RecorderTermCfg
+from isaaclab.utils import configclass
+
+
+class PreStepFlatCameraObservationsRecorder(RecorderTerm):
+    """Recorder term that records the camera observations in each step."""
+
+    def record_pre_step(self):
+        return "camera_obs", self._env.obs_buf["camera_obs"]
+
+
+@configclass
+class PreStepFlatCameraObservationsRecorderCfg(RecorderTermCfg):
+    """Configuration for the camera observation recorder term."""
+
+    class_type: type[RecorderTerm] = PreStepFlatCameraObservationsRecorder
+
+
+class PostStepFlatPolicyActionObservationRecorder(RecorderTerm):
+    """Recorder term that records the ``action`` observation group at the end of each step.
+
+    Mirrors the locomanip mimic patch's post-step action recorder, but no-ops on envs
+    whose policy does not expose an ``action`` observation group so it can be safely
+    enabled for any task.
+    """
+
+    def record_post_step(self):
+        obs_buf = getattr(self._env, "obs_buf", None)
+        if not isinstance(obs_buf, dict) or "action" not in obs_buf:
+            return None, None
+        return "action", obs_buf["action"]
+
+
+@configclass
+class PostStepFlatPolicyActionObservationRecorderCfg(RecorderTermCfg):
+    """Configuration for the post-step ``action`` observation recorder term."""
+
+    class_type: type[RecorderTerm] = PostStepFlatPolicyActionObservationRecorder
+
+
+@configclass
+class ArenaEnvRecorderManagerCfg(ActionStateRecorderManagerCfg):
+    """Action/state recorder manager extended with arena-specific recorder terms."""
+
+    record_pre_step_flat_camera_observations = PreStepFlatCameraObservationsRecorderCfg()
+    record_post_step_flat_policy_action_observations = PostStepFlatPolicyActionObservationRecorderCfg()

--- a/isaaclab_arena/utils/locomanip_mimic_patch.py
+++ b/isaaclab_arena/utils/locomanip_mimic_patch.py
@@ -10,8 +10,6 @@ import torch
 import warp as wp
 from isaaclab.envs import SubTaskConstraintType
 from isaaclab.managers import TerminationTermCfg
-from isaaclab.managers.recorder_manager import RecorderTerm, RecorderTermCfg
-from isaaclab.utils import configclass
 from isaaclab_mimic.datagen.waypoint import MultiWaypoint, Waypoint
 
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.action_constants import (
@@ -22,7 +20,6 @@ from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.action_constan
 
 def patch_recorders():
     from isaaclab.envs.mdp.recorders import PreStepActionsRecorder
-    from isaaclab.envs.mdp.recorders.recorders_cfg import ActionStateRecorderManagerCfg
 
     # Record p-controller generated navigation commands in the action buffer
     def record_pre_step(self):
@@ -34,18 +31,6 @@ def patch_recorders():
                 ).navigate_cmd
         return "actions", actions
 
-    # Record post step action observation group
-    class PostStepFlatPolicyObservationsRecorder(RecorderTerm):
-        def record_post_step(self):
-            return "action", self._env.obs_buf["action"]
-
-    @configclass
-    class PostStepFlatPolicyObservationsRecorderCfg(RecorderTermCfg):
-        class_type: type[RecorderTerm] = PostStepFlatPolicyObservationsRecorder
-
-    ActionStateRecorderManagerCfg.record_post_step_flat_policy_observations = (
-        PostStepFlatPolicyObservationsRecorderCfg()
-    )
     PreStepActionsRecorder.record_pre_step = record_pre_step
 
     print("\nPatched recorders for G1 Locomanip Mimic\n")

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -16,6 +16,9 @@ from isaaclab_arena_environments.franka_put_and_close_door_environment import Fr
 from isaaclab_arena_environments.galileo_g1_locomanip_pick_and_place_environment import (
     GalileoG1LocomanipPickAndPlaceEnvironment,
 )
+from isaaclab_arena_environments.galileo_g1_static_pick_and_place_environment import (
+    GalileoG1StaticPickAndPlaceEnvironment,
+)
 from isaaclab_arena_environments.galileo_pick_and_place_environment import GalileoPickAndPlaceEnvironment
 from isaaclab_arena_environments.gr1_open_microwave_environment import Gr1OpenMicrowaveEnvironment
 from isaaclab_arena_environments.gr1_put_and_close_door_environment import GR1PutAndCloseDoorEnvironment
@@ -42,6 +45,7 @@ ExampleEnvironments = {
     GalileoPickAndPlaceEnvironment.name: GalileoPickAndPlaceEnvironment,
     PickAndPlaceMapleTableEnvironment.name: PickAndPlaceMapleTableEnvironment,
     GalileoG1LocomanipPickAndPlaceEnvironment.name: GalileoG1LocomanipPickAndPlaceEnvironment,
+    GalileoG1StaticPickAndPlaceEnvironment.name: GalileoG1StaticPickAndPlaceEnvironment,
     PressButtonEnvironment.name: PressButtonEnvironment,
     CubeGoalPoseEnvironment.name: CubeGoalPoseEnvironment,
     DexsuiteLiftEnvironment.name: DexsuiteLiftEnvironment,

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -50,7 +50,7 @@ SHELF_AIRGAP = 0.005
 # plate's 30 cm footprint clears the apple without collision. Earlier we tried Y=0.30
 # for the apple but a smoke test showed it rolls off the shelf edge from there.
 PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
-DESTINATION_SPAWN_XY = (0.5785, -0.06)
+DESTINATION_SPAWN_XY = (0.6, -0.06)
 
 # Half-range of the apple's per-episode XY randomization at reset, in metres. Mirrors
 # the locomanip env's ``XY_RANGE_M = 0.025`` but tightened to 0.020 because the static

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static-base G1 pick-and-place environment (WBC stands the robot in place; no nav).
+
+This is a same-shelf-only variant of ``galileo_g1_locomanip_pick_and_place``: same
+``galileo_locomanip`` background, same OpenXR retargeter, same 23-D action layout. The
+default embodiment is ``g1_wbc_agile_pink`` (AGILE end-to-end velocity policy) instead of
+``g1_wbc_pink`` (HOMIE stand+walk pair) -- the static task never walks, so the AGILE
+single-policy backend is a better fit than HOMIE's stand/walk model split. The
+``g1_wbc_pink`` embodiment is still accepted via ``--embodiment`` for users who want
+HOMIE behaviour. The other differences from the locomanip env are:
+
+1. The destination plate sits on the *same* shelf as the apple (within arm's reach), so
+   the robot never needs to drive its base anywhere -- WBC just holds the standing pose.
+2. The apple's spawn pose is randomized per episode within ``APPLE_SPAWN_XY_RANGE_M``
+   (XY only) so recorded demos have spatial variation; the destination plate stays at a
+   fixed pose so the place target is identical across episodes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import warnings
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+
+# Pose tuning constants (all values empirically validated -- see commit history for the
+# manual procedure: spawn the destination plate at the locomanip apple z (0.0707) and
+# read the final z after gravity-settle; spawn the apple and read its USD AABB):
+#
+# - SHELF_SURFACE_Z: measured by gravity-settling the plate (whose USD origin sits at
+#   its bottom, i.e. BBox min_z = 0); the settled z = -0.030 in env-local frame is the
+#   actual shelf-top z in the galileo_locomanip scene.
+# - SHELF_AIRGAP: keeps PhysX from spawning objects in collider penetration with the
+#   shelf on the first sim tick (which would otherwise launch them upward).
+SHELF_SURFACE_Z = -0.030
+SHELF_AIRGAP = 0.005
+
+# Object XY spawn pose (env-local frame, shelf-relative). X mirrors the locomanip env
+# (the only on-shelf X we have ground-truth data for via the brown_box flow). The pickup
+# Y also mirrors locomanip (Y=0.18); the destination is offset -0.24 m in Y so the
+# plate's 30 cm footprint clears the apple without collision. Earlier we tried Y=0.30
+# for the apple but a smoke test showed it rolls off the shelf edge from there.
+PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
+DESTINATION_SPAWN_XY = (0.5785, -0.06)
+
+# Half-range of the apple's per-episode XY randomization at reset, in metres. Mirrors
+# the locomanip env's ``XY_RANGE_M = 0.025`` but tightened to 0.020 because the static
+# variant places the destination plate on the *same* shelf, so the spawn workspace is
+# narrower (apple at Y=0.18, plate's +Y edge at ~0.09 -> 9 cm headroom; 2 cm jitter
+# leaves 7 cm minimum gap to the plate). Without this jitter every recorded demo has
+# the apple at the exact same XY, which limits the spatial variation a finetuned policy
+# can generalize over. The destination plate is left at a fixed Pose so the place
+# target is identical across episodes.
+APPLE_SPAWN_XY_RANGE_M = 0.020
+
+# Per-asset Z offset from the asset's USD origin to its bottom face. Added on top of
+# ``SHELF_SURFACE_Z + SHELF_AIRGAP`` so the asset's *bottom* lands on the shelf rather
+# than its USD origin (which may sit anywhere inside the AABB depending on how the
+# asset was authored). Measured from each asset's USD AABB. Assets not in this table
+# are spawned with no Z compensation -- callers passing arbitrary ``--object`` /
+# ``--destination`` values are expected to verify the resulting spawn pose visually.
+_USD_ORIGIN_ABOVE_BOTTOM_M: dict[str, float] = {
+    "apple_01_objaverse_robolab": 0.0171,  # BBox min_z = -0.019, max_z = 0.049
+    "clay_plates_hot3d_robolab": 0.0,  # USD origin at plate bottom (BBox min_z = 0)
+}
+
+TUNED_PICK_UP_OBJECT_NAME = "apple_01_objaverse_robolab"
+TUNED_DESTINATION_NAME = "clay_plates_hot3d_robolab"
+
+# Per-asset uniform scale matching the tuned pick-up / destination pair. Assets not in
+# this table spawn at scale=(1.0, 1.0, 1.0) with a one-shot warning so the user knows
+# the resulting size may need visual verification.
+_TUNED_SCALES: dict[str, tuple[float, float, float]] = {
+    TUNED_PICK_UP_OBJECT_NAME: (0.009, 0.009, 0.009),
+    TUNED_DESTINATION_NAME: (0.5, 0.5, 0.5),
+}
+
+
+def _shelf_spawn_z(asset_name: str) -> float:
+    """Return the env-local Z to spawn ``asset_name`` flush on the shelf surface.
+
+    Falls back to ``SHELF_SURFACE_Z + SHELF_AIRGAP`` (no USD-origin compensation) for
+    assets we have not measured, with a one-shot warning so the user knows the spawn
+    pose may need visual verification.
+    """
+    if asset_name in _USD_ORIGIN_ABOVE_BOTTOM_M:
+        return SHELF_SURFACE_Z + SHELF_AIRGAP + _USD_ORIGIN_ABOVE_BOTTOM_M[asset_name]
+    warnings.warn(
+        "galileo_g1_static_pick_and_place: no measured USD-origin offset for "
+        f"'{asset_name}'; spawning at shelf surface with no compensation. Verify "
+        "the asset's bottom face actually lands on the shelf.",
+        stacklevel=2,
+    )
+    return SHELF_SURFACE_Z + SHELF_AIRGAP
+
+
+def _asset_scale(asset_name: str) -> tuple[float, float, float]:
+    """Return the tuned uniform scale for ``asset_name``, or 1.0 with a warning."""
+    if asset_name in _TUNED_SCALES:
+        return _TUNED_SCALES[asset_name]
+    warnings.warn(
+        "galileo_g1_static_pick_and_place: no measured scale for "
+        f"'{asset_name}'; spawning at scale=(1.0, 1.0, 1.0). Verify visually.",
+        stacklevel=2,
+    )
+    return (1.0, 1.0, 1.0)
+
+
+@register_environment
+class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
+    """G1 (WBC-balanced, no nav) pick-and-place on the locomanip warehouse shelf.
+
+    Defaults to the apple-to-plate pairing so this env composes cleanly into the existing
+    apple-to-plate workflow (record_demos -> replay -> eval) without requiring locomotion.
+    """
+
+    name: str = "galileo_g1_static_pick_and_place"
+
+    def get_env(self, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+        from isaaclab_arena.utils.pose import Pose, PoseRange
+
+        # Reuse the locomanip background USD: it bakes in lighting and provides the same
+        # shelf-in-front-of-robot geometry the locomanip env was tuned against.
+        background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+        pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=_asset_scale(args_cli.object))
+        destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
+            scale=_asset_scale(args_cli.destination)
+        )
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        # Robot pose mirrors the locomanip env exactly so the WBC controller stands the
+        # robot up in the same shelf-relative spot. The controller dynamically lifts the
+        # pelvis to ~z=0.74 at runtime; init_state.pos.z=0 is correct.
+        embodiment.set_initial_pose(Pose(position_xyz=(0.3, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        pick_up_object_x, pick_up_object_y = PICK_UP_OBJECT_SPAWN_XY
+        destination_x, destination_y = DESTINATION_SPAWN_XY
+        pick_up_object_z = _shelf_spawn_z(args_cli.object)
+        # ``PoseRange`` registers a ``randomize_object_pose`` reset event so the apple's
+        # XY is resampled every episode within ``APPLE_SPAWN_XY_RANGE_M``. Z and rotation
+        # are pinned (rpy_min == rpy_max) so the object always lands flush on the shelf
+        # in its authored orientation; we only randomize XY. This gives recorded demos
+        # spatial variation that lets a finetuned policy generalize over the spawn range.
+        pick_up_object.set_initial_pose(
+            PoseRange(
+                position_xyz_min=(
+                    pick_up_object_x - APPLE_SPAWN_XY_RANGE_M,
+                    pick_up_object_y - APPLE_SPAWN_XY_RANGE_M,
+                    pick_up_object_z,
+                ),
+                position_xyz_max=(
+                    pick_up_object_x + APPLE_SPAWN_XY_RANGE_M,
+                    pick_up_object_y + APPLE_SPAWN_XY_RANGE_M,
+                    pick_up_object_z,
+                ),
+                rpy_min=(0.0, 0.0, 0.0),
+                rpy_max=(0.0, 0.0, 0.0),
+            )
+        )
+        destination.set_initial_pose(
+            Pose(
+                position_xyz=(destination_x, destination_y, _shelf_spawn_z(args_cli.destination)),
+                rotation_xyzw=(0.0, 0.0, 0.0, 1.0),
+            )
+        )
+
+        if args_cli.task_description is not None:
+            task_description = args_cli.task_description
+        else:
+            object_label = args_cli.object.replace("_", " ")
+            destination_label = args_cli.destination.replace("_", " ")
+            task_description = (
+                f"Pick up the {object_label} from the shelf and place it onto the "
+                f"{destination_label} on the same shelf next to it."
+            )
+
+        scene = Scene(assets=[background, pick_up_object, destination])
+        return IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=PickAndPlaceTask(
+                pick_up_object=pick_up_object,
+                destination_location=destination,
+                background_scene=background,
+                episode_length_s=30.0,
+                task_description=task_description,
+                # Mirror the locomanip env's success thresholds so metrics are comparable.
+                force_threshold=0.5,
+                velocity_threshold=0.1,
+            ),
+            teleop_device=teleop_device,
+        )
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default=TUNED_PICK_UP_OBJECT_NAME)
+        parser.add_argument("--destination", type=str, default=TUNED_DESTINATION_NAME)
+        # Default embodiment is g1_wbc_agile_pink: AGILE end-to-end velocity policy for
+        # whole-body balance + PinkIK upper body. The static task never walks, so AGILE's
+        # single-policy backend is a better fit than HOMIE's stand+walk split (which
+        # ``g1_wbc_pink`` ships). Same 23-D action layout and OpenXR retargeter as the
+        # locomanip env -- the only knob that flips is which lower-body ONNX policy gets
+        # loaded by the WBC factory. ``g1_wbc_pink`` is still accepted as an override
+        # for users who specifically want HOMIE.
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_agile_pink")
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument(
+            "--task_description",
+            type=str,
+            default=None,
+            help=(
+                "Override the natural-language task description. Defaults to a template "
+                "derived from --object and --destination."
+            ),
+        )

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -26,7 +26,6 @@ import argparse
 import warnings
 from typing import TYPE_CHECKING
 
-from isaaclab_arena.assets.register import register_environment
 from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
 
 if TYPE_CHECKING:
@@ -116,7 +115,6 @@ def _asset_scale(asset_name: str) -> tuple[float, float, float]:
     return (1.0, 1.0, 1.0)
 
 
-@register_environment
 class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
     """G1 (WBC-balanced, no nav) pick-and-place on the locomanip warehouse shelf.
 

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 #   shelf on the first sim tick (which would otherwise launch them upward).
 SHELF_SURFACE_Z = -0.030
 SHELF_AIRGAP = 0.005
+SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - 0.02)
 
 # Object XY spawn pose (env-local frame, shelf-relative). X mirrors the locomanip env
 # (the only on-shelf X we have ground-truth data for via the brown_box flow). The pickup
@@ -50,7 +51,7 @@ SHELF_AIRGAP = 0.005
 # plate's 30 cm footprint clears the apple without collision. Earlier we tried Y=0.30
 # for the apple but a smoke test showed it rolls off the shelf edge from there.
 PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
-DESTINATION_SPAWN_XY = (0.6, -0.06)
+DESTINATION_SPAWN_XY = (0.5785, -0.06)
 
 # Half-range of the apple's per-episode XY randomization at reset, in metres. Mirrors
 # the locomanip env's ``XY_RANGE_M = 0.025`` but tightened to 0.020 because the static
@@ -133,6 +134,13 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # Reuse the locomanip background USD: it bakes in lighting and provides the same
         # shelf-in-front-of-robot geometry the locomanip env was tuned against.
         background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+        # The imported shelf mesh has uneven/perforated collision in the task region:
+        # small objects can fall through parts of the visible shelf. Add an invisible
+        # kinematic cuboid flush with the shelf top so task objects see a clean support.
+        shelf_support = self.asset_registry.get_asset_by_name("procedural_table")(
+            instance_name="static_pick_place_shelf_support",
+            prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
+        )
         pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=_asset_scale(args_cli.object))
         destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
             scale=_asset_scale(args_cli.destination)
@@ -148,6 +156,9 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # robot up in the same shelf-relative spot. The controller dynamically lifts the
         # pelvis to ~z=0.74 at runtime; init_state.pos.z=0 is correct.
         embodiment.set_initial_pose(Pose(position_xyz=(0.3, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        shelf_support.set_initial_pose(
+            Pose(position_xyz=SHELF_SUPPORT_PATCH_CENTER, rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+        )
         pick_up_object_x, pick_up_object_y = PICK_UP_OBJECT_SPAWN_XY
         destination_x, destination_y = DESTINATION_SPAWN_XY
         pick_up_object_z = _shelf_spawn_z(args_cli.object)
@@ -189,7 +200,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 f"{destination_label} on the same shelf next to it."
             )
 
-        scene = Scene(assets=[background, pick_up_object, destination])
+        scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
         return IsaacLabArenaEnvironment(
             name=self.name,
             embodiment=embodiment,

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
@@ -88,11 +88,29 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         self._navigate_cmd = torch.zeros([self.num_envs, 3], device=self.device)
         self._torso_orientation_rpy_cmd = torch.zeros([self.num_envs, 3], device=self.device)
 
-        # Create the PINK IK controller
+        # Create the PINK IK controller. By default the IK only drives the "arms" group;
+        # the embodiment may extend this via `upperbody_extra_active_joints` (e.g. AGILE-pink
+        # adds waist_roll_joint and waist_pitch_joint).
         self.upperbody_controller = G1WBCUpperbodyController(
             robot_model=self.robot_model,
-            body_active_joint_groups=["arms"],
+            body_active_joint_groups=list(self.cfg.upperbody_active_joint_groups),
+            extra_active_joints=list(self.cfg.upperbody_extra_active_joints),
         )
+
+        # Map any extra (non-"upper_body"-group) IK-active joints to their sim-side joint
+        # indices so we can splice the IK solution back into ``_processed_actions`` after
+        # the WBC postprocess (which writes only ``upper_body`` and ``lower_body`` slots).
+        self._extra_active_joint_sim_indices: list[int] = []
+        self._extra_active_joint_full_indices: list[int] = []
+        sim_joint_names = self._asset.data.joint_names
+        full_joint_names = self.robot_model.joint_names
+        for jn in self.cfg.upperbody_extra_active_joints:
+            if jn not in sim_joint_names:
+                raise ValueError(f"Extra active joint '{jn}' not found in articulation joint_names")
+            if jn not in full_joint_names:
+                raise ValueError(f"Extra active joint '{jn}' not found in robot_model joint_names")
+            self._extra_active_joint_sim_indices.append(sim_joint_names.index(jn))
+            self._extra_active_joint_full_indices.append(full_joint_names.index(jn))
 
     # Properties.
     # """
@@ -244,6 +262,9 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         # Reformat the joint position tensor to the correct order for G1 upper body
         target_upper_body_joints = target_robot_joints[self.robot_model.get_joint_group_indices("upper_body")]
 
+        # Stash the IK solution for the post-WBC writeback of extra (non-upper_body) joints.
+        self._last_ik_target_robot_joints = target_robot_joints
+
         """
         **************************************************
         WBC closedloop
@@ -347,6 +368,16 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         self._processed_actions = postprocess_actions(
             wbc_action, self._asset.data, self.wbc_g1_joints_order, self.device
         )
+
+        # WBC writes only ``upper_body`` and ``lower_body`` slots; for joints that the IK
+        # actively drives but live outside ``upper_body`` (e.g. waist_roll/pitch for the
+        # AGILE-pink combo), splice the IK target back into ``_processed_actions`` so they
+        # actually get applied to the simulator instead of staying at the lower-body
+        # policy's default (zero) target.
+        if self._extra_active_joint_sim_indices:
+            ik_targets = self._last_ik_target_robot_joints
+            for sim_idx, full_idx in zip(self._extra_active_joint_sim_indices, self._extra_active_joint_full_indices):
+                self._processed_actions[:, sim_idx] = float(ik_targets[full_idx])
 
     def apply_actions(self):
         """Apply the computed joint positions based on the WBC solution."""

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action.py
@@ -48,6 +48,20 @@ if TYPE_CHECKING:
     from isaaclab_arena.embodiments.g1.mdp.actions.g1_decoupled_wbc_pink_action_cfg import G1DecoupledWBCPinkActionCfg
 
 
+# Below this 2-norm we treat an xyzw quaternion as the all-zeros sentinel produced by
+# ``torch.zeros(action_space)`` and replace it with identity. Generous enough to also
+# absorb fp32 rounding around true-zero inputs without ever hitting a normalized quat
+# (whose 2-norm is 1.0).
+_QUAT_ZERO_NORM_TOL = 1e-6
+
+
+def _identity_if_zero_norm_xyzw(quat_xyzw: torch.Tensor) -> torch.Tensor:
+    """Return ``quat_xyzw`` unchanged, or identity ``(0, 0, 0, 1)`` if its 2-norm ~= 0."""
+    if torch.linalg.vector_norm(quat_xyzw) < _QUAT_ZERO_NORM_TOL:
+        return quat_xyzw.new_tensor([0.0, 0.0, 0.0, 1.0])
+    return quat_xyzw
+
+
 class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
     """Action term for the G1 decoupled WBC policy. Upper body PINK IK control, lower body RL-based policy."""
 
@@ -236,6 +250,14 @@ class G1DecoupledWBCPinkAction(G1DecoupledWBCJointAction):
         left_arm_quat = actions_clone[:, LEFT_WRIST_QUAT_START_IDX:LEFT_WRIST_QUAT_END_IDX].squeeze(0).cpu()
         right_arm_pos = actions_clone[:, RIGHT_WRIST_POS_START_IDX:RIGHT_WRIST_POS_END_IDX].squeeze(0).cpu()
         right_arm_quat = actions_clone[:, RIGHT_WRIST_QUAT_START_IDX:RIGHT_WRIST_QUAT_END_IDX].squeeze(0).cpu()
+
+        # Sanitize zero-norm wrist quaternions to xyzw=(0,0,0,1) identity so scipy's
+        # R.from_quat doesn't raise. Real teleop/Mimic/RL trajectories always produce
+        # normalized quats; this only catches bootstrapping cases like the
+        # ``zero_action`` eval policy or smoke tests stepping with ``torch.zeros(...)``,
+        # where the wrist quat slice is all zeros.
+        left_arm_quat = _identity_if_zero_norm_xyzw(left_arm_quat)
+        right_arm_quat = _identity_if_zero_norm_xyzw(right_arm_quat)
 
         # Convert from pos/quat to 4x4 transform matrix
         left_rotmat = R.from_quat(left_arm_quat).as_matrix()

--- a/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
+++ b/isaaclab_arena_g1/g1_env/mdp/actions/g1_decoupled_wbc_pink_action_cfg.py
@@ -36,3 +36,11 @@ class G1DecoupledWBCPinkActionCfg(G1DecoupledWBCJointActionCfg):
 
     # Navigation Segment: Max navigation steps
     max_navigation_steps: int = 700
+
+    # Upper-body PINK IK active joint configuration. By default, only the "arms" joint group
+    # is moved by the IK. Extra individual joint names can be activated on top -- e.g. for
+    # the AGILE-pink combo we activate waist_roll_joint and waist_pitch_joint so the IK can
+    # use the torso (the AGILE recurrent lower-body policy doesn't drive these joints, so
+    # leaving them under PINK IK control gives the arms more reach).
+    upperbody_active_joint_groups: list[str] = ["arms"]
+    upperbody_extra_active_joints: list[str] = []

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/configs.py
@@ -81,8 +81,13 @@ class AgileConfig(BaseConfig):
     wbc_version: Literal["agile"] = "agile"
     """Version of the whole body controller."""
 
+    # Locked to a specific commit SHA to prevent unintentional changes from upstream updates.
+    # Update to a new commit or release tag only when deliberately adopting a newer policy export.
+    # Currently set to a hotfix SHA; replace with an official tag once available.
+    COMMIT_HASH_FOR_WBC_AGILE_POLICY = "7259792cf10803aab814d101134d493d24c8f22f"
     wbc_model_path: str = (
-        "https://github.com/nvidia-isaac/WBC-AGILE/raw/v1.2/agile/data/policy/velocity_g1/unitree_g1_velocity_e2e.onnx"
+        f"https://github.com/nvidia-isaac/WBC-AGILE/raw/{COMMIT_HASH_FOR_WBC_AGILE_POLICY}/"
+        "agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx"
     )
     """Path to WBC model file (GitHub URL, resolved via retrieve_file_path)"""
 

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_agile.yaml
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/config/g1_agile.yaml
@@ -36,17 +36,17 @@ onnx_input_joint_names:
   - left_wrist_yaw_joint
   - right_wrist_yaw_joint
 
-# Joint ordering for ONNX model outputs (14 controlled joints in agile output order).
-# Must match the action_joint_pos element_names from unitree_g1_velocity_e2e.yaml.
+# Joint ordering for ONNX model outputs (12 leg joints in agile output order).
+# Recurrent student outputs JointPositionActionCfg(LEG_JOINT_NAMES); waist roll/pitch
+# are NOT controlled by this policy, so the leg-only ordering is the original 14-entry
+# list with waist_roll_joint and waist_pitch_joint removed.
 controlled_joint_names:
   - left_hip_pitch_joint
   - right_hip_pitch_joint
   - left_hip_roll_joint
   - right_hip_roll_joint
-  - waist_roll_joint
   - left_hip_yaw_joint
   - right_hip_yaw_joint
-  - waist_pitch_joint
   - left_knee_joint
   - right_knee_joint
   - left_ankle_pitch_joint
@@ -54,8 +54,45 @@ controlled_joint_names:
   - left_ankle_roll_joint
   - right_ankle_roll_joint
 
-num_actions: 14
+num_actions: 12
 num_body_joints: 29
 
-# Initial commands
-cmd_init: [0.0, 0.0, 0.0]
+# 4-channel velocity-height command [v_x, v_y, w_z, h]. Default pelvis height = 0.72 m
+# (matches the WBC standing-height default used by the zero-action baseline).
+cmd_init: [0.0, 0.0, 0.0, 0.72]
+
+# Matches `scale=0.1` on `joint_vel` in StudentVelocityPolicyCfg
+# (agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py).
+joint_vel_scale: 0.1
+
+# Per-joint action post-processing, mirrored from the agile training
+# JointPositionActionCfg (G1_ACTION_SCALE_LOWER, use_default_offset=True, clip=[-6, 6]).
+# Order matches `controlled_joint_names` above.
+# Final joint target = clip(raw_action, -6, 6) * action_scale + action_offset.
+action_clip: [-6.0, 6.0]
+action_scale:
+  - 0.5475464463233948  # left_hip_pitch_joint
+  - 0.5475464463233948  # right_hip_pitch_joint
+  - 0.3506614565849304  # left_hip_roll_joint
+  - 0.3506614565849304  # right_hip_roll_joint
+  - 0.5475464463233948  # left_hip_yaw_joint
+  - 0.5475464463233948  # right_hip_yaw_joint
+  - 0.3506614565849304  # left_knee_joint
+  - 0.3506614565849304  # right_knee_joint
+  - 0.4385773241519928  # left_ankle_pitch_joint
+  - 0.4385773241519928  # right_ankle_pitch_joint
+  - 0.4385773241519928  # left_ankle_roll_joint
+  - 0.4385773241519928  # right_ankle_roll_joint
+action_offset:
+  - -0.10  # left_hip_pitch_joint
+  - -0.10  # right_hip_pitch_joint
+  - 0.0    # left_hip_roll_joint
+  - 0.0    # right_hip_roll_joint
+  - 0.0    # left_hip_yaw_joint
+  - 0.0    # right_hip_yaw_joint
+  - 0.30   # left_knee_joint
+  - 0.30   # right_knee_joint
+  - -0.20  # left_ankle_pitch_joint
+  - -0.20  # right_ankle_pitch_joint
+  - 0.0    # left_ankle_roll_joint
+  - 0.0    # right_ankle_roll_joint

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/g1_wbc_upperbody_ik/g1_wbc_upperbody_controller.py
@@ -24,8 +24,16 @@ class G1BodyIKSolverSettings:
         self.posture_cost = 0.01
         self.posture_lm_damping = 1.0
         self.link_costs = {"hand": {"orientation_cost": 0.5, "position_cost": 1.0}}
+        # Per-joint posture-task weights (relative to the default of 1.0). Higher
+        # values make the IK resist deviating that joint from its rest pose.
+        # Both `waist_pitch` and `waist_roll` are set to 10.0 because, when these
+        # joints are in the IK's active set (e.g. AGILE-pink), the iterative
+        # integration of `pink.Configuration.q` accumulates small numerical drifts
+        # that, over hundreds of steps, manifest as a slow tilt; the strong
+        # posture weight pulls them back toward the default pose each step.
         self.posture_weight = {
             "waist_pitch": 10.0,
+            "waist_roll": 10.0,
             "shoulder_pitch": 4.0,
             "shoulder_roll": 3.0,
             "shoulder_yaw": 2.0,
@@ -202,10 +210,33 @@ class G1WBCUpperbodyController:
         self,
         robot_model: RobotModel,
         body_active_joint_groups: list[str] | None = None,
+        extra_active_joints: list[str] | None = None,
     ):
+        """Initialize the upperbody controller.
+
+        Args:
+            robot_model: Full robot model.
+            body_active_joint_groups: Joint group names whose joints stay active (driven by IK).
+                All other joints are fixed. If None and ``extra_active_joints`` is also None,
+                the full robot is used (no reduction).
+            extra_active_joints: Additional individual joint names to keep active on top of
+                ``body_active_joint_groups``. Useful when you want a partial group, e.g.
+                only ``waist_roll_joint`` and ``waist_pitch_joint`` from the ``waist`` group.
+        """
         # Initialize the body
-        if body_active_joint_groups is not None:
-            self.body = ReducedRobotModel.from_active_groups(robot_model, body_active_joint_groups)
+        active_groups = body_active_joint_groups
+        extra_joints = list(extra_active_joints) if extra_active_joints else []
+        if active_groups is not None or extra_joints:
+            # Compute the union of group joints + extra joints, then derive fixed joints.
+            active_joint_names: set[str] = set(extra_joints)
+            if active_groups is not None:
+                for group_name in active_groups:
+                    if group_name not in robot_model.supplemental_info.joint_groups:
+                        raise ValueError(f"Unknown joint group: {group_name}")
+                    group_indices = robot_model.get_joint_group_indices(group_name)
+                    active_joint_names.update(robot_model.joint_names[idx] for idx in group_indices)
+            fixed_joints = [name for name in robot_model.joint_names if name not in active_joint_names]
+            self.body = ReducedRobotModel(robot_model, fixed_joints)
             self.full_robot = self.body.full_robot
             self.using_reduced_robot_model = True
         else:

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/policy/g1_agile_policy.py
@@ -15,25 +15,29 @@ from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.base import WB
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.utils.homie_utils import load_config
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.utils.onnx_utils import OnnxInferenceSession
 
-# ONNX feedback state keys and their per-environment shapes (excluding batch dim).
-_STATE_KEYS_AND_SHAPES: dict[str, tuple[int, ...]] = {
-    "last_actions": (14,),
-    "base_ang_vel_history": (5, 3),
-    "projected_gravity_history": (5, 3),
-    "velocity_commands_history": (5, 3),
-    "controlled_joint_pos_history": (5, 14),
-    "controlled_joint_vel_history": (5, 14),
-    "actions_history": (5, 14),
-}
+# LSTM hidden state shape baked into the recurrent student ONNX.
+_LSTM_NUM_LAYERS = 1
+_LSTM_HIDDEN_SIZE = 256
 
 
 class G1AgilePolicy(WBCPolicy):
-    """G1 robot policy using the WBC-AGILE end-to-end neural network.
+    """G1 robot policy using the recurrent LSTM student exported from
+    ``agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py``.
 
-    This policy uses a single ONNX model that takes raw sensor inputs and
-    manages observation history internally via feedback connections. The model
-    outputs target joint positions along with per-joint Kp/Kd gains for 14
-    controlled joints (legs + waist_roll + waist_pitch).
+    The ONNX has three inputs: a flat ``obs`` vector and the LSTM hidden/cell
+    states ``h_in``/``c_in``. ``obs`` is laid out as::
+
+        [velocity_height_commands(4),  # [v_x, v_y, w_z, h]
+         base_ang_vel(3),
+         projected_gravity(3),
+         joint_pos_rel(29) = q - q_default,
+         joint_vel_rel(29) * joint_vel_scale,
+         last_action(num_actions=12)]
+
+    The 12 outputs are the leg target joint positions (no waist roll/pitch).
+
+    Note: the ONNX has a static batch dim of 1, so this policy only supports
+    ``num_envs == 1``. Re-export with dynamic axes if batched eval is needed.
     """
 
     def __init__(self, robot_model: RobotModel, config_path: str, model_path: str, num_envs: int = 1):
@@ -44,8 +48,14 @@ class G1AgilePolicy(WBCPolicy):
             config_path: Path to policy YAML configuration file (relative to wbc_policy dir).
             model_path: Path to the ONNX model file. Can be an S3/Nucleus URL
                 (resolved and cached by retrieve_file_path) or a local path.
-            num_envs: Number of environments.
+            num_envs: Number of environments. Must be 1 for the static-batch ONNX.
         """
+        assert num_envs == 1, (
+            "G1AgilePolicy uses a recurrent LSTM ONNX with static batch=1; "
+            f"got num_envs={num_envs}. Re-export the ONNX with dynamic batch axis "
+            "to support num_envs > 1."
+        )
+
         parent_dir = pathlib.Path(__file__).parent.parent
         self.config = load_config(str(parent_dir / config_path))
         self.robot_model = robot_model
@@ -58,10 +68,10 @@ class G1AgilePolicy(WBCPolicy):
         model_full_path = parent_dir / model_local_path
         self.session = OnnxInferenceSession(str(model_full_path))
 
-        # Build joint index mappings between WBC order and agile ONNX order
+        # Build joint index mappings between WBC order and agile ONNX order.
         self._build_joint_mappings()
 
-        # Initialize state
+        # Initialize state.
         self._init_state()
 
     def _build_joint_mappings(self):
@@ -73,8 +83,10 @@ class G1AgilePolicy(WBCPolicy):
         onnx_input_names = self.config["onnx_input_joint_names"]
         self.wbc_to_agile_input = np.array([wbc_order[name] for name in onnx_input_names])
 
-        # Mapping for ONNX output: for each of the 14 agile output joints, the
-        # position in the 15-element lower_body array to write to.
+        # Mapping for ONNX output: for each of the 12 agile output joints, the
+        # position in the 15-slot ``lower_body`` array (12 legs + 3 waist; see
+        # ``G1SupplementalInfo.joint_groups`` in ``g1_supplemental_info.py``).
+        # AGILE only drives the 12 leg slots; the 3 waist slots stay at zero.
         controlled_names = self.config["controlled_joint_names"]
         lower_body_indices = self.robot_model.get_joint_group_indices("lower_body")
         self.agile_idx_to_lower_body_idx = np.array(
@@ -82,16 +94,47 @@ class G1AgilePolicy(WBCPolicy):
         )
 
         self.num_lower_body = len(lower_body_indices)
+        self.num_actions = int(self.config["num_actions"])
 
     def _init_state(self):
         """Initialize all per-environment state variables."""
         self.observation = None
-        self.cmd = np.tile(self.config["cmd_init"], (self.num_envs, 1))
 
-        # Batched ONNX feedback state: each array has shape (num_envs, ...).
-        self.state = {
-            key: np.zeros((self.num_envs, *shape), dtype=np.float32) for key, shape in _STATE_KEYS_AND_SHAPES.items()
-        }
+        # 4-dim command: [v_x, v_y, w_z, h].
+        self._cmd_init = np.array(self.config["cmd_init"], dtype=np.float32)
+        assert self._cmd_init.shape == (4,), f"cmd_init must be 4-dim, got {self._cmd_init.shape}"
+        self.cmd = np.tile(self._cmd_init, (self.num_envs, 1))
+
+        # LSTM feedback state.
+        self.h_state = np.zeros((_LSTM_NUM_LAYERS, self.num_envs, _LSTM_HIDDEN_SIZE), dtype=np.float32)
+        self.c_state = np.zeros_like(self.h_state)
+
+        # Previous action fed back as part of obs.
+        self.last_action = np.zeros((self.num_envs, self.num_actions), dtype=np.float32)
+
+        self.joint_vel_scale = float(self.config.get("joint_vel_scale", 0.1))
+
+        # Action post-processing (matches agile JointPositionActionCfg):
+        #   target_q = clip(raw_action, action_clip) * action_scale + action_offset
+        action_clip = self.config.get("action_clip")
+        if action_clip is not None:
+            self._action_clip_min = float(action_clip[0])
+            self._action_clip_max = float(action_clip[1])
+        else:
+            self._action_clip_min = -np.inf
+            self._action_clip_max = np.inf
+        action_scale = self.config.get("action_scale", [1.0] * self.num_actions)
+        action_offset = self.config.get("action_offset", [0.0] * self.num_actions)
+        self._action_scale = np.array(action_scale, dtype=np.float32).reshape(1, -1)
+        self._action_offset = np.array(action_offset, dtype=np.float32).reshape(1, -1)
+        assert self._action_scale.shape == (
+            1,
+            self.num_actions,
+        ), f"action_scale must have {self.num_actions} entries, got {self._action_scale.shape}"
+        assert self._action_offset.shape == (
+            1,
+            self.num_actions,
+        ), f"action_offset must have {self.num_actions} entries, got {self._action_offset.shape}"
 
     def reset(self, env_ids: torch.Tensor):
         """Reset the policy state for the given environment ids.
@@ -99,10 +142,11 @@ class G1AgilePolicy(WBCPolicy):
         Args:
             env_ids: The environment ids to reset.
         """
-        idx = env_ids.cpu().numpy()
-        for key, shape in _STATE_KEYS_AND_SHAPES.items():
-            self.state[key][idx] = np.zeros(shape, dtype=np.float32)
-        self.cmd[idx] = self.config["cmd_init"]
+        idx = env_ids.cpu().numpy() if isinstance(env_ids, torch.Tensor) else np.asarray(env_ids)
+        self.h_state[:, idx, :] = 0.0
+        self.c_state[:, idx, :] = 0.0
+        self.last_action[idx] = 0.0
+        self.cmd[idx] = self._cmd_init
 
     def set_observation(self, observation: dict[str, Any]):
         """Store the current observation for the next get_action call.
@@ -115,12 +159,34 @@ class G1AgilePolicy(WBCPolicy):
     def set_goal(self, goal: dict[str, Any]):
         """Set the goal for the policy.
 
+        ``self.cmd`` is a 4-wide buffer ``[v_x, v_y, w_z, h]`` initialized from
+        ``cmd_init``. Each key below updates only its own slice, so callers that
+        provide one without the other (e.g. a velocity-only navigation override)
+        leave the height channel at its previous value rather than silently
+        no-op'ing.
+
         Args:
             goal: Dictionary containing goals. Supported keys:
                 - "navigate_cmd": velocity command array of shape (num_envs, 3)
+                - "base_height_command": height command of shape (num_envs, 1)
         """
-        if "navigate_cmd" in goal:
-            self.cmd = goal["navigate_cmd"]
+        nav = goal.get("navigate_cmd")
+        if nav is not None:
+            nav = np.asarray(nav, dtype=np.float32)
+            assert nav.shape == (
+                self.num_envs,
+                3,
+            ), f"navigate_cmd must have shape ({self.num_envs}, 3), got {nav.shape}"
+            self.cmd[:, :3] = nav
+
+        height = goal.get("base_height_command")
+        if height is not None:
+            height = np.asarray(height, dtype=np.float32)
+            assert height.shape == (
+                self.num_envs,
+                1,
+            ), f"base_height_command must have shape ({self.num_envs}, 1), got {height.shape}"
+            self.cmd[:, 3:4] = height
 
     def get_action(self, time: float | None = None) -> dict[str, Any]:
         """Compute and return the next action based on current observation.
@@ -134,26 +200,38 @@ class G1AgilePolicy(WBCPolicy):
 
         obs = self.observation
 
-        # Build batched ONNX inputs (all envs at once)
-        ort_inputs = {
-            "root_link_quat_w": obs["floating_base_pose"][:, 3:7].astype(np.float32),
-            "root_ang_vel_b": obs["floating_base_vel"][:, 3:6].astype(np.float32),
-            "velocity_commands": self.cmd.astype(np.float32),
-            "joint_pos": obs["q"][:, self.wbc_to_agile_input].astype(np.float32),
-            "joint_vel": obs["dq"][:, self.wbc_to_agile_input].astype(np.float32),
-            **{key: self.state[key] for key in _STATE_KEYS_AND_SHAPES},
-        }
+        # Use root_ang_vel_b (COM frame) to match `mdp.base_ang_vel` from training.
+        ang_vel_b = obs["root_ang_vel_b"].astype(np.float32)
+        proj_grav = obs["projected_gravity_b"].astype(np.float32)
 
-        # Run batched inference
-        result = self.session.run(ort_inputs)
+        # Reorder WBC-ordered q/dq/default_q into the agile training order.
+        q_agile = obs["q"][:, self.wbc_to_agile_input].astype(np.float32)
+        dq_agile = obs["dq"][:, self.wbc_to_agile_input].astype(np.float32)
+        q_default_agile = obs["default_q"][:, self.wbc_to_agile_input].astype(np.float32)
 
-        # Update feedback state for next step
-        for key in _STATE_KEYS_AND_SHAPES:
-            self.state[key] = result[f"{key}_out"]
+        joint_pos_rel = q_agile - q_default_agile
+        joint_vel_rel = dq_agile * self.joint_vel_scale
 
-        # Map 14 agile output joints to the 15-joint lower_body array.
-        # waist_yaw (not controlled by agile) stays at 0.0.
+        flat_obs = np.concatenate(
+            [self.cmd, ang_vel_b, proj_grav, joint_pos_rel, joint_vel_rel, self.last_action],
+            axis=1,
+        )
+
+        result = self.session.run({"obs": flat_obs.astype(np.float32), "h_in": self.h_state, "c_in": self.c_state})
+
+        actions = result["actions"].astype(np.float32)  # (N, num_actions)
+        self.h_state = result["h_out"]
+        self.c_state = result["c_out"]
+
+        # Feed back the *raw* (pre-processed) action: this matches mdp.last_action
+        # which returns env.action_manager.action (the policy output before scale/offset).
+        self.last_action = actions
+
+        # Match the agile training JointPositionActionCfg post-processing:
+        #   target_q = clip(raw_action, clip_min, clip_max) * scale + offset
+        target_q = np.clip(actions, self._action_clip_min, self._action_clip_max)
+        target_q = target_q * self._action_scale + self._action_offset
+
         body_action = np.zeros((self.num_envs, self.num_lower_body), dtype=np.float32)
-        body_action[:, self.agile_idx_to_lower_body_idx] = result["action_joint_pos"]
-
+        body_action[:, self.agile_idx_to_lower_body_idx] = target_q
         return {"body_action": body_action}

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/run_policy.py
@@ -64,6 +64,7 @@ def prepare_observations(
     # Get robot joint observations
     sim_joint_pos = wp.to_torch(robot_data.joint_pos).cpu().numpy()
     sim_joint_vel = wp.to_torch(robot_data.joint_vel).cpu().numpy()
+    sim_default_joint_pos = wp.to_torch(robot_data.default_joint_pos).cpu().numpy()
     num_joints = len(robot_data.joint_names)
 
     # Convert joints data from Lab's order to GR00T's order saved in config yaml
@@ -72,6 +73,9 @@ def prepare_observations(
     wbc_joint_acc = np.zeros((num_envs, num_joints))
     wbc_joint_pos = convert_sim_joint_to_wbc_joint(sim_joint_pos, robot_data.joint_names, wbc_joints_order)
     wbc_joint_vel = convert_sim_joint_to_wbc_joint(sim_joint_vel, robot_data.joint_names, wbc_joints_order)
+    wbc_default_joint_pos = convert_sim_joint_to_wbc_joint(
+        sim_default_joint_pos, robot_data.joint_names, wbc_joints_order
+    )
 
     # Prepare obs dict for WBC policy input to G1DecoupledWholeBodyPolicy class
     assert wbc_joint_pos.shape == wbc_joint_vel.shape == wbc_joint_acc.shape == (num_envs, num_joints)
@@ -92,15 +96,24 @@ def prepare_observations(
 
     torso_link_ang_vel_b = math_utils.quat_apply_inverse(torso_link_quat_w_xyzw, torso_link_ang_vel_w)
 
+    projected_gravity_b = wp.to_torch(robot_data.projected_gravity_b).cpu().numpy()
+    # `mdp.base_ang_vel` returns `root_ang_vel_b` (COM frame). The AGILE recurrent policy
+    # was trained with this exact quantity, so expose it separately from the link-frame
+    # `floating_base_vel` that other WBC policies consume.
+    root_ang_vel_b = wp.to_torch(robot_data.root_ang_vel_b).cpu().numpy()
+
     # Prepare obs tmers
     wbc_obs = {
         "q": wbc_joint_pos,
         "dq": wbc_joint_vel,
+        "default_q": wbc_default_joint_pos,
         "ddq": np.zeros((num_envs, num_joints)),  # Not used by Standing Waist Height Policy
         "tau_est": np.zeros((num_envs, num_joints)),  # Not used by Standing Waist Height Policy
         "floating_base_pose": base_pose_w,  # wrt world frame, used to project gravity vector to local frame
-        "floating_base_vel": base_vel_b,  # wrt body frame
+        "floating_base_vel": base_vel_b,  # root_link_*_vel_b (link frame), used by Homie WBC
         "floating_base_acc": np.zeros((num_envs, 6)),  # Not used by Standing Waist Height Policy
+        "projected_gravity_b": projected_gravity_b,  # gravity projected into base frame, used by AGILE recurrent
+        "root_ang_vel_b": root_ang_vel_b,  # COM-frame angular velocity, used by AGILE recurrent
         "torso_quat": torso_link_quat_w_wxyz.cpu().numpy(),
         "torso_ang_vel": torso_link_ang_vel_b.cpu().numpy(),
     }

--- a/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py
+++ b/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+External data configuration module for UnitreeG1 WBC simulation.
+"""
+
+from gr00t.configs.data.embodiment_configs import register_modality_config
+from gr00t.data.embodiment_tags import EmbodimentTag
+from gr00t.data.types import ActionConfig, ActionFormat, ActionRepresentation, ActionType, ModalityConfig
+
+unitree_g1_sim_wbc_config = {
+    "video": ModalityConfig(
+        delta_indices=[0],
+        modality_keys=["ego_view"],
+    ),
+    "state": ModalityConfig(
+        delta_indices=[0],
+        modality_keys=["left_arm", "right_arm", "left_hand", "right_hand", "waist"],
+    ),
+    "action": ModalityConfig(
+        delta_indices=list(range(40)),
+        modality_keys=[
+            "left_arm",
+            "right_arm",
+            "left_hand",
+            "right_hand",
+            "waist",
+            "base_height_command",
+            "navigate_command",
+        ],
+        action_configs=[
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            ),
+        ],
+    ),
+    "language": ModalityConfig(
+        delta_indices=[0],
+        modality_keys=["annotation.human.task_description"],
+    ),
+}
+
+register_modality_config(unitree_g1_sim_wbc_config, embodiment_tag=EmbodimentTag.NEW_EMBODIMENT)

--- a/isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml
+++ b/isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Gr00tDatasetConfig Example Configuration
+# This file shows how to configure the Gr00tDatasetConfig dataclass using YAML
+# Example for G1 static (no-nav) apple-to-plate task
+
+# Root directory for all data storage
+data_root: "/datasets/isaaclab_arena/static_apple_tutorial"
+
+# Instruction given to the policy in natural language
+language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+task_index: 3
+
+# Name of the HDF5 file to use for the dataset (matches the recorder output from
+# isaaclab_arena/scripts/imitation_learning/record_demos.py per static_apple/step_2_teleoperation;
+# rename here if you choose a different --dataset_file in step 2).
+hdf5_name: "arena_g1_static_apple_dataset_recorded.hdf5"
+
+# HDF5 datafield names (matches the schema written by record_demos.py +
+# isaaclab_arena.utils.isaaclab_utils.recorders.ArenaEnvRecorderManagerCfg)
+state_name_sim: "robot_joint_pos"
+left_eef_pos_name_sim: "left_eef_pos"
+left_eef_quat_name_sim: "left_eef_quat"
+right_eef_pos_name_sim: "right_eef_pos"
+right_eef_quat_name_sim: "right_eef_quat"
+teleop_base_height_command_name_sim: "base_height_cmd"
+teleop_navigate_command_name_sim: "navigate_cmd"
+teleop_torso_orientation_rpy_command_name_sim: "torso_orientation_rpy_cmd"
+action_name_sim: "processed_actions"
+pov_cam_name_sim: "robot_head_cam_rgb"
+
+# Gr00t-LeRobot datafield names
+state_name_lerobot: "observation.state"
+action_name_lerobot: "action"
+action_eef_name_sim: "action.eef"
+video_name_lerobot: "observation.images.ego_view"
+task_description_lerobot: "annotation.human.task_description"
+
+# Parquet configuration
+chunks_size: 1000
+
+# Video configuration
+fps: 50
+
+# File path templates
+data_path: "data/chunk-{episode_chunk:03d}/episode_{episode_index:06d}.parquet"
+video_path: "videos/chunk-{episode_chunk:03d}/{video_key}/episode_{episode_index:06d}.mp4"
+
+# Configuration file paths
+modality_template_path: "isaaclab_arena_gr00t/embodiments/g1/modality.json"
+modality_fname: "modality.json"
+episodes_fname: "episodes.jsonl"
+tasks_fname: "tasks.jsonl"
+info_template_path: "isaaclab_arena_gr00t/embodiments/g1/info.json"
+info_fname: "info.json"
+
+# policy specific parameters (gr00t demonstration data stored in lerobot format)
+policy_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml"
+robot_type: "unitree_g1"
+
+# Robot simulation specific parameters
+action_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
+state_joints_config_path: "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
+
+# Image configuration (height, width, channels)
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]

--- a/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Server-side Gr00tRemoteServerSidePolicy config for the G1 static apple-to-plate task.
+#
+# Used with Arena's remote-policy server stack (docs: example_workflows/static_apple/step_4_evaluation).
+# The matching client is `isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy`.
+# The model is finetuned from `nvidia/GR00T-N1.7-3B` per `static_apple/step_3_policy_training`.
+#
+# Container/server path conventions:
+#   Host:      $MODELS_DIR/static_apple_n17_finetune/checkpoint-20000
+#   Docker:    /models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000
+#              (mount $MODELS_DIR -> /models, e.g. via `run_gr00t_server.sh -m $MODELS_DIR` or
+#               `-v $MODELS_DIR:/models` on raw `docker run`).
+model_path: /models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000
+language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+
+# Must match the diffusion head's action_horizon baked into the finetuned checkpoint
+# (set via the action modality's `delta_indices=list(range(N))` in
+# isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py).
+# step_3_policy_training trains at 40, if you change one, change both.
+action_horizon: 40
+
+# step_3_policy_training uses --embodiment-tag new_embodiment, which `gr00t` resolves to
+# EmbodimentTag.NEW_EMBODIMENT. The Arena cfg also asserts NEW_EMBODIMENT for g1_locomanipulation.
+embodiment_tag: NEW_EMBODIMENT
+
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+# Number of actions the server emits per chunk; <= action_horizon.
+action_chunk_length: 40
+pov_cam_name_sim: "robot_head_cam_rgb"
+
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""GR00T remote closed-loop policy using GR00T's native PolicyClient.
+
+This policy connects to a GR00T policy server (launched via
+``gr00t/eval/run_gr00t_server.py``) and uses its own observation/action translation pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gymnasium as gym
+import torch
+from dataclasses import dataclass, field
+from typing import Any
+
+from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
+
+from isaaclab_arena.policy.action_chunking import ActionChunkingState
+from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
+from isaaclab_arena_gr00t.policy.gr00t_core import (
+    Gr00tBasePolicyArgs,
+    build_gr00t_action_tensor,
+    build_gr00t_policy_observations,
+    compute_action_dim,
+    extract_obs_numpy_from_torch,
+    load_gr00t_joint_configs,
+)
+from isaaclab_arena_gr00t.utils.io_utils import create_config_from_yaml, load_gr00t_modality_config_from_file
+
+
+# TODO(xinjieyao, 2026-04-27): consider adding RemotePolicyArgs to inherit from BasePolicyArgs
+# and then having Gr00tRemoteClosedloopPolicyArgs inherit from RemotePolicyArgs
+@dataclass
+class Gr00tRemoteClosedloopPolicyArgs(Gr00tBasePolicyArgs):
+    """Configuration for Gr00tRemoteClosedloopPolicy.
+
+    Inherits policy_config_yaml_path and policy_device from Gr00tBasePolicyArgs,
+    and adds remote server connection parameters and num_envs.
+    """
+
+    num_envs: int = field(default=1, metadata={"help": "Number of environments to simulate"})
+    remote_host: str = field(default="localhost", metadata={"help": "GR00T policy server hostname"})
+    remote_port: int = field(default=5555, metadata={"help": "GR00T policy server port"})
+    remote_api_token: str | None = field(default=None, metadata={"help": "API token for the policy server"})
+
+    @classmethod
+    def from_cli_args(cls, args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicyArgs:
+        """Create configuration from parsed CLI arguments."""
+        return cls(
+            policy_config_yaml_path=args.policy_config_yaml_path,
+            policy_device=args.policy_device,
+            num_envs=args.num_envs,
+            remote_host=args.remote_host,
+            remote_port=args.remote_port,
+            remote_api_token=getattr(args, "remote_api_token", None),
+        )
+
+
+# TODO(xinjieyao, 2026-04-27): add policy registry
+class Gr00tRemoteClosedloopPolicy(PolicyBase):
+    """GR00T closed-loop policy that delegates inference to a remote GR00T server.
+
+    Uses GR00T's native ``PolicyClient`` (from ``gr00t.policy.server_client``)
+    to communicate with a GR00T policy server.
+    """
+
+    name = "gr00t_remote_closedloop"
+    config_class = Gr00tRemoteClosedloopPolicyArgs
+
+    def __init__(self, config: Gr00tRemoteClosedloopPolicyArgs):
+        super().__init__(config)
+
+        # Policy config (for obs/action translation — no model loading)
+        # TODO(xinjieyao, 2026-04-27): to be refactored
+        self.policy_config: Gr00tClosedloopPolicyConfig = create_config_from_yaml(
+            config.policy_config_yaml_path, Gr00tClosedloopPolicyConfig
+        )
+        self.num_envs = config.num_envs
+        self.device = config.policy_device
+        self.task_mode = TaskMode(self.policy_config.task_mode_name)
+
+        # Joint configs (for sim from/to policy joint space remapping)
+        (
+            self.policy_joints_config,
+            self.robot_action_joints_config,
+            self.robot_state_joints_config,
+        ) = load_gr00t_joint_configs(self.policy_config)
+
+        self.modality_configs = load_gr00t_modality_config_from_file(
+            self.policy_config.modality_config_path,
+            self.policy_config.embodiment_tag,
+        )
+
+        # Action / chunk shapes
+        self.action_dim = compute_action_dim(self.task_mode, self.robot_action_joints_config)
+        self.action_chunk_length = self.policy_config.action_chunk_length
+
+        # TODO(xinjieyao, 2026-04-27): consider adding & using ActionChunkingScheduler instead
+        self._chunking_state = ActionChunkingState(
+            num_envs=self.num_envs,
+            action_chunk_length=self.action_chunk_length,
+            action_horizon=self.policy_config.action_horizon,
+            action_dim=self.action_dim,
+            device=self.device,
+            dtype=torch.float,
+        )
+
+        # Connect to GR00T's native PolicyClient
+        self._client = Gr00tPolicyClient(
+            host=config.remote_host,
+            port=config.remote_port,
+            api_token=config.remote_api_token,
+            strict=False,
+        )
+        if not self._client.ping():
+            raise ConnectionError(f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}")
+
+        self.task_description: str | None = None
+
+    # ---------------------- CLI helpers -------------------
+
+    @staticmethod
+    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        group = parser.add_argument_group(
+            "Gr00t Remote Closedloop Policy",
+            "Arguments for GR00T remote closed-loop policy evaluation.",
+        )
+        group.add_argument(
+            "--policy_config_yaml_path",
+            type=str,
+            required=True,
+            help="Path to the Gr00t closedloop policy config YAML file",
+        )
+        group.add_argument(
+            "--policy_device",
+            type=str,
+            default="cuda",
+            help="Device for Arena-side tensor operations (default: cuda)",
+        )
+        group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
+        group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
+        group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")
+        return parser
+
+    @staticmethod
+    def from_args(args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicy:
+        config = Gr00tRemoteClosedloopPolicyArgs.from_cli_args(args)
+        return Gr00tRemoteClosedloopPolicy(config)
+
+    # ---------------------- Policy interface -------------------
+
+    def set_task_description(self, task_description: str | None) -> str:
+        if task_description is None:
+            task_description = self.policy_config.language_instruction
+        if not task_description:
+            raise ValueError(
+                "No language instruction provided. Set 'language_instruction' in the job config, "
+                "pass --language_instruction on the CLI, or define 'task_description' on the task class."
+            )
+        self.task_description = task_description
+        return self.task_description
+
+    def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
+        def fetch_chunk() -> torch.Tensor:
+            return self._get_action_chunk(observation, self.policy_config.pov_cam_name_sim)
+
+        return self._chunking_state.get_action(fetch_chunk)
+
+    def _get_action_chunk(
+        self, observation: dict[str, Any], camera_names: list[str] | str = "robot_head_cam_rgb"
+    ) -> torch.Tensor:
+        """Get an action chunk from the remote GR00T server.
+
+        Calls GR00T's PolicyClient to get the action chunk.
+        """
+        if isinstance(camera_names, str):
+            camera_names = [camera_names]
+
+        # 1. Reuse the same obs translation as local policy
+        assert self.task_description is not None, "Task description is not set"
+        rgb_list_np, joint_pos_sim_np = extract_obs_numpy_from_torch(nested_obs=observation, camera_names=camera_names)
+        policy_observations = build_gr00t_policy_observations(
+            rgb_list_np=rgb_list_np,
+            joint_pos_sim_np=joint_pos_sim_np,
+            task_description=self.task_description,
+            policy_config=self.policy_config,
+            robot_state_joints_config=self.robot_state_joints_config,
+            policy_joints_config=self.policy_joints_config,
+            modality_configs=self.modality_configs,
+        )
+
+        # 2. Call GR00T's own client
+        robot_action_policy, _ = self._client.get_action(policy_observations)
+
+        # 3. Action translation from policy output to sim action tensor
+        action_tensor = build_gr00t_action_tensor(
+            robot_action_policy=robot_action_policy,
+            task_mode=self.task_mode,
+            policy_joints_config=self.policy_joints_config,
+            robot_action_joints_config=self.robot_action_joints_config,
+            device=self.device,
+            embodiment_tag=self.policy_config.embodiment_tag,
+        )
+
+        assert action_tensor.shape[0] == self.num_envs and action_tensor.shape[1] >= self.action_chunk_length
+        return action_tensor
+
+    def reset(self, env_ids: torch.Tensor | None = None):
+        if env_ids is None:
+            env_ids = slice(None)
+        self._client.reset()
+        self._chunking_state.reset(env_ids)

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for Gr00tRemoteClosedloopPolicy.
+
+Exercises the real obs/action translation pipeline and mocks only ``Gr00tPolicyClient`` -- the wire
+boundary to a remote GR00T server -- so no server is required.
+
+Verifies:
+- the obs dict sent to the server has the expected language/video/state structure;
+- the action dict returned by the server is converted to a tensor of the
+  expected (num_envs, action_chunk_length, action_dim) shape;
+- ``reset`` propagates to the client;
+- a failing ping during construction raises ``ConnectionError``.
+"""
+# TODO(xinjieyao, 2026-04-27):will be moved to base container test when removing deprecated local policy
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import yaml
+from typing import Any
+
+import pytest
+
+from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
+
+NUM_ENVS = 2
+ORIGINAL_HEIGHT = 480
+ORIGINAL_WIDTH = 640
+NUM_CHANNELS = 3
+NUM_SIM_JOINTS = 43  # G1 43-DoF
+ACTION_HORIZON = 50
+ACTION_CHUNK_LENGTH = 50
+EXPECTED_ACTION_DIM = 50  # 43 joints + 3 nav + 1 base height + 3 torso rpy
+
+# Joint group sizes from gr00t_43dof_joint_space.yaml (must match the YAML).
+POLICY_GROUP_SIZES = {
+    "left_leg": 6,
+    "right_leg": 6,
+    "waist": 3,
+    "left_arm": 7,
+    "left_hand": 7,
+    "right_arm": 7,
+    "right_hand": 7,
+}
+
+
+# ----------------------------- fixtures ------------------------------ #
+
+
+@pytest.fixture
+def policy_config_yaml(tmp_path):
+    """Write a copy of the g1 locomanip test config with model_path set to a
+    HuggingFace repo id so ``Gr00tClosedloopPolicyConfig.__post_init__`` passes
+    without a real checkpoint on disk (the remote policy never loads it)."""
+    src = Gr00tTestConstants.test_data_dir + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
+    with open(src) as f:
+        cfg = yaml.safe_load(f)
+    cfg["model_path"] = "nvidia/GR00T-N1.6-3B"  # HF id passes _is_huggingface_model_id
+    dst = tmp_path / "remote_closedloop_config.yaml"
+    with open(dst, "w") as f:
+        yaml.dump(cfg, f)
+    return str(dst)
+
+
+@pytest.fixture
+def synthetic_observation():
+    """Env-shaped torch obs: one ego camera + 43 joint positions per env."""
+    rgb = torch.randint(0, 255, (NUM_ENVS, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS), dtype=torch.uint8)
+    joint_pos = torch.randn(NUM_ENVS, NUM_SIM_JOINTS, dtype=torch.float32)
+    return {
+        "camera_obs": {"robot_head_cam_rgb": rgb},
+        "policy": {"robot_joint_pos": joint_pos},
+    }
+
+
+def _make_action_response(num_envs: int, horizon: int) -> dict[str, np.ndarray]:
+    """Synthetic GR00T-server response in the format ``build_gr00t_action_np`` expects."""
+    response: dict[str, np.ndarray] = {}
+    for group, size in POLICY_GROUP_SIZES.items():
+        response[group] = np.random.randn(num_envs, horizon, size).astype(np.float32)
+    response["navigate_command"] = np.random.randn(num_envs, horizon, 3).astype(np.float32)
+    response["base_height_command"] = np.random.randn(num_envs, horizon, 1).astype(np.float32)
+    return response
+
+
+class _FakePolicyClient:
+    """Minimal stand-in for ``gr00t.policy.server_client.PolicyClient``."""
+
+    def __init__(self, *args, ping_ok: bool = True, **kwargs):
+        self.init_kwargs = kwargs
+        self._ping_ok = ping_ok
+        self.last_observation: dict[str, Any] | None = None
+        self.get_action_calls = 0
+        self.reset_called = False
+
+    def ping(self) -> bool:
+        return self._ping_ok
+
+    def get_action(self, observation: dict[str, Any]):
+        self.last_observation = observation
+        self.get_action_calls += 1
+        # Match the real PolicyClient return signature: (action_dict, latency_or_meta).
+        return _make_action_response(NUM_ENVS, ACTION_HORIZON), None
+
+    def reset(self):
+        self.reset_called = True
+
+
+@pytest.fixture
+def fake_client_factory(monkeypatch):
+    """Patch ``Gr00tPolicyClient`` in the policy module's namespace and return
+    a factory that gives access to the most recently constructed fake."""
+    from isaaclab_arena_gr00t.policy import gr00t_remote_closedloop_policy as mod
+
+    created: list[_FakePolicyClient] = []
+
+    def factory(ping_ok: bool = True):
+        def _ctor(*args, **kwargs):
+            client = _FakePolicyClient(*args, ping_ok=ping_ok, **kwargs)
+            created.append(client)
+            return client
+
+        monkeypatch.setattr(mod, "Gr00tPolicyClient", _ctor)
+        return created
+
+    return factory
+
+
+def _build_policy(policy_config_yaml: str):
+    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
+        Gr00tRemoteClosedloopPolicy,
+        Gr00tRemoteClosedloopPolicyArgs,
+    )
+
+    args = Gr00tRemoteClosedloopPolicyArgs(
+        policy_config_yaml_path=policy_config_yaml,
+        policy_device="cpu",  # keep the test portable; remote policy does no GPU compute
+        num_envs=NUM_ENVS,
+        remote_host="unused",
+        remote_port=0,
+        remote_api_token=None,
+    )
+    return Gr00tRemoteClosedloopPolicy(args)
+
+
+# ------------------------------- tests ------------------------------- #
+
+
+def test_observation_sent_to_server_has_expected_structure(
+    policy_config_yaml, synthetic_observation, fake_client_factory
+):
+    """The dict passed to ``PolicyClient.get_action`` matches GR00T's expected
+    language/video/state layout for the g1 sim WBC modality config."""
+    clients = fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    policy.set_task_description("pick up the brown box")
+
+    policy._get_action_chunk(synthetic_observation, ["robot_head_cam_rgb"])
+
+    assert len(clients) == 1
+    sent = clients[0].last_observation
+    assert sent is not None and clients[0].get_action_calls == 1
+
+    # language: one [task] entry per env
+    assert "language" in sent
+    lang = sent["language"]["annotation.human.task_description"]
+    assert lang == [["pick up the brown box"]] * NUM_ENVS
+
+    # video: one ego view, shaped (N, 1, H, W, C) and uint8
+    assert "video" in sent and "ego_view" in sent["video"]
+    ego = sent["video"]["ego_view"]
+    assert ego.shape == (NUM_ENVS, 1, ORIGINAL_HEIGHT, ORIGINAL_WIDTH, NUM_CHANNELS)
+    assert ego.dtype == np.uint8
+
+    # state: one (N, 1, dof_in_group) entry per modality state key
+    expected_state_keys = {"left_arm", "right_arm", "left_hand", "right_hand", "waist"}
+    assert set(sent["state"].keys()) == expected_state_keys
+    for key in expected_state_keys:
+        arr = sent["state"][key]
+        assert arr.ndim == 3
+        assert arr.shape[0] == NUM_ENVS
+        assert arr.shape[1] == 1
+        assert arr.shape[2] == POLICY_GROUP_SIZES[key]
+
+
+def test_action_response_is_translated_to_correct_tensor_shape(
+    policy_config_yaml, synthetic_observation, fake_client_factory
+):
+    """Server's grouped joint dict is reassembled into a (N, chunk, action_dim) tensor."""
+    fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    policy.set_task_description("pick up the brown box")
+
+    action = policy._get_action_chunk(synthetic_observation, ["robot_head_cam_rgb"])
+
+    assert isinstance(action, torch.Tensor)
+    # _get_action_chunk asserts action_tensor.shape[1] >= action_chunk_length, but
+    # the full horizon is returned; pin both dims explicitly.
+    assert action.shape == (NUM_ENVS, ACTION_HORIZON, EXPECTED_ACTION_DIM)
+    assert action.device.type == "cpu"
+
+
+def test_reset_propagates_to_client(policy_config_yaml, fake_client_factory):
+    clients = fake_client_factory(ping_ok=True)
+    policy = _build_policy(policy_config_yaml)
+    assert clients[0].reset_called is False
+    policy.reset()
+    assert clients[0].reset_called is True
+
+
+def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_client_factory):
+    fake_client_factory(ping_ok=False)
+    with pytest.raises(ConnectionError):
+        _build_policy(policy_config_yaml)

--- a/isaaclab_arena_gr00t/utils/io_utils.py
+++ b/isaaclab_arena_gr00t/utils/io_utils.py
@@ -206,11 +206,34 @@ def load_gr00t_modality_config_from_file(modality_config_path: str | Path, embod
     """
     from gr00t.configs.data.embodiment_configs import MODALITY_CONFIGS
     from gr00t.data.embodiment_tags import EmbodimentTag
-    from gr00t.experiment.launch_finetune import load_modality_config
 
+    # TODO(xinjieyao, 2026-04-27): to be refactored after adding gr00t remote policy
     if modality_config_path:
-        # Import module for side-effect registration
-        load_modality_config(modality_config_path)
+        # Import the user's modality config module for its side-effect of
+        # registering entries into MODALITY_CONFIGS.
+        #
+        # Prefer GR00T's own helper when available (full GR00T container),
+        # but fall back to an inlined copy so the base container — which
+        # ships GR00T as source only and does not install training deps
+        # like tyro — still works.
+        try:
+            from gr00t.experiment.launch_finetune import load_modality_config
+
+            load_modality_config(modality_config_path)
+        except ImportError:
+            import importlib.util
+
+            path = Path(modality_config_path)
+            if not (path.exists() and path.suffix == ".py"):
+                raise FileNotFoundError(f"Modality config path does not exist: {modality_config_path}")
+            # Load by file location so we (a) don't mutate sys.path and (b) always
+            # execute the module body — register_modality_config() runs every call,
+            # rather than being skipped on a sys.modules cache hit.
+            spec = importlib.util.spec_from_file_location(path.stem, path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not load modality config from {path}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
 
     # Get the embodiment tag from policy config and convert to EmbodimentTag enum
     # Handle case-insensitive lookup (e.g., "NEW_EMBODIMENT" or "new_embodiment" both work)


### PR DESCRIPTION
## Summary

Cherry-picks the new G1 static (no-nav) apple-to-plate workflow ([#651](https://github.com/isaac-sim/IsaacLab-Arena/pull/651)) into `dev/release/0.2.1` for the upcoming dot release, plus the minimal dependency chain it needs:

- [#634](https://github.com/isaac-sim/IsaacLab-Arena/pull/634) — re-deslopify Pick-and-Place task (introduces the `force_threshold` / `velocity_threshold` parameters the static env passes to `PickAndPlaceTask`)
- [#562](https://github.com/isaac-sim/IsaacLab-Arena/pull/562) — adds `G1WBCAgilePinkEmbodiment` (the AGILE+PinkIK embodiment the new static env defaults to)
- [#661](https://github.com/isaac-sim/IsaacLab-Arena/pull/661) — AGILE recurrent student WBC policy (this is the "new checkpoint" baked into the deployed AGILE backend)
- [#651](https://github.com/isaac-sim/IsaacLab-Arena/pull/651) — the static apple-to-plate env, task tests, and 4-step workflow docs

Plus two adaptation commits on top:

- Drop the `@register_environment` decorator on the new env (it lands in [#598](https://github.com/isaac-sim/IsaacLab-Arena/pull/598), not yet on `dev/release/0.2.1`) and register the env the 0.2.1 way — via `isaaclab_arena_environments/cli.py`'s `ExampleEnvironments` dict.
- Wire the new HuggingFace dataset and checkpoint into the static apple workflow docs:
  - Dataset: [`nvidia/Arena-G1-Static-PickNPlace-Task`](https://huggingface.co/datasets/nvidia/Arena-G1-Static-PickNPlace-Task)
  - Checkpoint: [`nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace`](https://huggingface.co/nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace)

### Commit breakdown

| # | Commit | Source |
|---|--------|--------|
| 1 | re-deslopify Pick and place task | cherry-pick of #634 |
| 2 | Add G1 AGILE tabletop apple-to-plate environment | cherry-pick of #562 |
| 3 | Add G1 AGILE recurrent student WBC policy | cherry-pick of #661 |
| 4 | Add G1 static (no-nav) apple-to-plate env for tabletop manipulation | cherry-pick of #651 |
| 5 | Adapt static G1 pick-and-place env to dev/release/0.2.1 registry | new |
| 6 | Add HF dataset/checkpoint links to static apple-to-plate workflow | new |

### Conflict resolution notes

- **#562 on top of #634**: #562 re-introduced ``success_proximity_max_distance`` and the proximity-guard branch that #634 had just removed. Kept the post-#634 (clean) state in both `pick_and_place_task.py` and `terminations.py`; took only the AGILE-relevant pieces from #562. Also dropped the `g1_agile_tabletop_apple_to_plate_environment.py` env + test file that #634 had already deleted (kept the rest of #562's changes — `retargeter_library.py` updates, `G1WBCAgilePinkEmbodiment`, `cli.py` minus the dropped env entry).
- **#651 Dockerfile conflict**: trivial — took the `jq` / `ffmpeg` additions.
- **#651 modify/delete on `test_g1_locomanip_apple_to_plate.py`**: dropped the file (it depends on #611's apple-to-plate locomanip env, which is not in this cherry-pick chain).

### What's out of scope

This intentionally does **not** cherry-pick #611 (loco-manip apple-to-plate env) or #598 (env registration refactor). They have their own deeper dependency chains and the static workflow + AGILE checkpoint deliver the user-visible value on their own.

## Test plan

- [ ] CI is green on `bokal/cherrypick/0.2.1/g1-static-pick-and-place`
- [ ] `pytest isaaclab_arena/tests/test_g1_static_pick_and_place.py` passes (2 sim tests)
- [ ] `python isaaclab_arena/scripts/imitation_learning/record_demos.py galileo_g1_static_pick_and_place` smoke-loads the env
- [ ] `hf download nvidia/Arena-G1-Static-PickNPlace-Task ... && replay_demos.py` round-trips a HF demo
- [ ] `hf download nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace ...` + `policy_runner.py` runs closed-loop eval against the downloaded checkpoint
- [ ] Existing locomanip workflow still works (`test_g1_locomanip_box_pick_and_place.py` regression check)
- [ ] Docs build cleanly (`sphinx-build docs/ docs/_build/`)