### PR TITLE
Release GR00T GPU memory between eval jobs

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -210,6 +210,7 @@ def main():
 
                 finally:
                     try:
+                        # close the policy and env, also collect garbage and clear cuda cache
                         _close_job_resources(policy, env)
                     finally:
                         policy = None

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -92,6 +92,40 @@ def get_policy_from_job(job: Job) -> "PolicyBase":
     return policy
 
 
+def _collect_garbage_and_clear_cuda_cache() -> None:
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _close_policy(policy: "PolicyBase | None") -> None:
+    try:
+        if policy is not None:
+            policy.close()
+    finally:
+        _collect_garbage_and_clear_cuda_cache()
+
+
+def _close_env(env) -> None:
+    if env is None:
+        return
+    try:
+        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
+    finally:
+        try:
+            # cleanup managers, including recorder manager closing hdf5 file
+            env.close()
+        finally:
+            _collect_garbage_and_clear_cuda_cache()
+
+
+def _close_job_resources(policy: "PolicyBase | None", env) -> None:
+    try:
+        _close_policy(policy)
+    finally:
+        _close_env(env)
+
+
 def main():
     args_parser = get_isaaclab_arena_cli_parser()
     args_cli, unknown = args_parser.parse_known_args()
@@ -175,23 +209,12 @@ def main():
                         raise
 
                 finally:
-                    if policy is not None:
-                        policy.close()
-                    if policy is not None:
-                        del policy
+                    try:
+                        _close_job_resources(policy, env)
+                    finally:
                         policy = None
-                    gc.collect()
-                    if torch.cuda.is_available():
-                        torch.cuda.empty_cache()
-                    # Only stop env if it was successfully created
-                    if env is not None:
-                        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
-                        # cleanup managers, including recorder manager closing hdf5 file
-                        env.close()
                         env = None
-                        gc.collect()
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
+                        _collect_garbage_and_clear_cuda_cache()
 
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -5,8 +5,10 @@
 
 import argparse
 import dataclasses
+import gc
 import json
 import os
+import torch
 import traceback
 from gymnasium.wrappers import RecordVideo
 from typing import TYPE_CHECKING
@@ -122,6 +124,7 @@ def main():
         for job in job_manager:
             if job is not None:
                 env = None
+                policy = None
                 try:
                     render_mode = "rgb_array" if args_cli.video else None
                     env = load_env(job.arena_env_args, job.name, render_mode=render_mode)
@@ -172,11 +175,23 @@ def main():
                         raise
 
                 finally:
+                    if policy is not None:
+                        policy.close()
+                    if policy is not None:
+                        del policy
+                        policy = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
                     # Only stop env if it was successfully created
                     if env is not None:
                         teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
                         # cleanup managers, including recorder manager closing hdf5 file
                         env.close()
