### PR TITLE
Remove GR00T model path from policy configs

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
@@ -43,14 +43,13 @@ Step 1: Run Single Environment Evaluation
 
 We first run the policy in a single environment with visualization via the GUI.
 
-The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/g1_locomanip_gr00t_closedloop_config.yaml``.
+The Arena GR00T evaluation client is configured by a config file at ``isaaclab_arena_gr00t/g1_locomanip_gr00t_closedloop_config.yaml``.
 
 .. dropdown:: Configuration file (``g1_locomanip_gr00t_closedloop_config.yaml``):
    :animate: fade-in
 
    .. code-block:: yaml
 
-      model_path: /models/isaaclab_arena/locomanipulation_tutorial/checkpoint-20000
       language_instruction: "Pick up the brown box from the shelf, and place it into the blue bin on the table located at the right of the shelf."
       action_horizon: 50
       embodiment_tag: NEW_EMBODIMENT

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
@@ -43,14 +43,12 @@ Step 1: Run Single Environment Evaluation
 
 We first run the policy in a single environment with visualization via the GUI.
 
-The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml``.
+The Arena GR00T evaluation client is configured by a config file at ``isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml``.
 
 .. dropdown:: Configuration file (``gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml``):
    :animate: fade-in
 
    .. code-block:: yaml
-
-      model_path: /models/isaaclab_arena/sequential_static_manipulation_tutorial/checkpoint-20000
 
       language_instruction: "Place the sauce bottle on the top shelf of the fridge, and close the fridge door."
       action_horizon: 16

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -61,11 +61,8 @@ same machine).
 
 .. caution::
 
-   Before running, edit ``model_path`` in
-   ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml`` to point at
-   the finetuned checkpoint directory you produced in :doc:`step_3_policy_training` (for example,
-   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000``).
-   It must match the ``--model-path`` you passed to ``run_gr00t_server.py`` in Step 1.
+   Before running, make sure the GR00T server from Step 1 was launched with the finetuned checkpoint
+   directory you produced in :doc:`step_3_policy_training`.
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
@@ -38,14 +38,12 @@ Step 1: Run Single Environment Evaluation
 
 We first run the policy in a single environment with visualization via the GUI.
 
-The GR00T model is configured by a config file at ``isaaclab_arena_gr00t/gr1_manip_gr00t_closedloop_config.yaml``.
+The Arena GR00T evaluation client is configured by a config file at ``isaaclab_arena_gr00t/gr1_manip_gr00t_closedloop_config.yaml``.
 
 .. dropdown:: Configuration file (``gr1_manip_gr00t_closedloop_config.yaml``):
    :animate: fade-in
 
    .. code-block:: yaml
-
-      model_path: /models/isaaclab_arena/static_manipulation_tutorial/checkpoint-20000
 
       language_instruction: "Reach out to the microwave and open it."
       action_horizon: 16

--- a/isaaclab_arena_gr00t/policy/config/droid_manip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/droid_manip_gr00t_closedloop_config.yaml
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-model_path: nvidia/GR00T-N1.6-DROID
 # Action horizon is the number of actions predicted by the policy per inference rollout, defined in the modality_config_path.
 action_horizon: 32
 embodiment_tag: OXE_DROID

--- a/isaaclab_arena_gr00t/policy/config/g1_locomanip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/g1_locomanip_gr00t_closedloop_config.yaml
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This file shows how to configure the Gr00tRemoteClosedloopPolicy class for G1 locomanipulation task
-# NOTE(alexmillane, 2025-10-31): The model path here aligns with the model used in the static manipulation tutorial.
-model_path: /models/isaaclab_arena/locomanipulation_tutorial/checkpoint-20000
 language_instruction: "Pick up the brown box from the shelf, and place it into the blue bin on the table located at the right of the shelf."
 # Action horizon is the number of actions predicted by the policy per inference rollout, defined in the GN1.6 modality_config_path.
 action_horizon: 50

--- a/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
@@ -8,13 +8,6 @@
 # Used with Arena's remote-policy server stack (docs: example_workflows/static_apple/step_4_evaluation).
 # The matching client is `isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy`.
 # The model is finetuned from `nvidia/GR00T-N1.7-3B` per `static_apple/step_3_policy_training`.
-#
-# Container/server path conventions:
-#   Host:      $MODELS_DIR/static_apple_n17_finetune/checkpoint-20000
-#   Docker:    /models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000
-#              (mount $MODELS_DIR -> /models, e.g. via `run_gr00t_server.sh -m $MODELS_DIR` or
-#               `-v $MODELS_DIR:/models` on raw `docker run`).
-model_path: /models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000
 language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
 
 # Must match the diffusion head's action_horizon baked into the finetuned checkpoint

