### PR TITLE
Add ObjectRelation & Task Registries

### DIFF
--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -17,7 +17,7 @@ from isaaclab_arena.assets.registries import (
 
 # Decorator to register an asset with the AssetRegistry.
 def register_asset(cls):
-    if AssetRegistry().is_registered(cls.name):
+    if AssetRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Asset {cls.name} is already registered. Doing nothing.")
     else:
         AssetRegistry().register(cls, cls.name)
@@ -26,7 +26,7 @@ def register_asset(cls):
 
 # Decorator to register an device with the DeviceRegistry.
 def register_device(cls):
-    if DeviceRegistry().is_registered(cls.name):
+    if DeviceRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Device {cls.name} is already registered. Doing nothing.")
     else:
         DeviceRegistry().register(cls, cls.name)
@@ -37,7 +37,7 @@ def register_device(cls):
 def register_retargeter(cls):
     retargeter_key = (cls.device, cls.embodiment)
     retargeter_key_str = RetargeterRegistry().convert_tuple_to_str(retargeter_key)
-    if RetargeterRegistry().is_registered(retargeter_key_str):
+    if RetargeterRegistry().is_registered(retargeter_key_str, ensure_loaded=False):
         print(f"WARNING: Retargeter {cls.device} for {cls.embodiment} is already registered. Doing nothing.")
     else:
         RetargeterRegistry().register(cls, retargeter_key_str)
@@ -46,7 +46,7 @@ def register_retargeter(cls):
 
 # Decorator to register a policy with the PolicyRegistry.
 def register_policy(cls):
-    if PolicyRegistry().is_registered(cls.name):
+    if PolicyRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Policy {cls.name} is already registered. Doing nothing.")
     else:
         PolicyRegistry().register(cls, cls.name)
@@ -55,7 +55,7 @@ def register_policy(cls):
 
 # Decorator to register an HDRImage with the HDRImageRegistry.
 def register_hdr(cls):
-    if HDRImageRegistry().is_registered(cls.name):
+    if HDRImageRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: HDRImage {cls.name} is already registered. Doing nothing.")
     else:
         HDRImageRegistry().register(cls, cls.name)
@@ -65,7 +65,7 @@ def register_hdr(cls):
 # Decorator to register an environment with the EnvironmentRegistry.
 def register_environment(cls):
     registry = EnvironmentRegistry()
-    if registry.is_registered(cls.name):
+    if registry.is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Environment {cls.name} is already registered. Doing nothing.")
     else:
         registry.register(cls, cls.name)
@@ -75,7 +75,7 @@ def register_environment(cls):
 # Decorator to register a RelationBase subclass with the ObjectRelationLibraryRegistry.
 def register_object_relation(cls):
     registry = ObjectRelationLibraryRegistry()
-    if registry.is_registered(cls.name):
+    if registry.is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Object relation {cls.name} is already registered. Doing nothing.")
     else:
         registry.register(cls, cls.name)
@@ -87,7 +87,7 @@ def register_object_relation(cls):
 # requiring a separate `name` attribute on every task class.
 def register_task(cls):
     registry = TaskRegistry()
-    if registry.is_registered(cls.__name__):
+    if registry.is_registered(cls.__name__, ensure_loaded=False):
         print(f"WARNING: Task {cls.__name__} is already registered. Doing nothing.")
     else:
         registry.register(cls, cls.__name__)

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -11,6 +11,7 @@ from isaaclab_arena.assets.registries import (
     ObjectRelationLibraryRegistry,
     PolicyRegistry,
     RetargeterRegistry,
+    TaskRegistry,
 )
 
 
@@ -78,4 +79,16 @@ def register_object_relation(cls):
         print(f"WARNING: Object relation {cls.name} is already registered. Doing nothing.")
     else:
         registry.register(cls, cls.name)
+    return cls
+
+
+# Decorator to register a TaskBase subclass with the TaskRegistry.
+# Keyed by `cls.__name__` so the YAML `type: PascalCase` lookups match without
+# requiring a separate `name` attribute on every task class.
+def register_task(cls):
+    registry = TaskRegistry()
+    if registry.is_registered(cls.__name__):
+        print(f"WARNING: Task {cls.__name__} is already registered. Doing nothing.")
+    else:
+        registry.register(cls, cls.__name__)
     return cls

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -8,6 +8,7 @@ from isaaclab_arena.assets.registries import (
     DeviceRegistry,
     EnvironmentRegistry,
     HDRImageRegistry,
+    ObjectRelationLibraryRegistry,
     PolicyRegistry,
     RetargeterRegistry,
 )
@@ -65,6 +66,16 @@ def register_environment(cls):
     registry = EnvironmentRegistry()
     if registry.is_registered(cls.name):
         print(f"WARNING: Environment {cls.name} is already registered. Doing nothing.")
+    else:
+        registry.register(cls, cls.name)
+    return cls
+
+
+# Decorator to register a RelationBase subclass with the ObjectRelationLibraryRegistry.
+def register_object_relation(cls):
+    registry = ObjectRelationLibraryRegistry()
+    if registry.is_registered(cls.name):
+        print(f"WARNING: Object relation {cls.name} is already registered. Doing nothing.")
     else:
         registry.register(cls, cls.name)
     return cls

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
     from isaaclab_arena.policy.policy_base import PolicyBase
     from isaaclab_arena.relations.relations import RelationBase
+    from isaaclab_arena.tasks.task_base import TaskBase
 
 
 # Have to define all classes here in order to avoid circular import.
@@ -52,6 +53,7 @@ class Registry(metaclass=SingletonMeta):
                 PolicyRegistry,
                 HDRImageRegistry,
                 ObjectRelationLibraryRegistry,
+                TaskRegistry,
             ),
         ):
             ensure_assets_registered()
