### PR TITLE
Ignore agent metadata in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 **/.mypy_cache
 **/__pycache__
 /.git
+/.agents
+/.claude


### PR DESCRIPTION
## Summary
Ignore agent metadata in Docker builds. Without this, it prevents new docker build.

## Detailed description: 
- Why: The Dockerfile has COPY *.* ${WORKDIR}/, and Docker’s glob matches hidden dot-directories too. After .agents and .claude were added, that copy step pulled both into the image context; .claude/skills is a symlink to .agents/skills, so both paths collide while copying into the same destination.
- How: Exclude .agents and .claude from Docker context to prevent COPY *.* collisions.
