### PR TITLE
enable external cam in teleop

### DIFF
--- a/isaaclab_arena/scripts/imitation_learning/teleop.py
+++ b/isaaclab_arena/scripts/imitation_learning/teleop.py
@@ -77,9 +77,9 @@ def main() -> None:
         env_cfg.terminations.object_reached_goal = DoneTerm(func=mdp.object_reached_goal)
 
     if args_cli.xr:
-        # External cameras are not supported with XR teleop
-        # Check for any camera configs and disable them
-        env_cfg = remove_camera_configs(env_cfg)
+        # If cameras are not enabled and XR is enabled, remove camera configs
+        if not args_cli.enable_cameras:
+            env_cfg = remove_camera_configs(env_cfg)
         env_cfg.sim.render.antialiasing_mode = "DLSS"
 
     try:


### PR DESCRIPTION
## Summary
Cherrypick from https://github.com/isaac-sim/IsaacLab-Arena/pull/696

## Detailed description
- `teleop.py` unconditionally called `remove_camera_configs(env_cfg)` whenever `args_cli.xr` was true, even with `--enable_cameras` set. `args_cli.xr` is auto-set by openxr teleop devices, so any user combining `--teleop_device openxr` with `--enable_cameras` ended up with camera scene entities stripped but the matching `camera_obs.<cam>_rgb` observation terms still in place. The env failed to construct with `The scene entity 'robot_head_cam' does not exist`.
- Gate the call on `not args_cli.enable_cameras`, mirroring the existing logic in `record_demos.py`.