### PR TITLE
Add Agent Skills library and refocus AGENTS.md

### DIFF
--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-and-pr
-description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, or open a pull request.
+description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, open a pull request, make a PR, submit changes, or mark work as ready to merge.
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(pre-commit *) Bash(gh pr create *) Bash(gh pr view *)
 ---

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -40,7 +40,7 @@ EOF
 
 ## Branch
 
-Branch naming: `<username>/<feature-desc>` — e.g. `cvolk/feature-video-recording`, `cvolk/refactor-no-unwrap`, `mimil/create-arena-external-workflow-skill`.
+Branch naming: `<username>/<feature-desc>` with a kebab-case feature description — e.g. `<username>/feature-video-recording`, `<username>/refactor-no-unwrap`.
 
 Do not use `feature/...`, `fix/...`, or `docs/...` prefixes.
 

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: commit-and-pr
 description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, or open a pull request.
 disable-model-invocation: true
-allowed-tools: Bash(git *) Bash(gh pr create *) Bash(gh pr view *)
+allowed-tools: Bash(git *) Bash(pre-commit *) Bash(gh pr create *) Bash(gh pr view *)
 ---
 
 # Commit and Pull Request

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: commit-and-pr
+description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and develop as the default base branch. Use when the user asks to commit, stage changes, push the current branch, or open a pull request.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh pr create *) Bash(gh pr view *)
+---
+
+# Commit and Pull Request
+
+Creates commits and PRs that follow Arena's contributor guidelines.
+
+## Commit
+
+1. Run the `pre-commit-check` skill (or `pre-commit run --all-files`) until the working tree is clean. Do not commit through hook failures.
+2. Stage **specific files** rather than using `git add -A` — this avoids accidentally committing dotfiles, credentials, or large untracked artifacts.
+3. Sign off the commit (DCO is required by Arena):
+
+   ```bash
+   git commit -s -m "<subject>"
+   ```
+
+4. **Subject line:** imperative mood, ~50 characters, no trailing period.
+   - Good: `Fix attribute access on wrapped env`
+   - Bad: `Fixed the attribute access on the wrapped env.` (past tense, trailing period)
+5. **Body** (when needed): blank line after the subject, wrap at 72 chars, explain *what* and *why* — not *how* (the diff shows that).
+6. **No AI attribution lines.** Do not include `Co-Authored-By: Claude...`, `Generated with Claude Code`, or similar footers. The DCO sign-off is the only required trailer.
+
+Use a heredoc for multi-paragraph messages so quoting stays clean:
+
+```bash
+git commit -s -m "$(cat <<'EOF'
+<subject>
+
+<body paragraph 1>
+
+<body paragraph 2>
+EOF
+)"
+```
+
+## Branch
+
+Branch naming: `<username>/<feature-desc>` — e.g. `cvolk/feature-video-recording`, `cvolk/refactor-no-unwrap`, `mimil/create-arena-external-workflow-skill`.
+
+Do not use `feature/...`, `fix/...`, or `docs/...` prefixes.
+
+## Pull request
+
+1. Push the branch (set upstream on first push):
+
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+2. Open the PR against `develop` (the active branch — `main` is under SQA and only receives fixes):
+
+   ```bash
+   gh pr create --base develop \
+     --title "<short imperative subject>" \
+     --body "<summary + test plan>"
+   ```
+
+3. PR title follows the same rules as a commit subject: imperative, ~70 chars max, no trailing period.
+
+## Iterating on review feedback
+
+When addressing review comments, **add new commits**. Do not `--amend` and force-push, because reviewers need to see each round of changes as a discrete commit.
+
+```bash
+# good
+git commit -s -m "Address review: rename foo to bar"
+git push
+
+# avoid
+git commit --amend
+git push --force
+```
+
+The exception: if a single commit is *purely* a typo fix in your own as-yet-unmerged work and no one has reviewed it, `--amend` is fine.
+
+## Verify
+
+Before declaring the work done:
+
+```bash
+gh pr view --json title,baseRefName,statusCheckRollup
+```
+
+Confirm:
+- `baseRefName` is `develop` (not `main`).
+- Title has no trailing period and is in imperative mood.
+- CI checks are running or green. Investigate any failures before requesting review.

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -83,10 +83,9 @@ The exception: if a single commit is *purely* a typo fix in your own as-yet-unme
 Before declaring the work done:
 
 ```bash
-gh pr view --json title,baseRefName,statusCheckRollup
+gh pr view --json title,baseRefName
 ```
 
 Confirm:
 - `baseRefName` is `main`.
 - Title has no trailing period and is in imperative mood.
