### PR TITLE
CP from release/0.2.1: Fix failed to parse env config issue

### DIFF
--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -179,7 +179,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
 
         class StaticShelfSupport(Object):
             def __init__(self):
-                self.spawner_cfg = sim_utils.CuboidCfg(
+                spawner_cfg = sim_utils.CuboidCfg(
                     size=SHELF_SUPPORT_PATCH_SIZE,
                     collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
                     visible=False,
@@ -187,7 +187,8 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
                 super().__init__(
                     name="static_pick_place_shelf_support",
                     prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
-                    object_type=ObjectType.SPAWNER,
+                    object_type=ObjectType.BASE,
+                    spawner_cfg=spawner_cfg,
                     initial_pose=Pose(
                         position_xyz=SHELF_SUPPORT_PATCH_CENTER,
                         rotation_xyzw=(0.0, 0.0, 0.0, 1.0),

--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -176,19 +176,29 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # Reuse the locomanip background USD: it bakes in lighting and provides the same
         # shelf-in-front-of-robot geometry the locomanip env was tuned against.
         background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-        # This is a local collision patch for this exact scene rather than a reusable
-        # library asset. The imported shelf mesh has uneven/perforated collision in the
-        # static task region, so small objects can fall through parts of the visible shelf.
-        shelf_support = Object(
-            name="static_pick_place_shelf_support",
-            prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
-            object_type=ObjectType.BASE,
-            spawner_cfg=sim_utils.CuboidCfg(
-                size=SHELF_SUPPORT_PATCH_SIZE,
-                collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-                visible=False,
-            ),
-        )
+
+        class StaticShelfSupport(Object):
+            def __init__(self):
+                self.spawner_cfg = sim_utils.CuboidCfg(
+                    size=SHELF_SUPPORT_PATCH_SIZE,
+                    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+                    visible=False,
+                )
+                super().__init__(
+                    name="static_pick_place_shelf_support",
+                    prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
+                    object_type=ObjectType.SPAWNER,
+                    initial_pose=Pose(
+                        position_xyz=SHELF_SUPPORT_PATCH_CENTER,
+                        rotation_xyzw=(0.0, 0.0, 0.0, 1.0),
+                    ),
+                    tags=["background", "procedural"],
+                )
+
+        # The imported shelf mesh has uneven/perforated collision in the task region:
+        # small objects can fall through parts of the visible shelf. Add an invisible
+        # static cuboid flush with the shelf top so task objects see a clean support.
+        shelf_support = StaticShelfSupport()
         pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(scale=_asset_scale(args_cli.object))
         destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
             scale=_asset_scale(args_cli.destination)
@@ -215,9 +225,6 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         # init_state.pos.z=0 is correct.
         embodiment.set_initial_pose(Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
         embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
-        shelf_support.set_initial_pose(
-            Pose(position_xyz=SHELF_SUPPORT_PATCH_CENTER, rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
-        )
         pick_up_object_x, pick_up_object_y = PICK_UP_OBJECT_SPAWN_XY
         destination_x, destination_y = DESTINATION_SPAWN_XY
         pick_up_object_z = _shelf_spawn_z(args_cli.object)


### PR DESCRIPTION
## Summary
CP of https://github.com/isaac-sim/IsaacLab-Arena/pull/714 from release/0.2.1
Fix static apple env config parsing
https://nvbugspro.nvidia.com/bug/6217567
https://nvbugspro.nvidia.com/bug/6217687

## Detailed description
- The main and release branches currently differ in their object APIs: release has ObjectType.SPAWNER, while main does not.
- Updated the main-branch MR to use ObjectType.BASE with spawner_cfg, which is the compatible API on main.
- The static apple environment failed during config parsing because the local invisible shelf support was created as an `ObjectType.BASE` asset without a `usd_path`.
- Changed the shelf support to a procedural spawner object backed by a `CuboidCfg`, with its initial pose set during object construction.
- This preserves the invisible collision support for the shelf while avoiding the `usd_path` assertion, allowing demo recording and environment creation to proceed normally.