### PR TITLE
[main] Address docs feedback for static apple wf

### DIFF
--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -51,9 +51,9 @@ balances the standing pose (no locomotion, no squat), and PinkIK drives the uppe
    * - **Post-training**
      - Imitation Learning
    * - **Dataset**
-     - Self-recorded (collect via Step 2)
+     - `Arena-G1-Static-PickNPlace-Task <https://huggingface.co/datasets/nvidia/Arena-G1-Static-PickNPlace-Task>`_
    * - **Checkpoint**
-     - Self-trained (post-train via Step 4)
+     - `GN1x-Tuned-Arena-G1-Static-PickNPlace <https://huggingface.co/nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace>`_
    * - **Physics**
      - PhysX (200Hz @ 4 decimation)
    * - **Closed-loop**

--- a/docs/pages/example_workflows/static_apple/index.rst
+++ b/docs/pages/example_workflows/static_apple/index.rst
@@ -106,7 +106,8 @@ Standalone Isaac-GR00T (N1.7) checkout (used in :doc:`step_3_policy_training` an
 
 Open another terminal outside the Arena Base Docker container and set up the native GR00T
 ``uv`` environment from ``$ISAAC_GR00T_DIR`` by following the
-`GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_.
+`GR00T installation guide
+<https://github.com/NVIDIA/Isaac-GR00T/blob/4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e/README.md#installation-guide>`_.
 
 This venv is **separate** from Arena's container, but Arena's policy runner still imports the
 GR00T ``PolicyClient`` from the Arena-pinned ``submodules/Isaac-GR00T`` checkout. Keep the

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -33,7 +33,7 @@ who specifically want HOMIE.
    the policy is trained on the joint-space targets that PinkIK *produced* during recording. This
    matters for finetuning: see :doc:`step_3_policy_training` for the rationale.
 
-.. dropdown:: The Galileo G1 Static Pick-and-Place Environment
+.. dropdown:: The Galileo G1 Static Pick-and-Place Environment (abridged)
    :animate: fade-in
 
    .. code-block:: python
@@ -43,34 +43,105 @@ who specifically want HOMIE.
 
        SHELF_SURFACE_Z = -0.030
        SHELF_AIRGAP = 0.005
-       PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.18)
-       DESTINATION_SPAWN_XY = (0.5785, -0.06)
+       SHELF_SUPPORT_PATCH_SIZE = (0.8, 1.5, 0.04)
+       SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - SHELF_SUPPORT_PATCH_SIZE[2] / 2.0)
+       PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.27)
+       DESTINATION_SPAWN_XY = (0.5785, 0.06)
+       APPLE_SPAWN_XY_RANGE_M = 0.0
 
        _USD_ORIGIN_ABOVE_BOTTOM_M = {
-           "apple_01_objaverse_robolab": 0.019,
+           "apple_01_objaverse_robolab": 0.0171,
            "clay_plates_hot3d_robolab": 0.0,
        }
 
        TUNED_PICK_UP_OBJECT_NAME = "apple_01_objaverse_robolab"
        TUNED_DESTINATION_NAME = "clay_plates_hot3d_robolab"
+       _TUNED_SCALES = {
+           TUNED_PICK_UP_OBJECT_NAME: (0.009, 0.009, 0.009),
+           TUNED_DESTINATION_NAME: (0.5, 0.5, 0.5),
+       }
+
+       _BACKGROUND_PRIMS_TO_DEACTIVATE = (
+           "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_06",
+           "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_03",
+           "galileo_locomanip/BackgroundAssets/boxes/hesai_box_06",
+       )
+
+
+       def _shelf_spawn_z(asset_name):
+           if asset_name in _USD_ORIGIN_ABOVE_BOTTOM_M:
+               return SHELF_SURFACE_Z + SHELF_AIRGAP + _USD_ORIGIN_ABOVE_BOTTOM_M[asset_name]
+           return SHELF_SURFACE_Z + SHELF_AIRGAP
+
+
+       def _asset_scale(asset_name):
+           return _TUNED_SCALES.get(asset_name, (1.0, 1.0, 1.0))
+
+
+       def _deactivate_background_prims(env, env_ids, prim_relative_paths):
+           # Deactivates selected box prims that otherwise clutter the static task workspace.
+           ...
 
 
        @register_environment
        class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
-
            name: str = "galileo_g1_static_pick_and_place"
 
            def get_env(self, args_cli):
+               from isaaclab import sim as sim_utils
+               from isaaclab.managers import EventTermCfg
+
+               from isaaclab_arena.assets.object import Object
+               from isaaclab_arena.assets.object_base import ObjectType
                from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
                from isaaclab_arena.scene.scene import Scene
                from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
-               from isaaclab_arena.utils.pose import Pose
+               from isaaclab_arena.utils.pose import Pose, PoseRange
+               from isaaclab_arena_environments.mdp.galileo_g1_static_pick_and_place.robot_configs import (
+                   G1_STATIC_FINGER_DYNAMIC_FRICTION,
+                   G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
+                   G1_STATIC_FINGER_PRIM_NAME_MARKERS,
+                   G1_STATIC_FINGER_STATIC_FRICTION,
+                   G1_STATIC_OPEN_ARM_JOINT_POS,
+               )
 
                background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
-               destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
+
+               class StaticShelfSupport(Object):
+                   def __init__(self):
+                       spawner_cfg = sim_utils.CuboidCfg(
+                           size=SHELF_SUPPORT_PATCH_SIZE,
+                           collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+                           visible=False,
+                       )
+                       super().__init__(
+                           name="static_pick_place_shelf_support",
+                           prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
+                           object_type=ObjectType.BASE,
+                           spawner_cfg=spawner_cfg,
+                           initial_pose=Pose(
+                               position_xyz=SHELF_SUPPORT_PATCH_CENTER,
+                               rotation_xyzw=(0.0, 0.0, 0.0, 1.0),
+                           ),
+                           tags=["background", "procedural"],
+                       )
+
+               shelf_support = StaticShelfSupport()
+               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(
+                   scale=_asset_scale(args_cli.object)
+               )
+               destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
+                   scale=_asset_scale(args_cli.destination)
+               )
                embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
-                   enable_cameras=args_cli.enable_cameras
+                   enable_cameras=args_cli.enable_cameras,
+                   lock_waist=args_cli.lock_waist,
+               )
+               embodiment.set_finger_contact_friction(
+                   material_path=G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
+                   static_friction=G1_STATIC_FINGER_STATIC_FRICTION,
+                   dynamic_friction=G1_STATIC_FINGER_DYNAMIC_FRICTION,
+                   prim_name_markers=G1_STATIC_FINGER_PRIM_NAME_MARKERS,
                )
 
                teleop_device = (
@@ -79,20 +150,41 @@ who specifically want HOMIE.
                )
 
                embodiment.set_initial_pose(
-                   Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+                   Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
                )
+               embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
+
                px, py = PICK_UP_OBJECT_SPAWN_XY
                dx, dy = DESTINATION_SPAWN_XY
