### PR TITLE
Change the commit for gr00t standalone for eval compatibility

### DIFF
--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -102,15 +102,17 @@ Standalone Isaac-GR00T (N1.7) checkout (used in :doc:`step_3_policy_training` an
     # Pin to the commit this workflow was validated against.
     git clone https://github.com/NVIDIA/Isaac-GR00T.git /path/to/Isaac-GR00T
     export ISAAC_GR00T_DIR=/path/to/Isaac-GR00T
-    cd $ISAAC_GR00T_DIR && git checkout 3df8b3825d67f755e69141446f4315f281b9b7e6
+    cd $ISAAC_GR00T_DIR && git checkout 4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e
 
 Open another terminal outside the Arena Base Docker container and set up the native GR00T
 ``uv`` environment from ``$ISAAC_GR00T_DIR`` by following the
 `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_.
 
-This venv is **separate** from Arena's container. Finetuning and the policy server both run from
-this standalone checkout so you can pick up new GR00T releases (e.g. N1.7 → next) without rebuilding
-Arena's container or bumping ``submodules/Isaac-GR00T``.
+This venv is **separate** from Arena's container, but Arena's policy runner still imports the
+GR00T ``PolicyClient`` from the Arena-pinned ``submodules/Isaac-GR00T`` checkout. Keep the
+standalone GR00T checkout at the pinned commit above for this workflow. If you move the standalone
+checkout to a newer GR00T commit, the GR00T server and Arena's GR00T client may be incompatible
+unless Arena's GR00T client/submodule is updated as well.
 
 
 Workflow Steps


### PR DESCRIPTION
## Summary
Pin compatible GR00T checkout for eval

## Detailed description
- The previous static apple docs pinned a newer standalone Isaac-GR00T commit that can be incompatible with Arena’s pinned GR00T `PolicyClient`.
- Updated the recommended standalone Isaac-GR00T commit to `4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e`, which is compatible with Arena’s current GR00T client/submodule.
- Added a note explaining that newer standalone GR00T commits may require updating Arena’s GR00T client/submodule as well.
- This prevents evaluation failures caused by GR00T server/client serializer mismatch, such as `Video key 'ego_view' must be a numpy array. Got <class 'dict'>`.