### PR TITLE
Update main with fixes on release 0.2.1 branch:  G1 static apple-to-plate workflow 

### DIFF
--- a/isaaclab_arena/tests/test_g1_static_pick_and_place.py
+++ b/isaaclab_arena/tests/test_g1_static_pick_and_place.py
@@ -50,7 +50,7 @@ def get_test_environment(num_envs: int):
     the WBC stack itself.
     """
 
-    from isaaclab_arena.assets.asset_registry import AssetRegistry
+    from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.embodiments.g1.g1 import G1WBCAgileJointEmbodiment
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder

--- a/isaaclab_arena/tests/test_g1_static_pick_and_place.py
+++ b/isaaclab_arena/tests/test_g1_static_pick_and_place.py
@@ -30,6 +30,8 @@ APPLE_SETTLE_STEPS = 50
 HEADLESS = True
 ENABLE_CAMERAS = True
 
+APPLE_SCALE = (0.009, 0.009, 0.009)
+PLATE_SCALE = (0.5, 0.5, 0.5)
 APPLE_INITIAL_POSITION_M = (0.15, 0.15, 0.05)
 PLATE_INITIAL_POSITION_M = (0.15, -0.40, 0.02)
 # Drop height for the success-case teleport. Kept small so the apple has a short, contained
@@ -48,7 +50,7 @@ def get_test_environment(num_envs: int):
     the WBC stack itself.
     """
 
-    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.assets.asset_registry import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.embodiments.g1.g1 import G1WBCAgileJointEmbodiment
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
@@ -59,8 +61,8 @@ def get_test_environment(num_envs: int):
 
     asset_registry = AssetRegistry()
     background = asset_registry.get_asset_by_name("table")()
-    apple = asset_registry.get_asset_by_name("apple_01_objaverse_robolab")()
-    plate = asset_registry.get_asset_by_name("clay_plates_hot3d_robolab")()
+    apple = asset_registry.get_asset_by_name("apple_01_objaverse_robolab")(scale=APPLE_SCALE)
+    plate = asset_registry.get_asset_by_name("clay_plates_hot3d_robolab")(scale=PLATE_SCALE)
 
     apple.set_initial_pose(Pose(position_xyz=APPLE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
     plate.set_initial_pose(Pose(position_xyz=PLATE_INITIAL_POSITION_M, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 #   shelf on the first sim tick (which would otherwise launch them upward).
 SHELF_SURFACE_Z = -0.030
 SHELF_AIRGAP = 0.005
+SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - 0.02)
 
 # Object XY spawn pose (env-local frame, shelf-relative). X mirrors the locomanip env
 # (the only on-shelf X we have ground-truth data for via the brown_box flow). The pickup
@@ -135,6 +136,13 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # Reuse the locomanip background USD: it bakes in lighting and provides the same
         # shelf-in-front-of-robot geometry the locomanip env was tuned against.
         background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+        # The imported shelf mesh has uneven/perforated collision in the task region:
+        # small objects can fall through parts of the visible shelf. Add an invisible
+        # kinematic cuboid flush with the shelf top so task objects see a clean support.
+        shelf_support = self.asset_registry.get_asset_by_name("procedural_table")(
+            instance_name="static_pick_place_shelf_support",
+            prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
+        )
         pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=_asset_scale(args_cli.object))
         destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
             scale=_asset_scale(args_cli.destination)
@@ -150,6 +158,9 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # robot up in the same shelf-relative spot. The controller dynamically lifts the
         # pelvis to ~z=0.74 at runtime; init_state.pos.z=0 is correct.
         embodiment.set_initial_pose(Pose(position_xyz=(0.3, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        shelf_support.set_initial_pose(
+            Pose(position_xyz=SHELF_SUPPORT_PATCH_CENTER, rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+        )
         pick_up_object_x, pick_up_object_y = PICK_UP_OBJECT_SPAWN_XY
         destination_x, destination_y = DESTINATION_SPAWN_XY
         pick_up_object_z = _shelf_spawn_z(args_cli.object)
@@ -191,7 +202,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 f"{destination_label} on the same shelf next to it."
             )
 
-        scene = Scene(assets=[background, pick_up_object, destination])
+        scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
         return IsaacLabArenaEnvironment(
             name=self.name,
             embodiment=embodiment,

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 #   shelf on the first sim tick (which would otherwise launch them upward).
 SHELF_SURFACE_Z = -0.030
 SHELF_AIRGAP = 0.005
+# Cuboid center: top face = SHELF_SURFACE_Z. This assumes procedural_table height is 0.04 m.
 SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - 0.02)
 
 # Object XY spawn pose (env-local frame, shelf-relative). X mirrors the locomanip env

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -139,6 +139,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # The imported shelf mesh has uneven/perforated collision in the task region:
         # small objects can fall through parts of the visible shelf. Add an invisible
         # kinematic cuboid flush with the shelf top so task objects see a clean support.
+        # This has only reproduced in GPU simulation; CPU runs have not shown the issue.
         shelf_support = self.asset_registry.get_asset_by_name("procedural_table")(
             instance_name="static_pick_place_shelf_support",
             prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",


### PR DESCRIPTION
## Summary

This cherry-picks the G1 static apple-to-plate workflow fixes from release 0.2.1 branch into main.

Changes:
- Adds explicit apple and plate test scales so the static pick-and-place test uses realistic object geometry.
- Adds an invisible `procedural_table` support patch under the Galileo static pick-and-place shelf area.

## Motivation

The imported Galileo locomanip shelf mesh appears to have uneven or perforated collision in part of the task region. Small objects like the apple or plate can fall through the visible shelf surface depending on where they spawn.

The support patch gives the task objects a clean collision surface without changing the visible scene geometry.