+               pz = _shelf_spawn_z(args_cli.object)
                pick_up_object.set_initial_pose(
-                   Pose(position_xyz=(px, py, _shelf_spawn_z(args_cli.object)),
-                        rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+                   PoseRange(
+                       position_xyz_min=(px - APPLE_SPAWN_XY_RANGE_M, py - APPLE_SPAWN_XY_RANGE_M, pz),
+                       position_xyz_max=(px + APPLE_SPAWN_XY_RANGE_M, py + APPLE_SPAWN_XY_RANGE_M, pz),
+                       rpy_min=(0.0, 0.0, 0.0),
+                       rpy_max=(0.0, 0.0, 0.0),
+                   )
                )
                destination.set_initial_pose(
                    Pose(position_xyz=(dx, dy, _shelf_spawn_z(args_cli.destination)),
                         rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
                )
 
-               scene = Scene(assets=[background, pick_up_object, destination])
+               task_description = args_cli.task_description or (
+                   f"Pick up the {args_cli.object.replace('_', ' ')} from the shelf and place it onto the "
+                   f"{args_cli.destination.replace('_', ' ')} on the same shelf next to it."
+               )
+
+               def env_cfg_callback(env_cfg):
+                   env_cfg.events.deactivate_static_pick_place_background_prims = EventTermCfg(
+                       func=_deactivate_background_prims,
+                       mode="prestartup",
+                       params={"prim_relative_paths": _BACKGROUND_PRIMS_TO_DEACTIVATE},
+                   )
+                   env_cfg.num_rerenders_on_reset = 1
+                   return env_cfg
+
+               scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
                return IsaacLabArenaEnvironment(
                    name=self.name,
                    embodiment=embodiment,
@@ -101,10 +193,13 @@ who specifically want HOMIE.
                        pick_up_object=pick_up_object,
                        destination_location=destination,
                        background_scene=background,
+                       episode_length_s=6.0,
+                       task_description=task_description,
                        force_threshold=0.5,
                        velocity_threshold=0.1,
                    ),
                    teleop_device=teleop_device,
+                   env_cfg_callback=env_cfg_callback,
                )
 
 
@@ -116,10 +211,22 @@ Step-by-Step Breakdown
 .. code-block:: python
 
     background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
-    destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
+    shelf_support = StaticShelfSupport()
+    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(
+        scale=_asset_scale(args_cli.object)
+    )
+    destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
+        scale=_asset_scale(args_cli.destination)
+    )
     embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
-        enable_cameras=args_cli.enable_cameras
+        enable_cameras=args_cli.enable_cameras,
+        lock_waist=args_cli.lock_waist,
+    )
+    embodiment.set_finger_contact_friction(
+        material_path=G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
+        static_friction=G1_STATIC_FINGER_STATIC_FRICTION,
+        dynamic_friction=G1_STATIC_FINGER_DYNAMIC_FRICTION,
+        prim_name_markers=G1_STATIC_FINGER_PRIM_NAME_MARKERS,
     )
 
 The static workflow shares the ``galileo_locomanip`` background with the loco-manipulation variant
@@ -127,9 +234,12 @@ on purpose: the lighting, shelf geometry and 23-D action layout are already tune
 thing that changes is *where* the destination sits and which lower-body WBC backend balances the
 robot. The default ``g1_wbc_agile_pink`` embodiment swaps HOMIE's stand+walk pair for AGILE's
 single end-to-end velocity policy, which is a better fit for a no-locomotion task; ``g1_wbc_pink`` is
-accepted as an override for users who want HOMIE behaviour. ``teleop_device`` is left as ``None``
-when ``--teleop_device`` is not supplied so that scripts like ``replay_demos.py`` and
-``policy_runner.py`` can launch the same environment without instantiating an XR runtime.
+accepted as an override for users who want HOMIE behaviour. The tuned apple and plate are spawned
+with explicit scales, the ``StaticShelfSupport`` cuboid gives small objects a clean invisible
+collision surface on top of the imported shelf mesh, and the static task locks the waist by default
+through ``--lock_waist`` while applying task-specific finger contact friction. ``teleop_device`` is
+left as ``None`` when ``--teleop_device`` is not supplied so that scripts like ``replay_demos.py``
+and ``policy_runner.py`` can launch the same environment without instantiating an XR runtime.
 
 
 **2. Position the Objects**
