### PR TITLE
Add optional full sim buffer reset in record_demos script and fix E2E…

### DIFF
--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -167,6 +167,7 @@ Step 4: Record with the headset device
         --dataset_file $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
         --num_demos 10 \
         --num_success_steps 10 \
+        --disable_full_sim_buffer_reset \
         galileo_g1_static_pick_and_place \
         --object apple_01_objaverse_robolab \
         --destination clay_plates_hot3d_robolab \

--- a/isaaclab_arena/scripts/imitation_learning/record_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/record_demos.py
@@ -24,6 +24,8 @@ optional arguments:
     --step_hz                 Environment stepping rate in Hz. (default: 30)
     --num_demos               Number of demonstrations to record. (default: 0)
     --num_success_steps       Number of continuous steps with task success for concluding a demo as successful. (default: 10)
+    --disable_full_sim_buffer_reset
+                              Disable env.sim.reset() calls that fully clear sim context buffers before each episode. (default: False)
 """
 
 """Launch Isaac Sim Simulator first."""
@@ -49,6 +51,13 @@ parser.add_argument(
     type=int,
     default=10,
     help="Number of continuous steps with task success for concluding a demo as successful. Default is 10.",
+)
+parser.add_argument(
+    "--disable_full_sim_buffer_reset",
+    dest="disable_full_sim_buffer_reset",
+    action="store_true",
+    default=False,
+    help="Disable calling env.sim.reset() to fully clear sim context buffers before each episode recording.",
 )
 # Add the example environments CLI args
 # NOTE(alexmillane, 2025.09.04): This has to be added last, because
@@ -377,7 +386,8 @@ def handle_reset(
         int: Reset success step count (0)
     """
     print("Resetting environment...")
-    env.sim.reset()
+    if not args_cli.disable_full_sim_buffer_reset:
+        env.sim.reset()
     env.recorder_manager.reset()
     env.reset()
     success_step_count = 0
@@ -414,6 +424,12 @@ def run_simulation_loop(
     # Callback closures for the teleop device
     def reset_recording_instance():
         nonlocal should_reset_recording_instance
+        if success_step_count > 0:
+            print(
+                "Manual reset ignored. Success has fired and post-success steps are still recording. Please wait for"
+                " the auto-reset."
+            )
+            return
         should_reset_recording_instance = True
         print("Recording instance reset requested")
 
@@ -448,7 +464,8 @@ def run_simulation_loop(
         nonlocal running_recording_instance, label_text
 
         # Reset before starting
-        env.sim.reset()
+        if not args_cli.disable_full_sim_buffer_reset:
+            env.sim.reset()
         env.reset()
         teleop_interface.reset()
 


### PR DESCRIPTION
… workflow bugs (#704)

## Summary

1. Add parameter to optionally disable full sim buffer reset in record_demos script. By default, this flush is still enabled. For use cases such as the GR00T E2E workflow where large quantities of demos need to be recorded, the flush is disable to prevent overflowing underlying sim structures due to excessive re-initializations.
2. Update E2E workflow docs to disable full sim buffer flush during reset.
3. Add guard in record_demos script to prevent manual reset when an episode ends in success and additional steps are being recorded. Prevents accidental reset during this period which corrupts the success state.

(cherry picked from commit 7b5bd3c324dd38ce85ac03adf5986d2de11bcfb3)

## Summary
Short description of the change (max 50 chars)

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
