### PR TITLE
Static apple pick and place: Tune reset timeout and reset camera frame

### DIFF
--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -81,6 +81,12 @@ same machine).
 Note the lower ``--num_steps`` (600 instead of 1500): with no walking phase, a successful
 static apple-to-plate episode runs for roughly half as long as the loco-manipulation variant.
 
+.. note::
+
+   The 600-step command is intended as a quick smoke test. To get a more representative
+   success rate, run a longer evaluation with roughly 1000 policy steps; for this task,
+   that corresponds to setting ``--num_steps 30000``.
+
 The evaluation should produce the following output on the console at the end of the evaluation.
 You should see similar metrics.
 

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -242,9 +242,9 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 mode="prestartup",
                 params={"prim_relative_paths": _BACKGROUND_PRIMS_TO_DEACTIVATE},
             )
-            # The GR00T policy consumes camera observations. After timeout reset,
-            # force one RTX sensor refresh so the first post-reset policy query
-            # does not see the previous episode's final rendered frame.
+            # The GR00T policy consumes camera observations. Force one RTX sensor
+            # refresh after reset so the next policy query does not see the
+            # previous episode's final rendered frame.
             env_cfg.num_rerenders_on_reset = 1
             return env_cfg
 

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -242,6 +242,10 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 mode="prestartup",
                 params={"prim_relative_paths": _BACKGROUND_PRIMS_TO_DEACTIVATE},
             )
+            # The GR00T policy consumes camera observations. After timeout reset,
+            # force one RTX sensor refresh so the first post-reset policy query
+            # does not see the previous episode's final rendered frame.
+            env_cfg.num_rerenders_on_reset = 1
             return env_cfg
 
         scene = Scene(assets=[background, shelf_support, pick_up_object, destination])

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -253,7 +253,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 pick_up_object=pick_up_object,
                 destination_location=destination,
                 background_scene=background,
-                episode_length_s=30.0,
+                episode_length_s=6.0,
                 task_description=task_description,
                 # Mirror the locomanip env's success thresholds so metrics are comparable.
                 force_threshold=0.5,


### PR DESCRIPTION
## Summary
Tune static G1 timeout and reset camera

## Detailed description
- The change was needed because unsuccessful static apple pick-and-place trials were waiting too long before reset, and repeated evaluations could query GR00T with a stale camera frame immediately after timeout reset.
- This MR reduces `galileo_g1_static_pick_and_place` task duration from `30.0s` to `6.0s`, giving the robot enough time for about two pickup attempts before moving to the next trial.
- This MR also sets `env_cfg.num_rerenders_on_reset = 1` so RTX camera observations are refreshed after timeout reset before the next GR00T policy query.
- The impact is faster repeated evaluation with `--num_steps`, cleaner post-reset camera observations, and a small overhead of one extra render after each reset.