@@ -137,34 +247,45 @@ when ``--teleop_device`` is not supplied so that scripts like ``replay_demos.py`
 .. code-block:: python
 
    embodiment.set_initial_pose(
-       Pose(position_xyz=(0.0, 0.18, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+       Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
    )
+   embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
+
+   px, py = PICK_UP_OBJECT_SPAWN_XY
+   pz = _shelf_spawn_z(args_cli.object)
    pick_up_object.set_initial_pose(
-       Pose(position_xyz=(0.5785, 0.18, _shelf_spawn_z(args_cli.object)),
-            rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+       PoseRange(
+           position_xyz_min=(px - APPLE_SPAWN_XY_RANGE_M, py - APPLE_SPAWN_XY_RANGE_M, pz),
+           position_xyz_max=(px + APPLE_SPAWN_XY_RANGE_M, py + APPLE_SPAWN_XY_RANGE_M, pz),
+           rpy_min=(0.0, 0.0, 0.0),
+           rpy_max=(0.0, 0.0, 0.0),
+       )
    )
    destination.set_initial_pose(
-       Pose(position_xyz=(0.5785, -0.06, _shelf_spawn_z(args_cli.destination)),
+       Pose(position_xyz=(0.5785, 0.06, _shelf_spawn_z(args_cli.destination)),
             rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
    )
 
-The robot pose mirrors the loco-manipulation env exactly so the WBC controller stands the robot up
-in the same shelf-relative spot. The apple is placed at a measured on-shelf X/Y, and the plate is
-offset 24 cm in -Y so its 30 cm footprint clears the apple without collision. ``_shelf_spawn_z``
-consults a per-asset USD-origin table so each asset's *bottom face* — not its USD origin — lands
-flush on the shelf surface; assets not in the table fall back to ``SHELF_SURFACE_Z + SHELF_AIRGAP``
-and emit a warning so you know to verify the spawn pose visually before recording demonstrations.
+The robot starts slightly forward of the loco-manipulation pose so both arms can comfortably reach
+the same-shelf workspace. The apple is centered at ``(0.5785, 0.27)`` and the plate at
+``(0.5785, 0.06)``, so the plate is 21 cm away along the shelf while staying within arm's reach.
+``PoseRange`` is used for the apple so per-episode XY randomization can be enabled by changing
+``APPLE_SPAWN_XY_RANGE_M``; the current tuned workflow keeps it at ``0.0`` for deterministic demos.
+``_shelf_spawn_z`` consults a per-asset USD-origin table so each asset's *bottom face* — not its USD
+origin — lands flush on the shelf surface; assets not in the table fall back to
+``SHELF_SURFACE_Z + SHELF_AIRGAP`` and emit a warning so you know to verify the spawn pose visually
+before recording demonstrations.
 
 
 **3. Compose the Scene**
 
 .. code-block:: python
 
-    scene = Scene(assets=[background, pick_up_object, destination])
+    scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
 
-The static env uses a single shelf-anchored background plus the pick-up object and the destination;
-no second table is needed because the destination plate sits on the same shelf as the apple.
-See :doc:`../../concepts/scene/index` for scene composition details.
+The static env uses a single shelf-anchored background plus the invisible shelf support, the pick-up
+object, and the destination. No second table is needed because the destination plate sits on the
+same shelf as the apple. See :doc:`../../concepts/scene/index` for scene composition details.
 
 
 **4. Create the Pick and Place Task**
@@ -175,6 +296,8 @@ See :doc:`../../concepts/scene/index` for scene composition details.
         pick_up_object=pick_up_object,
         destination_location=destination,
         background_scene=background,
+        episode_length_s=6.0,
+        task_description=task_description,
         force_threshold=0.5,
         velocity_threshold=0.1,
     )
@@ -182,7 +305,9 @@ See :doc:`../../concepts/scene/index` for scene composition details.
 The static env uses ``PickAndPlaceTask`` directly. The task wires the apple,
 plate, and background into the standard pick-and-place termination logic;
 ``force_threshold`` / ``velocity_threshold`` mirror the locomanip env so success
-metrics are directly comparable.
+metrics are directly comparable. Episodes are capped at 6 seconds because the
+same-shelf task has no locomotion phase, and the task description is generated
+from ``--object`` / ``--destination`` unless the user passes ``--task_description``.
 
 See :doc:`../../concepts/task/index` for task creation details.
 
@@ -197,9 +322,13 @@ See :doc:`../../concepts/task/index` for task creation details.
         scene=scene,
         task=task,
         teleop_device=teleop_device,
+        env_cfg_callback=env_cfg_callback,
     )
 
-Finally, we assemble all the pieces into a complete, runnable environment.
+Finally, we assemble all the pieces into a complete, runnable environment. The
+``env_cfg_callback`` deactivates a few box prims from the reused background that would otherwise
+clutter the static workspace and forces one camera rerender after reset so GR00T policy inputs do
+not see the previous episode's final frame.
 See :doc:`../../concepts/concept_overview` for environment composition details.
 
 

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -13,16 +13,13 @@ and validate that we can load it in Isaac Lab.
 Environment Description
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The static apple-to-plate workflow ships its own ``GalileoG1StaticPickAndPlaceEnvironment`` registered
-under ``galileo_g1_static_pick_and_place``. It reuses the same ``galileo_locomanip`` background USD
-and the same OpenXR retargeter as the loco-manipulation apple-to-plate environment, but defaults to
-the ``g1_wbc_agile_pink`` embodiment (AGILE end-to-end velocity policy) instead of ``g1_wbc_pink``
-(HOMIE stand+walk pair). The static task never walks, so AGILE's single-policy backend is a better
-fit than HOMIE's stand/walk model split — both share the same 23-D action layout and OpenXR
-retargeter pipeline, so only the lower-body ONNX backend changes. Both the apple and the destination
-plate are placed on the *same* shelf so the robot never needs to drive its base anywhere — WBC just
-holds the standing pose. The ``g1_wbc_pink`` embodiment is still accepted as an override for users
-who specifically want HOMIE.
+The static apple-to-plate workflow ships its own ``GalileoG1StaticPickAndPlaceEnvironment``,
+exposed by the example-environment registry as ``galileo_g1_static_pick_and_place``. It reuses the
+same ``galileo_locomanip`` shelf scene and the same OpenXR retargeter as the loco-manipulation
+apple-to-plate environment, but defaults to the ``g1_wbc_agile_pink`` embodiment for recording. The
+static task never walks, so AGILE's single-policy lower-body backend is a better fit than HOMIE's
+stand/walk model split. Both the apple and destination plate are placed on the same shelf, so the
+WBC only needs to hold the standing pose.
 
 .. note::
 
@@ -30,306 +27,84 @@ who specifically want HOMIE.
    default ``g1_wbc_agile_pink`` (PinkIK + AGILE), while closed-loop policy evaluation in
    :doc:`step_4_evaluation` uses ``g1_wbc_agile_joint`` (direct joint control + AGILE). Both share
    the same AGILE lower-body backend; the ``_joint`` twin just bypasses PinkIK at inference because
-   the policy is trained on the joint-space targets that PinkIK *produced* during recording. This
+   the policy is trained on the joint-space targets that PinkIK produced during recording. This
    matters for finetuning: see :doc:`step_3_policy_training` for the rationale.
 
-.. dropdown:: The Galileo G1 Static Pick-and-Place Environment (abridged)
-   :animate: fade-in
 
-   .. code-block:: python
-
-       from isaaclab_arena.assets.register import register_environment
-       from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
-
-       SHELF_SURFACE_Z = -0.030
-       SHELF_AIRGAP = 0.005
-       SHELF_SUPPORT_PATCH_SIZE = (0.8, 1.5, 0.04)
-       SHELF_SUPPORT_PATCH_CENTER = (0.62, 0.0, SHELF_SURFACE_Z - SHELF_SUPPORT_PATCH_SIZE[2] / 2.0)
-       PICK_UP_OBJECT_SPAWN_XY = (0.5785, 0.27)
-       DESTINATION_SPAWN_XY = (0.5785, 0.06)
-       APPLE_SPAWN_XY_RANGE_M = 0.0
-
-       _USD_ORIGIN_ABOVE_BOTTOM_M = {
-           "apple_01_objaverse_robolab": 0.0171,
-           "clay_plates_hot3d_robolab": 0.0,
-       }
-
-       TUNED_PICK_UP_OBJECT_NAME = "apple_01_objaverse_robolab"
-       TUNED_DESTINATION_NAME = "clay_plates_hot3d_robolab"
-       _TUNED_SCALES = {
-           TUNED_PICK_UP_OBJECT_NAME: (0.009, 0.009, 0.009),
-           TUNED_DESTINATION_NAME: (0.5, 0.5, 0.5),
-       }
-
-       _BACKGROUND_PRIMS_TO_DEACTIVATE = (
-           "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_06",
-           "galileo_locomanip/BackgroundAssets/boxes/jetson_orin_03",
-           "galileo_locomanip/BackgroundAssets/boxes/hesai_box_06",
-       )
-
-
-       def _shelf_spawn_z(asset_name):
-           if asset_name in _USD_ORIGIN_ABOVE_BOTTOM_M:
-               return SHELF_SURFACE_Z + SHELF_AIRGAP + _USD_ORIGIN_ABOVE_BOTTOM_M[asset_name]
-           return SHELF_SURFACE_Z + SHELF_AIRGAP
-
-
-       def _asset_scale(asset_name):
-           return _TUNED_SCALES.get(asset_name, (1.0, 1.0, 1.0))
-
-
-       def _deactivate_background_prims(env, env_ids, prim_relative_paths):
-           # Deactivates selected box prims that otherwise clutter the static task workspace.
-           ...
-
-
-       @register_environment
-       class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
-           name: str = "galileo_g1_static_pick_and_place"
-
-           def get_env(self, args_cli):
-               from isaaclab import sim as sim_utils
-               from isaaclab.managers import EventTermCfg
-
-               from isaaclab_arena.assets.object import Object
-               from isaaclab_arena.assets.object_base import ObjectType
-               from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-               from isaaclab_arena.scene.scene import Scene
-               from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
-               from isaaclab_arena.utils.pose import Pose, PoseRange
-               from isaaclab_arena_environments.mdp.galileo_g1_static_pick_and_place.robot_configs import (
-                   G1_STATIC_FINGER_DYNAMIC_FRICTION,
-                   G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
-                   G1_STATIC_FINGER_PRIM_NAME_MARKERS,
-                   G1_STATIC_FINGER_STATIC_FRICTION,
-                   G1_STATIC_OPEN_ARM_JOINT_POS,
-               )
-
-               background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-
-               class StaticShelfSupport(Object):
-                   def __init__(self):
-                       spawner_cfg = sim_utils.CuboidCfg(
-                           size=SHELF_SUPPORT_PATCH_SIZE,
-                           collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-                           visible=False,
-                       )
-                       super().__init__(
-                           name="static_pick_place_shelf_support",
-                           prim_path="{ENV_REGEX_NS}/static_pick_place_shelf_support",
-                           object_type=ObjectType.BASE,
-                           spawner_cfg=spawner_cfg,
-                           initial_pose=Pose(
-                               position_xyz=SHELF_SUPPORT_PATCH_CENTER,
-                               rotation_xyzw=(0.0, 0.0, 0.0, 1.0),
-                           ),
-                           tags=["background", "procedural"],
-                       )
-
-               shelf_support = StaticShelfSupport()
-               pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(
-                   scale=_asset_scale(args_cli.object)
-               )
-               destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
-                   scale=_asset_scale(args_cli.destination)
-               )
-               embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
-                   enable_cameras=args_cli.enable_cameras,
-                   lock_waist=args_cli.lock_waist,
-               )
-               embodiment.set_finger_contact_friction(
-                   material_path=G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
-                   static_friction=G1_STATIC_FINGER_STATIC_FRICTION,
-                   dynamic_friction=G1_STATIC_FINGER_DYNAMIC_FRICTION,
-                   prim_name_markers=G1_STATIC_FINGER_PRIM_NAME_MARKERS,
-               )
-
-               teleop_device = (
-                   self.device_registry.get_device_by_name(args_cli.teleop_device)()
-                   if args_cli.teleop_device is not None else None
-               )
-
-               embodiment.set_initial_pose(
-                   Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
-               )
-               embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
-
-               px, py = PICK_UP_OBJECT_SPAWN_XY
-               dx, dy = DESTINATION_SPAWN_XY
-               pz = _shelf_spawn_z(args_cli.object)
-               pick_up_object.set_initial_pose(
-                   PoseRange(
-                       position_xyz_min=(px - APPLE_SPAWN_XY_RANGE_M, py - APPLE_SPAWN_XY_RANGE_M, pz),
-                       position_xyz_max=(px + APPLE_SPAWN_XY_RANGE_M, py + APPLE_SPAWN_XY_RANGE_M, pz),
-                       rpy_min=(0.0, 0.0, 0.0),
-                       rpy_max=(0.0, 0.0, 0.0),
-                   )
-               )
-               destination.set_initial_pose(
-                   Pose(position_xyz=(dx, dy, _shelf_spawn_z(args_cli.destination)),
-                        rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
-               )
-
-               task_description = args_cli.task_description or (
-                   f"Pick up the {args_cli.object.replace('_', ' ')} from the shelf and place it onto the "
-                   f"{args_cli.destination.replace('_', ' ')} on the same shelf next to it."
-               )
-
-               def env_cfg_callback(env_cfg):
-                   env_cfg.events.deactivate_static_pick_place_background_prims = EventTermCfg(
-                       func=_deactivate_background_prims,
-                       mode="prestartup",
-                       params={"prim_relative_paths": _BACKGROUND_PRIMS_TO_DEACTIVATE},
-                   )
-                   env_cfg.num_rerenders_on_reset = 1
-                   return env_cfg
-
-               scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
-               return IsaacLabArenaEnvironment(
-                   name=self.name,
-                   embodiment=embodiment,
-                   scene=scene,
-                   task=PickAndPlaceTask(
-                       pick_up_object=pick_up_object,
-                       destination_location=destination,
-                       background_scene=background,
-                       episode_length_s=6.0,
-                       task_description=task_description,
-                       force_threshold=0.5,
-                       velocity_threshold=0.1,
-                   ),
-                   teleop_device=teleop_device,
-                   env_cfg_callback=env_cfg_callback,
-               )
-
-
-Step-by-Step Breakdown
+Environment Composition
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-**1. Interact with the Asset and Device Registry**
+The full implementation lives in
+``isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py``. This page keeps the
+breakdown at the composition level so the docs stay focused on how an Arena environment is assembled
+instead of mirroring every placement constant or scene utility in the source file.
+
+.. list-table::
+   :widths: 28 72
+   :header-rows: 1
+
+   * - Component
+     - Role in this workflow
+   * - Environment name
+     - ``galileo_g1_static_pick_and_place``
+   * - Background
+     - ``galileo_locomanip`` provides the Galileo shelf scene reused from the locomotion workflow.
+   * - Embodiment
+     - ``g1_wbc_agile_pink`` is the recording default; ``g1_wbc_agile_joint`` is used for policy
+       evaluation after training.
+   * - Pick-up object
+     - ``apple_01_objaverse_robolab`` by default, selected through ``--object``.
+   * - Destination
+     - ``clay_plates_hot3d_robolab`` by default, selected through ``--destination``.
+   * - Scene utilities
+     - The registered environment handles tuned object placement, object scale, shelf support,
+       finger contact friction, and background cleanup internally.
+   * - Task
+     - ``PickAndPlaceTask`` checks whether the apple is moved onto the plate and provides the
+       success metrics used later in evaluation.
+   * - Teleop device
+     - ``openxr`` is attached only when ``--teleop_device openxr`` is passed, so the same
+       environment can also be used for replay and policy evaluation without XR.
+
+At a high level, defining an Arena environment is just selecting assets, composing a scene, choosing
+a task, and returning an ``IsaacLabArenaEnvironment``:
 
 .. code-block:: python
 
-    background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
-    shelf_support = StaticShelfSupport()
-    pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)(
-        scale=_asset_scale(args_cli.object)
-    )
-    destination = self.asset_registry.get_asset_by_name(args_cli.destination)(
-        scale=_asset_scale(args_cli.destination)
-    )
-    embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
-        enable_cameras=args_cli.enable_cameras,
-        lock_waist=args_cli.lock_waist,
-    )
-    embodiment.set_finger_contact_friction(
-        material_path=G1_STATIC_FINGER_FRICTION_MATERIAL_PATH,
-        static_friction=G1_STATIC_FINGER_STATIC_FRICTION,
-        dynamic_friction=G1_STATIC_FINGER_DYNAMIC_FRICTION,
-        prim_name_markers=G1_STATIC_FINGER_PRIM_NAME_MARKERS,
-    )
-
-The static workflow shares the ``galileo_locomanip`` background with the loco-manipulation variant
-on purpose: the lighting, shelf geometry and 23-D action layout are already tuned, so the only
-thing that changes is *where* the destination sits and which lower-body WBC backend balances the
-robot. The default ``g1_wbc_agile_pink`` embodiment swaps HOMIE's stand+walk pair for AGILE's
-single end-to-end velocity policy, which is a better fit for a no-locomotion task; ``g1_wbc_pink`` is
-accepted as an override for users who want HOMIE behaviour. The tuned apple and plate are spawned
-with explicit scales, the ``StaticShelfSupport`` cuboid gives small objects a clean invisible
-collision surface on top of the imported shelf mesh, and the static task locks the waist by default
-through ``--lock_waist`` while applying task-specific finger contact friction. ``teleop_device`` is
-left as ``None`` when ``--teleop_device`` is not supplied so that scripts like ``replay_demos.py``
-and ``policy_runner.py`` can launch the same environment without instantiating an XR runtime.
-
-
-**2. Position the Objects**
-
-.. code-block:: python
-
-   embodiment.set_initial_pose(
-       Pose(position_xyz=(0.25, 0.08, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+   background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+   pick_up_object = self.asset_registry.get_asset_by_name(args_cli.object)()
+   destination = self.asset_registry.get_asset_by_name(args_cli.destination)()
+   embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
+       enable_cameras=args_cli.enable_cameras
    )
-   embodiment.set_joint_initial_pos(G1_STATIC_OPEN_ARM_JOINT_POS)
-
-   px, py = PICK_UP_OBJECT_SPAWN_XY
-   pz = _shelf_spawn_z(args_cli.object)
-   pick_up_object.set_initial_pose(
-       PoseRange(
-           position_xyz_min=(px - APPLE_SPAWN_XY_RANGE_M, py - APPLE_SPAWN_XY_RANGE_M, pz),
-           position_xyz_max=(px + APPLE_SPAWN_XY_RANGE_M, py + APPLE_SPAWN_XY_RANGE_M, pz),
-           rpy_min=(0.0, 0.0, 0.0),
-           rpy_max=(0.0, 0.0, 0.0),
-       )
-   )
-   destination.set_initial_pose(
-       Pose(position_xyz=(0.5785, 0.06, _shelf_spawn_z(args_cli.destination)),
-            rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+   teleop_device = (
+       self.device_registry.get_device_by_name(args_cli.teleop_device)()
+       if args_cli.teleop_device is not None else None
    )
 
-The robot starts slightly forward of the loco-manipulation pose so both arms can comfortably reach
-the same-shelf workspace. The apple is centered at ``(0.5785, 0.27)`` and the plate at
-``(0.5785, 0.06)``, so the plate is 21 cm away along the shelf while staying within arm's reach.
-``PoseRange`` is used for the apple so per-episode XY randomization can be enabled by changing
-``APPLE_SPAWN_XY_RANGE_M``; the current tuned workflow keeps it at ``0.0`` for deterministic demos.
-``_shelf_spawn_z`` consults a per-asset USD-origin table so each asset's *bottom face* — not its USD
-origin — lands flush on the shelf surface; assets not in the table fall back to
-``SHELF_SURFACE_Z + SHELF_AIRGAP`` and emit a warning so you know to verify the spawn pose visually
-before recording demonstrations.
+   scene = Scene(assets=[background, pick_up_object, destination])
+   task = PickAndPlaceTask(
+       pick_up_object=pick_up_object,
+       destination_location=destination,
+       background_scene=background,
+   )
 
+   return IsaacLabArenaEnvironment(
+       name=self.name,
+       embodiment=embodiment,
+       scene=scene,
+       task=task,
+       teleop_device=teleop_device,
+   )
 
-**3. Compose the Scene**
+The production environment adds task-specific defaults around this core composition: same-shelf
+poses for the apple and plate, a short episode timeout, an invisible shelf support surface, tuned
+contact/friction settings, and cleanup of a few reused background props. Those details are handled
+inside the registered environment so workflow users can run it through the CLI without editing the
+scene setup code.
 
-.. code-block:: python
-
-    scene = Scene(assets=[background, shelf_support, pick_up_object, destination])
-
-The static env uses a single shelf-anchored background plus the invisible shelf support, the pick-up
-object, and the destination. No second table is needed because the destination plate sits on the
-same shelf as the apple. See :doc:`../../concepts/scene/index` for scene composition details.
-
-
-**4. Create the Pick and Place Task**
-
-.. code-block:: python
-
-    task = PickAndPlaceTask(
-        pick_up_object=pick_up_object,
-        destination_location=destination,
-        background_scene=background,
-        episode_length_s=6.0,
-        task_description=task_description,
-        force_threshold=0.5,
-        velocity_threshold=0.1,
-    )
-
-The static env uses ``PickAndPlaceTask`` directly. The task wires the apple,
-plate, and background into the standard pick-and-place termination logic;
-``force_threshold`` / ``velocity_threshold`` mirror the locomanip env so success
-metrics are directly comparable. Episodes are capped at 6 seconds because the
-same-shelf task has no locomotion phase, and the task description is generated
-from ``--object`` / ``--destination`` unless the user passes ``--task_description``.
-
-See :doc:`../../concepts/task/index` for task creation details.
-
-
-**5. Create the IsaacLab Arena Environment**
-
-.. code-block:: python
-
-    isaaclab_arena_environment = IsaacLabArenaEnvironment(
-        name=self.name,
-        embodiment=embodiment,
-        scene=scene,
-        task=task,
-        teleop_device=teleop_device,
-        env_cfg_callback=env_cfg_callback,
-    )
-
-Finally, we assemble all the pieces into a complete, runnable environment. The
-``env_cfg_callback`` deactivates a few box prims from the reused background that would otherwise
-clutter the static workspace and forces one camera rerender after reset so GR00T policy inputs do
-not see the previous episode's final frame.
-See :doc:`../../concepts/concept_overview` for environment composition details.
+See :doc:`../../concepts/concept_overview`, :doc:`../../concepts/scene/index`, and
+:doc:`../../concepts/task/index` for more details on Arena environment composition.
 
 
 Validate Environment with Automated Tests

--- a/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_apple/step_1_environment_setup.rst
@@ -48,7 +48,8 @@ instead of mirroring every placement constant or scene utility in the source fil
    * - Environment name
      - ``galileo_g1_static_pick_and_place``
    * - Background
-     - ``galileo_locomanip`` provides the Galileo shelf scene reused from the locomotion workflow.
+     - ``galileo_locomanip`` provides the Galileo shelf scene reused from the
+       :doc:`loco-manipulation workflow <../locomanipulation/index>`.
    * - Embodiment
      - ``g1_wbc_agile_pink`` is the recording default; ``g1_wbc_agile_joint`` is used for policy
        evaluation after training.

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -128,6 +128,16 @@ A strong wireless connection is essential for a high-quality streaming experienc
          :alt: IsaacSim view
          :align: center
 
+   .. note::
+
+      If the robot does not align with your body direction after connecting the headset, reset the
+      headset view before recording. On Meta Quest, hold the Meta/Oculus button or use
+      **Quick controls** > **Reset view**. On PICO 4 Ultra, look straight ahead and hold the
+      controller **Home** button for at least 1 second. See Meta's
+      `Quest guide <https://www.meta.com/help/quest/149215193811647/>`_ and the
+      `PICO 4 Ultra User Guide
+      <https://p16-platform-static-va.ibyteimg.com/tos-maliva-i-jo6vmmv194-us/pico4-ultra-user-guide-apac.pdf>`_.
+
 #. **Teleoperation Controls**:
 
    * **Left joystick**: Move the body forward/backward/left/right.

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -125,22 +125,31 @@ Training Configuration:
 - **Embodiment tag:** ``new_embodiment`` (case-insensitive; resolved to
   ``EmbodimentTag.NEW_EMBODIMENT`` by ``gr00t``)
 
