### PR TITLE
Support parallel envs in Pi0RemotePolicy

### DIFF
--- a/isaaclab_arena_openpi/policy/droid_adapter.py
+++ b/isaaclab_arena_openpi/policy/droid_adapter.py
@@ -16,7 +16,7 @@ from isaaclab_arena_openpi.policy.pi0_remote_policy import Pi0EmbodimentAdapter
 
 @dataclass(frozen=True)
 class DroidObservation:
-    """env-0 tensors needed to assemble an openpi DROID request."""
+    """Per-env tensors needed to assemble an openpi DROID request."""
 
     exterior_image: np.ndarray  # (H, W, 3) uint8
     wrist_image: np.ndarray  # (H, W, 3) uint8
@@ -50,14 +50,14 @@ class Pi0DroidAdapter(Pi0EmbodimentAdapter):
     arena_camera_obs_group = "camera_obs"
     arena_policy_obs_group = "policy"
 
-    def extract(self, observation: dict[str, Any]) -> DroidObservation:
+    def extract(self, observation: dict[str, Any], env_id: int) -> DroidObservation:
         cam = observation[self.arena_camera_obs_group]
         proprio = observation[self.arena_policy_obs_group]
         return DroidObservation(
-            exterior_image=cam[self.arena_external_camera_key][0].detach().cpu().numpy(),
-            wrist_image=cam[self.arena_wrist_camera_key][0].detach().cpu().numpy(),
-            joint_position=proprio["joint_pos"][0].detach().cpu().numpy(),
-            gripper_position=proprio["gripper_pos"][0].detach().cpu().numpy(),
+            exterior_image=cam[self.arena_external_camera_key][env_id].detach().cpu().numpy(),
+            wrist_image=cam[self.arena_wrist_camera_key][env_id].detach().cpu().numpy(),
+            joint_position=proprio["joint_pos"][env_id].detach().cpu().numpy(),
+            gripper_position=proprio["gripper_pos"][env_id].detach().cpu().numpy(),
         )
 
     def pack_request(self, extracted: DroidObservation, language_instruction: str) -> dict[str, Any]:

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -180,7 +180,7 @@ class Pi0RemotePolicy(PolicyBase):
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
         if self._cached_action_chunks is None:
             return  # not yet initialized; nothing to clear
-        ids = range(len(self._cached_action_chunks)) if env_ids is None else env_ids.tolist()
+        ids = range(len(self._cached_action_chunks)) if env_ids is None else env_ids.reshape(-1).tolist()
         for env_id in ids:
             self._cached_action_chunks[env_id] = None
             self._next_chunk_steps[env_id] = 0

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -30,8 +30,12 @@ class Pi0EmbodimentAdapter(ABC):
     open_loop_horizon_by_variant: dict[str, int]
 
     @abstractmethod
-    def extract(self, observation: dict[str, Any]) -> Any:
-        """Pull env tensors out of the arena gym observation dict.
+    def extract(self, observation: dict[str, Any], env_id: int) -> Any:
+        """Pull a single env's tensors out of the arena gym observation dict.
+
+        ``env_id`` selects which slice of each per-env tensor to read. openpi's
+        wire format takes one observation per request, so the policy loops over
+        envs and calls this once per env to assemble the per-env requests.
 
         Concrete return type is adapter-defined (typically a frozen dataclass);
         the policy treats it as an opaque value to round-trip through
@@ -80,8 +84,11 @@ class Pi0RemotePolicy(PolicyBase):
         )
         print("[Pi0RemotePolicy] Connected.")
 
-        self._cached_action_chunk: np.ndarray | None = None
-        self._next_chunk_step: int = 0
+        # Per-env action cache. Lazy-allocated on the first get_action call when
+        # num_envs is known. openpi's wire format is one obs per request, so we
+        # keep one chunk + one step counter per env and loop over them.
+        self._cached_action_chunks: list[np.ndarray | None] | None = None
+        self._next_chunk_steps: list[int] | None = None
         self.task_description: str | None = None
 
     @staticmethod
@@ -143,32 +150,40 @@ class Pi0RemotePolicy(PolicyBase):
         return cls(Pi0RemotePolicyArgs(**config_dict), openpi_embodiment_adapter=openpi_embodiment_adapter)
 
     def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
