### PR TITLE
Fix daqp version in Arena dockerfile for compatibility with qpsolvers 4.12.0

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -53,7 +53,7 @@ RUN /isaac-sim/python.sh -m pip install --no-deps -e ${WORKDIR}/submodules/Isaac
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 
 # DAQP version required for latest qpsolvers 4.12.0. Backport of IsaacLab #5556.
-# Can be dropped once the Isaac Lab submodule is bumped past 66aa08aed8e68290ac743ca136cf7ad5eade5c9d.
+# Can be dropped once the Isaac Lab submodule is bumped past 4934cd0ce5a53b86342f32d89e5491016c841769.
 RUN /isaac-sim/python.sh -m pip install --upgrade --force-reinstall daqp==0.8.5
 
 # Install Isaac Teleop Python APIs (retargeters, device I/O, OpenXR bindings)

--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -54,7 +54,7 @@ RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 
 # DAQP version required for latest qpsolvers 4.12.0. Backport of IsaacLab #5556.
 # Can be dropped once the Isaac Lab submodule is bumped past 4934cd0ce5a53b86342f32d89e5491016c841769.
-RUN /isaac-sim/python.sh -m pip install --upgrade --force-reinstall daqp==0.8.5
+RUN /isaac-sim/python.sh -m pip install --force-reinstall daqp==0.8.5
 
 # Install Isaac Teleop Python APIs (retargeters, device I/O, OpenXR bindings)
 RUN /isaac-sim/python.sh -m pip install isaacteleop~=1.1.0 --extra-index-url https://pypi.nvidia.com

--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -52,6 +52,10 @@ RUN /isaac-sim/python.sh -m pip install --no-deps -e ${WORKDIR}/submodules/Isaac
 # Install isaaclab
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 
+# DAQP version required for latest qpsolvers 4.12.0. Backport of IsaacLab #5556.
+# Can be dropped once the Isaac Lab submodule is bumped past 66aa08aed8e68290ac743ca136cf7ad5eade5c9d.
+RUN /isaac-sim/python.sh -m pip install --upgrade --force-reinstall daqp==0.8.5
+
 # Install Isaac Teleop Python APIs (retargeters, device I/O, OpenXR bindings)
 RUN /isaac-sim/python.sh -m pip install isaacteleop~=1.1.0 --extra-index-url https://pypi.nvidia.com
 


### PR DESCRIPTION
## Summary
Fixes compatibility of Pink IK with latest version of qpsolvers 4.12.0 which requires daqp >= 0.8.5. 

Isaac Lab has resolved this upstream in a [merged PR](https://github.com/isaac-sim/IsaacLab/pull/5556). This PR updates the version of dqap in the Arena dockerfile manually. The change can be dropped after the Isaac Lab submodule is bumped past commit [4934cd0ce5a53b86342f32d89e5491016c841769](https://github.com/isaac-sim/IsaacLab/commit/4934cd0ce5a53b86342f32d89e5491016c841769). 

