### PR TITLE
Record per-camera obs videos when --video is set

### DIFF
--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gym wrapper that records one mp4 per camera in ``obs['camera_obs']``.
+
+Mirrors ``gymnasium.wrappers.RecordVideo`` — same ``step_trigger`` /
+``video_length`` semantics and the same moviepy ``ImageSequenceClip``
+encoder, but frames come from ``obs["camera_obs"][<cam>]`` rather than
+``env.render()``. Output is one mp4 per camera under ``video_folder``,
+named ``<name_prefix>-<cam>-step-<N>.mp4``.
+
+policy_runner.py wraps the env with this alongside ``RecordVideo`` so
+the kit viewport mp4 (third-person scene view) and the embodiment-
+mounted camera mp4s (what the policy actually sees) are written
+together when ``--video`` is set.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+
+def _to_uint8(frame: torch.Tensor | np.ndarray) -> np.ndarray:
+    if isinstance(frame, torch.Tensor):
+        frame = frame.detach().cpu().numpy()
+    if frame.dtype == np.uint8:
+        return frame
+    if frame.dtype.kind == "f":
+        # mdp.image with normalize=True returns float in [0, 1]; rescale.
+        scale = 255.0 if float(frame.max()) <= 1.0 else 1.0
+        return np.clip(frame * scale, 0, 255).astype(np.uint8)
+    return frame.astype(np.uint8)
+
+
+class CameraObsVideoRecorder(gym.Wrapper):
+    """Record an mp4 per camera in ``obs['camera_obs']``."""
+
+    def __init__(
+        self,
+        env: gym.Env,
+        video_folder: str,
+        step_trigger: Callable[[int], bool],
+        video_length: int,
+        name_prefix: str = "rl-video",
+        fps: int | None = None,
+    ):
+        super().__init__(env)
+        os.makedirs(video_folder, exist_ok=True)
+        self.video_folder = video_folder
+        self.step_trigger = step_trigger
+        self.video_length = video_length
+        self.name_prefix = name_prefix
+        self.fps = fps if fps is not None else int(env.metadata.get("render_fps", 30))
+
+        self.step_id = -1
+        self.recording = False
+        self.recording_start_step = 0
+        self.buffers: dict[str, list[np.ndarray]] = {}
+
+    def step(self, action):
+        result = self.env.step(action)
+        self.step_id += 1
+        obs = result[0]
+        cam_obs = obs.get("camera_obs", {}) if isinstance(obs, dict) else {}
+
+        if not self.recording and self.step_trigger(self.step_id):
+            self.recording = True
+            self.recording_start_step = self.step_id
+            self.buffers = {k: [] for k in cam_obs}
+
+        if self.recording and cam_obs:
+            for k, frame in cam_obs.items():
+                self.buffers.setdefault(k, []).append(_to_uint8(frame[0]))
+            if self.buffers and all(len(v) >= self.video_length for v in self.buffers.values()):
+                self._flush()
+
+        return result
+
+    def _flush(self) -> None:
+        from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+
+        for cam, frames in self.buffers.items():
+            if not frames:
+                continue
+            path = os.path.join(
+                self.video_folder,
+                f"{self.name_prefix}-{cam}-step-{self.recording_start_step}.mp4",
+            )
+            clip = ImageSequenceClip(list(frames), fps=self.fps)
+            clip.write_videofile(path, logger=None, audio=False)
+            del clip
+        self.recording = False
+        self.buffers = {}
+
+    def close(self) -> None:
+        if self.recording and any(len(v) > 0 for v in self.buffers.values()):
+            self._flush()
+        return self.env.close()

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -14,17 +14,26 @@ named ``<name_prefix>-<cam>-step-<N>.mp4``.
 policy_runner.py wraps the env with this alongside ``RecordVideo`` so
 the kit viewport mp4 (third-person scene view) and the embodiment-
 mounted camera mp4s (what the policy actually sees) are written