-- CI checks are running or green. Investigate any failures before requesting review.

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-and-pr
-description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and develop as the default base branch. Use when the user asks to commit, stage changes, push the current branch, or open a pull request.
+description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, or open a pull request.
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(gh pr create *) Bash(gh pr view *)
 ---
@@ -52,10 +52,10 @@ Do not use `feature/...`, `fix/...`, or `docs/...` prefixes.
    git push -u origin <branch-name>
    ```
 
-2. Open the PR against `develop` (the active branch — `main` is under SQA and only receives fixes):
+2. Open the PR against `main` (the active branch):
 
    ```bash
-   gh pr create --base develop \
+   gh pr create --base main \
      --title "<short imperative subject>" \
      --body "<summary + test plan>"
    ```
@@ -87,6 +87,6 @@ gh pr view --json title,baseRefName,statusCheckRollup
 ```
 
 Confirm:
-- `baseRefName` is `develop` (not `main`).
+- `baseRefName` is `main`.
 - Title has no trailing period and is in imperative mood.
 - CI checks are running or green. Investigate any failures before requesting review.

--- a/.agents/skills/commit-and-pr/SKILL.md
+++ b/.agents/skills/commit-and-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-and-pr
-description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<feature-desc> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, open a pull request, make a PR, submit changes, or mark work as ready to merge.
+description: Creates Arena-conformant commits and pull requests. Enforces DCO sign-off (git commit -s), no AI attribution lines (no Co-Authored-By, no Generated-with-Claude footers), <username>/<type>/<short-description> branch naming, separate new commits rather than --amend when iterating on PR feedback, and main as the default base branch. Use when the user asks to commit, stage changes, push the current branch, open a pull request, make a PR, submit changes, or mark work as ready to merge.
 disable-model-invocation: true
 allowed-tools: Bash(git *) Bash(pre-commit *) Bash(gh pr create *) Bash(gh pr view *)
 ---
@@ -11,9 +11,9 @@ Creates commits and PRs that follow Arena's contributor guidelines.
 
 ## Commit
 
-1. Run the `pre-commit-check` skill (or `pre-commit run --all-files`) until the working tree is clean. Do not commit through hook failures.
+1. Run the `pre-commit-check` skill (or `pre-commit run --all-files` on the host — pre-commit is not installed in the container) until the working tree is clean. Do not commit through hook failures.
 2. Stage **specific files** rather than using `git add -A` — this avoids accidentally committing dotfiles, credentials, or large untracked artifacts.
-3. Sign off the commit (DCO is required by Arena):
+3. Sign off the commit (per `CONTRIBUTING.md` — Arena currently requires DCO sign-off; the policy is on the books but not yet CI-enforced):
 
    ```bash
    git commit -s -m "<subject>"
@@ -40,9 +40,11 @@ EOF
 
 ## Branch
 
-Branch naming: `<username>/<feature-desc>` with a kebab-case feature description — e.g. `<username>/feature-video-recording`, `<username>/refactor-no-unwrap`.
+Branch naming: `<username>/<type>/<short-description>` where `<type>` is one of `feature`, `fix`, `docs`, `refactor`, `chore`, `ci`, and `<short-description>` is kebab-case.
 
-Do not use `feature/...`, `fix/...`, or `docs/...` prefixes.
+Examples: `<username>/feature/video-recording`, `<username>/fix/eval-runner-teardown`, `<username>/docs/update-readme`.
+
+Do not use top-level type prefixes that omit the username (e.g. `feature/foo`, `fix/bar`).
 
 ## Pull request
 
@@ -57,10 +59,24 @@ Do not use `feature/...`, `fix/...`, or `docs/...` prefixes.
    ```bash
    gh pr create --base main \
      --title "<short imperative subject>" \
