### PR TITLE
Adds explicit policy cleanup for eval jobs

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -91,6 +91,40 @@ def get_policy_from_job(job: Job) -> "PolicyBase":
     return policy
 
 
+def _collect_garbage_and_clear_cuda_cache() -> None:
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
+def _close_policy(policy: "PolicyBase | None") -> None:
+    try:
+        if policy is not None:
+            policy.close()
+    finally:
+        _collect_garbage_and_clear_cuda_cache()
+
+
+def _close_env(env) -> None:
+    if env is None:
+        return
+    try:
+        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
+    finally:
+        try:
+            # cleanup managers, including recorder manager closing hdf5 file
+            env.close()
+        finally:
+            _collect_garbage_and_clear_cuda_cache()
+
+
+def _close_job_resources(policy: "PolicyBase | None", env) -> None:
+    try:
+        _close_policy(policy)
+    finally:
+        _close_env(env)
+
+
 def main():
     args_parser = get_isaaclab_arena_cli_parser()
     args_cli, unknown = args_parser.parse_known_args()
@@ -175,24 +209,11 @@ def main():
 
                 finally:
                     try:
-                        if policy is not None:
-                            policy.close()
+                        _close_job_resources(policy, env)
                     finally:
-                        if policy is not None:
-                            del policy
-                            policy = None
-                        gc.collect()
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
-                        # Only stop env if it was successfully created
-                        if env is not None:
-                            teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
-                            # cleanup managers, including recorder manager closing hdf5 file
-                            env.close()
-                            env = None
-                            gc.collect()
-                            if torch.cuda.is_available():
-                                torch.cuda.empty_cache()
+                        policy = None
+                        env = None
+                        _collect_garbage_and_clear_cuda_cache()
 
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -5,8 +5,10 @@
 
 import argparse
 import dataclasses
+import gc
 import json
 import os
+import torch
 import traceback
 from gymnasium.wrappers import RecordVideo
 from typing import TYPE_CHECKING
@@ -121,6 +123,7 @@ def main():
         for job in job_manager:
             if job is not None:
                 env = None
+                policy = None
                 try:
                     render_mode = "rgb_array" if args_cli.video else None
                     env = load_env(job.arena_env_args, job.name, render_mode=render_mode)
@@ -171,11 +174,25 @@ def main():
                         raise
 
                 finally:
-                    # Only stop env if it was successfully created
-                    if env is not None:
-                        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
-                        # cleanup managers, including recorder manager closing hdf5 file
-                        env.close()
+                    try:
+                        if policy is not None:
+                            policy.close()
+                    finally:
+                        if policy is not None:
+                            del policy
+                            policy = None
+                        gc.collect()
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
+                        # Only stop env if it was successfully created
+                        if env is not None:
+                            teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
+                            # cleanup managers, including recorder manager closing hdf5 file
+                            env.close()
+                            env = None
+                            gc.collect()
+                            if torch.cuda.is_available():
+                                torch.cuda.empty_cache()
 
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -73,6 +73,10 @@ class PolicyBase(ABC):
         """
         pass
 
+    def close(self) -> None:
+        """Release resources held by the policy."""
+        pass
+
     def set_task_description(self, task_description: str | None) -> str:
         """Set the task description of the task being evaluated."""
         self.task_description = task_description

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -258,13 +258,17 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
     def close(self) -> None:
         """Release Arena-side resources for the remote GR00T policy client."""
         client = self._client
-        if client is not None:
-            socket = getattr(client, "socket", None)
-            if socket is not None:
-                socket.close(linger=0)
-            context = getattr(client, "context", None)
-            if context is not None:
-                context.term()
-        self._client = None
-        self._chunking_state = None
-        self.modality_configs = None
+        try:
+            if client is not None:
+                socket = getattr(client, "socket", None)
+                context = getattr(client, "context", None)
+                try:
+                    if socket is not None:
+                        socket.close(linger=0)
+                finally:
+                    if context is not None:
+                        context.term()
+        finally:
+            self._client = None
+            self._chunking_state = None
+            self.modality_configs = None

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -104,7 +104,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         self.action_dim = compute_action_dim(self.task_mode, self.robot_action_joints_config)
         self.action_chunk_length = self.policy_config.action_chunk_length
 
-        self._chunking_state = action_scheduler_cls(
+        self._chunking_state: ActionScheduler | None = action_scheduler_cls(
             num_envs=self.num_envs,
             action_chunk_length=self.action_chunk_length,
             action_horizon=self.policy_config.action_horizon,
@@ -114,13 +114,14 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         )
 
         # Connect to GR00T's native PolicyClient
-        self._client = Gr00tPolicyClient(
+        client = Gr00tPolicyClient(
             host=config.remote_host,
             port=config.remote_port,
             api_token=config.remote_api_token,
             strict=False,
         )
-        if not self._client.ping():
+        self._client: Gr00tPolicyClient | None = client
+        if not client.ping():
             raise ConnectionError(f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}")
 
         self.task_description: str | None = None
@@ -185,6 +186,8 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
         return self.task_description
 
     def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
+        assert self._chunking_state is not None, "GR00T remote policy has been closed"
+
         def fetch_chunk() -> torch.Tensor:
             return self._get_action_chunk(observation, self.policy_config.pov_cam_name_sim)
 
@@ -216,6 +219,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
 
         # 1. Reuse the same obs translation as local policy
         assert self.task_description is not None, "Task description is not set"
+        assert self._client is not None, "GR00T remote policy has been closed"
         rgb_list_np, joint_pos_sim_np = extract_obs_numpy_from_torch(nested_obs=observation, camera_names=camera_names)
         policy_observations = build_gr00t_policy_observations(
             rgb_list_np=rgb_list_np,
@@ -246,5 +250,21 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
     def reset(self, env_ids: torch.Tensor | None = None):
         if env_ids is None:
             env_ids = slice(None)
+        assert self._client is not None, "GR00T remote policy has been closed"
+        assert self._chunking_state is not None, "GR00T remote policy has been closed"
         self._client.reset()
         self._chunking_state.reset(env_ids)
+
+    def close(self) -> None:
+        """Release Arena-side resources for the remote GR00T policy client."""
+        client = self._client
+        if client is not None:
+            socket = getattr(client, "socket", None)
+            if socket is not None:
+                socket.close(linger=0)
+            context = getattr(client, "context", None)
+            if context is not None:
+                context.term()
+        self._client = None
+        self._chunking_state = None
+        self.modality_configs = None


### PR DESCRIPTION
## Summary
Adds explicit policy cleanup for eval jobs

## Detailed description
- Why: eval jobs need an explicit policy cleanup path so policy-side resources, remote clients, and CUDA cache are released between jobs
- What: delete policy refs, empty stall cuda cache, and garbage collection on client side
- Impact: policies can now release resources during sequential eval jobs. For remote GR00T, cleanup is limited to local Arena client because the GR00T model lives in the remote server process
