### PR TITLE
Remove few boxes on the table top of the static apple scene

### DIFF
--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -87,6 +87,23 @@ _TUNED_SCALES: dict[str, tuple[float, float, float]] = {
     TUNED_DESTINATION_NAME: (0.5, 0.5, 0.5),
 }
 
+_BACKGROUND_PRIMS_TO_DEACTIVATE: tuple[str, ...] = (
+    "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_06",
+    "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_03",
+    "galileo_locomanip/BackgroundAssets/boxes/hesai_box_06",
+)
+
+
+def _deactivate_background_prims(env, env_ids, prim_relative_paths: tuple[str, ...]) -> None:
+    """Deactivate selected referenced background prims before simulation starts."""
+    del env_ids
+    stage = env.sim.stage
+    for env_prim_path in env.scene.env_prim_paths:
+        for prim_relative_path in prim_relative_paths:
+            prim_path = f"{env_prim_path}/{prim_relative_path}"
+            if stage.GetPrimAtPath(prim_path).IsValid():
+                stage.OverridePrim(prim_path).SetActive(False)
+
 
 def _shelf_spawn_z(asset_name: str) -> float:
     """Return the env-local Z to spawn ``asset_name`` flush on the shelf surface.
@@ -204,6 +221,19 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 f"{destination_label} on the same shelf next to it."
             )
 
+        def env_cfg_callback(env_cfg):
+            from isaaclab.managers import EventTermCfg
+
+            # The source galileo_locomanip USD includes boxes that sit in the
+            # static task workspace. Deactivate the referenced prims at startup so
+            # they are absent from the composed scene for every cloned environment.
+            env_cfg.events.deactivate_static_pick_place_background_prims = EventTermCfg(
+                func=_deactivate_background_prims,
+                mode="prestartup",
+                params={"prim_relative_paths": _BACKGROUND_PRIMS_TO_DEACTIVATE},
+            )
+            return env_cfg
+
         scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
         return IsaacLabArenaEnvironment(
             name=self.name,
@@ -220,6 +250,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 velocity_threshold=0.1,
             ),
             teleop_device=teleop_device,
+            env_cfg_callback=env_cfg_callback,
         )
 
     @staticmethod

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -87,6 +87,9 @@ _TUNED_SCALES: dict[str, tuple[float, float, float]] = {
     TUNED_DESTINATION_NAME: (0.5, 0.5, 0.5),
 }
 
+# The sim scene includes these boxes on the shelf/table workspace used by
+# the static pick-and-place task, where they can block or clutter the
+# apple-to-plate interaction area.
 _BACKGROUND_PRIMS_TO_DEACTIVATE: tuple[str, ...] = (
     "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_06",
     "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_03",
@@ -101,8 +104,15 @@ def _deactivate_background_prims(env, env_ids, prim_relative_paths: tuple[str, .
     for env_prim_path in env.scene.env_prim_paths:
         for prim_relative_path in prim_relative_paths:
             prim_path = f"{env_prim_path}/{prim_relative_path}"
-            if stage.GetPrimAtPath(prim_path).IsValid():
+            prim = stage.GetPrimAtPath(prim_path)
+            if prim.IsValid():
                 stage.OverridePrim(prim_path).SetActive(False)
+            else:
+                warnings.warn(
+                    f"_deactivate_background_prims: prim not found at '{prim_path}'; "
+                    "the background asset may still be visible.",
+                    stacklevel=1,
+                )
 
 
 def _shelf_spawn_z(asset_name: str) -> float:


### PR DESCRIPTION
## Summary
This PR removes a few background boxes from the `galileo_g1_static_pick_and_place` workspace so the static pick-and-place scene has clear table/shelf space.

## Detailed description
- The change was needed because several background box assets from the reused `galileo_locomanip` USD scene were sitting in the `galileo_g1_static_pick_and_place` workspace.
- This PR adds a prestartup environment callback that deactivates the specific `jetson_orin_06`, `jetson_orin_03`, and `hesai_box_06` background prims for every cloned environment.
- The static pick-and-place scene now has a clearer shelf/table workspace while preserving the rest of the `galileo_locomanip` background, lighting, and scene geometry.
- Only `isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py` is changed.

Before:
<img width="938" height="378" alt="before" src="https://github.com/user-attachments/assets/338753a4-04df-40b5-ae64-6c55ada4c3ce" />


After:
<img width="1183" height="425" alt="after" src="https://github.com/user-attachments/assets/e5c1c3d9-9813-4461-965e-a00caeb39842" />