-To post-train the policy, open another terminal **outside** the Arena Base Docker container
-and ``cd`` to ``$ISAAC_GR00T_DIR``. Set up GR00T's native ``uv`` environment by following
-the `GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_,
-then run the finetuning command below. Replace ``/path/to/IsaacLab-Arena`` with the absolute
-path to your Arena clone so the ``--modality-config-path`` argument can register the WBC
-modality from Arena's source tree. The dataset and output paths assume the default Arena Docker
-mounts (``~/datasets`` and ``~/models`` on the host); adjust them if you launched Arena with
-custom mount directories.
+To post-train the policy, open another terminal **outside** the Arena Base Docker container, set up
+GR00T's native ``uv`` environment by following the
+`GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_, and ``cd``
+to ``$ISAAC_GR00T_DIR``. The launcher runs inside the standalone repo's ``uv``-managed venv. Replace
+``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone so the
+``--modality-config-path`` argument can register the WBC modality from Arena's source tree.
+
+Because finetuning runs outside the Arena Docker container, set ``DATASET_DIR`` and ``MODELS_DIR``
+in the standalone GR00T terminal to the host paths that correspond to the Docker mounts. With the
+default Arena Docker mounts, these are usually:
 
 .. code-block:: bash
+
+   export DATASET_DIR=~/datasets/isaaclab_arena/static_apple_tutorial
+   export MODELS_DIR=~/models/isaaclab_arena/static_apple_tutorial
+
+.. code-block:: bash
+
+   cd $ISAAC_GR00T_DIR
 
    uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
      gr00t/experiment/launch_finetune.py \
      --base-model-path nvidia/GR00T-N1.7-3B \