-     --body "<summary + test plan>"
+     --body "<see body format below>"
    ```
 
 3. PR title follows the same rules as a commit subject: imperative, ~70 chars max, no trailing period.
+
+4. PR body follows `.github/pull_request_template.md`:
+
+   ```markdown
+   ## Summary
+   <one-line description of the change, ≤50 chars>
+
+   ## Detailed description
+   - <why the change was needed>
+   - <what was changed>
+   - <impact / what to watch for>
+   ```
+
+   Keep it terse — 2–5 detail bullets total. Agent-generated PR bodies tend toward 5+ sections and 500+ words; resist that. The template's bullet form is the standard.
 
 ## Iterating on review feedback
 

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-container
-description: Sets up and manages the isaaclab_arena Docker container — the single environment used for Arena's development, testing, training, and evaluation. Use when the user asks to set up the dev environment, bootstrap the project, get started on a fresh clone, start developing, build or rebuild the image, start or attach to the container, or run any command inside it. Also covers ./docker/run_docker.sh flag combinations (-r rebuild, -g GR00T N1.6 dependencies, -d/-m/-e custom dataset/model/eval mounts), docker exec usage, and the /isaac-sim/python.sh aliasing.
+description: Sets up and manages the isaaclab_arena Docker container — the single environment used for Arena's development, testing, training, and evaluation. Use when the user asks to set up the dev environment, bootstrap the project, get started on a fresh clone, start developing, build or rebuild the image, start or attach to the container, or run any command inside it. Also covers ./docker/run_docker.sh flag combinations (-r rebuild, -R rebuild without cache, -d/-m/-e custom dataset/model/eval mounts), docker exec usage, and the /isaac-sim/python.sh aliasing.
 allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker ps *)
 ---
 
@@ -21,7 +21,7 @@ Idempotent: builds the image if it does not exist, starts the container if it is
 | Flag | Purpose |
 |---|---|
 | `-r` | Force image rebuild |
-| `-g` | Include GR00T N1.6 dependencies |
+| `-R` | Force image rebuild **without cache** |
 | `-d <path>` | Mount a custom dataset directory |
 | `-m <path>` | Mount a custom model directory |
 | `-e <path>` | Mount a custom eval directory |

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: dev-container
+description: Manages the isaaclab_arena Docker container — the single container that serves as Arena's dev, test, training, and eval environment. Covers ./docker/run_docker.sh flag combinations (-r rebuild, -g include GR00T N1.6 dependencies, -d/-m/-e custom dataset/model/eval mounts), executing commands in the running container via docker exec, and the /isaac-sim/python.sh aliasing. Use when the user asks to build, rebuild, start, attach to, or run a command inside the container.
+allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker ps *)
+---
+
+# Dev Container
+
+Arena uses a single Docker container (`isaaclab_arena-latest`) as the dev, test, training, and eval environment. There is no separate dev container.
+
+## Start or attach
+
+```bash
+./docker/run_docker.sh
+```
+
+Idempotent: builds the image if it does not exist, starts the container if it is not running, then attaches.
+
+## Common flag combinations
+
+| Flag | Purpose |
+|---|---|
+| `-r` | Force image rebuild |
+| `-g` | Include GR00T N1.6 dependencies |
+| `-d <path>` | Mount a custom dataset directory |
+| `-m <path>` | Mount a custom model directory |
+| `-e <path>` | Mount a custom eval directory |
+
+Example with custom mounts:
+
+```bash
+./docker/run_docker.sh -d ~/datasets -m ~/models -e ~/eval
+```
+
+## Run a command in the already-running container
+
+```bash
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && <command>"
+```
+
+The repo root is mounted at `/workspaces/isaaclab_arena` inside the container.
+
+## Python invocation
+
+Inside the container, `python` is aliased to `/isaac-sim/python.sh`. Both forms work, but **prefer `/isaac-sim/python.sh` explicitly** in `docker exec` invocations from outside the container, where the alias is not active.
+
+## Verify
+
+A container is up and importable when:
+
+```bash
+docker exec isaaclab_arena-latest bash -c \
+  "/isaac-sim/python.sh -c 'import isaaclab_arena; print(isaaclab_arena.__file__)'"
+```
+
+prints a path under `/workspaces/isaaclab_arena/`.

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-container
-description: Manages the isaaclab_arena Docker container — the single container that serves as Arena's dev, test, training, and eval environment. Covers ./docker/run_docker.sh flag combinations (-r rebuild, -g include GR00T N1.6 dependencies, -d/-m/-e custom dataset/model/eval mounts), executing commands in the running container via docker exec, and the /isaac-sim/python.sh aliasing. Use when the user asks to build, rebuild, start, attach to, or run a command inside the container.
+description: Sets up and manages the isaaclab_arena Docker container — the single environment used for Arena's development, testing, training, and evaluation. Use when the user asks to set up the dev environment, bootstrap the project, get started on a fresh clone, start developing, build or rebuild the image, start or attach to the container, or run any command inside it. Also covers ./docker/run_docker.sh flag combinations (-r rebuild, -g GR00T N1.6 dependencies, -d/-m/-e custom dataset/model/eval mounts), docker exec usage, and the /isaac-sim/python.sh aliasing.
 allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker ps *)
 ---
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: run-tests
+description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, verify the test suite passes, check whether a change broke anything, smoke-test the install, run smoke tests, or run coverage for a specific module.
+argument-hint: "[smoke]"
+allowed-tools: Bash(docker exec *)
+---
+
+# Run Tests
+
+**Default (no argument):** run all three phases in order.
+**`smoke`:** Phase 1 only (no-cameras, no-subprocess) — the fast install / sanity check used in the first-touch journey.
+
+The three phases use mutually exclusive pytest markers and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
+
+All commands run inside the already-running container via `docker exec`. If the container is not running, use the `dev-container` skill first.
+
+## Phase 1 — no cameras, no subprocess
+
+The fastest phase. Suitable on its own as a smoke check after install or after small edits.
+
+```bash
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && \
+   /isaac-sim/python.sh -m pytest -sv \
+   -m 'not with_cameras and not with_subprocess' isaaclab_arena/tests"
+```
+
+## Phase 2 — with cameras
+
+```bash
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && \
+   /isaac-sim/python.sh -m pytest -sv \
+   -m 'with_cameras and not with_subprocess' isaaclab_arena/tests"
+```
+
+## Phase 3 — with subprocess
+
+```bash
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && \
+   /isaac-sim/python.sh -m pytest -sv \
+   -m 'with_subprocess' isaaclab_arena/tests"
+```
+
+## Run a single test file or function
+
+```bash
+# single file
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && \
+   /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py"
+
+# single function
+docker exec isaaclab_arena-latest bash -c \
+  "cd /workspaces/isaaclab_arena && \
+   /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py::test_default_assets_registered"
+```
+
+## On failure
+
+1. Report the failing phase and the first failing test (file, function, and one-line error).
+2. Stop. Do not run later phases until the failure is investigated.
+3. If the failure looks unrelated to recent changes, run the same test in isolation to confirm.
+
+A run is "all green" only when all three phases pass with no failures or errors.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -12,7 +12,7 @@ allowed-tools: Bash(docker exec *)
 **`phase2`:** with-cameras only.
 **`phase3`:** with-subprocess only.
 
-The three phases use mutually exclusive pytest markers and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
+The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
 All commands run inside the already-running container via `docker exec`. If the container is not running, use the `dev-container` skill first.
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-tests
-description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, verify the test suite passes, check whether a change broke anything, smoke-test the install, run smoke tests, or run coverage for a specific module.
+description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, test their changes, verify the test suite passes, check whether a change broke anything (e.g. "did I break anything", "do the tests still pass", "is everything still working"), smoke-test the install, run smoke tests, or run coverage for a specific module.
 argument-hint: "[smoke]"
 allowed-tools: Bash(docker exec *)
 ---

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: run-tests
-description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, test their changes, verify the test suite passes, check whether a change broke anything (e.g. "did I break anything", "do the tests still pass", "is everything still working"), smoke-test the install, run smoke tests, or run coverage for a specific module.
-argument-hint: "[smoke]"
+description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, test their changes, verify the test suite passes, check whether a change broke anything (e.g. "did I break anything", "do the tests still pass", "is everything still working"), run only one specific phase (e.g. "run Phase 1", "run only the no-camera tests", "skip the camera and subprocess tests"), or run coverage for a specific module.
+argument-hint: "[phase1|phase2|phase3]"
 allowed-tools: Bash(docker exec *)
 ---
 
 # Run Tests
 
 **Default (no argument):** run all three phases in order.
-**`smoke`:** Phase 1 only (no-cameras, no-subprocess) — the fast install / sanity check used in the first-touch journey.
+**`phase1`:** no-cameras, no-subprocess only.
+**`phase2`:** with-cameras only.
+**`phase3`:** with-subprocess only.
 
 The three phases use mutually exclusive pytest markers and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
@@ -16,7 +18,7 @@ All commands run inside the already-running container via `docker exec`. If the 
 
 ## Phase 1 — no cameras, no subprocess
 
-The fastest phase. Suitable on its own as a smoke check after install or after small edits.
+The fastest of the three. Useful on its own when iterating on changes that don't touch rendering or subprocess paths.
 
 ```bash
 docker exec isaaclab_arena-latest bash -c \

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,12 @@ Isaac Lab-Arena is a composable environment-creation and policy-evaluation libra
 
 Recurring multi-step workflows (container management, the three-phase test suite, commits and PRs) are captured as Agent Skills under `.agents/skills/`. When a task matches a skill, prefer invoking it over re-deriving the procedure from this file.
 