-together when ``--video`` is set.
+together when ``--video --camera_video`` is set.
+
+Multi-env note: Arena batches camera observations as
+``[N_envs, H, W, C]``. This wrapper records env 0 only (``frame[0]``);
+other envs are silently dropped. ``RecordVideo`` for the kit viewport
+is unaffected — the viewport shows the full scene regardless of
+``num_envs``.
 """
 
 from __future__ import annotations
 
-import os
-from collections.abc import Callable
-
 import gymnasium as gym
 import numpy as np
+import os
 import torch
+from collections.abc import Callable
+
+from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+
+CAMERA_OBS_GROUP_KEY = "camera_obs"
 
 
 def _to_uint8(frame: torch.Tensor | np.ndarray) -> np.ndarray:
@@ -39,8 +48,17 @@ def _to_uint8(frame: torch.Tensor | np.ndarray) -> np.ndarray:
     return frame.astype(np.uint8)
 
 
+def _sanitize_cam_key(key: str) -> str:
+    """Strip path separators so a camera key can't escape video_folder."""
+    return key.replace("/", "_").replace(os.sep, "_")
+
+
 class CameraObsVideoRecorder(gym.Wrapper):
-    """Record an mp4 per camera in ``obs['camera_obs']``."""
+    """Record an mp4 per camera in ``obs['camera_obs']``.
+
+    Records env 0 only: cameras are batched as ``[N_envs, H, W, C]`` and the
+    wrapper picks ``frame[0]``. Intended for single-env evaluation rollouts.
+    """
 
     def __init__(
         self,
@@ -48,7 +66,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
         video_folder: str,
         step_trigger: Callable[[int], bool],
         video_length: int,
-        name_prefix: str = "rl-video",
+        name_prefix: str = "robot-cam",
         fps: int | None = None,
     ):
         super().__init__(env)
@@ -68,7 +86,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
         result = self.env.step(action)
         self.step_id += 1
         obs = result[0]
-        cam_obs = obs.get("camera_obs", {}) if isinstance(obs, dict) else {}
+        cam_obs = obs.get(CAMERA_OBS_GROUP_KEY, {}) if isinstance(obs, dict) else {}
 
         if not self.recording and self.step_trigger(self.step_id):
             self.recording = True
@@ -77,6 +95,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
 
         if self.recording and cam_obs:
             for k, frame in cam_obs.items():
+                # frame: [N_envs, H, W, C]; record env 0 only.
                 self.buffers.setdefault(k, []).append(_to_uint8(frame[0]))
             if self.buffers and all(len(v) >= self.video_length for v in self.buffers.values()):
                 self._flush()
@@ -84,14 +103,12 @@ class CameraObsVideoRecorder(gym.Wrapper):
         return result
 
     def _flush(self) -> None:
-        from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
-
         for cam, frames in self.buffers.items():
             if not frames:
                 continue
             path = os.path.join(
                 self.video_folder,
-                f"{self.name_prefix}-{cam}-step-{self.recording_start_step}.mp4",
+                f"{self.name_prefix}-{_sanitize_cam_key(cam)}-step-{self.recording_start_step}.mp4",
             )
             clip = ImageSequenceClip(list(frames), fps=self.fps)
             clip.write_videofile(path, logger=None, audio=False)
@@ -100,6 +117,8 @@ class CameraObsVideoRecorder(gym.Wrapper):
         self.buffers = {}
 
     def close(self) -> None:
-        if self.recording and any(len(v) > 0 for v in self.buffers.values()):
-            self._flush()
-        return self.env.close()
+        try:
+            if self.recording and any(len(v) > 0 for v in self.buffers.values()):
+                self._flush()
+        finally:
+            self.env.close()

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -12,6 +12,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.evaluation.camera_video import CameraObsVideoRecorder
 from isaaclab_arena.evaluation.policy_runner_cli import add_policy_runner_arguments
 from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -215,6 +216,15 @@ def main():
                 step_trigger=lambda step: step == 0,
                 video_length=video_length,
                 disable_logger=True,
+            )
+            # Also capture the embodiment-mounted cameras (what the policy sees).
+            # RecordVideo above grabs the kit viewport; this wrapper writes one
+            # mp4 per camera from obs["camera_obs"] using the same encoder.
+            env = CameraObsVideoRecorder(
+                env,
+                video_folder=args_cli.video_dir,
+                step_trigger=lambda step: step == 0,
+                video_length=video_length,
             )
             print(f"[Rank {local_rank}/{world_size}] Recording {video_length}-step video to: {args_cli.video_dir}")
 

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -200,9 +200,10 @@ def main():
             else:
                 raise ValueError(f"[Rank {local_rank}/{world_size}] Either num_steps or num_episodes must be provided")
 
