### PR TITLE
Add optional full sim buffer reset in record_demos script and fix E2E workflow bugs

### DIFF
--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -174,6 +174,7 @@ Step 4: Record with the headset device
         --dataset_file $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
         --num_demos 10 \
         --num_success_steps 10 \
+        --disable_full_sim_buffer_reset \
         galileo_g1_static_pick_and_place \
         --object apple_01_objaverse_robolab \
         --destination clay_plates_hot3d_robolab \
@@ -194,6 +195,16 @@ Step 4: Record with the headset device
    above records ``--num_demos 10`` for a fast tutorial pass. For better inference results, change it
    to ``--num_demos 400`` and keep ``--num_success_steps 10`` so each successful episode includes
    extra stable frames after the success condition is triggered.
+
+.. note::
+
+   **Record in smaller batches.** Rather than collecting all demonstrations in a single
+   ``record_demos.py`` session, split the run into smaller batches (ideally **50 or fewer demos per
+   batch**). Use a different ``--dataset_file`` path per batch (e.g.
+   ``arena_g1_static_apple_dataset_recorded_batch01.hdf5``,
+   ``..._batch02.hdf5``, ...) and merge the HDF5 files afterward. Smaller batches reduce the risk
+   of losing all progress to a long-session crash, keep simulator state cleaner across episodes,
+   and let you take breaks between batches so demonstration quality stays consistent.
 
    Policy success rate depends heavily on both dataset quality and dataset size. For better success
    rates, collect more clean demonstrations with smooth actions, stable grasps, and no unnecessary

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -196,16 +196,6 @@ Step 4: Record with the headset device
    to ``--num_demos 400`` and keep ``--num_success_steps 10`` so each successful episode includes
    extra stable frames after the success condition is triggered.
 
-.. note::
-
-   **Record in smaller batches.** Rather than collecting all demonstrations in a single
-   ``record_demos.py`` session, split the run into smaller batches (ideally **50 or fewer demos per
-   batch**). Use a different ``--dataset_file`` path per batch (e.g.
-   ``arena_g1_static_apple_dataset_recorded_batch01.hdf5``,
-   ``..._batch02.hdf5``, ...) and merge the HDF5 files afterward. Smaller batches reduce the risk
-   of losing all progress to a long-session crash, keep simulator state cleaner across episodes,
-   and let you take breaks between batches so demonstration quality stays consistent.
-
    Policy success rate depends heavily on both dataset quality and dataset size. For better success
    rates, collect more clean demonstrations with smooth actions, stable grasps, and no unnecessary
    collisions.

--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -57,9 +57,7 @@ parser.add_argument(
     dest="disable_full_sim_buffer_reset",
     action="store_true",
     default=False,
-    help=(
-        "Disable calling env.sim.reset() to fully clear sim context buffers before each episode recording."
-    ),
+    help="Disable calling env.sim.reset() to fully clear sim context buffers before each episode recording.",
 )
 # Add the example environments CLI args
 # NOTE(alexmillane, 2025.09.04): This has to be added last, because

--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -424,11 +424,10 @@ def run_simulation_loop(
     # Callback closures for the teleop device
     def reset_recording_instance():
         nonlocal should_reset_recording_instance
-        # Block manual reset while post-success steps are still being recorded.
         if success_step_count > 0:
             print(
-                "Manual reset ignored. Success has fired and post-success steps are still recording"
-                f" ({success_step_count}/{args_cli.num_success_steps}). Please wait for the auto-reset."
+                "Manual reset ignored. Success has fired and post-success steps are still recording. Please wait for"
+                " the auto-reset."
             )
             return
         should_reset_recording_instance = True

--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -24,6 +24,8 @@ optional arguments:
     --step_hz                 Environment stepping rate in Hz. (default: 30)
     --num_demos               Number of demonstrations to record. (default: 0)
     --num_success_steps       Number of continuous steps with task success for concluding a demo as successful. (default: 10)
+    --disable_full_sim_buffer_reset
+                              Disable env.sim.reset() calls that fully clear sim context buffers before each episode. (default: False)
 """
 
 """Launch Isaac Sim Simulator first."""
@@ -49,6 +51,15 @@ parser.add_argument(
     type=int,
     default=10,
     help="Number of continuous steps with task success for concluding a demo as successful. Default is 10.",
+)
+parser.add_argument(
+    "--disable_full_sim_buffer_reset",
+    dest="disable_full_sim_buffer_reset",
+    action="store_true",
+    default=False,
+    help=(
+        "Disable calling env.sim.reset() to fully clear sim context buffers before each episode recording."
+    ),
 )
 # Add the example environments CLI args
 # NOTE(alexmillane, 2025.09.04): This has to be added last, because
@@ -377,7 +388,8 @@ def handle_reset(
         int: Reset success step count (0)
     """
     print("Resetting environment...")
-    env.sim.reset()
+    if not args_cli.disable_full_sim_buffer_reset:
+        env.sim.reset()
     env.recorder_manager.reset()
     env.reset()
     success_step_count = 0
@@ -414,6 +426,13 @@ def run_simulation_loop(
     # Callback closures for the teleop device
     def reset_recording_instance():
         nonlocal should_reset_recording_instance
+        # Block manual reset while post-success steps are still being recorded.
+        if success_step_count > 0:
+            print(
+                "Manual reset ignored. Success has fired and post-success steps are still recording"
+                f" ({success_step_count}/{args_cli.num_success_steps}). Please wait for the auto-reset."
+            )
+            return
         should_reset_recording_instance = True
         print("Recording instance reset requested")
 
@@ -448,7 +467,8 @@ def run_simulation_loop(
         nonlocal running_recording_instance, label_text
 
         # Reset before starting
-        env.sim.reset()
+        if not args_cli.disable_full_sim_buffer_reset:
+            env.sim.reset()
         env.reset()
         teleop_interface.reset()
 


### PR DESCRIPTION
## Summary

1. Add parameter to optionally disable full sim buffer reset in record_demos script. By default, this flush is still enabled. For use cases such as the GR00T E2E workflow where large quantities of demos need to be recorded, the flush is disable to prevent overflowing underlying sim structures due to excessive re-initializations.
2. Update E2E workflow docs to disable full sim buffer flush during reset.
3. Add guard in record_demos script to prevent manual reset when an episode ends in success and additional steps are being recorded. Prevents accidental reset during this period which corrupts the success state.