+Claude Code reads the library via the committed `.claude/skills` symlink; Codex scans `.agents/skills/` directly.
+
 Fresh-clone setup (run once):
 
 ```bash
-ln -s ../.agents/skills .claude/skills    # so Claude Code reads the skill library
-pre-commit install                         # register git hooks
+pre-commit install    # register git hooks
 ```
 
 ## Docker environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,91 +2,39 @@
 
 This file provides guidance to AI coding agents (Claude Code, OpenAI Codex, etc.) when working with code in this repository.
 
-## Docker Environment
+## Project
 
-All commands (tests, linting, training scripts, etc.) must be run inside the Docker container. The default container is `isaaclab_arena-latest`, started via:
+Isaac Lab-Arena is a composable environment-creation and policy-evaluation library for robotics simulation, built on Isaac Sim 5.1 and Isaac Lab 2.3. Status: alpha (`v0.2.x`); APIs are unstable. `develop` is the active branch; `main` is under SQA and receives only fixes.
 
-```bash
-./docker/run_docker.sh          # build image (if needed) and start/attach
-./docker/run_docker.sh -r       # force rebuild
-./docker/run_docker.sh -g       # include GR00T N1.6 dependencies
-./docker/run_docker.sh -d ~/datasets -m ~/models -e ~/eval  # custom mount dirs
-```
+## Skill library
 
