### PR TITLE
remove Doc build upon newton branch post merge

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ name: GitHub Pages
 
 on:
   push:
-    branches: [ "main", "feature/isaac_lab_3_newton" ]
+    branches: [ "main" ]
 
 # Concurrency control to prevent parallel runs on the same PR
 concurrency:


### PR DESCRIPTION
## Summary
Multi-version doc build and deploy shall only be triggered by main branch.