-        # Optionally wrap with RecordVideo. Mirrors the eval_runner.py wiring so the same
-        # mp4 layout works between policy_runner and eval_runner.
-        if args_cli.video:
+        # Optionally wrap with RecordVideo and/or CameraObsVideoRecorder. The two flags
+        # are independent: --video records the kit viewport (via env.render()),
+        # --camera_video records the embodiment-mounted cameras (from obs["camera_obs"]).
+        if args_cli.video or args_cli.camera_video:
             os.makedirs(args_cli.video_dir, exist_ok=True)
             if num_steps is not None:
                 video_length = num_steps
@@ -210,6 +211,8 @@ def main():
                 # When num_episodes is set, capture exactly one episode's worth of frames.
                 # max_episode_length is in environment steps, which matches our rollout cadence.
                 video_length = num_episodes * env.unwrapped.max_episode_length
+
+        if args_cli.video:
             env = RecordVideo(
                 env,
                 video_folder=args_cli.video_dir,
@@ -217,16 +220,24 @@ def main():
                 video_length=video_length,
                 disable_logger=True,
             )
-            # Also capture the embodiment-mounted cameras (what the policy sees).
-            # RecordVideo above grabs the kit viewport; this wrapper writes one
-            # mp4 per camera from obs["camera_obs"] using the same encoder.
+            print(
+                f"[Rank {local_rank}/{world_size}] Recording {video_length}-step viewport video to:"
+                f" {args_cli.video_dir}"
+            )
+
+        if args_cli.camera_video:
+            # Record one mp4 per camera in obs["camera_obs"] (what the policy sees),
+            # using the same encoder as RecordVideo.
             env = CameraObsVideoRecorder(
                 env,
                 video_folder=args_cli.video_dir,
                 step_trigger=lambda step: step == 0,
                 video_length=video_length,
             )
-            print(f"[Rank {local_rank}/{world_size}] Recording {video_length}-step video to: {args_cli.video_dir}")
+            print(
+                f"[Rank {local_rank}/{world_size}] Recording {video_length}-step per-camera videos to:"
+                f" {args_cli.video_dir}"
+            )
 
         steps_str = f"{num_steps} steps" if num_steps is not None else f"{num_episodes} episodes"
         print(f"[Rank {local_rank}/{world_size}] Starting rollout ({steps_str})")

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -43,5 +43,15 @@ def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:
         "--video-dir",
         type=str,
         default="/eval/videos",
-        help="Output directory for the recorded video. Created if missing. Used only with --video.",
+        help="Output directory for recorded videos. Created if missing. Used with --video and/or --camera_video.",
+    )
+    parser.add_argument(
+        "--camera_video",
+        "--camera-video",
+        action="store_true",
+        default=False,
+        help=(
+            "Record one mp4 per camera in obs['camera_obs'] (what the policy actually sees)."
+            " Independent of --video; use either or both."
+        ),
     )


### PR DESCRIPTION
## Summary

**Change:** add per-camera obs videos to `policy_runner.py --video`. Today it only writes the kit viewport via `RecordVideo` (third-person spectator view); this MR also writes one mp4 per camera in `obs["camera_obs"]`, in the **same format as the viewport mp4** (same `step_trigger` / `video_length` semantics, same moviepy `ImageSequenceClip` encoder, libx264 mp4).

**Use case:** debugging sensor offsets and comparing simulator camera outputs against Universal Video Action (UVA) model inputs/outputs side by side — the per-camera mp4 is exactly what the policy sees.

**Output:** `<video_dir>/rl-video-<cam>-step-<N>.mp4`, one file per `obs["camera_obs"]` key, alongside the existing `rl-video-step-<N>.mp4` viewport. No new flags; no change when `--video` is not set.

## Test plan

**Environment:**
- Container: `nvcr.io/nvidia/isaac-lab:3.0.0-beta1`
- IsaacLab: 4.5.24, editable-installed from `submodules/IsaacLab`

Any embodiment with `obs["camera_obs"]`. Example (DROID, 30 steps):

```bash
/isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \
  --policy_type zero_action --num_steps 30 \
  --enable_cameras --viz kit \
  --video --video_dir /eval/cam_video_check \
  pick_and_place_maple_table --embodiment droid_abs_joint_pos \
  --pick_up_object rubiks_cube_hot3d_robolab \
  --destination_location bowl_ycb_robolab --hdr home_office_robolab
```

Confirm `external_camera_rgb`, `external_camera_2_rgb`, `wrist_camera_rgb` mp4s land under `--video_dir` alongside the viewport mp4.