--- a/isaaclab_arena_gr00t/policy/config/gr00t_closedloop_policy_config.py
+++ b/isaaclab_arena_gr00t/policy/config/gr00t_closedloop_policy_config.py
@@ -9,22 +9,11 @@ from pathlib import Path
 from isaaclab_arena_gr00t.policy.config.task_mode import TaskMode
 
 
-def _is_huggingface_model_id(model_path: str) -> bool:
-    """Return True if model_path looks like a HuggingFace Hub repo id (e.g. 'nvidia/GR00T-N1.6-3B')."""
-    if not model_path:
-        return False
-    # HF repo ids are "owner/repo_name" - no leading path sep, and not an existing local path
-    return "/" in model_path and not model_path.startswith(("/", ".")) and not Path(model_path).exists()
-
-
 @dataclass
 class Gr00tClosedloopPolicyConfig:
 
     language_instruction: str = field(
         default="", metadata={"description": "Instruction given to the policy in natural language."}
-    )
-    model_path: str = field(
-        default=None, metadata={"description": "Full path to the tuned model checkpoint directory."}
     )
     action_horizon: int = field(
         default=16, metadata={"description": "Number of actions in the policy's predictionhorizon."}
@@ -107,9 +96,6 @@ class Gr00tClosedloopPolicyConfig:
         assert Path(
             self.state_joints_config_path
         ).exists(), f"state_joints_config_path does not exist: {self.state_joints_config_path}"
-        assert Path(self.model_path).exists() or _is_huggingface_model_id(
-            self.model_path
-        ), f"model_path does not exist and is not a HuggingFace model id: {self.model_path}"
         if self.modality_config_path:
             assert Path(
                 self.modality_config_path

--- a/isaaclab_arena_gr00t/policy/config/gr1_manip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/gr1_manip_gr00t_closedloop_config.yaml
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This file shows how to configure the Gr00tRemoteClosedloopPolicy class for GR1 tabletop manipulation task
-# NOTE(alexmillane, 2025-10-31): The model path here aligns with the model used in the static manipulation tutorial.
-model_path: /models/isaaclab_arena/static_manipulation_tutorial/checkpoint-20000
 language_instruction: "Reach out to the microwave and open it."
 # Action horizon is the number of actions predicted by the policy per inference rollout, defined in the modality_config_path.
 action_horizon: 16

--- a/isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This file shows how to configure the Gr00tRemoteClosedloopPolicy class for GR1 tabletop manipulation task
-# NOTE(alexmillane, 2025-10-31): The model path here aligns with the model used in the static manipulation tutorial.
-model_path: /models/isaaclab_arena/sequential_static_manipulation_tutorial/checkpoint-20000
 language_instruction: "Place the sauce bottle on the top shelf of the fridge, and close the fridge door."
 # Action horizon is the number of actions predicted by the policy per inference rollout, defined in the GN1.6 policy data_config 'fourier_gr1_arms_only'.
 action_horizon: 16

--- a/isaaclab_arena_gr00t/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/tests/test_data/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # This file shows how to configure the Gr00tRemoteClosedloopPolicy class for G1 locomanipulation task
-model_path: /checkpoints/gn1_5_g1_galileo_box_npnp/checkpoint-20000
 action_horizon: 50
 embodiment_tag: NEW_EMBODIMENT
 video_backend: decord

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import numpy as np
 import torch
-import yaml
 from typing import Any
 
 import pytest
@@ -55,18 +54,11 @@ POLICY_GROUP_SIZES = {
 
 
 @pytest.fixture
-def policy_config_yaml(tmp_path):
-    """Write a copy of the g1 locomanip test config with model_path set to a
-    HuggingFace repo id so ``Gr00tClosedloopPolicyConfig.__post_init__`` passes
-    without a real checkpoint on disk (the remote policy never loads it)."""
-    src = Gr00tTestConstants.test_data_dir + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
-    with open(src) as f:
-        cfg = yaml.safe_load(f)
-    cfg["model_path"] = "nvidia/GR00T-N1.6-3B"  # HF id passes _is_huggingface_model_id
-    dst = tmp_path / "remote_closedloop_config.yaml"
-    with open(dst, "w") as f:
-        yaml.dump(cfg, f)
-    return str(dst)
+def policy_config_yaml():
+    """Return the g1 locomanip test config used for Arena-side obs/action translation."""
+    return (
+        Gr00tTestConstants.test_data_dir + "/test_g1_locomanip_lerobot/test_g1_locomanip_gr00t_closedloop_config.yaml"
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
  Summary:

  - Remove model_path from Gr00tClosedloopPolicyConfig.
  - Drop model_path entries from GR00T closed-loop policy YAMLs.