@@ -76,6 +78,7 @@ class Registry(metaclass=SingletonMeta):
                 PolicyRegistry,
                 HDRImageRegistry,
                 ObjectRelationLibraryRegistry,
+                TaskRegistry,
             ),
         ):
             ensure_assets_registered()
@@ -98,6 +101,7 @@ class Registry(metaclass=SingletonMeta):
                 PolicyRegistry,
                 HDRImageRegistry,
                 ObjectRelationLibraryRegistry,
+                TaskRegistry,
             ),
         ):
             ensure_assets_registered()
@@ -264,6 +268,22 @@ class ObjectRelationLibraryRegistry(Registry):
         return self.get_component_by_name(name)
 
 
+class TaskRegistry(Registry):
+    """Registry for TaskBase subclasses."""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_task_by_name(self, name: str) -> type["TaskBase"]:
+        """Gets a task class by name.
+
+        Args:
+            name (str): The name of the task class (typically the class __name__).
+        """
+        ensure_assets_registered()
+        return self.get_component_by_name(name)
+
+
 # Lazy registration to avoid circular imports
 _assets_registered = False
 
@@ -281,5 +301,6 @@ def ensure_assets_registered():
         import isaaclab_arena.embodiments  # noqa: F401
         import isaaclab_arena.policy  # noqa: F401
         import isaaclab_arena.relations.relations  # noqa: F401
+        import isaaclab_arena.tasks  # noqa: F401
 
         _assets_registered = True

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -43,19 +43,7 @@ class Registry(metaclass=SingletonMeta):
         Args:
             key (str): The name of the component.
         """
-        # For AssetRegistry and DeviceRegistry, ensure assets are registered before checking
-        if isinstance(
-            self,
-            (
-                AssetRegistry,
-                DeviceRegistry,
-                RetargeterRegistry,
-                PolicyRegistry,
-                HDRImageRegistry,
-                ObjectRelationLibraryRegistry,
-                TaskRegistry,
-            ),
-        ):
+        if isinstance(self, REGISTRIES):
             ensure_assets_registered()
         return key in self._components
 
@@ -68,19 +56,7 @@ class Registry(metaclass=SingletonMeta):
         Returns:
             Any: The component.
         """
-        # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(
-            self,
-            (
-                AssetRegistry,
-                DeviceRegistry,
-                RetargeterRegistry,
-                PolicyRegistry,
-                HDRImageRegistry,
-                ObjectRelationLibraryRegistry,
-                TaskRegistry,
-            ),
-        ):
+        if isinstance(self, REGISTRIES):
             ensure_assets_registered()
         assert key in self._components, f"component {key} not found, please check if requested component is registered"
         return self._components[key]