-     --dataset-path ~/datasets/isaaclab_arena/static_apple_tutorial/arena_g1_static_apple_dataset_recorded/lerobot \
-     --output-dir ~/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune \
+     --dataset-path $DATASET_DIR/arena_g1_static_apple_dataset_recorded/lerobot \
+     --output-dir $MODELS_DIR/static_apple_n17_finetune \
      --modality-config-path /path/to/IsaacLab-Arena/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py \
      --embodiment-tag new_embodiment \
      --global-batch-size 96 \
@@ -217,11 +226,12 @@ whether the finetuned policy actually works in the AGILE-joint runtime:
    between training and serving.
 
 #. **Pick** ``action_horizon`` **deliberately.** The default (40) gives an 800 ms inference chunk at
-   50 Hz, which trades responsiveness against compute. For static apple-to-plate (~600 step
-   episodes) 40 is a good default. Going lower (e.g., 20) gives more responsive closed-loop control
-   at the cost of more frequent policy queries; going higher (e.g., 60) gives a longer inference
-   horizon at the cost of more compute per step. Whichever value you pick, **keep the modality
-   config and the server YAML in sync** (see the caution above).
+   50 Hz, which trades responsiveness against compute, and is the maximum supported by the released
+   GR00T N1.7 base model (``max_action_horizon = 40`` is baked into the checkpoint). For static
+   apple-to-plate (~600 step episodes) 40 is a good default. You can go lower (e.g., 20) for more
+   responsive closed-loop control at the cost of more frequent policy queries; you cannot go higher
+   without retraining the base model. Whichever value you pick, **keep the modality config and the
+   server YAML in sync** (see the caution above).
 
 If you adjust any of these and the resulting checkpoint behaves badly at evaluation, the most
 common culprits in order are: (i) too few or low-quality demonstrations, (ii) modality config /

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -1,7 +1,9 @@
 Policy Post-Training (GR00T N1.7)
 ---------------------------------
 