-The repo root is mounted at `/workspaces/isaaclab_arena` inside the container. To run a command in the already-running container:
+Recurring multi-step workflows (container management, the three-phase test suite, commits and PRs) are captured as Agent Skills under `.agents/skills/`. When a task matches a skill, prefer invoking it over re-deriving the procedure from this file.
+
+Fresh-clone setup (run once):
 
 ```bash
-docker exec isaaclab_arena-latest bash -c "cd /workspaces/isaaclab_arena && <command>"
+ln -s ../.agents/skills .claude/skills    # so Claude Code reads the skill library
+pre-commit install                         # register git hooks
 ```
 
-**Important:** Inside the container, `python` is aliased to `/isaac-sim/python.sh`, so both forms work. Prefer `/isaac-sim/python.sh` for explicitness (e.g. in `docker exec` commands run from outside the container, where the alias is not active).
+## Docker environment
 
-```bash
-# Example: run kitchen_pick_and_place with zero_action policy
-docker exec isaaclab_arena-latest bash -c "cd /workspaces/isaaclab_arena && \
-  /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \
-  --policy_type zero_action \
-  --num_steps 10 \
-  kitchen_pick_and_place \
-  --object cracker_box \
-  --embodiment franka_ik"
-```
+All commands (tests, linting, training scripts) must run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
-## Common Commands
+Use the `dev-container` skill for build, start, attach, and exec.
 
-### Running Tests
+## Repository layout
 
-Tests require Isaac Sim and run via pytest:
+- `isaaclab_arena/` — core package: `tasks/`, `policy/`, `evaluation/`, `embodiments/`, `scene/`, `assets/`, `tests/`
+- `isaaclab_arena_environments/`, `isaaclab_arena_examples/`, `isaaclab_arena_g1/`, `isaaclab_arena_gr00t/` — first-party extension packages
+- `docker/` — container build and run scripts
+- `submodules/` — vendored dependencies (IsaacLab, Isaac-GR00T, …)
+- `osmo/` — OSMO policy-runner workflow
+- `docs/` — Sphinx documentation
 