@@ -91,19 +67,7 @@ class Registry(metaclass=SingletonMeta):
         Returns:
             list[str]: The list of keys.
         """
-        # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(
-            self,
-            (
-                AssetRegistry,
-                DeviceRegistry,
-                RetargeterRegistry,
-                PolicyRegistry,
-                HDRImageRegistry,
-                ObjectRelationLibraryRegistry,
-                TaskRegistry,
-            ),
-        ):
+        if isinstance(self, REGISTRIES):
             ensure_assets_registered()
         return list(self._components.keys())
 
@@ -282,6 +246,19 @@ class TaskRegistry(Registry):
         """
         ensure_assets_registered()
         return self.get_component_by_name(name)
+
+
+# Registries populated lazily by ensure_assets_registered(). EnvironmentRegistry is
+# excluded: triggering the cascade during env registration causes an env<->tasks cycle.
+REGISTRIES = (
+    AssetRegistry,
+    DeviceRegistry,
+    RetargeterRegistry,
+    PolicyRegistry,
+    HDRImageRegistry,
+    ObjectRelationLibraryRegistry,
+    TaskRegistry,
+)
 
 
 # Lazy registration to avoid circular imports

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.assets.hdr_image import HDRImage
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
     from isaaclab_arena.policy.policy_base import PolicyBase
+    from isaaclab_arena.relations.relations import RelationBase
 
 
 # Have to define all classes here in order to avoid circular import.
@@ -217,6 +218,22 @@ class EnvironmentRegistry(Registry):
         super().__init__()
 
 
+class ObjectRelationLibraryRegistry(Registry):
+    """Registry for object relation classes."""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_object_relation_by_name(self, name: str) -> type["RelationBase"]:
+        """Gets an object relation by name.
+
+        Args:
+            name (str): The name of the object relation.
+        """
+        ensure_assets_registered()
+        return self.get_component_by_name(name)
+
+
 # Lazy registration to avoid circular imports
 _assets_registered = False
 
@@ -233,5 +250,6 @@ def ensure_assets_registered():
         import isaaclab_arena.assets.retargeter_library  # noqa: F401
         import isaaclab_arena.embodiments  # noqa: F401
         import isaaclab_arena.policy  # noqa: F401
+        import isaaclab_arena.relations.relations  # noqa: F401
 
         _assets_registered = True

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -43,7 +43,17 @@ class Registry(metaclass=SingletonMeta):
             key (str): The name of the component.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before checking
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRImageRegistry)):
+        if isinstance(
+            self,
+            (
+                AssetRegistry,
+                DeviceRegistry,
+                RetargeterRegistry,
+                PolicyRegistry,
+                HDRImageRegistry,
+                ObjectRelationLibraryRegistry,
+            ),
+        ):
             ensure_assets_registered()
         return key in self._components
 
@@ -57,7 +67,17 @@ class Registry(metaclass=SingletonMeta):
             Any: The component.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRImageRegistry)):
+        if isinstance(
+            self,
+            (
+                AssetRegistry,
+                DeviceRegistry,
+                RetargeterRegistry,
+                PolicyRegistry,
+                HDRImageRegistry,
+                ObjectRelationLibraryRegistry,
+            ),
+        ):
             ensure_assets_registered()
         assert key in self._components, f"component {key} not found, please check if requested component is registered"
         return self._components[key]
@@ -69,7 +89,17 @@ class Registry(metaclass=SingletonMeta):
             list[str]: The list of keys.
         """
         # For AssetRegistry and DeviceRegistry, ensure assets are registered before accessing
-        if isinstance(self, (AssetRegistry, DeviceRegistry, RetargeterRegistry, PolicyRegistry, HDRImageRegistry)):
+        if isinstance(
+            self,
+            (
+                AssetRegistry,
+                DeviceRegistry,
+                RetargeterRegistry,
+                PolicyRegistry,
+                HDRImageRegistry,
+                ObjectRelationLibraryRegistry,
+            ),
+        ):
             ensure_assets_registered()
         return list(self._components.keys())
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -37,13 +37,28 @@ class Registry(metaclass=SingletonMeta):
         assert key is not None, "component name is not set"
         self._components[key] = component
 
-    def is_registered(self, key: str) -> bool:
-        """Check if an component is registered.
+    def is_registered(self, key: str, ensure_loaded: bool = True) -> bool:
+        """Check whether a component is already registered under ``key``.
 
         Args:
-            key (str): The name of the component.
+            key: The name to look up.
+            ensure_loaded: Whether to load every component before answering.
+
+                Components register themselves lazily: nothing is in the registry until
+                ``ensure_assets_registered()`` imports all the library modules. So a plain
+                membership check can say "not registered" simply because the libraries
+                haven't been imported yet. With ``ensure_loaded=True`` (the default) we
+                import them first, so the answer reflects everything that exists.
+
+                The ``register_*`` decorators pass ``False``. They run *while* those
+                library modules are being imported, and all they need is to spot a
+                duplicate key. Forcing a full load at that moment would re-enter the
+                import that's already in progress and pull in the task/environment modules
+                — which import Isaac Sim's ``pxr``/USD packages. If that happens during
+                pytest collection (before ``SimulationApp()`` starts) the simulator
+                segfaults, because those packages must be imported only after it starts.
         """