-This workflow covers post-training a `GR00T N1.7 <https://github.com/NVIDIA/Isaac-GR00T>`_ policy
+This workflow covers post-training a
+`GR00T N1.7 <https://github.com/NVIDIA/Isaac-GR00T/tree/4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e>`_
+policy
 directly on the **teleoperated demonstrations** exported in HDF5 from :doc:`step_2_teleoperation`.
 The recorded HDF5 is converted to LeRobot format inside the Arena container, then handed off to a
 **standalone Isaac-GR00T checkout** (``$ISAAC_GR00T_DIR`` from :doc:`index`) for finetuning. The
@@ -48,10 +50,12 @@ Once inside the container, set the dataset directory:
 
       hf download \
          nvidia/Arena-G1-Static-PickNPlace-Task \
-         arena_g1_static_apple_dataset_recorded.hdf5 \
+         arena_g1_static_apple_dataset_recorded_200_demos.hdf5 \
          --repo-type dataset \
-         --revision arena_v0.2_lab_v3.0 \
          --local-dir $DATASET_DIR
+
+      mv "$DATASET_DIR/arena_g1_static_apple_dataset_recorded_200_demos.hdf5" \
+         "$DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5"
 
 .. caution::
 
@@ -62,7 +66,8 @@ Once inside the container, set the dataset directory:
 
 Edit ``isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml`` so ``hdf5_name`` matches
 your recorded file (``arena_g1_static_apple_dataset_recorded.hdf5``) and ``data_root`` matches
-``$DATASET_DIR``.
+``$DATASET_DIR``. The Hugging Face download command above renames the released HDF5 to this local
+tutorial filename so the default config can be used unchanged.
 
 Convert the HDF5 dataset to LeRobot format for policy post-training:
 
@@ -147,8 +152,9 @@ Training Configuration:
 
 To post-train the policy, open another terminal **outside** the Arena Base Docker container, set up
 GR00T's native ``uv`` environment by following the
-`GR00T installation guide <https://github.com/NVIDIA/Isaac-GR00T#installation-guide>`_, and ``cd``
-to ``$ISAAC_GR00T_DIR``. The launcher runs inside the standalone repo's ``uv``-managed venv. Replace
+`GR00T installation guide
+<https://github.com/NVIDIA/Isaac-GR00T/blob/4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e/README.md#installation-guide>`_,
+and ``cd`` to ``$ISAAC_GR00T_DIR``. The launcher runs inside the standalone repo's ``uv``-managed venv. Replace
 ``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone so the
 ``--modality-config-path`` argument can register the WBC modality from Arena's source tree.
 
@@ -216,7 +222,8 @@ default Arena Docker mounts, these are usually:
       ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml``.
 
 If you have less powerful GPUs, please see the
-`GR00T fine-tuning guidelines <https://github.com/NVIDIA/Isaac-GR00T#3-fine-tuning>`_ for
+`GR00T fine-tuning guidelines
+<https://github.com/NVIDIA/Isaac-GR00T/blob/4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e/README.md#3-fine-tuning>`_ for
 information on how to adjust the training configuration to your hardware. We recommend fine-tuning
 the visual backbone, projector, and diffusion model for better results.
 

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -12,9 +12,9 @@ The N1.7 finetune script lives in the standalone Isaac-GR00T repo, not in Arena'
 ``submodules/Isaac-GR00T``. This lets you train on the latest GR00T release without bumping the
 Arena submodule.
 
-This page assumes you have a successful recording at
+This page assumes you have either a successful recording at
 ``$DATASET_DIR/arena_g1_static_apple_dataset_recorded.hdf5`` from
-:doc:`step_2_teleoperation`.
+:doc:`step_2_teleoperation` or the pre-generated HDF5 dataset downloaded below.
 
 
 Step 1: Convert to LeRobot Format
@@ -32,6 +32,23 @@ Once inside the container, set the dataset directory:
 .. code:: bash
 
     export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
+
+.. dropdown:: Download Pre-generated Dataset (skip teleoperation)
+   :animate: fade-in
+
+   These commands can be used to download the pre-recorded static apple HDF5 dataset ready for
+   LeRobot conversion, such that the teleoperation step can be skipped.
+
+   To download run:
+
+   .. code-block:: bash
+
+      hf download \
+         nvidia/Arena-G1-Static-PickNPlace-Task \
+         arena_g1_static_apple_dataset_recorded.hdf5 \
+         --repo-type dataset \
+         --revision arena_v0.2_lab_v3.0 \
+         --local-dir $DATASET_DIR
 
 .. caution::
 

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -129,22 +129,21 @@ We post-train the GR00T N1.7 policy on the task using the **standalone Isaac-GR0
 GR00T's dependencies do not have to coexist with the Arena/Isaac Sim ones.
 
 The GR00T N1.7 policy has 3 billion parameters so post-training is an expensive operation.
-We provide one post-training option, 8 GPUs with 48 GB memory, to achieve the best quality.
+The command below is the tested single-GPU configuration for this workflow.
 
-Training takes approximately 4-8 hours on 8x L40s GPUs.
+Training takes approximately 2-3 hours for 20,000 steps on a single NVIDIA RTX 6000 Ada GPU.
 
 Compute Requirements:
 