-```bash
-# Run all tests
-# Our tests are separated into different phases of running. To run the full test suite requires three commands.
-/isaac-sim/python.sh -m pytest -sv -m "not with_cameras and not with_subprocess" isaaclab_arena/tests
-/isaac-sim/python.sh -m pytest  -sv -m "with_cameras and not with_subprocess" isaaclab_arena/tests
-/isaac-sim/python.sh -m pytest  -sv -m "with_subprocess" isaaclab_arena/tests
+## Coding style
 
-# Run a single test file
-/isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py
-
-# Run a specific test function
-/isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py::test_default_assets_registered
-
-# Run tests that require cameras
-/isaac-sim/python.sh -m pytest isaaclab_arena/tests/ -m with_cameras
-```
-
-### Linting, Formatting, and Coding Style
-
-Pre-commit hooks enforce the style guide: black (line length 120), flake8, isort, pyupgrade (py310+), and codespell. Run checks **before** committing — not after:
-
-```bash
-# Install pre-commit hooks
-pre-commit install
-
-# Run all checks (if hooks modify files, stage them and re-run before committing)
-pre-commit run --all-files
-```
-
-### Contributing
-
-All commits must be signed off per DCO requirements:
-```bash
-git commit -s -m "Your commit message"
-```
-
-**Branch naming:** `<username>/feature-desc` (e.g. `cvolk/feature-video-recording`, `cvolk/refactor-no-unwrap`).
-
-**Commit messages:**
-- Subject: imperative mood, ~50 chars, no trailing period (e.g. "Fix attribute access on wrapped env")
-- Separate subject from body with a blank line
-- Body: explain *what* and *why* (not how — the diff shows that), wrap at 72 chars
-- Do not include AI attribution lines (e.g. "Co-Authored-By: Claude...")
-
-**PR iteration:** when addressing review feedback, add new commits rather than amending existing ones — this lets reviewers easily verify each change was addressed.
-
-### Coding Style
-
-- Prefer `assert` over `if-then-raise ValueError` for internal invariant checks. Use `assert condition, "message"` instead of `if not condition: raise ValueError("message")`.
+- Prefer `assert condition, "message"` over `if not condition: raise ValueError("message")` for internal invariant checks. (Formatting, imports, and typing are enforced by `pre-commit` — see `.pre-commit-config.yaml`.)
 
 ## Conventions
 
