### PR TITLE
Refactor: Metrics in IsaacLabArenaManagerBasedRLEnvCfg

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -21,7 +21,7 @@ from isaaclab_teleop import IsaacTeleopCfg
 from isaaclab_arena.assets.registries import DeviceRegistry
 from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-from isaaclab_arena.environments.isaaclab_arena_manager_based_env import (
+from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import (
     IsaacArenaManagerBasedMimicEnvCfg,
     IsaacLabArenaManagerBasedRLEnvCfg,
 )
@@ -82,12 +82,7 @@ class ArenaEnvBuilder:
 
     @staticmethod
     def _metrics_to_metrics_cfg(metrics: list[MetricBase] | None) -> object | None:
-        """Build a configclass container with one ``MetricTermCfg`` field per metric.
-
-        Mirrors how Isaac Lab shapes ``cfg.rewards`` / ``cfg.terminations`` so that
-        the runtime :class:`MetricsManager` can iterate the container's fields the
-        same way ``RewardManager`` / ``TerminationManager`` do.
-        """
+        """Build a configclass container with one ``MetricTermCfg`` field per metric."""
         if not metrics:
             return None
         fields = [(m.name, MetricTermCfg, m.get_metric_term_cfg()) for m in metrics]
@@ -247,7 +242,7 @@ class ArenaEnvBuilder:
         # This runs after the callback so the user's CLI choice is the final authority.
         presets = getattr(self.args, "presets", None)
         if presets is not None:
-            from isaaclab_arena.environments.isaaclab_arena_manager_based_env import ArenaPhysicsCfg
+            from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import ArenaPhysicsCfg
 
             env_cfg.sim.physics = getattr(ArenaPhysicsCfg(), presets)
 

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -26,6 +26,8 @@ from isaaclab_arena.environments.isaaclab_arena_manager_based_env import (
     IsaacLabArenaManagerBasedRLEnvCfg,
 )
 from isaaclab_arena.environments.relation_solver_interface import solve_and_apply_relation_placement
+from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
 from isaaclab_arena.metrics.recorder_manager_utils import metrics_to_recorder_manager_cfg
 from isaaclab_arena.tasks.no_task import NoTask
 from isaaclab_arena.utils.configclass import combine_configclass_instances, make_configclass
@@ -77,6 +79,19 @@ class ArenaEnvBuilder:
             f"{base}_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}_rank{get_local_rank()}"
         )
         return recorder_cfg
+
+    @staticmethod
+    def _metrics_to_metrics_cfg(metrics: list[MetricBase] | None) -> object | None:
+        """Build a configclass container with one ``MetricTermCfg`` field per metric.
+
+        Mirrors how Isaac Lab shapes ``cfg.rewards`` / ``cfg.terminations`` so that
+        the runtime :class:`MetricsManager` can iterate the container's fields the
+        same way ``RewardManager`` / ``TerminationManager`` do.
+        """
+        if not metrics:
+            return None
+        fields = [(m.name, MetricTermCfg, m.get_metric_term_cfg()) for m in metrics]
+        return make_configclass("MetricsCfg", fields)()
 
     def compose_manager_cfg(self) -> IsaacLabArenaManagerBasedRLEnvCfg:
         """Return base ManagerBased cfg (scene+events+terminations+xr), no registration."""
@@ -133,6 +148,7 @@ class ArenaEnvBuilder:
             elif isinstance(device_cfg, DeviceCfg):
                 teleop_devices_cfg = DevicesCfg(devices={self.arena_env.teleop_device.name: device_cfg})
         metrics = task.get_metrics()
+        metrics_cfg = self._metrics_to_metrics_cfg(metrics)
         metrics_recorder_manager_cfg = metrics_to_recorder_manager_cfg(metrics)
 
         # Base has to be specified explicitly to avoid type errors and not lose inheritance.
@@ -187,7 +203,7 @@ class ArenaEnvBuilder:
                 isaac_teleop=isaac_teleop_cfg,
                 teleop_devices=teleop_devices_cfg,
                 recorders=recorder_manager_cfg,
-                metrics=metrics,
+                metrics=metrics_cfg,
                 isaaclab_arena_env=isaaclab_arena_env,
                 viewer=viewer_cfg,
             )
@@ -217,7 +233,7 @@ class ArenaEnvBuilder:
                 # NOTE(alexmillane, 2025-09-25): Metric + recorders excluded from mimic env,
                 # I assume that they're not needed for the mimic env.
                 # recorders=recorder_manager_cfg,
-                # metrics=metrics,
+                # metrics=metrics_cfg,
                 isaaclab_arena_env=isaaclab_arena_env,
                 viewer=viewer_cfg,
             )
@@ -252,7 +268,7 @@ class ArenaEnvBuilder:
             ), "Mimic mode requires an embodiment to be specified"
             return embodiment.get_mimic_env()
         else:
-            return "isaaclab.envs:ManagerBasedRLEnv"
+            return "isaaclab_arena.environments.isaaclab_arena_manager_based_env:IsaacLabArenaManagerBasedRLEnv"
 
     def build_registered(
         self, env_cfg: None | IsaacLabArenaManagerBasedRLEnvCfg = None

--- a/isaaclab_arena/environments/isaaclab_arena_environment.py
+++ b/isaaclab_arena/environments/isaaclab_arena_environment.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
     from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
-    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnvCfg
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import IsaacLabArenaManagerBasedRLEnvCfg
     from isaaclab_arena.scene.scene import Scene
     from isaaclab_arena.tasks.task_base import TaskBase
 

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
-from isaaclab.envs import ManagerBasedRLEnvCfg
+from typing import Any
+
+from isaaclab.envs import ManagerBasedRLEnv, ManagerBasedRLEnvCfg
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
 from isaaclab.sim import SimulationCfg
 from isaaclab.utils import configclass
@@ -14,7 +16,7 @@ from isaaclab_physx.physics import PhysxCfg
 from isaaclab_tasks.utils import PresetCfg
 
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metrics_manager import MetricsManager
 
 
 @configclass
@@ -65,8 +67,9 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     rewards = None
     curriculum = None
 
-    # Metrics
-    metrics: list[MetricBase] | None = None
+    # Metrics: a configclass container with one ``MetricTermCfg`` field per metric (or ``None``).
+    # Mirrors how ``rewards`` / ``terminations`` are shaped on ``ManagerBasedRLEnvCfg``.
+    metrics: object | None = None
 
     # Isaaclab Arena Env. Held as a member to allow use of internal functions
     isaaclab_arena_env: IsaacLabArenaEnvironment | None = None
@@ -88,3 +91,29 @@ class IsaacArenaManagerBasedMimicEnvCfg(IsaacLabArenaManagerBasedRLEnvCfg, Mimic
     # subtask_configs: dict[str, list[SubTaskConfig]] = {}
     # task_constraint_configs: list[SubTaskConstraintConfig] = []
     pass
+
+
+class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
+    """Arena run-time env that adds an offline :class:`MetricsManager` to the base class.
+
+    Mirrors how Isaac Lab attaches a :class:`isaaclab.managers.RewardManager` /
+    :class:`isaaclab.managers.TerminationManager` in :meth:`load_managers`. The metrics
+    manager itself is lightweight and only runs after rollout (see
+    :class:`isaaclab_arena.metrics.metrics_manager.MetricsManager`).
+    """
+
+    cfg: IsaacLabArenaManagerBasedRLEnvCfg
+
+    def load_managers(self) -> None:
+        super().load_managers()
+        self.metrics_manager = MetricsManager(self.cfg.metrics, self)
+        print("[INFO] Metrics Manager: ", self.metrics_manager)
+
+    def compute_metrics(self) -> dict[str, Any]:
+        """Compute all registered metrics from the recorded HDF5 dataset.
+
+        Returns:
+            A dictionary mapping metric name to metric value. Always includes a
+            ``"num_episodes"`` entry.
+        """
+        return self.metrics_manager.compute()

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -7,110 +7,23 @@ from __future__ import annotations
 
 from typing import Any
 
-from isaaclab.envs import ManagerBasedRLEnv, ManagerBasedRLEnvCfg
-from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
-from isaaclab.sim import SimulationCfg
-from isaaclab.utils import configclass
-from isaaclab_newton.physics.newton_manager_cfg import MJWarpSolverCfg, NewtonCfg
-from isaaclab_physx.physics import PhysxCfg
-from isaaclab_tasks.utils import PresetCfg
+from isaaclab.envs import ManagerBasedRLEnv
 
-from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import IsaacLabArenaManagerBasedRLEnvCfg
 from isaaclab_arena.metrics.metrics_manager import MetricsManager
 
 
-@configclass
-class ArenaPhysicsCfg(PresetCfg):
-    """Physics backend presets available to all Arena environments.
-
-    ``default`` / ``physx`` use the stock PhysX backend.
-    ``newton`` uses MuJoCo-Warp via Newton with solver parameters tuned
-    for dexterous manipulation (matches ``KukaAllegroPhysicsCfg.newton``).
-    """
-
-    physx = PhysxCfg()
-    newton = NewtonCfg(
-        solver_cfg=MJWarpSolverCfg(
-            solver="newton",
-            integrator="implicitfast",
-            njmax=300,
-            nconmax=400,
-            impratio=10.0,
-            cone="elliptic",
-            update_data_interval=2,
-            iterations=100,
-            ls_iterations=15,
-            ls_parallel=False,
-            use_mujoco_contacts=False,
-            ccd_iterations=15000,
-        ),
-        num_substeps=2,
-        debug_mode=False,
-    )
-    default = physx
-
-
-@configclass
-class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
-    """Configuration for an IsaacLab Arena environment."""
-
-    # NOTE(alexmillane, 2025-07-29): The following definitions are taken from the base class.
-    # scene: InteractiveSceneCfg
-    # observations: object
-    # actions: object
-    # events: object
-    # terminations: object
-    # recorders: object
-
-    # Kill the unused managers
-    commands = None
-    rewards = None
-    curriculum = None
-
-    # Metrics: a configclass container with one ``MetricTermCfg`` field per metric (or ``None``).
-    # Mirrors how ``rewards`` / ``terminations`` are shaped on ``ManagerBasedRLEnvCfg``.
-    metrics: object | None = None
-
-    # Isaaclab Arena Env. Held as a member to allow use of internal functions
-    isaaclab_arena_env: IsaacLabArenaEnvironment | None = None
-
-    # Overriding defaults from base class
-    sim: SimulationCfg = SimulationCfg(dt=1 / 200, render_interval=2)
-    decimation: int = 4
-    episode_length_s: float = 50.0
-    wait_for_textures: bool = False
-
-
-@configclass
-class IsaacArenaManagerBasedMimicEnvCfg(IsaacLabArenaManagerBasedRLEnvCfg, MimicEnvCfg):
-    """Configuration for an IsaacLab Arena environment."""
-
-    # NOTE(alexmillane, 2025-09-10): The following members are defined in the MimicEnvCfg class.
-    # Restated here for clarity.
-    # datagen_config: DataGenConfig = DataGenConfig()
-    # subtask_configs: dict[str, list[SubTaskConfig]] = {}
-    # task_constraint_configs: list[SubTaskConstraintConfig] = []
-    pass
-
-
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
-    """Arena run-time env that adds an offline :class:`MetricsManager` to the base class.
-
-    Mirrors how Isaac Lab attaches a :class:`isaaclab.managers.RewardManager` /
-    :class:`isaaclab.managers.TerminationManager` in :meth:`load_managers`. The metrics
-    manager itself is lightweight and only runs after rollout (see
-    :class:`isaaclab_arena.metrics.metrics_manager.MetricsManager`).
-    """
+    """Arena extension to ManagerBasedRLEnv that adds metrics."""
 
     cfg: IsaacLabArenaManagerBasedRLEnvCfg
 
     def load_managers(self) -> None:
         super().load_managers()
         self.metrics_manager = MetricsManager(self.cfg.metrics, self)
-        print("[INFO] Metrics Manager: ", self.metrics_manager)
 
     def compute_metrics(self) -> dict[str, Any]:
-        """Compute all registered metrics from the recorded HDF5 dataset.
+        """Compute all registered metrics.
 
         Returns:
             A dictionary mapping metric name to metric value. Always includes a

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
+from isaaclab.sim import SimulationCfg
+from isaaclab.utils import configclass
+from isaaclab_newton.physics.newton_manager_cfg import MJWarpSolverCfg, NewtonCfg
+from isaaclab_physx.physics import PhysxCfg
+from isaaclab_tasks.utils import PresetCfg
+
+from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+
+@configclass
+class ArenaPhysicsCfg(PresetCfg):
+    """Physics backend presets available to all Arena environments.
+
+    ``default`` / ``physx`` use the stock PhysX backend.
+    ``newton`` uses MuJoCo-Warp via Newton with solver parameters tuned
+    for dexterous manipulation (matches ``KukaAllegroPhysicsCfg.newton``).
+    """
+
+    physx = PhysxCfg()
+    newton = NewtonCfg(
+        solver_cfg=MJWarpSolverCfg(
+            solver="newton",
+            integrator="implicitfast",
+            njmax=300,
+            nconmax=400,
+            impratio=10.0,
+            cone="elliptic",
+            update_data_interval=2,
+            iterations=100,
+            ls_iterations=15,
+            ls_parallel=False,
+            use_mujoco_contacts=False,
+            ccd_iterations=15000,
+        ),
+        num_substeps=2,
+        debug_mode=False,
+    )
+    default = physx
+
+
+@configclass
+class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
+    """Configuration for an IsaacLab Arena environment."""
+
+    # NOTE(alexmillane, 2025-07-29): The following definitions are taken from the base class.
+    # scene: InteractiveSceneCfg
+    # observations: object
+    # actions: object
+    # events: object
+    # terminations: object
+    # recorders: object
+
+    # Kill the unused managers
+    commands = None
+    rewards = None
+    curriculum = None
+
+    metrics: object | None = None
+
+    # Isaaclab Arena Env. Held as a member to allow use of internal functions
+    isaaclab_arena_env: IsaacLabArenaEnvironment | None = None
+
+    # Overriding defaults from base class
+    sim: SimulationCfg = SimulationCfg(dt=1 / 200, render_interval=2)
+    decimation: int = 4
+    episode_length_s: float = 50.0
+    wait_for_textures: bool = False
+
+
+@configclass
+class IsaacArenaManagerBasedMimicEnvCfg(IsaacLabArenaManagerBasedRLEnvCfg, MimicEnvCfg):
+    """Configuration for an IsaacLab Arena environment."""
+
+    # NOTE(alexmillane, 2025-09-10): The following members are defined in the MimicEnvCfg class.
+    # Restated here for clarity.
+    # datagen_config: DataGenConfig = DataGenConfig()
+    # subtask_configs: dict[str, list[SubTaskConfig]] = {}
+    # task_constraint_configs: list[SubTaskConstraintConfig] = []
+    pass

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -127,7 +127,7 @@ def rollout_policy(
 
     else:
 
-        # Only compute metrics if env has a non-None metrics container (e.g. NoTask leaves metrics as None).
+        # Only compute metrics if env has non-None metrics.
         # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
         if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
             return env.unwrapped.compute_metrics()

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -102,9 +102,7 @@ def rollout_policy(
                     completed_episodes = env_ids.shape[0]
                     num_episodes_completed += completed_episodes
                     if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-                        from isaaclab_arena.metrics.metrics import compute_metrics
-
-                        metrics = compute_metrics(env.unwrapped)
+                        metrics = env.unwrapped.compute_metrics()
                         tqdm.tqdm.write(
                             f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
                             f" {metrics_to_plain_python_types(metrics)}"
@@ -129,14 +127,10 @@ def rollout_policy(
 
     else:
 
-        # Only compute metrics if env has a non-None metrics list (e.g. NoTask leaves metrics as None).
+        # Only compute metrics if env has a non-None metrics container (e.g. NoTask leaves metrics as None).
         # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
         if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-            # NOTE(xinjieyao, 2025-10-07): lazy import to prevent app stalling caused by omni.kit
-            from isaaclab_arena.metrics.metrics import compute_metrics
-
-            metrics = compute_metrics(env.unwrapped)
-            return metrics
+            return env.unwrapped.compute_metrics()
         return None
 
 

--- a/isaaclab_arena/examples/compile_env_notebook.py
+++ b/isaaclab_arena/examples/compile_env_notebook.py
@@ -31,7 +31,7 @@ embodiment = asset_registry.get_asset_by_name("franka_ik")()
 cracker_box = asset_registry.get_asset_by_name("cracker_box")()
 tomato_soup_can = asset_registry.get_asset_by_name("tomato_soup_can")()
 
-cracker_box.set_initial_pose(Pose(position_xyz=(0.4, 0.0, 0.1), rotation_wxyz=(1.0, 0.0, 0.0, 0.0)))
+cracker_box.set_initial_pose(Pose(position_xyz=(0.4, 0.0, 0.1), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
 cracker_box.add_relation(IsAnchor())
 tomato_soup_can.add_relation(On(cracker_box))
 

--- a/isaaclab_arena/metrics/metric_base.py
+++ b/isaaclab_arena/metrics/metric_base.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import numpy as np
 from abc import ABC, abstractmethod
 
 from isaaclab.managers.recorder_manager import RecorderTermCfg
@@ -25,12 +24,8 @@ class MetricBase(ABC):
         """Return the metric term configuration.
 
         The returned config carries a pointer to the module-level offline compute
-        function (``func``) together with the parameters needed to call it. Used by
-        the runtime ``MetricsManager`` to compute the metric value once a rollout has
-        finished.
+        function (``compute_metric_func``) together with the parameters needed to call
+        it. Used by the runtime ``MetricsManager`` to compute the metric value once a
+        rollout has finished.
         """
-        raise NotImplementedError("Function not implemented yet.")
-
-    @abstractmethod
-    def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
         raise NotImplementedError("Function not implemented yet.")

--- a/isaaclab_arena/metrics/metric_base.py
+++ b/isaaclab_arena/metrics/metric_base.py
@@ -8,6 +8,8 @@ from abc import ABC, abstractmethod
 
 from isaaclab.managers.recorder_manager import RecorderTermCfg
 
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
+
 
 class MetricBase(ABC):
 
@@ -16,6 +18,17 @@ class MetricBase(ABC):
 
     @abstractmethod
     def get_recorder_term_cfg(self) -> RecorderTermCfg:
+        raise NotImplementedError("Function not implemented yet.")
+
+    @abstractmethod
+    def get_metric_term_cfg(self) -> MetricTermCfg:
+        """Return the metric term configuration.
+
+        The returned config carries a pointer to the module-level offline compute
+        function (``func``) together with the parameters needed to call it. Used by
+        the runtime ``MetricsManager`` to compute the metric value once a rollout has
+        finished.
+        """
         raise NotImplementedError("Function not implemented yet.")
 
     @abstractmethod

--- a/isaaclab_arena/metrics/metric_term_cfg.py
+++ b/isaaclab_arena/metrics/metric_term_cfg.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Callable
+from dataclasses import MISSING
+from typing import Any
+
+from isaaclab.utils import configclass
+
+
+@configclass
+class MetricTermCfg:
+    """Configuration for a metric term.
+
+    Metrics are computed offline from data captured by an associated recorder term during
+    rollout. The ``func`` callable receives the recorded data for the recorder term named
+    by :attr:`recorder_term_name` (a list of per-episode arrays) plus any parameters in
+    :attr:`params` and returns a scalar metric value.
+    """
+
+    func: Callable[..., Any] = MISSING
+    """The function used to compute the metric value from the recorded data.
+
+    Signature: ``func(recorded_metric_data: list[np.ndarray], **params) -> Any``.
+
+    The return is typically a ``float`` (e.g. success rate), but a metric may also
+    return a list (e.g. per-subtask success rates).
+    """
+
+    params: dict[str, Any] = dict()
+    """The keyword arguments forwarded to :attr:`func`. Defaults to an empty dict."""
+
+    recorder_term_name: str = MISSING
+    """The name of the recorder term whose recorded data is fed to :attr:`func`."""

--- a/isaaclab_arena/metrics/metric_term_cfg.py
+++ b/isaaclab_arena/metrics/metric_term_cfg.py
@@ -14,23 +14,20 @@ from isaaclab.utils import configclass
 class MetricTermCfg:
     """Configuration for a metric term.
 
-    Metrics are computed offline from data captured by an associated recorder term during
-    rollout. The ``func`` callable receives the recorded data for the recorder term named
-    by :attr:`recorder_term_name` (a list of per-episode arrays) plus any parameters in
-    :attr:`params` and returns a scalar metric value.
+    Metrics are a combination of a recorder and a function that computes a metric from the recorded data.
     """
 
-    func: Callable[..., Any] = MISSING
+    compute_metric_func: Callable[..., Any] = MISSING
     """The function used to compute the metric value from the recorded data.
 
-    Signature: ``func(recorded_metric_data: list[np.ndarray], **params) -> Any``.
+    Signature: ``compute_metric_func(recorded_metric_data: list[np.ndarray], **params) -> Any``.
 
     The return is typically a ``float`` (e.g. success rate), but a metric may also
     return a list (e.g. per-subtask success rates).
     """
 
     params: dict[str, Any] = dict()
-    """The keyword arguments forwarded to :attr:`func`. Defaults to an empty dict."""
+    """The keyword arguments forwarded to :attr:`compute_metric_func`. Defaults to an empty dict."""
 
     recorder_term_name: str = MISSING
-    """The name of the recorder term whose recorded data is fed to :attr:`func`."""
+    """The name of the recorder term whose recorded data is fed to :attr:`compute_metric_func`."""

--- a/isaaclab_arena/metrics/metrics.py
+++ b/isaaclab_arena/metrics/metrics.py
@@ -11,30 +11,6 @@ from isaaclab.envs.manager_based_rl_env import ManagerBasedRLEnv
 from isaaclab.utils.datasets import HDF5DatasetFileHandler
 
 
-def compute_metrics(env: ManagerBasedRLEnv) -> dict[str, float]:
-    """Computes the metrics registered in the environment.
-
-    Args:
-        env: The environment to compute the metrics for.
-
-    Returns:
-        A dictionary of metrics. Maps metric name to metric value.
-    """
-    assert hasattr(env.unwrapped.cfg, "metrics")
-    # Get the path where the recorded data is stored
-    dataset_path = get_metric_recorder_dataset_path(env)
-    # For each registered metric
-    metrics_data = {}
-    for metric in env.unwrapped.cfg.metrics:
-        # Load the recorded data from disk for this metric
-        recorded_metric_data = get_recorded_metric_data(dataset_path, metric.recorder_term_name)
-        # Compute the metric value from the recorded data
-        metrics_data[metric.name] = metric.compute_metric_from_recording(recorded_metric_data)
-    # Also add the number of episodes as a metric
-    metrics_data["num_episodes"] = get_num_episodes(dataset_path)
-    return metrics_data
-
-
 def get_recorded_metric_data(dataset_path: pathlib.Path, recorder_term_name: str) -> list[np.ndarray]:
     """Gets the recorded metric data for a given metric name.
 

--- a/isaaclab_arena/metrics/metrics_manager.py
+++ b/isaaclab_arena/metrics/metrics_manager.py
@@ -17,11 +17,6 @@ if TYPE_CHECKING:
 class MetricsManager:
     """Run-time manager that computes metrics.
 
-    Mirrors the Isaac Lab manager pattern (:class:`isaaclab.managers.RewardManager`,
-    :class:`isaaclab.managers.TerminationManager`, ...) but is intentionally lightweight:
-    metric computation runs *after* a rollout has finished, so there is no need for
-    per-step hooks or the full :class:`isaaclab.managers.ManagerBase` machinery.
-
     The manager parses a configclass container of `MetricTermCfg` instances --
     one field per metric -- and exposes a method `compute` to load the recorded data for
     each term and compute the metric.
@@ -45,8 +40,6 @@ class MetricsManager:
         if cfg is None:
             return
         for term_name, term_cfg in cfg.__dict__.items():
-            if term_cfg is None:
-                continue
             self._term_names.append(term_name)
             self._term_cfgs.append(term_cfg)
 

--- a/isaaclab_arena/metrics/metrics_manager.py
+++ b/isaaclab_arena/metrics/metrics_manager.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Any
+
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
+from isaaclab_arena.metrics.metrics import (
+    get_metric_recorder_dataset_path,
+    get_num_episodes,
+    get_recorded_metric_data,
+)
+
+if TYPE_CHECKING:
+    from isaaclab.envs.manager_based_rl_env import ManagerBasedRLEnv
+
+
+class MetricsManager:
+    """Run-time manager that computes metrics offline from a recorded HDF5 dataset.
+
+    Mirrors the Isaac Lab manager pattern (:class:`isaaclab.managers.RewardManager`,
+    :class:`isaaclab.managers.TerminationManager`, ...) but is intentionally lightweight:
+    metric computation runs *after* a rollout has finished, so there is no need for
+    per-step hooks or the full :class:`isaaclab.managers.ManagerBase` machinery.
+
+    The manager parses a configclass container of :class:`MetricTermCfg` instances --
+    one field per metric -- and exposes :meth:`compute` to load the recorded data for
+    each term and invoke ``term_cfg.func(recorded_data, **term_cfg.params)``.
+    """
+
+    def __init__(self, cfg: object | None, env: ManagerBasedRLEnv):
+        """Initialize the metrics manager.
+
+        Args:
+            cfg: A configclass container with one ``MetricTermCfg`` field per metric,
+                or ``None`` if the environment has no metrics.
+            env: The environment owning this manager. Used at compute time to locate
+                the recorder dataset.
+        """
+        self._env = env
+        self._term_names: list[str] = []
+        self._term_cfgs: list[MetricTermCfg] = []
+        self._prepare_terms(cfg)
+
+    def _prepare_terms(self, cfg: object | None) -> None:
+        if cfg is None:
+            return
+        cfg_items = cfg.items() if isinstance(cfg, dict) else cfg.__dict__.items()
+        for term_name, term_cfg in cfg_items:
+            if term_cfg is None:
+                continue
+            if not isinstance(term_cfg, MetricTermCfg):
+                raise TypeError(
+                    f"Configuration for the metric term '{term_name}' is not of type MetricTermCfg."
+                    f" Received: '{type(term_cfg)}'."
+                )
+            self._term_names.append(term_name)
+            self._term_cfgs.append(term_cfg)
+
+    @property
+    def active_terms(self) -> list[str]:
+        """Names of the metric terms registered on this manager."""
+        return list(self._term_names)
+
+    def compute(self, dataset_path: pathlib.Path | None = None) -> dict[str, Any]:
+        """Compute every registered metric from the recorded HDF5 dataset.
+
+        Args:
+            dataset_path: Path to the recorded HDF5 dataset. If ``None``, the path is
+                resolved from the environment's recorder manager configuration.
+
+        Returns:
+            A dictionary mapping metric name to metric value. Always includes a
+            ``"num_episodes"`` entry with the number of completed episodes.
+        """
+        if dataset_path is None:
+            dataset_path = get_metric_recorder_dataset_path(self._env)
+        metrics_data: dict[str, Any] = {}
+        for term_name, term_cfg in zip(self._term_names, self._term_cfgs):
+            recorded_metric_data = get_recorded_metric_data(dataset_path, term_cfg.recorder_term_name)
+            metrics_data[term_name] = term_cfg.func(recorded_metric_data, **term_cfg.params)
+        metrics_data["num_episodes"] = get_num_episodes(dataset_path)
+        return metrics_data

--- a/isaaclab_arena/metrics/metrics_manager.py
+++ b/isaaclab_arena/metrics/metrics_manager.py
@@ -5,31 +5,26 @@
 
 from __future__ import annotations
 
-import pathlib
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
-from isaaclab_arena.metrics.metrics import (
-    get_metric_recorder_dataset_path,
-    get_num_episodes,
-    get_recorded_metric_data,
-)
+from isaaclab_arena.metrics.metrics import get_metric_recorder_dataset_path, get_num_episodes, get_recorded_metric_data
 
 if TYPE_CHECKING:
     from isaaclab.envs.manager_based_rl_env import ManagerBasedRLEnv
 
 
 class MetricsManager:
-    """Run-time manager that computes metrics offline from a recorded HDF5 dataset.
+    """Run-time manager that computes metrics.
 
     Mirrors the Isaac Lab manager pattern (:class:`isaaclab.managers.RewardManager`,
     :class:`isaaclab.managers.TerminationManager`, ...) but is intentionally lightweight:
     metric computation runs *after* a rollout has finished, so there is no need for
     per-step hooks or the full :class:`isaaclab.managers.ManagerBase` machinery.
 
-    The manager parses a configclass container of :class:`MetricTermCfg` instances --
-    one field per metric -- and exposes :meth:`compute` to load the recorded data for
-    each term and invoke ``term_cfg.func(recorded_data, **term_cfg.params)``.
+    The manager parses a configclass container of `MetricTermCfg` instances --
+    one field per metric -- and exposes a method `compute` to load the recorded data for
+    each term and compute the metric.
     """
 
     def __init__(self, cfg: object | None, env: ManagerBasedRLEnv):
@@ -49,15 +44,9 @@ class MetricsManager:
     def _prepare_terms(self, cfg: object | None) -> None:
         if cfg is None:
             return
-        cfg_items = cfg.items() if isinstance(cfg, dict) else cfg.__dict__.items()
-        for term_name, term_cfg in cfg_items:
+        for term_name, term_cfg in cfg.__dict__.items():
             if term_cfg is None:
                 continue
-            if not isinstance(term_cfg, MetricTermCfg):
-                raise TypeError(
-                    f"Configuration for the metric term '{term_name}' is not of type MetricTermCfg."
-                    f" Received: '{type(term_cfg)}'."
-                )
             self._term_names.append(term_name)
             self._term_cfgs.append(term_cfg)
 
@@ -66,22 +55,17 @@ class MetricsManager:
         """Names of the metric terms registered on this manager."""
         return list(self._term_names)
 
-    def compute(self, dataset_path: pathlib.Path | None = None) -> dict[str, Any]:
+    def compute(self) -> dict[str, Any]:
         """Compute every registered metric from the recorded HDF5 dataset.
-
-        Args:
-            dataset_path: Path to the recorded HDF5 dataset. If ``None``, the path is
-                resolved from the environment's recorder manager configuration.
 
         Returns:
             A dictionary mapping metric name to metric value. Always includes a
             ``"num_episodes"`` entry with the number of completed episodes.
         """
-        if dataset_path is None:
-            dataset_path = get_metric_recorder_dataset_path(self._env)
+        dataset_path = get_metric_recorder_dataset_path(self._env)
         metrics_data: dict[str, Any] = {}
         for term_name, term_cfg in zip(self._term_names, self._term_cfgs):
             recorded_metric_data = get_recorded_metric_data(dataset_path, term_cfg.recorder_term_name)
-            metrics_data[term_name] = term_cfg.func(recorded_metric_data, **term_cfg.params)
+            metrics_data[term_name] = term_cfg.compute_metric_func(recorded_metric_data, **term_cfg.params)
         metrics_data["num_episodes"] = get_num_episodes(dataset_path)
         return metrics_data

--- a/isaaclab_arena/metrics/object_moved.py
+++ b/isaaclab_arena/metrics/object_moved.py
@@ -13,6 +13,7 @@ from isaaclab.utils import configclass
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
 
 
 class ObjectVelocityRecorder(RecorderTerm):
@@ -36,6 +37,31 @@ class ObjectVelocityRecorderCfg(RecorderTermCfg):
     class_type: type[RecorderTerm] = ObjectVelocityRecorder
     name: str = "object_linear_velocity"
     object_name: str = MISSING
+
+
+def compute_object_moved_rate(
+    recorded_metric_data: list[np.ndarray], object_velocity_threshold: float
+) -> float:
+    """Computes the object-moved rate from the recorded metric data.
+
+    Args:
+        recorded_metric_data(list[np.ndarray]): The recorded object velocity per simulated episode.
+        object_velocity_threshold(float): The threshold for the object velocity to be considered moved.
+
+    Returns:
+        The object-moved rate(float). Value between 0 and 1. The proportion of episodes
+            in which the object moved.
+    """
+    object_velocity_per_demo = recorded_metric_data
+    object_moved_per_demo = []
+    for object_velocity in object_velocity_per_demo:
+        assert object_velocity.ndim == 2
+        assert object_velocity.shape[1] == 3
+        object_linear_velocity_magnitude = np.linalg.norm(object_velocity, axis=-1)
+        object_moved = np.any(object_linear_velocity_magnitude > object_velocity_threshold)
+        object_moved_per_demo.append(object_moved)
+    object_moved_rate = np.mean(object_moved_per_demo)
+    return object_moved_rate
 
 
 class ObjectMovedRateMetric(MetricBase):
@@ -63,23 +89,13 @@ class ObjectMovedRateMetric(MetricBase):
         """Return the recorder term configuration for the object-moved rate metric."""
         return ObjectVelocityRecorderCfg(name=self.recorder_term_name, object_name=self.object.name)
 
+    def get_metric_term_cfg(self) -> MetricTermCfg:
+        """Return the metric term configuration for the object-moved rate metric."""
+        return MetricTermCfg(
+            func=compute_object_moved_rate,
+            params={"object_velocity_threshold": self.object_velocity_threshold},
+            recorder_term_name=self.recorder_term_name,
+        )
+
     def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        """Computes the object-moved rate from the recorded metric data.
-
-        Args:
-            recorded_metric_data(list[np.ndarray]): The recorded object velocity per simulated episode.
-
-        Returns:
-            The object-moved rate(float). Value between 0 and 1. The proportion of episodes
-                in which the object moved.
-        """
-        object_velocity_per_demo = recorded_metric_data
-        object_moved_per_demo = []
-        for object_velocity in object_velocity_per_demo:
-            assert object_velocity.ndim == 2
-            assert object_velocity.shape[1] == 3
-            object_linear_velocity_magnitude = np.linalg.norm(object_velocity, axis=-1)
-            object_moved = np.any(object_linear_velocity_magnitude > self.object_velocity_threshold)
-            object_moved_per_demo.append(object_moved)
-        object_moved_rate = np.mean(object_moved_per_demo)
-        return object_moved_rate
+        return compute_object_moved_rate(recorded_metric_data, self.object_velocity_threshold)

--- a/isaaclab_arena/metrics/object_moved.py
+++ b/isaaclab_arena/metrics/object_moved.py
@@ -39,9 +39,7 @@ class ObjectVelocityRecorderCfg(RecorderTermCfg):
     object_name: str = MISSING
 
 
-def compute_object_moved_rate(
-    recorded_metric_data: list[np.ndarray], object_velocity_threshold: float
-) -> float:
+def compute_object_moved_rate(recorded_metric_data: list[np.ndarray], object_velocity_threshold: float) -> float:
     """Computes the object-moved rate from the recorded metric data.
 
     Args:
@@ -92,10 +90,7 @@ class ObjectMovedRateMetric(MetricBase):
     def get_metric_term_cfg(self) -> MetricTermCfg:
         """Return the metric term configuration for the object-moved rate metric."""
         return MetricTermCfg(
-            func=compute_object_moved_rate,
+            compute_metric_func=compute_object_moved_rate,
             params={"object_velocity_threshold": self.object_velocity_threshold},
             recorder_term_name=self.recorder_term_name,
         )
-
-    def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        return compute_object_moved_rate(recorded_metric_data, self.object_velocity_threshold)

--- a/isaaclab_arena/metrics/revolute_joint_moved_rate.py
+++ b/isaaclab_arena/metrics/revolute_joint_moved_rate.py
@@ -98,17 +98,10 @@ class RevoluteJointMovedRateMetric(MetricBase):
     def get_metric_term_cfg(self) -> MetricTermCfg:
         """Return the metric term configuration for the revolute joint moved rate metric."""
         return MetricTermCfg(
-            func=compute_revolute_joint_moved_rate,
+            compute_metric_func=compute_revolute_joint_moved_rate,
             params={
                 "reset_joint_percentage": self.reset_joint_percentage,
                 "joint_percentage_delta_threshold": self.joint_percentage_delta_threshold,
             },
             recorder_term_name=self.recorder_term_name,
-        )
-
-    def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        return compute_revolute_joint_moved_rate(
-            recorded_metric_data,
-            self.reset_joint_percentage,
-            self.joint_percentage_delta_threshold,
         )

--- a/isaaclab_arena/metrics/revolute_joint_moved_rate.py
+++ b/isaaclab_arena/metrics/revolute_joint_moved_rate.py
@@ -13,6 +13,7 @@ from isaaclab.utils import configclass
 from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.assets.object_base import ObjectBase
 from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
 
 
 class RevoluteJointStateRecorder(RecorderTerm):
@@ -33,6 +34,36 @@ class JointStateRecorderCfg(RecorderTermCfg):
     class_type: type[RecorderTerm] = RevoluteJointStateRecorder
     name: str = "revolute_joint_state"
     object: ObjectBase = MISSING
+
+
+def compute_revolute_joint_moved_rate(
+    recorded_metric_data: list[np.ndarray],
+    reset_joint_percentage: float,
+    joint_percentage_delta_threshold: float,
+) -> float:
+    """Computes the revolute joint moved rate from the recorded metric data.
+
+    Args:
+        recorded_metric_data(list[np.ndarray]): The recorded revolute joint percentage per simulated
+            episode.
+        reset_joint_percentage(float): The initial joint position of the door (what the door resets to).
+        joint_percentage_delta_threshold(float): The threshold for the door joint percentage to be considered
+            moved. This is relative to the initial joint position of the door.
+
+    Returns:
+        The revolute joint moved rate(float). Value between 0 and 1. The proportion of episodes
+            in which the door moved.
+    """
+    if len(recorded_metric_data) == 0:
+        return 0.0
+    revolute_joint_moved_per_demo = []
+    for episode_data in recorded_metric_data:
+        # Check if joint moved in either direction from reset position
+        moved_open = np.any(episode_data > reset_joint_percentage + joint_percentage_delta_threshold)
+        moved_closed = np.any(episode_data < reset_joint_percentage - joint_percentage_delta_threshold)
+        revolute_joint_moved_per_demo.append(moved_open or moved_closed)
+    revolute_joint_moved_rate = np.mean(revolute_joint_moved_per_demo)
+    return revolute_joint_moved_rate
 
 
 class RevoluteJointMovedRateMetric(MetricBase):
@@ -64,24 +95,20 @@ class RevoluteJointMovedRateMetric(MetricBase):
         """Return the recorder term configuration for the revolute joint moved rate metric."""
         return JointStateRecorderCfg(name=self.recorder_term_name, object=self.object)
 
+    def get_metric_term_cfg(self) -> MetricTermCfg:
+        """Return the metric term configuration for the revolute joint moved rate metric."""
+        return MetricTermCfg(
+            func=compute_revolute_joint_moved_rate,
+            params={
+                "reset_joint_percentage": self.reset_joint_percentage,
+                "joint_percentage_delta_threshold": self.joint_percentage_delta_threshold,
+            },
+            recorder_term_name=self.recorder_term_name,
+        )
+
     def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        """Computes the revolute joint moved rate from the recorded metric data.
-
-        Args:
-            recorded_metric_data(list[np.ndarray]): The recorded revolute joint percentage per simulated
-                episode.
-
-        Returns:
-            The revolute joint moved rate(float). Value between 0 and 1. The proportion of episodes
-                in which the door moved.
-        """
-        if len(recorded_metric_data) == 0:
-            return 0.0
-        revolute_joint_moved_per_demo = []
-        for episode_data in recorded_metric_data:
-            # Check if joint moved in either direction from reset position
-            moved_open = np.any(episode_data > self.reset_joint_percentage + self.joint_percentage_delta_threshold)
-            moved_closed = np.any(episode_data < self.reset_joint_percentage - self.joint_percentage_delta_threshold)
-            revolute_joint_moved_per_demo.append(moved_open or moved_closed)
-        revolute_joint_moved_rate = np.mean(revolute_joint_moved_per_demo)
-        return revolute_joint_moved_rate
+        return compute_revolute_joint_moved_rate(
+            recorded_metric_data,
+            self.reset_joint_percentage,
+            self.joint_percentage_delta_threshold,
+        )

--- a/isaaclab_arena/metrics/success_rate.py
+++ b/isaaclab_arena/metrics/success_rate.py
@@ -83,10 +83,7 @@ class SuccessRateMetric(MetricBase):
     def get_metric_term_cfg(self) -> MetricTermCfg:
         """Return the metric term configuration for the success rate metric."""
         return MetricTermCfg(
-            func=compute_success_rate,
+            compute_metric_func=compute_success_rate,
             params={},
             recorder_term_name=self.recorder_term_name,
         )
-
-    def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        return compute_success_rate(recorded_metric_data)

--- a/isaaclab_arena/metrics/success_rate.py
+++ b/isaaclab_arena/metrics/success_rate.py
@@ -10,6 +10,7 @@ from isaaclab.managers.recorder_manager import RecorderTerm, RecorderTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
 
 
 class SuccessRecorder(RecorderTerm):
@@ -45,6 +46,26 @@ class SuccessRecorderCfg(RecorderTermCfg):
     name: str = "success"
 
 
+def compute_success_rate(recorded_metric_data: list[np.ndarray]) -> float:
+    """Gets the average success rate from a list of recorded success flags.
+
+    Args:
+        recorded_metric_data(list[np.ndarray]): The recorded success flags per simulated episode.
+
+    Returns:
+        The success rate(float). Value between 0 and 1. The proportion of episodes in
+            which the environment was successful.
+    """
+    num_demos = len(recorded_metric_data)
+    if num_demos == 0:
+        return 0.0
+    all_demos_success_flags = np.concatenate(recorded_metric_data)
+    assert all_demos_success_flags.ndim == 1
+    assert all_demos_success_flags.shape[0] == num_demos
+    success_rate = np.mean(all_demos_success_flags)
+    return success_rate
+
+
 class SuccessRateMetric(MetricBase):
     """Computes the success rate.
 
@@ -59,21 +80,13 @@ class SuccessRateMetric(MetricBase):
         """Return the recorder term configuration for the success rate metric."""
         return SuccessRecorderCfg(name=self.recorder_term_name)
 
+    def get_metric_term_cfg(self) -> MetricTermCfg:
+        """Return the metric term configuration for the success rate metric."""
+        return MetricTermCfg(
+            func=compute_success_rate,
+            params={},
+            recorder_term_name=self.recorder_term_name,
+        )
+
     def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> float:
-        """Gets the average success rate from a list of recorded success flags.
-
-        Args:
-            recorded_metric_data(list[np.ndarray]): The recorded success flags per simulated episode.
-
-        Returns:
-            The success rate(float). Value between 0 and 1. The proportion of episodes in
-                which the environment was successful.
-        """
-        num_demos = len(recorded_metric_data)
-        if num_demos == 0:
-            return 0.0
-        all_demos_success_flags = np.concatenate(recorded_metric_data)
-        assert all_demos_success_flags.ndim == 1
-        assert all_demos_success_flags.shape[0] == num_demos
-        success_rate = np.mean(all_demos_success_flags)
-        return success_rate
+        return compute_success_rate(recorded_metric_data)

--- a/isaaclab_arena/tasks/sequential_task_base.py
+++ b/isaaclab_arena/tasks/sequential_task_base.py
@@ -16,6 +16,7 @@ from isaaclab.utils import configclass
 
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.metric_term_cfg import MetricTermCfg
 from isaaclab_arena.tasks.common.mimic_default_params import MIMIC_DATAGEN_CONFIG_DEFAULTS
 from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.configclass import (
@@ -54,6 +55,30 @@ class SubtaskSuccessStateRecorderCfg(RecorderTermCfg):
     name: str = "subtask_success_rate"
 
 
+def compute_subtask_success_rate(recorded_metric_data: list[np.ndarray]) -> list:
+    """Computes per-subtask success rates.
+
+    Args:
+        recorded_metric_data: List of arrays, each shape (num_subtasks,) with bool values.
+
+    Returns:
+        List of success rates for each subtask.
+    """
+    num_demos = len(recorded_metric_data)
+    if num_demos == 0:
+        return [0.0]
+
+    num_subtasks = recorded_metric_data[0].shape[1]
+    subtask_successes = np.zeros(num_subtasks, dtype=float)
+
+    for ep in range(num_demos):
+        ep_subtask_success_result = np.any(recorded_metric_data[ep], axis=0).astype(float)
+        subtask_successes += ep_subtask_success_result
+    subtask_success_rates = subtask_successes / num_demos
+
+    return subtask_success_rates.tolist()
+
+
 class SubtaskSuccessRateMetric(MetricBase):
     """Computes the per-subtask success rates.
 
@@ -70,28 +95,16 @@ class SubtaskSuccessRateMetric(MetricBase):
         """Return the recorder term configuration for the subtask success state metric."""
         return SubtaskSuccessStateRecorderCfg(name=self.recorder_term_name)
 
+    def get_metric_term_cfg(self) -> MetricTermCfg:
+        """Return the metric term configuration for the subtask success rate metric."""
+        return MetricTermCfg(
+            func=compute_subtask_success_rate,
+            params={},
+            recorder_term_name=self.recorder_term_name,
+        )
+
     def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> list:
-        """Computes per-subtask success rates.
-
-        Args:
-            recorded_metric_data: List of arrays, each shape (num_subtasks,) with bool values.
-
-        Returns:
-            List of success rates for each subtask.
-        """
-        num_demos = len(recorded_metric_data)
-        if num_demos == 0:
-            return [0.0]
-
-        num_subtasks = recorded_metric_data[0].shape[1]
-        subtask_successes = np.zeros(num_subtasks, dtype=float)
-
-        for ep in range(num_demos):
-            ep_subtask_success_result = np.any(recorded_metric_data[ep], axis=0).astype(float)
-            subtask_successes += ep_subtask_success_result
-        subtask_success_rates = subtask_successes / num_demos
-
-        return subtask_success_rates.tolist()
+        return compute_subtask_success_rate(recorded_metric_data)
 
 
 class SequentialTaskBase(TaskBase):

--- a/isaaclab_arena/tasks/sequential_task_base.py
+++ b/isaaclab_arena/tasks/sequential_task_base.py
@@ -98,13 +98,10 @@ class SubtaskSuccessRateMetric(MetricBase):
     def get_metric_term_cfg(self) -> MetricTermCfg:
         """Return the metric term configuration for the subtask success rate metric."""
         return MetricTermCfg(
-            func=compute_subtask_success_rate,
+            compute_metric_func=compute_subtask_success_rate,
             params={},
             recorder_term_name=self.recorder_term_name,
         )
-
-    def compute_metric_from_recording(self, recorded_metric_data: list[np.ndarray]) -> list:
-        return compute_subtask_success_rate(recorded_metric_data)
 
 
 class SequentialTaskBase(TaskBase):

--- a/isaaclab_arena/tests/test_physics_presets.py
+++ b/isaaclab_arena/tests/test_physics_presets.py
@@ -9,7 +9,7 @@ import pytest
 from isaaclab_newton.physics.newton_manager_cfg import NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 
-from isaaclab_arena.environments.isaaclab_arena_manager_based_env import ArenaPhysicsCfg
+from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import ArenaPhysicsCfg
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
 
 HEADLESS = True

--- a/isaaclab_arena/tests/test_revolute_joint_moved_rate_metric.py
+++ b/isaaclab_arena/tests/test_revolute_joint_moved_rate_metric.py
@@ -31,7 +31,6 @@ def _test_revolute_joint_moved_rate(simulation_app):
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-    from isaaclab_arena.metrics.metrics import compute_metrics
     from isaaclab_arena.scene.scene import Scene
     from isaaclab_arena.tasks.open_door_task import OpenDoorTask
     from isaaclab_arena.utils.pose import Pose
@@ -71,7 +70,7 @@ def _test_revolute_joint_moved_rate(simulation_app):
                 actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
                 env.step(actions)
 
-        metrics = compute_metrics(env)
+        metrics = env.unwrapped.compute_metrics()
         print(f"Metrics: {metrics}")
 
         # Calculate the expected door moved rate.

--- a/isaaclab_arena/tests/test_success_rate_metric.py
+++ b/isaaclab_arena/tests/test_success_rate_metric.py
@@ -38,7 +38,6 @@ def _test_success_rate_metric(simulation_app):
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-    from isaaclab_arena.metrics.metrics import compute_metrics
     from isaaclab_arena.scene.scene import Scene
     from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
     from isaaclab_arena.terms.events import set_object_pose_per_env
@@ -100,7 +99,7 @@ def _test_success_rate_metric(simulation_app):
                 actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
                 env.step(actions)
 
-        metrics = compute_metrics(env)
+        metrics = env.unwrapped.compute_metrics()
         print(f"Metrics: {metrics}")
         assert "success_rate" in metrics
         assert "object_moved_rate" in metrics

--- a/isaaclab_arena_environments/mdp/env_callbacks.py
+++ b/isaaclab_arena_environments/mdp/env_callbacks.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnvCfg
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import IsaacLabArenaManagerBasedRLEnvCfg
 
 
 def assembly_env_cfg_callback(env_cfg: IsaacLabArenaManagerBasedRLEnvCfg) -> IsaacLabArenaManagerBasedRLEnvCfg:


### PR DESCRIPTION
## Summary
Refactors how metrics enter our `IsaacLabArenaManagerBasedRLEnvCfg` to match Isaac Lab convention.

## Detailed description
- We were attaching metrics runtime objects to the `IsaacLabArenaManagerBasedRLEnvCfg`
- Isaac Lab expects only `configclass`es in `*Cfg` objects.
- This changes our design to match more closely with Isaac Lab.
  - Metrics now enter the env through `MetricsCfg`s
  - Run-time metrics are then built at env build time by `IsaacLabArenaManagerBasedRLEnv`
  - This matches how things are done in IsaacLab - Cfgs are spcified by the user, and then run-time objects are built by the system based on those configs.
