### PR TITLE
Add CloudXR network setup to teleop doc prereqs

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -10,6 +10,14 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation task
    Before starting teleoperation, also review the `IsaacTeleop system requirements
    <https://nvidia.github.io/IsaacTeleop/main/references/requirements.html#teleoperation-with-isaac-sim-and-isaac-lab>`_.
 
+.. important::
+
+   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
+   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
+   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
+   and complete your network setup before starting the steps below.
+
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -82,8 +90,6 @@ Step 3: Connect from Meta Quest 3
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For detail instructions please refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_:
-
-A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
 
 #. Open the browser on your headset and navigate to `<https://nvidia.github.io/IsaacTeleop/client>`_.
 

--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -14,7 +14,8 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation task
 
    **Set up your network before you begin.** CloudXR streams the rendered simulation to your
    headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   video, dropped sessions, and failed connections. For the best experience, review the
+   `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
    and complete your network setup before starting the steps below.
 

--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -12,9 +12,9 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation task
 
 .. important::
 
-   For the best experience, review the `CloudXR network requirements
+   A stable network connection meeting the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   before starting the steps below.
+   is required before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_2_teleoperation.rst
@@ -12,12 +12,9 @@ This workflow covers collecting demonstrations for the G1 loco-manipulation task
 
 .. important::
 
-   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
-   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. For the best experience, review the
-   `CloudXR network requirements
+   For the best experience, review the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   and complete your network setup before starting the steps below.
+   before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -14,7 +14,8 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
    **Set up your network before you begin.** CloudXR streams the rendered simulation to your
    headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   video, dropped sessions, and failed connections. For the best experience, review the
+   `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
    and complete your network setup before starting the steps below.
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -10,6 +10,14 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
    Before starting teleoperation, also review the `IsaacTeleop system requirements
    <https://nvidia.github.io/IsaacTeleop/main/references/requirements.html#teleoperation-with-isaac-sim-and-isaac-lab>`_.
 
+.. important::
+
+   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
+   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
+   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
+   and complete your network setup before starting the steps below.
+
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -135,9 +143,6 @@ Step 3: Connect XR Device and Record
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For detailed instructions, refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_.
-
-A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
-
 
 .. tab-set::
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -12,12 +12,9 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
 .. important::
 
-   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
-   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. For the best experience, review the
-   `CloudXR network requirements
+   For the best experience, review the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   and complete your network setup before starting the steps below.
+   before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_2_teleoperation.rst
@@ -12,9 +12,9 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
 .. important::
 
-   For the best experience, review the `CloudXR network requirements
+   A stable network connection meeting the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   before starting the steps below.
+   is required before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -10,6 +10,14 @@ This workflow covers collecting demonstrations for the Unitree G1 static apple-t
    Before starting teleoperation, also review the `IsaacTeleop system requirements
    <https://nvidia.github.io/IsaacTeleop/main/references/requirements.html#teleoperation-with-isaac-sim-and-isaac-lab>`_.
 
+.. important::
+
+   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
+   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
+   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
+   and complete your network setup before starting the steps below.
+
 .. admonition:: No teleoperation hardware?
    :class: tip
 
@@ -150,8 +158,6 @@ Step 3: Connect from the headset device
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For detailed instructions please refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_:
-
-A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
 
 #. Open the browser on your headset and navigate to `<https://nvidia.github.io/IsaacTeleop/client>`_.
 

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -12,12 +12,9 @@ This workflow covers collecting demonstrations for the Unitree G1 static apple-t
 
 .. important::
 
-   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
-   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. For the best experience, review the
-   `CloudXR network requirements
+   For the best experience, review the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   and complete your network setup before starting the steps below.
+   before starting the steps below.
 
 .. admonition:: No teleoperation hardware?
    :class: tip

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -14,7 +14,8 @@ This workflow covers collecting demonstrations for the Unitree G1 static apple-t
 
    **Set up your network before you begin.** CloudXR streams the rendered simulation to your
    headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   video, dropped sessions, and failed connections. For the best experience, review the
+   `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
    and complete your network setup before starting the steps below.
 

--- a/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_apple/step_2_teleoperation.rst
@@ -12,9 +12,9 @@ This workflow covers collecting demonstrations for the Unitree G1 static apple-t
 
 .. important::
 
-   For the best experience, review the `CloudXR network requirements
+   A stable network connection meeting the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   before starting the steps below.
+   is required before starting the steps below.
 
 .. admonition:: No teleoperation hardware?
    :class: tip

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -10,6 +10,14 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
    Before starting teleoperation, also review the `IsaacTeleop system requirements
    <https://nvidia.github.io/IsaacTeleop/main/references/requirements.html#teleoperation-with-isaac-sim-and-isaac-lab>`_.
 
+.. important::
+
+   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
+   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
+   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
+   and complete your network setup before starting the steps below.
+
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -133,9 +141,6 @@ Step 3: Connect XR Device and Record
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For detailed instructions, refer to `Connect an XR Device <https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html#start-cloudxr-runtime>`_.
-
-A strong wireless connection is essential for a high-quality streaming experience. Refer to the `CloudXR Network Setup <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html>`_ guide for router configuration.
-
 
 .. tab-set::
 

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -14,7 +14,8 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
    **Set up your network before you begin.** CloudXR streams the rendered simulation to your
    headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. Review the `CloudXR network requirements
+   video, dropped sessions, and failed connections. For the best experience, review the
+   `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
    and complete your network setup before starting the steps below.
 

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -12,12 +12,9 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
 .. important::
 
-   **Set up your network before you begin.** CloudXR streams the rendered simulation to your
-   headset in real time, so a misconfigured network is the most common cause of laggy or frozen
-   video, dropped sessions, and failed connections. For the best experience, review the
-   `CloudXR network requirements
+   For the best experience, review the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   and complete your network setup before starting the steps below.
+   before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_2_teleoperation.rst
@@ -12,9 +12,9 @@ This workflow covers collecting demonstrations using Isaac Teleop with an XR dev
 
 .. important::
 
-   For the best experience, review the `CloudXR network requirements
+   A stable network connection meeting the `CloudXR network requirements
    <https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#network-requirements>`_
-   before starting the steps below.
+   is required before starting the steps below.
 
 Step 1: Start the CloudXR Runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
Add CloudXR network setup to teleop doc prereqs

## Detailed description
- The CloudXR network setup link was a soft, easy-to-skip prose line in Step 3 of each teleop workflow, so users often proceeded with a misconfigured network and poor streaming.
- Moved it into a prominent `.. important::` prerequisites callout at the top of all four teleop docs (locomanipulation, static_apple, static_manipulation, sequential_static_manipulation), naming the failure symptoms and linking the anchored CloudXR network requirements section.
- Removed the now-redundant Step 3 mention.
- Network requirements are now surfaced before any steps, reducing misconfigured-network setups during data collection.