### PR TITLE
Cherry-pick (#695) to release v0.2.1: Improve G1 static apple data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,14 @@ env.reset()
 
 Explore more examples in the [documentation](https://isaac-sim.github.io/IsaacLab-Arena/main/index.html), including:
 
+<p align="center">
+  <img src="docs/images/static_apple_pick_and_place.gif" alt="G1 static apple-to-plate pick and place" width="80%">
+</p>
+
 | Example | Description |
 |---------|-------------|
 | **Imitation Learning** | |
+| [G1 Static Apple-to-Plate](https://isaac-sim.github.io/IsaacLab-Arena/main/pages/example_workflows/static_apple/index.html) | G1 humanoid picks an apple and places it onto a plate on the same shelf without locomotion |
 | [G1 Loco-Manipulation Pick & Place](https://isaac-sim.github.io/IsaacLab-Arena/main/pages/example_workflows/locomanipulation/index.html) | G1 humanoid navigates, picks up a box, and places it in a bin |
 | [GR1 Open Microwave Door](https://isaac-sim.github.io/IsaacLab-Arena/main/pages/example_workflows/static_manipulation/index.html) | GR1 upper-body manipulation of an articulated microwave door |
 | [GR1 Sequential Pick & Place and Close Door](https://isaac-sim.github.io/IsaacLab-Arena/main/pages/example_workflows/sequential_static_manipulation/index.html) | GR1 picks an object, places it in a fridge, and closes the door |

--- a/docs/images/static_apple_pick_and_place.gif
+++ b/docs/images/static_apple_pick_and_place.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74b5e0f7bbf0f04247f3e655da74c83aa54ca6bb786c8bee18ec4f3c38c23831
+size 3509328

--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -3,6 +3,10 @@ Unitree G1 Static Apple-to-Plate Task
 
 This example demonstrates the complete workflow for the **Unitree G1 static (no-locomotion) apple-to-plate task** in Isaac Lab - Arena, covering environment setup and validation, teleoperation data collection (OpenXR with Meta Quest 3 or Pico 4 Ultra), policy post-training directly on the recorded teleop demonstrations, and closed-loop evaluation.
 
+.. image:: ../../../images/static_apple_pick_and_place.gif
+   :align: center
+   :height: 400px
+
 The training step uses a **standalone clone of NVIDIA's Isaac-GR00T (N1.7) repository** rather than
 the GR00T submodule pinned inside Arena, and evaluation runs over Arena's
 **server-client (remote-policy) architecture**: the GR00T server hosts the finetuned checkpoint in

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -172,7 +172,7 @@ Step 4: Record with the headset device
         --device cpu \
         --enable_cameras \
         --dataset_file $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
-        --num_demos 10 \
+        --num_demos 20 \
         --num_success_steps 10 \
         --disable_full_sim_buffer_reset \
         galileo_g1_static_pick_and_place \
@@ -184,7 +184,10 @@ Step 4: Record with the headset device
 
 #. Follow Step 3 to connect the headset again.
 
-#. Complete the task for each demo. Reset between demos. The script saves successful runs to the HDF5 file above.
+#. Complete the task for each demo. After a successful placement, wait for the demo to
+   automatically end and for the simulation to freeze before pressing **Reset**. Resetting
+   early can save an incomplete or failed demonstration. The script saves successful runs
+   to the HDF5 file above.
 
 .. important::
 
@@ -210,6 +213,8 @@ Step 4: Record with the headset device
      and side grasps, so the policy does not overfit to one approach direction.
    * **Clean successes only:** save only runs with no unnecessary collisions, no dropped objects before
      placement, and no recovery motions that would confuse the policy.
+   * **Wait for success freeze:** after releasing the apple onto the plate, keep the scene stable and
+     wait until the recording auto-terminates/freezes. Only reset after that happens.
    * **Trajectory length:** aim for demonstrations around 200--400 timesteps. Very long episodes slow
      down downstream data processing, while very short episodes tend to contain abrupt motion.
    * **Replay validation:** after recording, replay the HDF5 with Step 5 and inspect camera frames,
@@ -233,6 +238,13 @@ Step 4: Record with the headset device
 
    Releasing a small round object onto a flat plate is noticeably harder than dropping a box into a
    bin. Keep the release height low and the orientation stable.
+
+   .. figure:: ../../../images/static_apple_pick_and_place.gif
+      :width: 100%
+      :alt: Static apple-to-plate demonstration with the Unitree G1
+      :align: center
+
+      Example static apple-to-plate demonstration trajectory.
 
 
 Step 5: Replay Recorded Demos (Optional)

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping
 from typing import Any
 
 from isaaclab.envs import ManagerBasedRLMimicEnv
@@ -48,6 +49,12 @@ class EmbodimentBase(Asset):
 
     def set_initial_pose(self, pose: Pose) -> None:
         self.initial_pose = pose
+
+    def set_joint_initial_pos(self, joint_pos: Mapping[str, float]) -> None:
+        """Update the robot's initial joint positions by joint name."""
+        if self.scene_config is None or not hasattr(self.scene_config, "robot"):
+            raise RuntimeError("scene_config must be populated with a `robot` before calling `set_joint_initial_pos`.")
+        self.scene_config.robot.init_state.joint_pos.update(joint_pos)
 
     def get_scene_cfg(self) -> Any:
         if self.initial_pose is not None:

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -38,6 +38,8 @@ from isaaclab_arena_g1.g1_env.mdp import g1_observations as g1_observations_mdp
 from isaaclab_arena_g1.g1_env.mdp.actions.g1_decoupled_wbc_joint_action_cfg import G1DecoupledWBCJointActionCfg
 from isaaclab_arena_g1.g1_env.mdp.actions.g1_decoupled_wbc_pink_action_cfg import G1DecoupledWBCPinkActionCfg
 
+_G1_WAIST_JOINT_NAMES = ("waist_yaw_joint", "waist_roll_joint", "waist_pitch_joint")
+
 
 class G1EmbodimentBase(EmbodimentBase):
     """Embodiment for the G1 robot."""
@@ -75,6 +77,28 @@ class G1EmbodimentBase(EmbodimentBase):
         """Pelvis prim path so OpenXR teleop poses are rebased into robot base frame for IK."""
         return "/World/envs/env_0/Robot/pelvis"
 
+    def set_finger_contact_friction(
+        self,
+        *,
+        material_path: str,
+        static_friction: float,
+        dynamic_friction: float,
+        prim_name_markers: Sequence[str],
+    ) -> None:
+        """Configure a prestartup event that binds contact friction to G1 finger prims."""
+        if self.event_config is None or self.event_config is MISSING:
+            raise RuntimeError("event_config must be populated before calling `set_finger_contact_friction`.")
+        self.event_config.apply_high_friction_to_g1_fingers = EventTerm(
+            func=g1_events_mdp.apply_high_friction_to_g1_fingers,
+            mode="prestartup",
+            params={
+                "material_path": material_path,
+                "static_friction": static_friction,
+                "dynamic_friction": dynamic_friction,
+                "prim_name_markers": tuple(prim_name_markers),
+            },
+        )
+
 
 # Default camera offset pose
 _DEFAULT_G1_CAMERA_OFFSET = Pose(
@@ -97,6 +121,7 @@ class G1WBCJointEmbodiment(G1EmbodimentBase):
         initial_pose: Pose | None = None,
         camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
         use_tiled_camera: bool = True,  # Default to tiled for parallel evaluation
+        lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
         self.action_config = G1WBCJointActionCfg()
@@ -124,9 +149,12 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
         initial_pose: Pose | None = None,
         camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
         use_tiled_camera: bool = False,  # Default to regular for single env
+        lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
         self.action_config = G1WBCPinkActionCfg()
+        if lock_waist:
+            _remove_waist_from_pink_ik_action_config(self.action_config)
         self.observation_config = G1WBCPinkObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
@@ -154,10 +182,13 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         initial_pose: Pose | None = None,
         camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
         use_tiled_camera: bool = False,
+        lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
         self.scene_config = G1AgileSceneCfg()
         self.action_config = G1WBCAgilePinkActionCfg()
+        if lock_waist:
+            _remove_waist_from_pink_ik_action_config(self.action_config)
         self.observation_config = G1WBCPinkObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
@@ -187,6 +218,7 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         initial_pose: Pose | None = None,
         camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
         use_tiled_camera: bool = True,
+        lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
         self.scene_config = G1AgileSceneCfg()
@@ -770,12 +802,24 @@ class G1WBCAgilePinkActionCfg:
     )
 
 
+def _remove_waist_from_pink_ik_action_config(
+    action_config: G1WBCPinkActionCfg | G1WBCAgilePinkActionCfg,
+) -> None:
+    """Remove waist joints from a Pink IK action config's extra active joint set."""
+    action_config.g1_action.upperbody_extra_active_joints = [
+        joint_name
+        for joint_name in action_config.g1_action.upperbody_extra_active_joints
+        if joint_name not in _G1_WAIST_JOINT_NAMES
+    ]
+
+
 @configclass
 class G1WBCJointEventCfg:
     """Configuration for events."""
 
     reset_all = EventTerm(func=reset_all_articulation_joints, mode="reset")
     reset_wbc_policy = EventTerm(func=g1_events_mdp.reset_decoupled_wbc_joint_policy, mode="reset")
+    apply_high_friction_to_g1_fingers: EventTerm | None = None
 
 
 @configclass
@@ -784,6 +828,7 @@ class G1WBCPinkEventCfg:
 
     reset_all = EventTerm(func=reset_all_articulation_joints, mode="reset")
     reset_wbc_policy = EventTerm(func=g1_events_mdp.reset_decoupled_wbc_pink_policy, mode="reset")
+    apply_high_friction_to_g1_fingers: EventTerm | None = None
 
 
 class G1MimicEnv(ManagerBasedRLMimicEnv):

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -101,6 +101,14 @@ def rollout_policy(
                     # Break if number of episodes is reached
                     completed_episodes = env_ids.shape[0]
                     num_episodes_completed += completed_episodes
+                    if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
+                        from isaaclab_arena.metrics.metrics import compute_metrics
+
+                        metrics = compute_metrics(env.unwrapped)
+                        tqdm.tqdm.write(
+                            f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
+                            f" {metrics_to_plain_python_types(metrics)}"
+                        )
                     if num_episodes is not None:
                         pbar.update(completed_episodes)
                         if num_episodes_completed >= num_episodes:

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -15,9 +15,9 @@ HOMIE behaviour. The other differences from the locomanip env are:
 
 1. The destination plate sits on the *same* shelf as the apple (within arm's reach), so
    the robot never needs to drive its base anywhere -- WBC just holds the standing pose.
-2. The apple's spawn pose is randomized per episode within ``APPLE_SPAWN_XY_RANGE_M``
-   (XY only) so recorded demos have spatial variation; the destination plate stays at a
-   fixed pose so the place target is identical across episodes.
+2. The apple's spawn pose is configured through ``APPLE_SPAWN_XY_RANGE_M`` (XY only);
+   the branch sets that range to zero for deterministic demos. The destination plate
+   stays at a fixed pose so the place target is identical across episodes.
 """
 
 from __future__ import annotations
@@ -43,15 +43,17 @@ if TYPE_CHECKING:
 #   shelf on the first sim tick (which would otherwise launch them upward).
 SHELF_SURFACE_Z = -0.030
 SHELF_AIRGAP = 0.005
-SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - 0.02)
+SHELF_SUPPORT_PATCH_SIZE = (0.8, 1.5, 0.04)
+# Cuboid center: top face = SHELF_SURFACE_Z.
+SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - SHELF_SUPPORT_PATCH_SIZE[2] / 2.0)
 
-# Object XY spawn pose (env-local frame, shelf-relative). X mirrors the locomanip env
-# (the only on-shelf X we have ground-truth data for via the brown_box flow). The pickup
-# Y also mirrors locomanip (Y=0.18); the destination is offset -0.24 m in Y so the
-# plate's 30 cm footprint clears the apple without collision. Earlier we tried Y=0.30
-# for the apple but a smoke test showed it rolls off the shelf edge from there.
-PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
-DESTINATION_SPAWN_XY = (0.5785, -0.06)
+# Object XY spawn pose (env-local frame, table-relative). X mirrors the locomanip env
+# (the only on-table X we have ground-truth data for via the brown_box flow). Y values
+# are tuned for the static apple-to-plate setup: both objects sit left on the table,
+# and the plate is close enough to reduce unnecessary reach while still clearing the
+# apple.
+PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.27)
+DESTINATION_SPAWN_XY = (0.5785, 0.06)
 
 # Half-range of the apple's per-episode XY randomization at reset, in metres. Mirrors
 # the locomanip env's ``XY_RANGE_M = 0.025`` but tightened to 0.020 because the static
@@ -61,7 +63,7 @@ DESTINATION_SPAWN_XY = (0.5785, -0.06)
 # the apple at the exact same XY, which limits the spatial variation a finetuned policy
 # can generalize over. The destination plate is left at a fixed Pose so the place
 # target is identical across episodes.
-APPLE_SPAWN_XY_RANGE_M = 0.020
+APPLE_SPAWN_XY_RANGE_M = 0.0
 
 # Per-asset Z offset from the asset's USD origin to its bottom face. Added on top of
 # ``SHELF_SURFACE_Z + SHELF_AIRGAP`` so the asset's *bottom* lands on the shelf rather
@@ -153,36 +155,64 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
     name: str = "galileo_g1_static_pick_and_place"
 
     def get_env(self, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
+        from isaaclab import sim as sim_utils
+
+        from isaaclab_arena.assets.object import Object
+        from isaaclab_arena.assets.object_base import ObjectType
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.scene.scene import Scene
         from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
         from isaaclab_arena.utils.pose import Pose, PoseRange
+        from isaaclab_arena_environments.mdp.galileo_g1_static_pick_and_place.robot_configs import (
+            G1_STATIC_FINGER_DYNAMIC_FRICTION,
+            G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
+            G1_STATIC_FINGER_PRIM_NAME_MARKERS,
+            G1_STATIC_FINGER_STATIC_FRICTION,
+            G1_STATIC_OPEN_ARM_JOINT_POS,
+        )
 
         # Reuse the locomanip background USD: it bakes in lighting and provides the same
         # shelf-in-front-of-robot geometry the locomanip env was tuned against.
         background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-        # The imported shelf mesh has uneven/perforated collision in the task region:
-        # small objects can fall through parts of the visible shelf. Add an invisible
-        # kinematic cuboid flush with the shelf top so task objects see a clean support.
-        shelf_support = self.asset_registry.get_asset_by_name("procedural_table")(
-            instance_name="static_pick_place_shelf_support",
+        # This is a local collision patch for this exact scene rather than a reusable
+        # library asset. The imported shelf mesh has uneven/perforated collision in the
+        # static task region, so small objects can fall through parts of the visible shelf.
+        shelf_support = Object(
+            name="static_pick_place_shelf_support",
             prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
+            object_type=ObjectType.BASE,
+            spawner_cfg=sim_utils.CuboidCfg(
+                size=SHELF_SUPPORT_PATCH_SIZE,
+                collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+                visible=False,
+            ),
         )
         pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=_asset_scale(args_cli.object))
         destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
             scale=_asset_scale(args_cli.destination)
         )
-        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
+            enable_cameras=args_cli.enable_cameras,
+            lock_waist=args_cli.lock_waist,
+        )
+        embodiment.set_finger_contact_friction(
+            material_path=G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
+            static_friction=G1_STATIC_FINGER_STATIC_FRICTION,
+            dynamic_friction=G1_STATIC_FINGER_DYNAMIC_FRICTION,
+            prim_name_markers=G1_STATIC_FINGER_PRIM_NAME_MARKERS,
+        )
 
         if args_cli.teleop_device is not None:
             teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
         else:
             teleop_device = None
 
-        # Robot pose mirrors the locomanip env exactly so the WBC controller stands the
-        # robot up in the same shelf-relative spot. The controller dynamically lifts the
-        # pelvis to ~z=0.74 at runtime; init_state.pos.z=0 is correct.
-        embodiment.set_initial_pose(Pose(position_xyz=(0.3, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        # Robot pose is tuned for the same-shelf static task: slightly forward toward
+        # the table while preserving the lateral offset that keeps both arms usable.
+        # The controller dynamically lifts the pelvis to ~z=0.74 at runtime;
+        # init_state.pos.z=0 is correct.
+        embodiment.set_initial_pose(Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
         shelf_support.set_initial_pose(
             Pose(position_xyz=SHELF_SUPPORT_PATCH_CENTER, rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
         )
@@ -283,5 +313,20 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
             help=(
                 "Override the natural-language task description. Defaults to a template "
                 "derived from --object and --destination."
+            ),
+        )
+        # The static task is upper-body-only by design, so we lock the 3 waist
+        # joints by default. Pass ``--no-lock_waist`` to fall back to the default
+        # AGILE-pink behaviour (waist active in Pink IK for extended arm reach).
+        parser.add_argument(
+            "--lock_waist",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help=(
+                "Remove waist_yaw/roll/pitch from the upper-body Pink IK active set so "
+                "the torso stays fixed during teleoperation and recorded observations. "
+                "On by default for this static task; pass --no-lock_waist to allow the "
+                "IK to use the waist for extended arm reach (the production AGILE-pink "
+                "default)."
             ),
         )

--- a/isaaclab_arena_environments/mdp/galileo_g1_static_pick_and_place/__init__.py
+++ b/isaaclab_arena_environments/mdp/galileo_g1_static_pick_and_place/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MDP configuration helpers for the Galileo G1 static pick-and-place task."""
+
+from .robot_configs import *  # noqa: F401, F403

--- a/isaaclab_arena_environments/mdp/galileo_g1_static_pick_and_place/robot_configs.py
+++ b/isaaclab_arena_environments/mdp/galileo_g1_static_pick_and_place/robot_configs.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Robot-specific configuration constants for the G1 static apple task."""
+
+from __future__ import annotations
+
+# Mild open-arm posture using shoulder joints only. Shoulder yaw keeps the forearms in
+# the liked orientation; shoulder roll moves the arms away from the torso.
+G1_STATIC_OPEN_ARM_JOINT_POS: dict[str, float] = {
+    "left_shoulder_roll_joint": 0.25,
+    "right_shoulder_roll_joint": -0.25,
+    "left_shoulder_yaw_joint": 0.5,
+    "right_shoulder_yaw_joint": -0.5,
+}
+
+G1_STATIC_FINGER_FRICTION_MATERIAL_PATH = "/World/Materials/g1_static_pick_place_high_friction_fingers"
+G1_STATIC_FINGER_STATIC_FRICTION = 6.0
+G1_STATIC_FINGER_DYNAMIC_FRICTION = 5.0
+G1_STATIC_FINGER_PRIM_NAME_MARKERS: tuple[str, ...] = (
+    "hand",
+    "thumb",
+    "index",
+    "middle",
+)

--- a/isaaclab_arena_g1/g1_env/mdp/g1_events.py
+++ b/isaaclab_arena_g1/g1_env/mdp/g1_events.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import torch
+import warnings
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -31,3 +33,56 @@ def reset_decoupled_wbc_pink_policy(env: ManagerBasedEnv, env_ids: torch.Tensor)
     env.action_manager.get_term("g1_action")._is_navigating = False
     env.action_manager.get_term("g1_action")._navigation_goal_reached = False
     env.action_manager.get_term("g1_action")._num_navigation_subgoals_reached = -1
+
+
+def apply_high_friction_to_g1_fingers(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    material_path: str,
+    static_friction: float,
+    dynamic_friction: float,
+    prim_name_markers: Sequence[str],
+) -> None:
+    """Bind a high-friction contact material to G1 hand/finger collision prims."""
+    del env_ids
+    from isaaclab.sim import bind_physics_material
+    from isaaclab.sim.spawners.materials import RigidBodyMaterialCfg
+    from pxr import UsdPhysics, UsdShade
+
+    stage = env.sim.stage
+    material_cfg = RigidBodyMaterialCfg(
+        static_friction=static_friction,
+        dynamic_friction=dynamic_friction,
+        friction_combine_mode="max",
+    )
+    material_cfg.func(material_path, material_cfg)
+
+    bound_count = 0
+    for env_prim_path in env.scene.env_prim_paths:
+        robot_prim_path = f"{env_prim_path}/Robot"
+        for prim in stage.Traverse():
+            prim_path = str(prim.GetPath())
+            if not prim_path.startswith(robot_prim_path):
+                continue
+            prim_path_lower = prim_path.lower()
+            if not any(marker in prim_path_lower for marker in prim_name_markers):
+                continue
+            applied_schemas = set(prim.GetAppliedSchemas())
+            has_collision_api = prim.HasAPI(UsdPhysics.CollisionAPI) or "PhysicsCollisionAPI" in applied_schemas
+            if not has_collision_api:
+                continue
+
+            bind_physics_material(prim_path, material_path, stage=stage)
+            # bind_physics_material is decorated with apply_nested and returns None, so
+            # verify the resulting direct physics material binding explicitly.
+            material_binding_api = UsdShade.MaterialBindingAPI(prim)
+            direct_binding = material_binding_api.GetDirectBinding("physics")
+            if str(direct_binding.GetMaterialPath()) == material_path:
+                bound_count += 1
+
+    if bound_count == 0:
+        warnings.warn(
+            "apply_high_friction_to_g1_fingers: no G1 hand/finger collision prims were found; "
+            "G1 hand friction may be unchanged.",
+            stacklevel=1,
+        )


### PR DESCRIPTION
## Summary
This MR is cherry-pick of #695 from main branch
Improve static apple data collection

## Detailed description
- The static G1 apple-to-plate workflow needed more reliable teleoperation and demo collection for policy training.
- This change retunes the static pick-and-place scene by moving the apple and plate to a better same-shelf layout, moving the robot slightly closer to the table, setting apple XY randomization to zero, and keeping the plate fixed.
- It also improves grasp stability by applying high-friction material to G1 hand/finger collision prims, opens the initial arm posture, and locks the G1 waist by default to prevent torso motion from leaking into recorded demonstrations.
- The shelf support is changed to an invisible static cuboid, and the demo reset flow no longer calls `env.sim.reset()` before `env.reset()`.
- Documentation is updated with a static apple-to-plate GIF, README entry, and revised teleoperation guidance.
- Impact: static apple demo collection should be more deterministic, easier to teleoperate, and better suited for GR00T fine-tuning and closed-loop evaluation.