### PR TITLE
Cherry-pick (#699) to release v0.2.1: Add script to merge teleop HDF5 demo recordings

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -174,6 +174,13 @@ Step 4: Record with Quest 3
    #. Use the **right joystick** (up) to stand the robot back up.
    #. Use the control panel to **Reset**, then **Play** to start the next demo.
 
+.. hint::
+
+   Collecting a large dataset across several sittings? Record one HDF5 per session by varying
+   ``--dataset_file``, then concatenate the per-session files with
+   :ref:`static_apple_merge_demos`. The merge script is task-agnostic and works for every
+   Arena teleop workflow.
+
 
 Step 5: Replay Recorded Demos (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -225,3 +225,10 @@ at ``$DATASET_DIR/ranch_bottle_into_fridge_recorded.hdf5``.
    - Keep hands within tracking volume
    - Ensure good lighting for hand tracking
    - Complete at least 10 successful demonstrations
+
+.. hint::
+
+   Collecting a large dataset across several sittings? Record one HDF5 per session by varying
+   ``--dataset_file``, then concatenate the per-session files with
+   :ref:`static_apple_merge_demos`. The merge script is task-agnostic and works for every
+   Arena teleop workflow.

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -247,6 +247,66 @@ Step 4: Record with the headset device
       Example static apple-to-plate demonstration trajectory.
 
 
+.. _static_apple_merge_demos:
+
+Step 4b: Merge Multiple Recording Sessions (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Collecting 100+ clean demonstrations in a single sitting is impractical because of operator fatigue,
+and the realities of stopping and starting the Arena app for breaks. The
+recommended workflow is to record one HDF5 per session by pointing ``--dataset_file`` at a fresh
+path each time:
+
+.. code-block:: bash
+
+   # Session 1 (e.g. morning)
+   python isaaclab_arena/scripts/imitation_learning/record_demos.py \
+     ... --dataset_file $DATASET_DIR/session_a.hdf5 --num_demos 50 ...
+
+   # Session 2 (after lunch)
+   python isaaclab_arena/scripts/imitation_learning/record_demos.py \
+     ... --dataset_file $DATASET_DIR/session_b.hdf5 --num_demos 50 ...
+
+Then concatenate the per-session files into the single training-ready dataset that
+:doc:`step_3_policy_training` expects:
+
+.. code-block:: bash
+
+   python isaaclab_arena/scripts/imitation_learning/merge_demos.py \
+     -o $DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5 \
+     $DATASET_DIR/session_a.hdf5 $DATASET_DIR/session_b.hdf5
+
+The script is pure ``h5py`` (no Isaac Sim startup), so it returns in seconds. It validates
+that all inputs share the same ``format_version``, action shape, observation keys, and camera
+geometry, and prints a per-file summary with the demo and step counts:
+
+.. code-block:: text
+
+   [1/2] session_a.hdf5             demos=  50  steps=    12,805  size= 187.3 MiB  env=""  v=1  keys=14
+   [2/2] session_b.hdf5             demos=  50  steps=    11,422  size= 171.0 MiB  env=""  v=1  keys=14
+   ------------------------------------------------------------------------------------------
+           arena_g1_static_apple_dataset_recorded.hdf5 (output)   demos= 100  steps=    24,227  size= 358.3 MiB
+   Validation: format_version OK, schema OK, env_args OK
+   Demo numbering: demo_0..demo_99 (input order preserved)
+
+.. tip::
+
+   Pass ``--dry_run`` to inspect the report without writing the output file. This is a quick
+   compatibility check before clobbering an existing combined dataset, and it returns a non-zero
+   exit code if any input would block the merge.
+
+.. tip::
+
+   Successful demos are renumbered sequentially (``demo_0``, ``demo_1``, ...) in the order the
+   input files are listed, so list the sessions chronologically if you want the merged file to
+   reflect the order of collection.
+
+If a session was recorded against a slightly different environment (e.g. a different physics
+timestep) the merge will warn but still proceed. Schema-level differences (different action
+dimensions, missing observation keys, different camera resolutions) are hard errors: re-record
+the offending session against the canonical environment instead.
+
+
 Step 5: Replay Recorded Demos (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -223,3 +223,10 @@ at ``$DATASET_DIR/arena_gr1_manipulation_dataset_recorded.hdf5``.
    - Keep hands within tracking volume
    - Ensure good lighting for hand tracking
    - Complete at least 10 successful demonstrations
+
+.. hint::
+
+   Collecting a large dataset across several sittings? Record one HDF5 per session by varying
+   ``--dataset_file``, then concatenate the per-session files with
+   :ref:`static_apple_merge_demos`. The merge script is task-agnostic and works for every
+   Arena teleop workflow.

--- a/isaaclab_arena/scripts/imitation_learning/merge_demos.py
+++ b/isaaclab_arena/scripts/imitation_learning/merge_demos.py
@@ -1,0 +1,515 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Merge multiple Arena teleop HDF5 demonstration files into a single training-ready dataset.
+
+Teleoperators often collect 100+ demonstrations across several sessions rather than in one sitting,
+producing one HDF5 per session via :mod:`isaaclab_arena.scripts.imitation_learning.record_demos`.
+This script combines those files into a single dataset suitable for downstream consumers
+(:mod:`isaaclab_arena.scripts.imitation_learning.replay_demos`,
+:mod:`isaaclab_arena.scripts.imitation_learning.annotate_demos`,
+``convert_hdf5_to_lerobot.py``).
+
+Compared to upstream ``submodules/IsaacLab/scripts/tools/merge_hdf5_datasets.py``, this script:
+
+- Preserves the root ``format_version`` attribute (otherwise the loader assumes legacy WXYZ
+  quaternions and silently corrupts ``root_pose`` data).
+- Recomputes ``data.attrs["total"]`` from the per-demo ``num_samples`` sum.
+- Validates structural compatibility across inputs (``format_version``, dataset paths, per-key
+  shapes/dtypes) and warns on ``env_args`` mismatches.
+- Logs an operator-friendly per-file summary and aggregate report.
+- Uses a recursive ``h5py.Group.copy`` so new recorder terms added by future Isaac Lab versions
+  (new ``obs/*`` keys, new sensor groups, new metadata attrs) round-trip unchanged.
+
+The script has zero simulation dependency and only requires ``h5py``.
+
+Example
+-------
+.. code-block:: bash
+
+    python isaaclab_arena/scripts/imitation_learning/merge_demos.py \\
+        -o $DATASET_DIR/combined.hdf5 \\
+        $DATASET_DIR/session_a.hdf5 $DATASET_DIR/session_b.hdf5 $DATASET_DIR/session_c.hdf5
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import h5py
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+
+_TABLE_SEP_CHAR = "-"
+
+
+@dataclass
+class _FileInfo:
+    """Summary of one input HDF5 file, populated by :func:`_inspect_file`."""
+
+    path: str
+    format_version: int
+    env_args: dict
+    num_demos: int
+    total_steps: int
+    size_bytes: int
+    schema_fingerprint: dict[str, tuple[tuple[int, ...], str]] = field(default_factory=dict)
+    success_count: int = 0
+    no_success_attr_count: int = 0
+    failed_count: int = 0
+    untracked_step_demos: list[str] = field(default_factory=list)
+
+
+def _format_bytes(num_bytes: float) -> str:
+    """Format a byte count as a human-readable string."""
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024.0:
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PiB"
+
+
+def _format_int(n: int) -> str:
+    """Format an integer with thousands separators."""
+    return f"{n:,}"
+
+
+def _build_schema_fingerprint(demo_group: h5py.Group) -> dict[str, tuple[tuple[int, ...], str]]:
+    """Walk a demo group recursively and produce a ``path -> (shape[1:], dtype_str)`` map.
+
+    The leading time dimension is dropped because episode lengths legitimately vary across demos.
+    Everything else (action_dim, obs feature dim, image HxWxC, ...) must match for the merged
+    dataset to be usable by downstream consumers.
+    """
+    fingerprint: dict[str, tuple[tuple[int, ...], str]] = {}
+
+    def _visit(name: str, obj: h5py.Group | h5py.Dataset) -> None:
+        if isinstance(obj, h5py.Dataset):
+            fingerprint[name] = (tuple(obj.shape[1:]), obj.dtype.str)
+
+    demo_group.visititems(_visit)
+    return fingerprint
+
+
+def _sorted_demo_names(data_group: h5py.Group) -> list[str]:
+    """Return ``demo_*`` group names sorted by numeric suffix when possible."""
+    demo_names = [k for k in data_group.keys() if k.startswith("demo_")]
+
+    def _key(name: str) -> tuple[int, str]:
+        suffix = name[len("demo_") :]
+        if suffix.isdigit():
+            return (0, f"{int(suffix):020d}")
+        return (1, name)
+
+    return sorted(demo_names, key=_key)
+
+
+def _inspect_file(path: str) -> _FileInfo:
+    """Open an input HDF5 file read-only and build a :class:`_FileInfo` summary."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Input file does not exist: {path}")
+    size_bytes = os.path.getsize(path)
+
+    # Prepend the path to h5py's bare OSError on non-HDF5/truncated/locked inputs.
+    try:
+        h5_file = h5py.File(path, "r")
+    except OSError as e:
+        raise ValueError(f"{path}: cannot open as HDF5 ({e})") from e
+
+    with h5_file as f:
+        if "data" not in f:
+            raise ValueError(f"{path}: missing top-level 'data' group; not a record_demos HDF5 file")
+
+        format_version = int(f.attrs["format_version"]) if "format_version" in f.attrs else 0
+
+        data_group = f["data"]
+        env_args: dict = {}
+        raw_env_args = data_group.attrs.get("env_args")
+        if raw_env_args is not None:
+            try:
+                env_args = json.loads(raw_env_args)
+            except (json.JSONDecodeError, TypeError):
+                env_args = {"_raw": str(raw_env_args)}
+
+        demo_names = _sorted_demo_names(data_group)
+        num_demos = len(demo_names)
+        if num_demos == 0:
+            raise ValueError(f"{path}: contains no 'demo_*' groups; nothing to merge")
+
+        # Sample the schema from the first demo only. record_demos.py writes a uniform
+        # recorder stack within a single file, so this is the fast path. Intra-file
+        # inconsistency (e.g. a file that was manually edited mid-session) is not detected
+        # here; cross-file consistency is what _validate_compatibility checks.
+        schema_fingerprint = _build_schema_fingerprint(data_group[demo_names[0]])
+
+        total_steps = 0
+        success_count = 0
+        no_success_attr_count = 0
+        failed_count = 0
+        untracked_step_demos: list[str] = []
+        for name in demo_names:
+            demo = data_group[name]
+            if "num_samples" in demo.attrs:
+                total_steps += int(demo.attrs["num_samples"])
+            elif "actions" in demo:
+                total_steps += int(demo["actions"].shape[0])
+            else:
+                untracked_step_demos.append(name)
+
+            if "success" in demo.attrs:
+                if bool(demo.attrs["success"]):
+                    success_count += 1
+                else:
+                    failed_count += 1
+            else:
+                no_success_attr_count += 1
+
+    return _FileInfo(
+        path=path,
+        format_version=format_version,
+        env_args=env_args,
+        num_demos=num_demos,
+        total_steps=total_steps,
+        size_bytes=size_bytes,
+        schema_fingerprint=schema_fingerprint,
+        success_count=success_count,
+        no_success_attr_count=no_success_attr_count,
+        failed_count=failed_count,
+        untracked_step_demos=untracked_step_demos,
+    )
+
+
+def _diff_schema(
+    ref: dict[str, tuple[tuple[int, ...], str]], other: dict[str, tuple[tuple[int, ...], str]]
+) -> list[str]:
+    """Return human-readable list of differences between two schema fingerprints."""
+    out: list[str] = []
+    ref_keys = set(ref.keys())
+    other_keys = set(other.keys())
+    for k in sorted(ref_keys - other_keys):
+        out.append(f"only in first: {k} (shape={ref[k][0]}, dtype={ref[k][1]})")
+    for k in sorted(other_keys - ref_keys):
+        out.append(f"only in other: {k} (shape={other[k][0]}, dtype={other[k][1]})")
+    for k in sorted(ref_keys & other_keys):
+        if ref[k] != other[k]:
+            out.append(
+                f"shape/dtype differs at {k}: shape={ref[k][0]} dtype={ref[k][1]}"
+                f" vs shape={other[k][0]} dtype={other[k][1]}"
+            )
+    return out
+
+
+@dataclass
+class _ValidationReport:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+    schema_status: str = "OK"
+    format_version_status: str = "OK"
+    env_args_status: str = "OK"
+
+
+def _validate_compatibility(infos: list[_FileInfo]) -> _ValidationReport:
+    """Compare input files for compatibility and produce a :class:`_ValidationReport`."""
+    report = _ValidationReport()
+
+    versions = {i.format_version for i in infos}
+    if len(versions) > 1:
+        report.format_version_status = "MISMATCH"
+        report.errors.append(
+            f"format_version mismatch across inputs: {sorted(versions)}. Legacy WXYZ files "
+            "must be converted first via HDF5DatasetFileHandler.convert_dataset_to_xyzw()."
+        )
+
+    if len(infos) > 1:
+        ref = infos[0]
+        any_schema_diff = False
+        for other in infos[1:]:
+            diffs = _diff_schema(ref.schema_fingerprint, other.schema_fingerprint)
+            if not diffs:
+                continue
+            any_schema_diff = True
+            msg = f"Schema mismatch between {ref.path} and {other.path}:\n  " + "\n  ".join(diffs)
+            report.errors.append(msg)
+        if any_schema_diff:
+            report.schema_status = "MISMATCH"
+
+    env_names = {i.env_args.get("env_name", "") for i in infos}
+    sim_args_set = {json.dumps(i.env_args.get("sim_args", {}), sort_keys=True) for i in infos}
+    if len(env_names) > 1:
+        report.env_args_status = "WARN"
+        report.warnings.append(
+            f"env_args.env_name differs across inputs: {sorted(env_names)}. "
+            "record_demos.py typically writes an empty env_name, so this is often expected."
+        )
+    if len(sim_args_set) > 1:
+        report.env_args_status = "WARN"
+        report.warnings.append(
+            "env_args.sim_args differ across inputs (e.g. dt, decimation, render_interval, "
+            "num_envs). The first file's values will be written to the merged output."
+        )
+
+    for i in infos:
+        if i.failed_count > 0:
+            report.warnings.append(
+                f"{i.path}: {i.failed_count} demo(s) with success=False. record_demos.py "
+                "normally exports only successful demos; included as-is in the merged file."
+            )
+        if i.no_success_attr_count > 0:
+            report.info.append(
+                f"{i.path}: {i.no_success_attr_count} demo(s) without @success attribute (legacy format)."
+            )
+        if i.untracked_step_demos:
+            shown = ", ".join(i.untracked_step_demos[:3])
+            suffix = ", ..." if len(i.untracked_step_demos) > 3 else ""
+            report.warnings.append(
+                f"{i.path}: {len(i.untracked_step_demos)} demo(s) without 'num_samples' attribute"
+                f" or 'actions' dataset ({shown}{suffix}); contributed 0 to the reported step total."
+            )
+
+    return report
+
+
+def _print_summary(
+    infos: list[_FileInfo],
+    output_path: str,
+    *,
+    output_total_steps: int | None = None,
+    output_num_demos: int | None = None,
+    output_size_bytes: int | None = None,
+    report: _ValidationReport | None = None,
+    dry_run: bool = False,
+) -> None:
+    """Print an operator-friendly per-file table, aggregate row, and validation summary."""
+    n = len(infos)
+    if n == 0:
+        return
+
+    max_name_len = max(len(os.path.basename(i.path)) for i in infos)
+    max_name_len = max(max_name_len, len(os.path.basename(output_path)) + len(" (output)"), 25)
+
+    print()
+    for idx, i in enumerate(infos, start=1):
+        env_name = i.env_args.get("env_name", "")
+        print(
+            f"[{idx}/{n}] {os.path.basename(i.path):<{max_name_len}}  "
+            f"demos={i.num_demos:>4d}  "
+            f"steps={_format_int(i.total_steps):>10s}  "
+            f"size={_format_bytes(i.size_bytes):>10s}  "
+            f'env="{env_name}"  '
+            f"v={i.format_version}  "
+            f"keys={len(i.schema_fingerprint)}"
+        )
+
+    print(_TABLE_SEP_CHAR * (max_name_len + 65))
+
+    total_demos = output_num_demos if output_num_demos is not None else sum(i.num_demos for i in infos)
+    total_steps = output_total_steps if output_total_steps is not None else sum(i.total_steps for i in infos)
+    if output_size_bytes is not None:
+        size_str = _format_bytes(output_size_bytes)
+    else:
+        size_str = "~" + _format_bytes(sum(i.size_bytes for i in infos))
+
+    label = f"{os.path.basename(output_path)} ({'dry-run' if dry_run else 'output'})"
+    print(
+        f"        {label:<{max_name_len}}  "
+        f"demos={total_demos:>4d}  "
+        f"steps={_format_int(total_steps):>10s}  "
+        f"size={size_str:>10s}"
+    )
+
+    if report is not None:
+        print(
+            "Validation: "
+            f"format_version {report.format_version_status}, "
+            f"schema {report.schema_status}, "
+            f"env_args {report.env_args_status}"
+        )
+        for msg in report.info:
+            print(f"INFO: {msg}")
+        for msg in report.warnings:
+            print(f"WARNING: {msg}")
+        for msg in report.errors:
+            print(f"ERROR: {msg}")
+
+    if total_demos > 0:
+        print(f"Demo numbering: demo_0..demo_{total_demos - 1} (input order preserved)")
+    print()
+
+
+def _merge(infos: list[_FileInfo], output_path: str) -> tuple[int, int, int]:
+    """Write a merged HDF5 dataset from validated inputs.
+
+    Returns:
+        A tuple ``(output_size_bytes, total_steps_written, total_demos_written)``.
+    """
+    format_version = infos[0].format_version
+    merged_env_args = dict(infos[0].env_args)
+    for other in infos[1:]:
+        for k, v in other.env_args.items():
+            if k not in merged_env_args:
+                merged_env_args[k] = v
+
+    total_demos_written = 0
+    total_steps_written = 0
+
+    with h5py.File(output_path, "w") as out:
+        out.attrs["format_version"] = format_version
+        data_out = out.create_group("data")
+        data_out.attrs["env_args"] = json.dumps(merged_env_args)
+
+        for info in infos:
+            with h5py.File(info.path, "r") as src:
+                src_data = src["data"]
+                for src_demo_name in _sorted_demo_names(src_data):
+                    dst_demo_name = f"demo_{total_demos_written}"
+                    try:
+                        src.copy(src_data[src_demo_name], data_out, name=dst_demo_name)
+                    except (OSError, RuntimeError, ValueError) as e:
+                        # h5py error messages from deep recursive copies are notoriously opaque;
+                        # surface the offending source file and demo so the operator can
+                        # repair / drop the bad input without guessing.
+                        raise RuntimeError(
+                            f"Failed to copy {info.path}::{src_demo_name} into the merged"
+                            f" dataset as {dst_demo_name}: {e}"
+                        ) from e
+                    dst_demo = data_out[dst_demo_name]
+                    if "num_samples" in dst_demo.attrs:
+                        total_steps_written += int(dst_demo.attrs["num_samples"])
+                    elif "actions" in dst_demo:
+                        total_steps_written += int(dst_demo["actions"].shape[0])
+                    total_demos_written += 1
+
+        data_out.attrs["total"] = total_steps_written
+
+    output_size = os.path.getsize(output_path)
+    return output_size, total_steps_written, total_demos_written
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Merge multiple Arena teleop HDF5 demo files into a single training-ready dataset."
+            " Validates schema compatibility across inputs, renumbers demos sequentially, and"
+            " preserves all recorder data (forward-compatible to new recorder terms)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "input_files",
+        nargs="+",
+        type=str,
+        help="One or more input HDF5 demo files to merge. Files are merged in the given order.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path to write the merged HDF5 dataset.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Validate inputs and print the merge report without writing the output file.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns process exit code (0 success, non-zero on error)."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    output_abs = os.path.abspath(args.output_file)
+    tmp_abs = output_abs + ".tmp"
+    for inp in args.input_files:
+        if not os.path.exists(inp):
+            continue
+        inp_abs = os.path.abspath(inp)
+        if inp_abs == output_abs:
+            print(
+                f"ERROR: --output_file path equals an input path: {inp}",
+                file=sys.stderr,
+            )
+            return 2
+        if inp_abs == tmp_abs:
+            print(
+                f"ERROR: input path {inp} collides with the internal temp path "
+                f"{args.output_file}.tmp. Rename the input or choose a different --output_file.",
+                file=sys.stderr,
+            )
+            return 2
+    if not args.dry_run and os.path.exists(args.output_file) and not args.overwrite:
+        print(
+            f"ERROR: output file {args.output_file} already exists. Pass --overwrite to replace.",
+            file=sys.stderr,
+        )
+        return 2
+
+    infos: list[_FileInfo] = []
+    for path in args.input_files:
+        try:
+            infos.append(_inspect_file(path))
+        except (FileNotFoundError, ValueError, OSError) as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+
+    report = _validate_compatibility(infos)
+
+    if args.dry_run:
+        _print_summary(infos, args.output_file, report=report, dry_run=True)
+        return 1 if report.errors else 0
+
+    if report.errors:
+        _print_summary(infos, args.output_file, report=report, dry_run=True)
+        print(
+            "Merge aborted due to validation errors. Re-run with --dry_run to inspect.",
+            file=sys.stderr,
+        )
+        return 1
+
+    output_dir = os.path.dirname(output_abs) or "."
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Atomic write: stream into <output>.tmp and rename on success so a mid-merge
+    # failure does not leave a partial output or, under --overwrite, destroy the
+    # prior file.
+    tmp_path = args.output_file + ".tmp"
+    success = False
+    try:
+        output_size, total_steps, total_demos = _merge(infos, tmp_path)
+        os.replace(tmp_path, args.output_file)
+        success = True
+    except Exception as e:
+        print(f"ERROR: Merge failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        if not success and os.path.exists(tmp_path):
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+
+    _print_summary(
+        infos,
+        args.output_file,
+        output_total_steps=total_steps,
+        output_num_demos=total_demos,
+        output_size_bytes=output_size,
+        report=report,
+        dry_run=False,
+    )
+    print(f"Merged dataset written to: {args.output_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/isaaclab_arena/tests/test_merge_demos.py
+++ b/isaaclab_arena/tests/test_merge_demos.py
@@ -1,0 +1,470 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``isaaclab_arena/scripts/imitation_learning/merge_demos.py``.
+
+The merge script is pure ``h5py`` + ``numpy``, so every test below runs in the
+no-cameras / no-subprocess Phase 1 slot. Synthetic fixtures are built with the local
+:func:`_make_dataset` helper to mirror ``record_demos.py`` HDF5 output without
+needing Isaac Sim, the simulator app, or any real recording on disk.
+"""
+
+import h5py
+import importlib.util
+import json
+import numpy as np
+import os
+import sys
+
+import pytest
+
+_MERGE_SCRIPT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "scripts",
+    "imitation_learning",
+    "merge_demos.py",
+)
+_spec = importlib.util.spec_from_file_location("merge_demos", _MERGE_SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None, f"Could not load {_MERGE_SCRIPT_PATH}"
+merge_demos = importlib.util.module_from_spec(_spec)
+sys.modules["merge_demos"] = merge_demos
+_spec.loader.exec_module(merge_demos)
+
+
+def _make_dataset(
+    path,
+    *,
+    num_demos=3,
+    action_dim=8,
+    obs_terms=("robot_joint_pos",),
+    obs_dim=7,
+    camera_shapes=None,
+    format_version=1,
+    env_name="",
+    sim_dt=0.01,
+    decimation=2,
+    success=True,
+    extra_top_level_demo_attrs=None,
+    extra_obs_keys=(),
+    base_episode_len=100,
+):
+    """Build a ``record_demos.py``-shaped synthetic HDF5 file at ``path``.
+
+    The structure mirrors what
+    ``isaaclab.utils.datasets.HDF5DatasetFileHandler`` writes when invoked by
+    ``ActionStateRecorderManagerCfg`` + optional ``ArenaEnvRecorderManagerCfg``.
+    """
+    rng = np.random.default_rng(seed=42)
+    with h5py.File(path, "w") as f:
+        f.attrs["format_version"] = format_version
+        data = f.create_group("data")
+        env_args = {
+            "env_name": env_name,
+            "type": 2,
+            "sim_args": {
+                "dt": sim_dt,
+                "decimation": decimation,
+                "render_interval": 1,
+                "num_envs": 1,
+            },
+        }
+        data.attrs["env_args"] = json.dumps(env_args)
+        total = 0
+        for i in range(num_demos):
+            T = base_episode_len + i
+            demo = data.create_group(f"demo_{i}")
+            demo.attrs["num_samples"] = T
+            if success is not None:
+                demo.attrs["success"] = success
+            if extra_top_level_demo_attrs:
+                for k, v in extra_top_level_demo_attrs.items():
+                    demo.attrs[k] = v
+            demo.create_dataset(
+                "actions",
+                data=rng.standard_normal((T, action_dim)).astype(np.float32),
+                compression="gzip",
+            )
+            demo.create_dataset(
+                "processed_actions",
+                data=rng.standard_normal((T, action_dim)).astype(np.float32),
+                compression="gzip",
+            )
+            obs = demo.create_group("obs")
+            for term in obs_terms:
+                obs.create_dataset(
+                    term,
+                    data=rng.standard_normal((T, obs_dim)).astype(np.float32),
+                    compression="gzip",
+                )
+            for term in extra_obs_keys:
+                obs.create_dataset(
+                    term,
+                    data=rng.standard_normal((T, obs_dim)).astype(np.float32),
+                    compression="gzip",
+                )
+            if camera_shapes:
+                cam = demo.create_group("camera_obs")
+                for name, (H, W) in camera_shapes.items():
+                    cam.create_dataset(
+                        name,
+                        data=rng.integers(0, 255, (T, H, W, 3), dtype=np.uint8),
+                        compression="gzip",
+                    )
+            total += T
+        data.attrs["total"] = total
+
+
+def _run_merge(argv):
+    return merge_demos.main(argv)
+
+
+def _h5_demo_names(path):
+    with h5py.File(path, "r") as f:
+        return sorted(
+            [k for k in f["data"].keys() if k.startswith("demo_")],
+            key=lambda x: int(x.split("_")[-1]),
+        )
+
+
+def test_two_file_happy_path(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=3, base_episode_len=100)
+    _make_dataset(str(b), num_demos=2, base_episode_len=200)
+
+    assert _run_merge([str(a), str(b), "-o", str(out)]) == 0
+    assert out.exists()
+
+    with h5py.File(out, "r") as f:
+        assert int(f.attrs["format_version"]) == 1
+        data = f["data"]
+        demo_names = sorted([k for k in data.keys() if k.startswith("demo_")], key=lambda x: int(x.split("_")[-1]))
+        assert demo_names == [f"demo_{i}" for i in range(5)]
+        # a: 100 + 101 + 102 = 303; b: 200 + 201 = 401
+        assert int(data.attrs["total"]) == 303 + 401
+        for name in demo_names:
+            assert bool(data[name].attrs["success"]) is True
+
+
+def test_three_file_input_order(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    c = tmp_path / "c.hdf5"
+    out = tmp_path / "merged.hdf5"
+    for path, marker in ((a, 1.0), (b, 2.0), (c, 3.0)):
+        _make_dataset(str(path), num_demos=1, base_episode_len=10)
+        with h5py.File(path, "r+") as f:
+            f["data/demo_0/actions"][...] = marker
+
+    assert _run_merge([str(a), str(b), str(c), "-o", str(out)]) == 0
+    with h5py.File(out, "r") as f:
+        assert np.allclose(f["data/demo_0/actions"][...], 1.0)
+        assert np.allclose(f["data/demo_1/actions"][...], 2.0)
+        assert np.allclose(f["data/demo_2/actions"][...], 3.0)
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a))
+    assert _run_merge([str(a), "-o", str(out), "--dry_run"]) == 0
+    assert not out.exists()
+
+
+def test_overwrite_protects_existing(tmp_path):
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a))
+    out.write_text("placeholder")
+
+    assert _run_merge([str(a), "-o", str(out)]) != 0
+    assert out.read_text() == "placeholder"
+
+    assert _run_merge([str(a), "-o", str(out), "--overwrite"]) == 0
+    with h5py.File(out, "r") as f:
+        assert "data" in f
+
+
+def test_output_equals_input_rejected(tmp_path):
+    a = tmp_path / "a.hdf5"
+    _make_dataset(str(a), num_demos=2)
+    assert _run_merge([str(a), "-o", str(a)]) != 0
+    # input untouched and still readable
+    assert _h5_demo_names(a) == ["demo_0", "demo_1"]
+
+
+def test_input_collides_with_tmp_path_rejected(tmp_path):
+    """An input named <output>.tmp must be rejected before _merge truncates it."""
+    out = tmp_path / "merged.hdf5"
+    sneaky_input = tmp_path / "merged.hdf5.tmp"
+    _make_dataset(str(sneaky_input), num_demos=2)
+
+    assert _run_merge([str(sneaky_input), "-o", str(out)]) != 0
+    # The sneaky input must still be intact and readable.
+    assert _h5_demo_names(sneaky_input) == ["demo_0", "demo_1"]
+    assert not out.exists()
+
+
+def test_single_input_file_works(tmp_path):
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=4)
+    assert _run_merge([str(a), "-o", str(out)]) == 0
+    assert _h5_demo_names(out) == [f"demo_{i}" for i in range(4)]
+
+
+def test_format_version_mismatch(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), format_version=0)
+    _make_dataset(str(b), format_version=1)
+    assert _run_merge([str(a), str(b), "-o", str(out)]) != 0
+    assert not out.exists()
+
+
+def test_action_dim_mismatch_strict(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), action_dim=8)
+    _make_dataset(str(b), action_dim=6)
+    assert _run_merge([str(a), str(b), "-o", str(out)]) != 0
+    assert not out.exists()
+
+
+def test_missing_obs_key_strict(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), obs_terms=("robot_joint_pos", "left_eef_pos"))
+    _make_dataset(str(b), obs_terms=("robot_joint_pos",))
+    assert _run_merge([str(a), str(b), "-o", str(out)]) != 0
+
+
+def test_camera_shape_mismatch(tmp_path):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(
+        str(a),
+        camera_shapes={"robot_head_cam_rgb": (24, 32)},
+        base_episode_len=5,
+        num_demos=1,
+    )
+    _make_dataset(
+        str(b),
+        camera_shapes={"robot_head_cam_rgb": (48, 64)},
+        base_episode_len=5,
+        num_demos=1,
+    )
+    assert _run_merge([str(a), str(b), "-o", str(out)]) != 0
+
+
+def test_env_args_sim_dt_mismatch(tmp_path, capsys):
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), sim_dt=0.01)
+    _make_dataset(str(b), sim_dt=0.02)
+    assert _run_merge([str(a), str(b), "-o", str(out)]) == 0
+    # Single readouterr() — calling it twice clears the buffer and the second call returns
+    # empty strings, so any stderr output would be silently dropped.
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    # The mismatch should surface as a WARNING or in the validation status row
+    assert "sim_args" in combined or "WARN" in combined
+
+
+def test_empty_input_rejected(tmp_path):
+    empty = tmp_path / "empty.hdf5"
+    out = tmp_path / "merged.hdf5"
+    with h5py.File(empty, "w") as f:
+        f.attrs["format_version"] = 1
+        data = f.create_group("data")
+        data.attrs["env_args"] = json.dumps({"env_name": "", "type": 2})
+        data.attrs["total"] = 0
+    assert _run_merge([str(empty), "-o", str(out)]) != 0
+
+
+def test_forward_compat_new_key(tmp_path):
+    """An unknown future recorder key must round-trip via the recursive copy."""
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), extra_obs_keys=("future_unknown_term",))
+    _make_dataset(str(b), extra_obs_keys=("future_unknown_term",))
+
+    assert _run_merge([str(a), str(b), "-o", str(out)]) == 0
+    with h5py.File(out, "r") as f:
+        for name in f["data"].keys():
+            if not name.startswith("demo_"):
+                continue
+            assert "future_unknown_term" in f[f"data/{name}/obs"]
+
+
+def test_extra_top_level_demo_attr(tmp_path):
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), extra_top_level_demo_attrs={"recording_timestamp": 1700000000})
+
+    assert _run_merge([str(a), "-o", str(out)]) == 0
+    with h5py.File(out, "r") as f:
+        assert int(f["data/demo_0"].attrs["recording_timestamp"]) == 1700000000
+
+
+def test_legacy_file_without_success_attr(tmp_path):
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), success=None)
+    assert _run_merge([str(a), "-o", str(out)]) == 0
+
+
+def test_summary_log_format(tmp_path, capsys):
+    a = tmp_path / "session_a.hdf5"
+    b = tmp_path / "session_b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=3)
+    _make_dataset(str(b), num_demos=2)
+
+    assert _run_merge([str(a), str(b), "-o", str(out)]) == 0
+    text = capsys.readouterr().out
+    assert "session_a.hdf5" in text
+    assert "session_b.hdf5" in text
+    assert "[1/2]" in text
+    assert "[2/2]" in text
+    assert "merged.hdf5" in text
+    assert "Validation" in text
+    assert "format_version OK" in text
+    assert "demo_0" in text
+    assert "demo_4" in text
+
+
+def test_total_attr_recomputed_from_truth(tmp_path):
+    """Even if data.attrs['total'] is wrong on input, output recomputes from per-demo num_samples."""
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=2, base_episode_len=50)
+    with h5py.File(a, "r+") as f:
+        f["data"].attrs["total"] = 99999
+
+    assert _run_merge([str(a), "-o", str(out)]) == 0
+    with h5py.File(out, "r") as f:
+        assert int(f["data"].attrs["total"]) == 50 + 51
+
+
+def test_output_parent_directory_created(tmp_path):
+    """The script should mkdir -p the output's parent directory automatically."""
+    a = tmp_path / "a.hdf5"
+    _make_dataset(str(a))
+    nested_out = tmp_path / "fresh" / "subdir" / "merged.hdf5"
+    assert not nested_out.parent.exists()
+
+    assert _run_merge([str(a), "-o", str(nested_out)]) == 0
+    assert nested_out.exists()
+
+
+def test_demo_without_step_info_warns(tmp_path, capsys):
+    """A demo with no num_samples attr and no actions dataset should produce a warning."""
+    a = tmp_path / "a.hdf5"
+    _make_dataset(str(a), num_demos=2)
+    # Strip num_samples and remove the actions dataset from demo_1 to simulate a broken demo
+    with h5py.File(a, "r+") as f:
+        demo = f["data/demo_1"]
+        del demo.attrs["num_samples"]
+        del demo["actions"]
+
+    out = tmp_path / "merged.hdf5"
+    assert _run_merge([str(a), "-o", str(out)]) == 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "demo_1" in combined
+    assert "num_samples" in combined or "actions" in combined
+
+
+def test_non_hdf5_input_produces_clean_error(tmp_path, capsys):
+    """A plain-text file with .hdf5 extension should produce a clean ERROR, not a traceback."""
+    bogus = tmp_path / "not_actually_hdf5.hdf5"
+    bogus.write_text("this is plain text, not an HDF5 file")
+    out = tmp_path / "merged.hdf5"
+
+    assert _run_merge([str(bogus), "-o", str(out)]) == 2
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Traceback" not in combined
+    assert "ERROR" in combined
+    assert "not_actually_hdf5.hdf5" in combined
+    assert not out.exists()
+
+
+def test_merge_failure_cleans_up_partial_output(tmp_path, monkeypatch, capsys):
+    """If _merge raises mid-write, neither the final output nor the .tmp partial may linger."""
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a))
+
+    def _failing_merge(infos, output_path):
+        with open(output_path, "wb") as f:
+            f.write(b"partial garbage")
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(merge_demos, "_merge", _failing_merge)
+    assert _run_merge([str(a), "-o", str(out)]) == 1
+    assert not out.exists()
+    assert not (tmp_path / "merged.hdf5.tmp").exists()
+
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Traceback" not in combined
+    assert "ERROR" in combined
+
+
+def test_overwrite_failure_preserves_existing_output(tmp_path, monkeypatch):
+    """With --overwrite, a mid-merge failure must not destroy the operator's prior output."""
+    a = tmp_path / "a.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=2, base_episode_len=10)
+    # Sentinel episode length proves the original file is untouched after the failure.
+    _make_dataset(str(out), num_demos=1, base_episode_len=4242)
+
+    def _failing_merge(infos, output_path):
+        with open(output_path, "wb") as f:
+            f.write(b"partial garbage")
+        raise OSError("simulated mid-merge failure")
+
+    monkeypatch.setattr(merge_demos, "_merge", _failing_merge)
+    assert _run_merge([str(a), "-o", str(out), "--overwrite"]) == 1
+    assert out.exists()
+    with h5py.File(out, "r") as f:
+        assert int(f["data/demo_0"].attrs["num_samples"]) == 4242
+    assert not (tmp_path / "merged.hdf5.tmp").exists()
+
+
+def test_merged_file_loads_via_isaaclab_handler(tmp_path):
+    """Property test: merged file must be readable by isaaclab's HDF5DatasetFileHandler."""
+    try:
+        from isaaclab.utils.datasets import HDF5DatasetFileHandler
+    except ImportError as e:
+        pytest.skip(f"isaaclab.utils.datasets not importable in this context: {e}")
+
+    a = tmp_path / "a.hdf5"
+    b = tmp_path / "b.hdf5"
+    out = tmp_path / "merged.hdf5"
+    _make_dataset(str(a), num_demos=2)
+    _make_dataset(str(b), num_demos=3)
+
+    assert _run_merge([str(a), str(b), "-o", str(out)]) == 0
+
+    handler = HDF5DatasetFileHandler()
+    handler.open(str(out), mode="r")
+    try:
+        assert handler.get_num_episodes() == 5
+        for name in handler.get_episode_names():
+            episode = handler.load_episode(name, device="cpu")
+            assert episode is not None
+            assert bool(episode.success) is True
+            assert "actions" in episode.data
+    finally:
+        handler.close()


### PR DESCRIPTION
## Summary
Cherry-pick #699 onto release/0.2.1.

## Detailed description
- Brings the multi-session HDF5 merge tool (`merge_demos.py`) to the
  0.2.1 release so operators on the release branch can consolidate
  recordings from multiple teleop sittings without rerunning.
- Includes the 20 Phase-1 unit tests (~3s runtime) and the new Step 4b
  doc section in `static_apple/step_2_teleoperation.rst` plus
  cross-reference links from the three other teleop pages.
- Clean cherry-pick of c94e34d4f — no conflicts, no manual edits.