-- **GPUs:** 8x with at least 48 GB VRAM each (e.g. L40s, GB200, etc.)
-- **System RAM:** 256 GB or more recommended — multi-GPU training with large batch sizes
-  and multiple dataloader workers requires substantial host memory
+- **GPUs:** 1x NVIDIA RTX 6000 Ada or another GPU with at least 48 GB VRAM
+- **System RAM:** 128 GB or more recommended
 
 Training Configuration:
 
 - **Base Model:** GR00T-N1.7-3B (foundation model, downloaded from Hugging Face on first run)
 - **Tuned Modules:** Visual backbone, projector, diffusion model
 - **Frozen Modules:** LLM (language model)
-- **Batch Size:** 96 (adjust based on GPU memory)
+- **Batch Size:** 12 (adjust based on GPU memory)
 - **Training Steps:** 20,000
 - **Action horizon:** 40 (must match the diffusion head value used at evaluation; see note below)
 - **Embodiment tag:** ``new_embodiment`` (case-insensitive; resolved to
@@ -171,16 +170,16 @@ default Arena Docker mounts, these are usually:
 
    cd $ISAAC_GR00T_DIR
 
-   uv run python -m torch.distributed.run --nproc_per_node=8 --standalone \
+   uv run python -m torch.distributed.run --nproc_per_node=1 --standalone \
      gr00t/experiment/launch_finetune.py \
      --base-model-path nvidia/GR00T-N1.7-3B \
      --dataset-path $DATASET_DIR/arena_g1_static_apple_dataset_recorded/lerobot \
      --output-dir $MODELS_DIR/static_apple_n17_finetune \
      --modality-config-path /path/to/IsaacLab-Arena/isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_gr00t_n_1_7_config.py \
      --embodiment-tag new_embodiment \
-     --global-batch-size 96 \
+     --global-batch-size 12 \
      --max-steps 20000 \
-     --num-gpus 8 \
+     --num-gpus 1 \
      --save-steps 5000 \
      --save-total-limit 5 \
      --no-tune-llm \
@@ -221,7 +220,7 @@ default Arena Docker mounts, these are usually:
       server-side YAML at
       ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml``.
 
-If you have less powerful GPUs, please see the
+If you have more powerful GPUs, please see the
 `GR00T fine-tuning guidelines
 <https://github.com/NVIDIA/Isaac-GR00T/blob/4b1dca9d88d2a0b9ea5a65aa61c82ff89f5c4f0e/README.md#3-fine-tuning>`_ for
 information on how to adjust the training configuration to your hardware. We recommend fine-tuning

--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -38,6 +38,9 @@ Once inside the container, set the dataset directory:
 
    These commands can be used to download the pre-recorded static apple HDF5 dataset ready for
    LeRobot conversion, such that the teleoperation step can be skipped.
+   Run them where ``$DATASET_DIR`` points to the target directory; use the ``/datasets/...`` path
+   inside Docker, or the matching host path outside Docker. The Hugging Face CLI from
+   ``huggingface_hub`` must be installed in that environment.
 
    To download run:
 

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -212,8 +212,7 @@ computed over more episodes because multiple environments are stepped in paralle
    - ``ModuleNotFoundError`` on the client side — check the client's ``--policy_type``. This
      workflow must use the remote client wrapper
      ``isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy``,
-     together with ``--policy_config_yaml_path``. Do not use the local closed-loop policy or
-     server-side policy classes in the Arena client command.
+     together with ``--policy_config_yaml_path``.
    - Action shape mismatch on the server (e.g., ``Action key 'left_arm''s horizon must be 40.
      Got 50``) — the action modality used to launch the server does not match the checkpoint's
      training horizon. This workflow trains and serves GR00T N1.7 with ``action_horizon: 40``.

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -77,6 +77,13 @@ Once inside the container, set the dataset and models directories.
     export DATASET_DIR=/datasets/isaaclab_arena/static_apple_tutorial
     export MODELS_DIR=/models/isaaclab_arena/static_apple_tutorial
 
+.. note::
+
+   If Kit reports permission errors while writing
+   ``/isaac-sim/kit/data/Kit/IsaacLab/3.0/user.config.json`` or cache files, start from a clean
+   Arena container/cache or rebuild the Docker image. This can happen when stale Isaac Sim / Kit
+   state from another setup is reused with incompatible ownership.
+
 We first run the policy in a single environment with visualization via the GUI. Replace
 ``<SERVER_HOST>`` below with the IP of the host running Step 1 (or ``localhost`` if it is the
 same machine).

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -32,11 +32,17 @@ the finetuned checkpoint directory from :doc:`step_3_policy_training`.
    .. code-block:: bash
 
       export MODELS_DIR=~/models/isaaclab_arena/static_apple_tutorial
-      export MODEL_PATH=$MODELS_DIR/static_apple_n17_finetune/checkpoint-20000
+      export MODEL_PATH=$MODELS_DIR/gn1x_tuned_static_apple
 
+      mkdir -p "$MODEL_PATH"
       hf download \
          nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace \
+         --repo-type model \
          --local-dir $MODEL_PATH
+
+   If you trained your own checkpoint in :doc:`step_3_policy_training`, set ``MODEL_PATH`` to that
+   trainer output instead, for example
+   ``$MODELS_DIR/static_apple_n17_finetune/checkpoint-20000``.
 
 .. code-block:: bash
 
@@ -79,8 +85,11 @@ same machine).
 
    Before running, edit ``model_path`` in
    ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml`` to point at
-   the finetuned checkpoint directory you produced in :doc:`step_3_policy_training` (for example,
-   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000``).
+   the checkpoint directory you are serving (for example,
+   ``/models/isaaclab_arena/static_apple_tutorial/gn1x_tuned_static_apple`` for the Hugging Face
+   checkpoint, or
+   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000`` for
+   a locally trained checkpoint).
    It must match the ``--model-path`` you passed to ``run_gr00t_server.py`` in Step 1.
 
 .. code-block:: bash
@@ -128,7 +137,8 @@ Run Parallel Environments Evaluation (Optional)
 Parallel evaluation of the policy in multiple environments is also supported by the policy runner.
 The command below assumes the GR00T server from Step 1 is still running.
 
-Test the policy in 5 parallel environments with visualization via the GUI:
+Test the policy in 5 parallel environments with visualization via the GUI. The 600-step smoke test
+gives each environment enough steps to complete at least one full 6-second episode.
 
 .. code-block:: bash
 
@@ -138,7 +148,7 @@ Test the policy in 5 parallel environments with visualization via the GUI:
       --policy_config_yaml_path isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml \
       --remote_host <SERVER_HOST> \
       --remote_port 5555 \
-      --num_steps 500 \
+      --num_steps 600 \
       --num_envs 5 \
       --enable_cameras \
       galileo_g1_static_pick_and_place \

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -2,13 +2,13 @@ Closed-Loop Policy Inference and Evaluation
 -------------------------------------------
 
 This workflow demonstrates running the finetuned GR00T N1.7 policy in closed-loop and evaluating it
-in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **server-client (remote-policy)
-architecture**. The server hosts the finetuned checkpoint outside the Arena container; the Arena
-container runs the simulation and queries the server over ZeroMQ.
+in the Arena Unitree G1 Static Apple-to-Plate Task environment using Arena's **server-client
+(remote-policy) architecture**. The GR00T policy server, which hosts the finetuned checkpoint, runs
+outside the Arena container. The Arena container itself runs only the simulation and a thin GR00T
+client that queries the server for actions.
 
-Note that this tutorial assumes that you've completed the
-:doc:`preceding step (Policy Training) <step_3_policy_training>`.
-
+This tutorial uses the dataset you collected in :doc:`step_2_teleoperation` and the model
+you trained in :doc:`step_3_policy_training`.
 
 Step 1: Start the GR00T policy server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,8 +61,11 @@ same machine).
 
 .. caution::
 