-        # TODO(cvolk, 2026-05-18): extend to parallel envs once the openpi
-        # server supports batched observations; today it accepts one obs
-        # per request.
-        assert (
-            env.unwrapped.num_envs == 1
-        ), f"Pi0RemotePolicy only supports num_envs=1 (openpi server limitation), got num_envs={env.unwrapped.num_envs}"
         assert self.task_description, (
             "Pi0RemotePolicy requires a non-empty language instruction"
             " (set via --language_instruction or on the task definition)."
         )
 
-        chunk_exhausted = self._cached_action_chunk is None or self._next_chunk_step >= self._open_loop_horizon
-        if chunk_exhausted:
-            self._cached_action_chunk = self._fetch_action_chunk(observation)
-            self._next_chunk_step = 0
+        num_envs = env.unwrapped.num_envs
+        self._maybe_init_per_env_state(num_envs)
 
-        next_action_np = self._cached_action_chunk[self._next_chunk_step]
-        self._next_chunk_step += 1
-        return torch.from_numpy(next_action_np).to(dtype=torch.float32, device=self.device).unsqueeze(0)
+        # TODO(cvolk): openpi server takes one obs per request, so we iterate
+        # over envs and send one inference per env that needs a fresh chunk.
+        # This is N-times slower than a single batched call but is correct
+        # for parallel envs; switch to a single batched call when openpi
+        # grows batched-inference support upstream.
+        actions = []
+        for env_id in range(num_envs):
+            chunk_exhausted = (
+                self._cached_action_chunks[env_id] is None or self._next_chunk_steps[env_id] >= self._open_loop_horizon
+            )
+            if chunk_exhausted:
+                self._cached_action_chunks[env_id] = self._fetch_action_chunk(observation, env_id)
+                self._next_chunk_steps[env_id] = 0
+            actions.append(self._cached_action_chunks[env_id][self._next_chunk_steps[env_id]])
+            self._next_chunk_steps[env_id] += 1
+
+        batch = np.stack(actions)  # (num_envs, action_dim)
+        return torch.from_numpy(batch).to(dtype=torch.float32, device=self.device)
 
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
-        # TODO(cvolk, 2026-05-18): honor env_ids when parallel envs are
-        # supported; today the cache is single-env and we always reset the
-        # whole thing.
-        self._cached_action_chunk = None
-        self._next_chunk_step = 0
+        if self._cached_action_chunks is None:
+            return  # not yet initialized; nothing to clear
+        ids = range(len(self._cached_action_chunks)) if env_ids is None else env_ids.tolist()
+        for env_id in ids:
+            self._cached_action_chunks[env_id] = None
+            self._next_chunk_steps[env_id] = 0
 
     def close(self) -> None:
         """Release the local websocket connection to the openpi server.
@@ -178,8 +193,18 @@ class Pi0RemotePolicy(PolicyBase):
         _close_websocket_best_effort(self._websocket_client)
         self._websocket_client = None
 
-    def _fetch_action_chunk(self, observation: dict[str, Any]) -> np.ndarray:
-        extracted = self._openpi_embodiment_adapter.extract(observation)
+    def _maybe_init_per_env_state(self, num_envs: int) -> None:
+        if self._cached_action_chunks is None:
+            self._cached_action_chunks = [None] * num_envs
+            self._next_chunk_steps = [0] * num_envs
+            return
+        assert len(self._cached_action_chunks) == num_envs, (
+            f"Pi0RemotePolicy num_envs changed from {len(self._cached_action_chunks)}"
+            f" to {num_envs} mid-rollout; recreate the policy for the new num_envs."
+        )
+
+    def _fetch_action_chunk(self, observation: dict[str, Any], env_id: int) -> np.ndarray:
+        extracted = self._openpi_embodiment_adapter.extract(observation, env_id)
         request = self._openpi_embodiment_adapter.pack_request(extracted, self.task_description)
         response = self._call_server_with_retry(request)
 
@@ -218,8 +243,13 @@ class Pi0RemotePolicy(PolicyBase):
                 self._websocket_client = websocket_client_policy.WebsocketClientPolicy(
                     host=self._remote_host, port=self._remote_port
                 )
-                self._cached_action_chunk = None
-                self._next_chunk_step = 0
+                # Flush every env's cache: the reconnected server may have lost
+                # state, so we force a fresh observation on the next get_action
+                # for each env rather than replay cached actions.
+                if self._cached_action_chunks is not None:
+                    for i in range(len(self._cached_action_chunks)):
+                        self._cached_action_chunks[i] = None
+                        self._next_chunk_steps[i] = 0
         raise RuntimeError("unreachable")
 
 

--- a/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
@@ -78,7 +78,7 @@ def make_policy(monkeypatch):
 def test_droid_adapter_uses_pi0_wire_keys():
     """The wire-format contract between Pi0DroidAdapter and the openpi droid server."""
     adapter = Pi0DroidAdapter()
-    extracted = adapter.extract(_fake_observation())
+    extracted = adapter.extract(_fake_observation(), env_id=0)
     server_request = adapter.pack_request(extracted, "pick up the block")
 
     assert set(server_request.keys()) == {
@@ -136,6 +136,53 @@ def test_get_action_caches_chunk_and_advances_index(make_policy):
     assert second_action[0, -1].item() == pytest.approx(0.7)
 
 
+def test_get_action_parallel_envs_loops_per_env(monkeypatch):
+    """num_envs>1: one infer per env per chunk refill, batched into (num_envs, action_dim)."""
+    call_count = {"n": 0}
+
+    def counting_infer(self, request):
+        call_count["n"] += 1
+        return {"actions": _synthetic_chunk()}
+
+    _patch_websocket_client(monkeypatch, infer_impl=counting_infer)
+    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    num_envs = 3
+    env = _fake_env(num_envs=num_envs)
+    obs = _fake_observation(num_envs=num_envs)
+
+    first_action = policy.get_action(env, obs)
+    second_action = policy.get_action(env, obs)
+
+    # One infer call per env on the first get_action (cache miss); none on the
+    # second (chunk row 1 is still cached for each env).
+    assert call_count["n"] == num_envs
+    assert first_action.shape == (num_envs, 8)
+    assert second_action.shape == (num_envs, 8)
+    for env_id in range(num_envs):
+        assert first_action[env_id, -1].item() == pytest.approx(0.2)
+        assert second_action[env_id, -1].item() == pytest.approx(0.7)
+
+
+def test_reset_honors_env_ids(monkeypatch):
+    """reset(env_ids) clears only those envs' caches; others keep replaying."""
+    _patch_websocket_client(monkeypatch)
+    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy.set_task_description("pick up the block")
+    env = _fake_env(num_envs=3)
+    obs = _fake_observation(num_envs=3)
+
+    policy.get_action(env, obs)  # populates caches for all 3 envs
+
+    policy.reset(env_ids=torch.tensor([0, 2]))
+
+    assert policy._cached_action_chunks[0] is None
+    assert policy._cached_action_chunks[1] is not None  # untouched
+    assert policy._cached_action_chunks[2] is None
+    assert policy._next_chunk_steps == [0, 1, 0]
+
+
 def test_call_server_with_retry_reconnects_on_drop(monkeypatch):
     """Drop the first connection; second call succeeds and cache is flushed."""
     call_count = {"n": 0}