-        if isinstance(self, REGISTRIES):
+        if ensure_loaded and isinstance(self, REGISTRIES):
             ensure_assets_registered()
         return key in self._components
 
@@ -284,7 +299,7 @@ def ensure_assets_registered():
         import isaaclab_arena.embodiments  # noqa: F401
         import isaaclab_arena.policy  # noqa: F401
         import isaaclab_arena.relations.relations  # noqa: F401
-        import isaaclab_arena.tasks  # noqa: F401
+        import isaaclab_arena.tasks.task_library  # noqa: F401
 
         _assets_registered = True
     finally:

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -286,12 +286,18 @@ class TaskRegistry(Registry):
 
 # Lazy registration to avoid circular imports
 _assets_registered = False
+# Blocks re-entry: registration decorators call is_registered() -> ensure_assets_registered()
+# mid-import, which would re-import a partial module and raise a circular ImportError.
+_registration_in_progress = False
 
 
 def ensure_assets_registered():
     """Ensure all assets are registered. Call this before accessing the registry."""
-    global _assets_registered
-    if not _assets_registered:
+    global _assets_registered, _registration_in_progress
+    if _assets_registered or _registration_in_progress:
+        return
+    _registration_in_progress = True
+    try:
         # Import modules to trigger asset registration via decorators
         import isaaclab_arena.assets.background_library  # noqa: F401
         import isaaclab_arena.assets.device_library  # noqa: F401
@@ -304,3 +310,5 @@ def ensure_assets_registered():
         import isaaclab_arena.tasks  # noqa: F401
 
         _assets_registered = True
+    finally:
+        _registration_in_progress = False

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -6,7 +6,13 @@
 from collections.abc import Callable
 from enum import Enum
 from numbers import Real
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpatialConstraintType
+    from isaaclab_arena.relations.relations import RelationBase
 
 
 def as_dict(data: Any, spec_name: str) -> dict[str, Any]:
