### PR TITLE
Fix daqp version in Arena dockerfile for compatibility with qpsolvers…

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -49,6 +49,10 @@ RUN /isaac-sim/python.sh -m pip install --no-deps -e ${WORKDIR}/submodules/Isaac
 # Install isaaclab
 RUN ${ISAACLAB_PATH}/isaaclab.sh -i
 
+# DAQP version required for latest qpsolvers 4.12.0. Backport of IsaacLab #5556.
+# Can be dropped once the Isaac Lab submodule is bumped past 4934cd0ce5a53b86342f32d89e5491016c841769.
+RUN /isaac-sim/python.sh -m pip install --force-reinstall daqp==0.8.5
+
 # Install Isaac Teleop Python APIs (retargeters, device I/O, OpenXR bindings)
 RUN /isaac-sim/python.sh -m pip install isaacteleop~=1.1.0 --extra-index-url https://pypi.nvidia.com
 


### PR DESCRIPTION
… 4.12.0 (#667)

## Summary
Fixes compatibility of Pink IK with latest version of qpsolvers 4.12.0 which requires daqp >= 0.8.5.

Isaac Lab has resolved this upstream in a [merged
PR](https://github.com/isaac-sim/IsaacLab/pull/5556). This PR updates the version of dqap in the Arena dockerfile manually. The change can be dropped after the Isaac Lab submodule is bumped past commit [4934cd0ce5a53b86342f32d89e5491016c841769](https://github.com/isaac-sim/IsaacLab/commit/4934cd0ce5a53b86342f32d89e5491016c841769).

---------

## Summary
Short description of the change (max 50 chars)

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