@@ -150,15 +197,15 @@ def test_call_server_with_retry_reconnects_on_drop(monkeypatch):
     _patch_websocket_client(monkeypatch, infer_impl=flaky_infer)
     policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
     policy.set_task_description("pick up the block")
-    policy._cached_action_chunk = np.zeros((15, 8), dtype=np.float32)
-    policy._next_chunk_step = 5
+    policy._cached_action_chunks = [np.zeros((15, 8), dtype=np.float32)]
+    policy._next_chunk_steps = [5]
 
     response = policy._call_server_with_retry({"prompt": "x"})
 
     assert response is successful_response
     assert call_count["n"] == 2
-    assert policy._cached_action_chunk is None
-    assert policy._next_chunk_step == 0
+    assert policy._cached_action_chunks == [None]
+    assert policy._next_chunk_steps == [0]
 
 
 def test_call_server_with_retry_gives_up_after_max_attempts(monkeypatch):


### PR DESCRIPTION
## Summary

Arena rollouts can now request ``num_envs > 1`` instead of being restricted to single-env.

- Loop over envs on the Arena client side, with a per-env action-chunk cache and step counter (**openpi's format is still one obs per request**). 
- ``reset(env_ids)`` clears only the listed envs' caches, so per-env termination leaves untouched envs replaying uninterrupted.