+                        env = None
+                        gc.collect()
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
 
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -73,6 +73,10 @@ class PolicyBase(ABC):
         """
         pass
 
+    def close(self) -> None:
+        """Release resources held by the policy."""
+        pass
+
     def set_task_description(self, task_description: str | None) -> str:
         """Set the task description of the task being evaluated."""
         self.task_description = task_description

--- a/isaaclab_arena_gr00t/policy/gr00t_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_closedloop_policy.py
@@ -7,10 +7,12 @@
 from __future__ import annotations
 
 import argparse
+import gc
 import gymnasium as gym
 import torch
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import FrameType
 from typing import Any
 
 from gr00t.data.embodiment_tags import EmbodimentTag
@@ -35,6 +37,25 @@ from isaaclab_arena_gr00t.utils.io_utils import (
     load_gr00t_modality_config_from_file,
     load_robot_joints_config_from_yaml,
 )
+
+
+def _clear_stale_model_loading_frames() -> None:
+    """Clear retained GR00T/Transformers constructor frames that keep CUDA model locals alive."""
+    model_loading_frame_markers = (
+        "/gr00t/policy/gr00t_policy.py",
+        "/gr00t/model/gr00t_n1d6/gr00t_n1d6.py",
+        "/gr00t/model/modules/eagle_backbone.py",
+        "/transformers/modeling_utils.py",
+    )
+    for obj in gc.get_objects():
+        try:
+            if type(obj) is not FrameType:
+                continue
+            if any(marker in obj.f_code.co_filename for marker in model_loading_frame_markers):
+                obj.clear()
+        except (ReferenceError, RuntimeError):
+            # RuntimeError means the frame is still executing; leave it alone.
+            continue
 
 
 @dataclass
@@ -76,7 +97,7 @@ class Gr00tClosedloopPolicy(PolicyBase):
         self.policy_config: Gr00tClosedloopPolicyConfig = create_config_from_yaml(
             config.policy_config_yaml_path, Gr00tClosedloopPolicyConfig
         )
-        self.policy: Gr00tPolicy = load_gr00t_policy_from_config(self.policy_config)
+        self.policy: Gr00tPolicy | None = load_gr00t_policy_from_config(self.policy_config)
 
         # Basic attributes
         self.num_envs = config.num_envs
@@ -229,6 +250,7 @@ class Gr00tClosedloopPolicy(PolicyBase):
         if isinstance(camera_names, str):
             camera_names = [camera_names]
         policy_observations = self.get_observations(observation, camera_names)
+        assert self.policy is not None, "GR00T policy has been closed"
         robot_action_policy, _ = self.policy.get_action(policy_observations)
 
         action_tensor = build_gr00t_action_tensor(
@@ -248,5 +270,20 @@ class Gr00tClosedloopPolicy(PolicyBase):
         if env_ids is None:
             env_ids = slice(None)
         # placeholder for future reset options from GR00T repo
+        assert self.policy is not None, "GR00T policy has been closed"
         self.policy.reset()
         self._chunking_state.reset(env_ids)
+
+    def close(self) -> None:
+        """Release local GR00T model resources before deleting the wrapper policy."""
+        gr00t_policy = self.policy
+        if gr00t_policy is not None:
+            for attr_name in ("model", "processor", "collate_fn", "modality_configs"):
+                if hasattr(gr00t_policy, attr_name):
+                    setattr(gr00t_policy, attr_name, None)
+        self.policy = None
+        self._chunking_state = None
+        self.modality_configs = None
+        _clear_stale_model_loading_frames()
+        gc.collect()
+        _clear_stale_model_loading_frames()


### PR DESCRIPTION
## Summary
Release GR00T GPU memory between eval jobs to prevent memory accumulation OOM issue.

## Detailed description
- Why: sequential GR00T eval jobs were retaining local policy CUDA memory across jobs. GR00T policy has 6.4 forGib GPU mem cached without explicitly cleaning.
- What: clear GR00T model-related refs etc. and retained GR00T/Transformers model-loading frames
- Impact: GR00T local policy memory is released between/after jobs, matching mem stats from zero_action. 


• Before fix
```
  Checkpoint                                Total GPU   Torch allocated   Delta vs baseline
  ---------------------------------------   ---------   ---------------   -----------------
  Baseline                                   11,723 MiB         0 MiB              0 MiB
  Job 1 after rollout                        24,027 MiB     6,394 MiB        +12,304 MiB
  After job 1 cleanup / before job 2         20,081 MiB     6,394 MiB         +8,358 MiB
  Job 2 after policy create                  29,746 MiB    12,699 MiB        +18,023 MiB
  End of runner                              20,381 MiB     6,412 MiB         +8,658 MiB
```

• After fix
```
  Checkpoint                                Total GPU   Torch allocated   Delta vs baseline
  ---------------------------------------   ---------   ---------------   -----------------
  Baseline                                   11,722 MiB         0 MiB              0 MiB
  Job 1 after rollout                        22,851 MiB     6,394 MiB        +11,129 MiB
  After job 1 cleanup / before job 2         13,108 MiB        27 MiB         +1,386 MiB
  Job 2 after policy create                  22,729 MiB     6,333 MiB        +11,007 MiB
  End of runner                              13,467 MiB        45 MiB         +1,745 MiB
```