### PR TITLE
Fix droid camera offset quaternion ordering

### DIFF
--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -427,9 +427,7 @@ class DroidCameraCfg:
                 horizontal_aperture=5.376,
                 vertical_aperture=3.024,
             ),
-            offset=CameraCfg.OffsetCfg(
-                pos=(0.05, -0.57, 0.66), rot=(0.399, -0.195, -0.393, 0.805), convention="opengl"
-            ),
+            offset=OffsetClass(pos=(0.05, -0.57, 0.66), rot=(0.399, -0.195, -0.393, 0.805), convention="opengl"),
         )
         self.wrist_camera = CameraClass(
             prim_path="{ENV_REGEX_NS}/Robot/Gripper/Robotiq_2F_85/base_link/wrist_camera",
@@ -442,7 +440,5 @@ class DroidCameraCfg:
                 horizontal_aperture=5.376,
                 vertical_aperture=3.024,
             ),
-            offset=CameraCfg.OffsetCfg(
-                pos=(0.011, -0.031, -0.074), rot=(0.570, 0.576, -0.409, -0.420), convention="opengl"
-            ),
+            offset=OffsetClass(pos=(0.011, -0.031, -0.074), rot=(0.570, 0.576, -0.409, -0.420), convention="opengl"),
         )

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -414,7 +414,7 @@ class DroidCameraCfg:
                 horizontal_aperture=5.376,
                 vertical_aperture=3.024,
             ),
-            offset=OffsetClass(pos=(0.05, 0.57, 0.66), rot=(-0.393, -0.195, 0.399, 0.805), convention="opengl"),
+            offset=OffsetClass(pos=(0.05, 0.57, 0.66), rot=(-0.195, 0.399, 0.805, -0.393), convention="opengl"),
         )
         self.external_camera_2 = CameraClass(
             prim_path="{ENV_REGEX_NS}/Robot/external_camera_2",
@@ -428,7 +428,7 @@ class DroidCameraCfg:
                 vertical_aperture=3.024,
             ),
             offset=CameraCfg.OffsetCfg(
-                pos=(0.05, -0.57, 0.66), rot=(0.805, 0.399, -0.195, -0.393), convention="opengl"
+                pos=(0.05, -0.57, 0.66), rot=(0.399, -0.195, -0.393, 0.805), convention="opengl"
             ),
         )
         self.wrist_camera = CameraClass(
@@ -443,6 +443,6 @@ class DroidCameraCfg:
                 vertical_aperture=3.024,
             ),
             offset=CameraCfg.OffsetCfg(
-                pos=(0.011, -0.031, -0.074), rot=(-0.420, 0.570, 0.576, -0.409), convention="opengl"
+                pos=(0.011, -0.031, -0.074), rot=(0.570, 0.576, -0.409, -0.420), convention="opengl"
             ),
         )


### PR DESCRIPTION
## Summary
- Fix camera orientations on the DROID embodiment: the exterior view was upside-down and the wrist camera did not see the gripper.

## Root cause
`CameraCfg.OffsetCfg.rot` is read as `(x, y, z, w)` by the current IsaacLab, but the droid camera offsets were copied verbatim from an older IsaacLab (2.2.0) that read the same field as `(w, x, y, z)`. The rotations therefore produced wrong camera frames.

Reorder the `rot` tuples for `external_camera`, `external_camera_2`, and `wrist_camera` from `(w, x, y, z)` → `(x, y, z, w)`. `convention="opengl"` is unchanged.

## Test plan
- [x] Visually verified via debug image dump: exterior view is right-side up and wrist view sees the gripper.
- [x] Verified pi0/openpi closed-loop policy can now grasp objects under the `pick_and_place_maple_table` env with the DROID embodiment, matching robolab behavior.
- [ ] Reviewer: re-run any DROID-camera-dependent eval / data-collection job to confirm no regression on the other side.