-   Before running, make sure the GR00T server from Step 1 was launched with the finetuned checkpoint
-   directory you produced in :doc:`step_3_policy_training`.
+   Before running, edit ``model_path`` in
+   ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml`` to point at
+   the finetuned checkpoint directory you produced in :doc:`step_3_policy_training` (for example,
+   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000``).
+   It must match the ``--model-path`` you passed to ``run_gr00t_server.py`` in Step 1.
 
 .. code-block:: bash
 
@@ -106,8 +109,8 @@ by the quality of post-trained policy, the quality of the dataset, and number of
 Run Parallel Environments Evaluation (Optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Parallel evaluation of the policy in multiple parallel environments is also supported by the policy
-runner. The command below assumes the server from Step 1 is still running.
+Parallel evaluation of the policy in multiple environments is also supported by the policy runner.
+The command below assumes the GR00T server from Step 1 is still running.
 
 Test the policy in 5 parallel environments with visualization via the GUI:
 
@@ -127,19 +130,15 @@ Test the policy in 5 parallel environments with visualization via the GUI:
       --destination clay_plates_hot3d_robolab \
       --embodiment g1_wbc_agile_joint
 
-
-And during the evaluation, you should see the following output on the console at the end of the evaluation
-indicating which environments are terminated (task-specific conditions like the apple is placed onto the plate,
-or the episode length is exceeded by 6 seconds),
-or truncated (if timeouts are enabled, like the maximum episode length is exceeded).
+During evaluation, the console prints which environments terminated because the task succeeded or
+timed out, and which environments were truncated by runner-level limits.
 
 .. code-block:: text
 
    Resetting policy for terminated env_ids: tensor([3], device='cuda:0') and truncated env_ids: tensor([], device='cuda:0', dtype=torch.int64)
 
-At the end of the evaluation, you should see the following output on the console indicating the metrics.
-You can see that the success rate might not be 1.0 as more trials are being evaluated and randomizations are being introduced,
-and the number of episodes is more than the single environment evaluation because of the parallelization.
+At the end of the evaluation, you should see metrics similar to the single-environment run, but
+computed over more episodes because multiple environments are stepped in parallel.
 
 .. code-block:: text
 
@@ -155,14 +154,6 @@ and the number of episodes is more than the single environment evaluation becaus
    policy inputs, so we use the joint-control twin (``g1_wbc_agile_joint``) for closed-loop policy
    inference -- it shares the AGILE lower-body backend with the recording embodiment, just bypasses
    PinkIK.
-
-.. note::
-
-   The single-environment command above does not pass ``--device``, so Arena defaults to its
-   built-in physics backend. If your dataset was recorded on GPU physics, prefer ``--device cuda`` for both
-   single and parallel runs to keep evaluation physics aligned with training; if it was recorded
-   on CPU physics, add ``--device cpu`` to the single-environment command for per-episode
-   reproducibility (parallel throughput becomes the trade-off for CPU-trained policies).
 
 .. note::
 
@@ -185,3 +176,15 @@ and the number of episodes is more than the single environment evaluation becaus
      expects a 23-D PinkIK action, but the server is returning a 43-DoF joint chunk. Make sure the
      client uses ``--embodiment g1_wbc_agile_joint`` (joint twin), not
      ``g1_wbc_agile_pink`` (PinkIK twin).
+   - ``ModuleNotFoundError`` on the client side — check the client's ``--policy_type``. This
+     workflow must use the remote client wrapper
+     ``isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy``,
+     together with ``--policy_config_yaml_path``. Do not use the local closed-loop policy or
+     server-side policy classes in the Arena client command.
+   - Action shape mismatch on the server (e.g., ``Action key 'left_arm''s horizon must be 40.
+     Got 50``) — the action modality used to launch the server does not match the checkpoint's
+     training horizon. This workflow trains and serves GR00T N1.7 with ``action_horizon: 40``.
+     Re-finetune with the same action ``delta_indices`` horizon, or launch
+     ``run_gr00t_server.py`` with the same ``--modality-config-path`` used during finetuning. Keep
+     the Arena client YAML's ``action_horizon`` and ``action_chunk_length`` in sync as well (see
+     the caution in :doc:`step_3_policy_training`).

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -8,7 +8,7 @@ outside the Arena container. The Arena container itself runs only the simulation
 client that queries the server for actions.
 
 This tutorial uses the dataset you collected in :doc:`step_2_teleoperation` and the model
-you trained in :doc:`step_3_policy_training`.
+you trained in :doc:`step_3_policy_training`, or the released checkpoint downloaded below.
 
 Step 1: Start the GR00T policy server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,6 +21,22 @@ The server takes all of its configuration from CLI flags (model checkpoint, embo
 modality config from Arena's source tree, and bind host/port). Replace
 ``/path/to/IsaacLab-Arena`` with the absolute path to your Arena clone and ``${MODEL_PATH}`` with
 the finetuned checkpoint directory from :doc:`step_3_policy_training`.
+
+.. dropdown:: Download Pre-trained Model (skip policy post-training)
+   :animate: fade-in
+
+   These commands can be used to download the pre-trained GR00T N1.7 static apple checkpoint,
+   such that the policy post-training step can be skipped. Run them **outside Docker** in the
+   standalone Isaac-GR00T venv before starting the server.
+
+   .. code-block:: bash
+
+      export MODELS_DIR=~/models/isaaclab_arena/static_apple_tutorial
+      export MODEL_PATH=$MODELS_DIR/static_apple_n17_finetune/checkpoint-20000
+
+      hf download \
+         nvidia/GN1x-Tuned-Arena-G1-Static-PickNPlace \
+         --local-dir $MODEL_PATH
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
+++ b/docs/pages/example_workflows/static_apple/step_4_evaluation.rst
@@ -88,17 +88,6 @@ We first run the policy in a single environment with visualization via the GUI. 
 ``<SERVER_HOST>`` below with the IP of the host running Step 1 (or ``localhost`` if it is the
 same machine).
 
-.. caution::
-
-   Before running, edit ``model_path`` in
-   ``isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml`` to point at
-   the checkpoint directory you are serving (for example,
-   ``/models/isaaclab_arena/static_apple_tutorial/gn1x_tuned_static_apple`` for the Hugging Face
-   checkpoint, or
-   ``/models/isaaclab_arena/static_apple_tutorial/static_apple_n17_finetune/checkpoint-20000`` for
-   a locally trained checkpoint).
-   It must match the ``--model-path`` you passed to ``run_gr00t_server.py`` in Step 1.
-
 .. code-block:: bash
 
    /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py \


### PR DESCRIPTION
## Summary
Address IFR and SQA doc feedback

## Detailed description
- Reason: Address IFR and SQA feedback for the static apple workflow documentation, including usability improvements and bug fixes found during review.
- Changed: Refined the static apple setup, teleoperation, training, and evaluation docs; added Hugging Face dataset/checkpoint commands; documented Quest and PICO 4 Ultra view reset guidance; refreshed the environment example; and added parallel evaluation plus clearer troubleshooting notes.
- Impact: The workflow is easier to follow end to end, supports both self-collected and released artifacts, and gives users clearer guidance for data collection, GR00T setup, training, and evaluation.

Corresponding MR for main: #720 

Addressing bugs:
- https://nvbugspro.nvidia.com/bug/6180888
- https://nvbugspro.nvidia.com/bug/6196150
- https://nvbugspro.nvidia.com/bug/6219154
- https://nvbugspro.nvidia.com/bug/6219113
- https://nvbugspro.nvidia.com/bug/6180668