@@ -115,3 +63,10 @@ def test_foo():  # pytest-visible outer function
     result = run_simulation_app_function(_test_foo)
     assert result
 ```
+
+## Boundaries
+
+- **Never** force-push to `main`, `develop`, or `release/*`. **Instead**, push to a `<username>/feature-desc` branch and open a PR against `develop`.
+- **Never** add AI-attribution lines to commits (no `Co-Authored-By: Claude…`, no `Generated with…`). **Instead**, sign off with `git commit -s` — DCO is the only required trailer.
+- **Never** commit models, datasets, or secrets. **Instead**, keep them on the host and mount them via `./docker/run_docker.sh -d <datasets> -m <models> -e <eval>`.
+- **Ask first** before changing `docker/`, `.github/workflows/`, `.pre-commit-config.yaml`, or `submodules/` — these affect every contributor. **Instead** of pushing directly, open a draft PR or raise it in the relevant channel before merging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, OpenAI Codex, etc.
 
 ## Project
 
-Isaac Lab-Arena is a composable environment-creation and policy-evaluation library for robotics simulation, built on Isaac Sim 5.1 and Isaac Lab 2.3. Status: alpha (`v0.2.x`); APIs are unstable. `main` is the active development branch.
+Isaac Lab-Arena is a composable environment-creation and policy-evaluation library for robotics simulation, built on Isaac Sim 6.0 and Isaac Lab 3.0 Beta. Status: alpha (`v0.2.x`); APIs are unstable. `main` is the active development branch.
 
 ## Skill library
 
@@ -15,14 +15,16 @@ Claude Code reads the library via the committed `.claude/skills` symlink; Codex 
 Fresh-clone setup (run once):
 
 ```bash
-pre-commit install    # register git hooks
+pre-commit install    # on the host — registers git pre-commit hooks
 ```
 
 ## Docker environment
 
-All commands (tests, linting, training scripts) must run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
+Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
-Use the `dev-container` skill for build, start, attach, and exec.
+Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, isort, pyupgrade, codespell) runs **on the host**.
+
+Use the `dev-container` skill for build, start, attach, and exec inside the container.
 
 ## Repository layout
 
@@ -36,6 +38,7 @@ Use the `dev-container` skill for build, start, attach, and exec.
 ## Coding style
 
 - Prefer `assert condition, "message"` over `if not condition: raise ValueError("message")` for internal invariant checks. (Formatting, imports, and typing are enforced by `pre-commit` — see `.pre-commit-config.yaml`.)
+- PR bodies follow `.github/pull_request_template.md` — a one-line Summary plus 2–5 detail bullets. Resist the agent default of long, multi-section descriptions.
 
 ## Conventions
 
@@ -67,7 +70,7 @@ def test_foo():  # pytest-visible outer function
 
 ## Boundaries
 
-- **Never** force-push to `main` or `release/*`. **Instead**, push to a `<username>/feature-desc` branch and open a PR against `main`.
+- **Never** force-push to `main` or `release/*`. **Instead**, push to a `<username>/<type>/<short-description>` branch (`<type>` ∈ `feature`, `fix`, `docs`, `refactor`, `chore`, `ci`) and open a PR against `main`.
 - **Never** add AI-attribution lines to commits (no `Co-Authored-By: Claude…`, no `Generated with…`). **Instead**, sign off with `git commit -s` — DCO is the only required trailer.
 - **Never** commit models, datasets, or secrets. **Instead**, keep them on the host and mount them via `./docker/run_docker.sh -d <datasets> -m <models> -e <eval>`.
 - **Ask first** before changing `docker/`, `.github/workflows/`, `.pre-commit-config.yaml`, or `submodules/` — these affect every contributor. **Instead** of pushing directly, open a draft PR or raise it in the relevant channel before merging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, OpenAI Codex, etc.
 
 ## Project
 
-Isaac Lab-Arena is a composable environment-creation and policy-evaluation library for robotics simulation, built on Isaac Sim 5.1 and Isaac Lab 2.3. Status: alpha (`v0.2.x`); APIs are unstable. `develop` is the active branch; `main` is under SQA and receives only fixes.
+Isaac Lab-Arena is a composable environment-creation and policy-evaluation library for robotics simulation, built on Isaac Sim 5.1 and Isaac Lab 2.3. Status: alpha (`v0.2.x`); APIs are unstable. `main` is the active development branch.
 
 ## Skill library
 
@@ -66,7 +66,7 @@ def test_foo():  # pytest-visible outer function
 
 ## Boundaries
 
-- **Never** force-push to `main`, `develop`, or `release/*`. **Instead**, push to a `<username>/feature-desc` branch and open a PR against `develop`.
+- **Never** force-push to `main` or `release/*`. **Instead**, push to a `<username>/feature-desc` branch and open a PR against `main`.
 - **Never** add AI-attribution lines to commits (no `Co-Authored-By: Claude…`, no `Generated with…`). **Instead**, sign off with `git commit -s` — DCO is the only required trailer.
 - **Never** commit models, datasets, or secrets. **Instead**, keep them on the host and mount them via `./docker/run_docker.sh -d <datasets> -m <models> -e <eval>`.
 - **Ask first** before changing `docker/`, `.github/workflows/`, `.pre-commit-config.yaml`, or `submodules/` — these affect every contributor. **Instead** of pushing directly, open a draft PR or raise it in the relevant channel before merging.


### PR DESCRIPTION
## Summary

Starts an Agent Skills library for Arena under `.agents/skills/` with a `.claude/skills/` symlink for Claude Code compatibility, and refocuses `AGENTS.md`.

Three skills introduced:

- **`dev-container`** — Docker container lifecycle (build, start, exec, the `python` aliasing).
- **`run-tests`** — three-phase pytest suite with a `smoke` argument for fast install verification.
- **`commit-and-pr`** — DCO sign-off, branch naming, no-AI-attribution, `main` as base, new-commits-on-feedback rule. `disable-model-invocation: true` so it stays user-initiated.

`AGENTS.md` procedures move into skills, and new sections (Project / Repository layout / Boundaries with paired Don't/Do) cover the standing context that recent AGENTS.md best practices recommend.

## Test plan
On a fresh clone and newly spawned agent:
- [x] Prompt via `"Lets set up arena"` installs the container, checks mounted repo and installs pre-commit hook
- [x] skills are listed under `/skills`
- [x] `/dev-container` brings the container up; `docker exec ... import isaaclab_arena` resolves.
- [x] `/run-tests` (no argument) runs all three phases in order.
- [ ] Codex discovers all three skills from `.agents/skills/` without the symlink.
- [x] Claude Code discovers all three skills via the `.claude/skills/` symlink.

## References

- [A good AGENTS.md is a model upgrade — Augment Code, Apr 22 2026](https://www.augmentcode.com/blog/how-to-write-good-agents-dot-md-files)
- [How to Build Your AGENTS.md (2026) — Augment Code](https://www.augmentcode.com/guides/how-to-build-agents-md)