@@ -131,3 +137,18 @@ def assert_references_exist(nodes: list[Any], tasks: list[Any], state_specs: lis
 
 def _add_id_location(id_locations: dict[str, list[str]], spec_id: str, location: str) -> None:
     id_locations.setdefault(spec_id, []).append(location)
+
+
+def relation_class_for_spatial_constraint_type(
+    constraint_type: "ArenaEnvGraphSpatialConstraintType",
+) -> "type[RelationBase] | None":
+    """Resolve a spatial-constraint enum member to its RelationBase subclass.
+
+    Returns None for enum members that have no registered class yet (e.g. AT_POSE,
+    handled via set_initial_pose; IN, not yet supported by the solver).
+    # TODO(xinjieyao, 2026-05-28): add support for AT_POSE and IN.
+    """
+    registry = ObjectRelationLibraryRegistry()
+    if registry.is_registered(constraint_type.value):
+        return registry.get_object_relation_by_name(constraint_type.value)
+    return None

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from isaaclab.utils.math import euler_xyz_from_quat
 
+from isaaclab_arena.assets.register import register_object_relation
 from isaaclab_arena.utils.pose import PoseRange
 
 if TYPE_CHECKING:
@@ -60,6 +61,7 @@ class Relation(RelationBase):
         self.relation_loss_weight = relation_loss_weight
 
 
+@register_object_relation
 class NextTo(Relation):
     """Represents a 'next to' relationship between objects.
 
@@ -68,6 +70,8 @@ class NextTo(Relation):
 
     Note: Loss computation is handled by NextToLossStrategy in relation_loss_strategies.py.
     """
+
+    name = "next_to"
 
     def __init__(
         self,
@@ -99,6 +103,7 @@ class NextTo(Relation):
         self.cross_position_ratio = cross_position_ratio
 
 
+@register_object_relation
 class On(Relation):
     """Represents an 'on top of' relationship between objects.
 
@@ -108,6 +113,8 @@ class On(Relation):
 
     Note: Loss computation is handled by OnLossStrategy in relation_loss_strategies.py.
     """
+
+    name = "on"
 
     def __init__(
         self,
@@ -126,6 +133,7 @@ class On(Relation):
         self.clearance_m = clearance_m
 
 
+@register_object_relation
 class IsAnchor(RelationBase):
     """Marker indicating this object is an anchor for relation solving.
 
@@ -144,9 +152,10 @@ class IsAnchor(RelationBase):
         bin.add_relation(NextTo(chair))
     """
 
-    pass
+    name = "is_anchor"
 
 
+@register_object_relation
 class RandomAroundSolution(RelationBase):
     """Marker indicating the solver solution should be used as center of a PoseRange.
 
@@ -164,6 +173,8 @@ class RandomAroundSolution(RelationBase):
         box.add_relation(RandomAroundSolution(x_half_m=0.1, y_half_m=0.1))
         # -> ObjectPlacer sets a PoseRange spanning ±0.1m in X and Y around solved position
     """
+
+    name = "random_around_solution"
 
     def __init__(
         self,
@@ -236,6 +247,7 @@ class RandomAroundSolution(RelationBase):
         )
 
 
+@register_object_relation
 class RotateAroundSolution(RelationBase):
     """Marker specifying an explicit rotation to apply on top of the solver solution.
 
@@ -251,6 +263,8 @@ class RotateAroundSolution(RelationBase):
         box.add_relation(RotateAroundSolution(yaw_rad=math.pi / 4))
         # -> ObjectPlacer sets a Pose with solved position and 45° yaw rotation
     """
+
+    name = "rotate_around_solution"
 
     def __init__(
         self,
@@ -283,6 +297,7 @@ class RotateAroundSolution(RelationBase):
         return tuple(quat.tolist())
 
 
+@register_object_relation
 class AtPosition(UnaryRelation):
     """Constrains object to specific world coordinates.
 
@@ -298,6 +313,8 @@ class AtPosition(UnaryRelation):
         mug.add_relation(On(table))
         mug.add_relation(AtPosition(x=0.5, y=1.0))
     """
+
+    name = "at_position"
 
     def __init__(
         self,
@@ -322,6 +339,7 @@ class AtPosition(UnaryRelation):
         self.relation_loss_weight = relation_loss_weight
 
 
+@register_object_relation
 class PositionLimits(UnaryRelation):
     """Constrains object position to a world-coordinate axis-aligned box.
 
@@ -331,6 +349,8 @@ class PositionLimits(UnaryRelation):
         mug.add_relation(PositionLimits(x_min=-0.5, x_max=0.5, y_min=-0.5, y_max=0.5))
         mug.add_relation(PositionLimits(z_min=0.8))  # only constrain Z
     """
+
+    name = "position_limits"
 
     def __init__(
         self,

--- a/isaaclab_arena/tasks/__init__.py
+++ b/isaaclab_arena/tasks/__init__.py
@@ -2,3 +2,21 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Import concrete task modules so their @register_task decorators fire when the
+# tasks package is loaded (e.g. via ensure_assets_registered()).
+from isaaclab_arena.tasks import (  # noqa: F401
+    assembly_task,
+    close_door_task,
+    goal_pose_task,
+    lift_object_task,
+    no_task,
+    open_door_task,
+    pick_and_place_task,
+    place_upright_task,
+    press_button_task,
+    rotate_revolute_joint_task,
+    sequential_task_base,
+    sorting_task,
+    turn_knob_task,
+)

--- a/isaaclab_arena/tasks/__init__.py
+++ b/isaaclab_arena/tasks/__init__.py
@@ -3,20 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Import concrete task modules so their @register_task decorators fire when the
-# tasks package is loaded (e.g. via ensure_assets_registered()).
-from isaaclab_arena.tasks import (  # noqa: F401
-    assembly_task,
-    close_door_task,
-    goal_pose_task,
-    lift_object_task,
-    no_task,
-    open_door_task,
-    pick_and_place_task,
-    place_upright_task,
-    press_button_task,
-    rotate_revolute_joint_task,
-    sequential_task_base,
-    sorting_task,
-    turn_knob_task,
-)
+# NOTE: keep this package __init__ free of eager task-module imports. Concrete tasks are
+# registered via isaaclab_arena.tasks.task_library, imported lazily by
+# ensure_assets_registered().

--- a/isaaclab_arena/tasks/assembly_task.py
+++ b/isaaclab_arena/tasks/assembly_task.py
@@ -16,6 +16,7 @@ from isaaclab.utils import configclass
 
 import isaaclab_arena_environments.mdp as mdp
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.object_moved import ObjectMovedRateMetric
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
@@ -25,6 +26,7 @@ from isaaclab_arena.tasks.terminations import objects_in_proximity
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class AssemblyTask(TaskBase):
     """
     Assembly task where an object needs to be assembled with a base object, like peg insert, gear mesh, etc.

--- a/isaaclab_arena/tasks/close_door_task.py
+++ b/isaaclab_arena/tasks/close_door_task.py
@@ -10,11 +10,13 @@ from isaaclab.managers import TerminationTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.openable import Openable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.tasks.common.open_close_door_mimic import RotateDoorMimicEnvCfg
 from isaaclab_arena.tasks.rotate_revolute_joint_task import RotateRevoluteJointTask
 
 
+@register_task
 class CloseDoorTask(RotateRevoluteJointTask):
     def __init__(
         self,

--- a/isaaclab_arena/tasks/goal_pose_task.py
+++ b/isaaclab_arena/tasks/goal_pose_task.py
@@ -13,6 +13,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.object_moved import ObjectMovedRateMetric
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
@@ -21,6 +22,7 @@ from isaaclab_arena.tasks.terminations import goal_pose_task_termination
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class GoalPoseTask(TaskBase):
     def __init__(
         self,

--- a/isaaclab_arena/tasks/lift_object_task.py
+++ b/isaaclab_arena/tasks/lift_object_task.py
@@ -17,6 +17,7 @@ from isaaclab.utils import configclass
 from isaaclab_tasks.manager_based.manipulation.dexsuite import dexsuite_env_cfg as dexsuite
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
@@ -28,6 +29,7 @@ from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 from isaaclab_arena.utils.pose import PoseRange
 
 
+@register_task
 class LiftObjectTask(TaskBase):
     def __init__(
         self,
@@ -130,6 +132,7 @@ class LiftObjectTerminationsCfg:
     success: TerminationTermCfg = MISSING
 
 
+@register_task
 class LiftObjectTaskRL(LiftObjectTask):
     def __init__(
         self,
@@ -377,6 +380,7 @@ class DexsuiteLiftTerminationsCfg(dexsuite.TerminationsCfg):
     )
 
 
+@register_task
 class DexsuiteLiftTask(LiftObjectTask):
     """Dexsuite lift task for Arena evaluation.
 

--- a/isaaclab_arena/tasks/no_task.py
+++ b/isaaclab_arena/tasks/no_task.py
@@ -5,10 +5,12 @@
 
 from isaaclab.envs.common import ViewerCfg
 
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.tasks.task_base import TaskBase
 
 
+@register_task
 class NoTask(TaskBase):
     """Null object for environments without a task."""
 

--- a/isaaclab_arena/tasks/open_door_task.py
+++ b/isaaclab_arena/tasks/open_door_task.py
@@ -10,11 +10,13 @@ from isaaclab.managers import TerminationTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.openable import Openable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.tasks.common.open_close_door_mimic import RotateDoorMimicEnvCfg
 from isaaclab_arena.tasks.rotate_revolute_joint_task import RotateRevoluteJointTask
 
 
+@register_task
 class OpenDoorTask(RotateRevoluteJointTask):
     def __init__(
         self,

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -15,6 +15,7 @@ from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.object_moved import ObjectMovedRateMetric
@@ -25,6 +26,7 @@ from isaaclab_arena.tasks.terminations import object_on_destination
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class PickAndPlaceTask(TaskBase):
     """Pick-and-place task. Success fires when the pick-up object contacts the destination
     with low velocity. Failure (object_dropped) fires when the object falls below the

--- a/isaaclab_arena/tasks/place_upright_task.py
+++ b/isaaclab_arena/tasks/place_upright_task.py
@@ -14,6 +14,7 @@ from isaaclab.scene import InteractiveSceneCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.placeable import Placeable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.object_moved import ObjectMovedRateMetric
@@ -23,6 +24,7 @@ from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class PlaceUprightTask(TaskBase):
 
     def __init__(

--- a/isaaclab_arena/tasks/press_button_task.py
+++ b/isaaclab_arena/tasks/press_button_task.py
@@ -12,6 +12,7 @@ from isaaclab.managers import EventTermCfg, TerminationTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.pressable import Pressable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
@@ -19,6 +20,7 @@ from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class PressButtonTask(TaskBase):
     def __init__(
         self,

--- a/isaaclab_arena/tasks/rotate_revolute_joint_task.py
+++ b/isaaclab_arena/tasks/rotate_revolute_joint_task.py
@@ -11,6 +11,7 @@ from isaaclab.managers import EventTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.openable import Openable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.revolute_joint_moved_rate import RevoluteJointMovedRateMetric
@@ -19,6 +20,7 @@ from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class RotateRevoluteJointTask(TaskBase):
     def __init__(
         self,

--- a/isaaclab_arena/tasks/sorting_task.py
+++ b/isaaclab_arena/tasks/sorting_task.py
@@ -13,6 +13,7 @@ from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
 from isaaclab_arena.tasks.task_base import TaskBase
@@ -21,6 +22,7 @@ from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 from isaaclab_arena.utils.configclass import make_configclass
 
 
+@register_task
 class SortMultiObjectTask(TaskBase):
 
     def __init__(

--- a/isaaclab_arena/tasks/task_library.py
+++ b/isaaclab_arena/tasks/task_library.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Importing these concrete task modules fires their @register_task decorators. This must
+# NOT live in tasks/__init__.py: that runs on any `from isaaclab_arena.tasks.X import Y`,
+# including at pytest-collection time, and the cascade pulls in pxr/USD modules before
+# SimulationApp() is created — which segfaults the sim. Instead it is imported lazily by
+# ensure_assets_registered() (called after the sim app is up), mirroring object_library.
+from isaaclab_arena.tasks import (  # noqa: F401
+    assembly_task,
+    close_door_task,
+    goal_pose_task,
+    lift_object_task,
+    no_task,
+    open_door_task,
+    pick_and_place_task,
+    place_upright_task,
+    press_button_task,
+    rotate_revolute_joint_task,
+    sequential_task_base,
+    sorting_task,
+    turn_knob_task,
+)

--- a/isaaclab_arena/tasks/turn_knob_task.py
+++ b/isaaclab_arena/tasks/turn_knob_task.py
@@ -12,6 +12,7 @@ from isaaclab.managers import EventTermCfg, TerminationTermCfg
 from isaaclab.utils import configclass
 
 from isaaclab_arena.affordances.turnable import Turnable
+from isaaclab_arena.assets.register import register_task
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.metrics.success_rate import SuccessRateMetric
@@ -19,6 +20,7 @@ from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
+@register_task
 class TurnKnobTask(TaskBase):
     def __init__(
         self,

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 
 from isaaclab_arena.assets.object_type import ObjectType
+from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.environments.arena_env_graph_spec import (
     ArenaEnvGraphNodeType,
     ArenaEnvGraphObjectReferenceNodeSpec,
@@ -17,6 +18,14 @@ from isaaclab_arena.environments.graph_spec_utils import relation_class_for_spat
 from isaaclab_arena.relations.relations import IsAnchor, PositionLimits
 
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
+
+# Spatial-constraint enum members that intentionally have no registered relation:
+# AT_POSE is applied via set_initial_pose(), and IN is not yet supported by the solver.
+# TODO(xinjieyao, 2026-05-28): drop these once AT_POSE and IN gain relation classes.
+_RELATIONLESS_CONSTRAINT_TYPES = {
+    ArenaEnvGraphSpatialConstraintType.AT_POSE,
+    ArenaEnvGraphSpatialConstraintType.IN,
+}
 
 
 def test_arena_env_graph_spec_loads_pick_and_place_yaml():
@@ -80,6 +89,31 @@ def test_arena_env_graph_spec_loads_pick_and_place_yaml():
         relation_class_for_spatial_constraint_type(initial_mug_pose.type) is None
     )  # at_pose: handled via set_initial_pose
     assert relation_class_for_spatial_constraint_type(in_constraint.type) is None  # in: not yet supported by solver
+
+
+def test_registered_relations_match_spatial_constraint_enum():
+    """Registered relations and the spatial-constraint enum must stay in one-to-one sync.
+
+    Each registered RelationBase subclass is keyed by its `name`, which must equal the
+    `value` of a ArenaEnvGraphSpatialConstraintType member (so spec lookups resolve), and
+    every solver-backed enum member must have a relation. AT_POSE and IN are excluded —
+    see _RELATIONLESS_CONSTRAINT_TYPES. This guards against adding one side without the
+    other.
+    """
+    # Importing the module ran the @register_object_relation decorators at file top.
+    registered_names = set(ObjectRelationLibraryRegistry().get_all_keys())
+    enum_values = {
+        constraint.value
+        for constraint in ArenaEnvGraphSpatialConstraintType
+        if constraint not in _RELATIONLESS_CONSTRAINT_TYPES
+    }
+
+    assert registered_names == enum_values, (
+        "Registered relations and spatial-constraint enum are out of sync.\n"
+        f"  relations missing an enum member: {sorted(registered_names - enum_values)}\n"
+        f"  enum members missing a relation:  {sorted(enum_values - registered_names)}\n"
+        "  (AT_POSE and IN are intentionally excluded via _RELATIONLESS_CONSTRAINT_TYPES.)"
+    )
 
 
 def test_arena_env_graph_spec_parses_optional_task_constraints_and_at_pose():

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -13,6 +13,8 @@ from isaaclab_arena.environments.arena_env_graph_spec import (
     ArenaEnvGraphSpec,
     ArenaEnvGraphStateSpec,
 )
+from isaaclab_arena.environments.graph_spec_utils import relation_class_for_spatial_constraint_type
+from isaaclab_arena.relations.relations import IsAnchor, PositionLimits
 
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
 
@@ -69,6 +71,15 @@ def test_arena_env_graph_spec_loads_pick_and_place_yaml():
     assert final_mug_pose.parent == "mug_ycb_robolab"
     assert final_mug_pose.params["position_xyz"] == (0.65, 0.25, 0.85)
     assert final_mug_pose.params["rotation_xyzw"] == (0.0, 0.0, 0.0, 1.0)
+
+    table_anchor = initial_state.spatial_constraints[0]
+    assert table_anchor.type == ArenaEnvGraphSpatialConstraintType.IS_ANCHOR
+    assert relation_class_for_spatial_constraint_type(table_anchor.type) is IsAnchor
+    assert relation_class_for_spatial_constraint_type(cube_limits.type) is PositionLimits
+    assert (
+        relation_class_for_spatial_constraint_type(initial_mug_pose.type) is None
+    )  # at_pose: handled via set_initial_pose
+    assert relation_class_for_spatial_constraint_type(in_constraint.type) is None  # in: not yet supported by solver
 
 
 def test_arena_env_graph_spec_parses_optional_task_constraints_and_at_pose():

--- a/isaaclab_arena/tests/test_task_registry.py
+++ b/isaaclab_arena/tests/test_task_registry.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+
+def _test_task_registry_resolves_concrete_tasks(simulation_app):
+    from isaaclab_arena.assets.registries import TaskRegistry
+
+    expected = [
+        "NoTask",
+        "PickAndPlaceTask",
+        "PlaceUprightTask",
+        "LiftObjectTask",
+        "LiftObjectTaskRL",
+        "DexsuiteLiftTask",
+        "GoalPoseTask",
+        "PressButtonTask",
+        "RotateRevoluteJointTask",
+        "CloseDoorTask",
+        "OpenDoorTask",
+        "TurnKnobTask",
+        "AssemblyTask",
+        "SortMultiObjectTask",
+    ]
+    registry = TaskRegistry()
+    for name in expected:
+        cls = registry.get_task_by_name(name)
+        assert cls.__name__ == name, f"{name} -> {cls.__name__}"
+    return True
+
+
+def test_task_registry_resolves_concrete_tasks():
+    result = run_simulation_app_function(_test_task_registry_resolves_concrete_tasks)
+    assert result


### PR DESCRIPTION
## Summary
Add ObjectRelation Registry & Task Registry

## Detailed description
- Why: When constructing `ArenaEnv` from `EnvGraphSpec`, it requires matching spatial relationship & task to its class name. Without this registry, new relation/task need to be added in two places manually.
- What: Added `@register_object_relation` decorator backed by the added `ObjectRelationLibraryRegistry`. Added `@register_task` decorator backed by the added `TaskRegistry`.
- Leave TODO for `AT_POSE` and `IN` registry supports

### Note
- Added a Bool to block re-entry when using registration decorator. Without it, it triggers circular deps ImportError. It's caused by object relation registry.
