### PR TITLE
Add Rotation Initialization for Objects

### DIFF
--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -82,7 +82,8 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
         default=False,
         help=(
             "Randomly rotate objects (except anchors) around the Z-axis for scene variety. "
-            "Collisions use a larger enclosing box; the solver won't optimize this rotation."
+            "Collisions use a larger enclosing box; the solver won't optimize this rotation. "
+            "Only affects objects positioned by the placement solver; manually-placed objects are unaffected."
         ),
     )
 

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -76,6 +76,15 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             " layout."
         ),
     )
+    arena_group.add_argument(
+        "--random_yaw_init",
+        action="store_true",
+        default=False,
+        help=(
+            "Randomly rotate objects (except anchors) around the Z-axis for scene variety. "
+            "Collisions use a larger enclosing box; the solver won't optimize this rotation."
+        ),
+    )
 
 
 def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -70,6 +70,7 @@ class ArenaEnvBuilder:
             num_envs=self.args.num_envs,
             placement_seed=self.args.placement_seed,
             resolve_on_reset=self.args.resolve_on_reset,
+            random_yaw_init=self.args.random_yaw_init,
         )
 
     def _modify_recorder_cfg_dataset_filename(self, recorder_cfg: RecorderManagerBaseCfg) -> RecorderManagerBaseCfg:

--- a/isaaclab_arena/environments/relation_solver_interface.py
+++ b/isaaclab_arena/environments/relation_solver_interface.py
@@ -12,7 +12,7 @@ from isaaclab_arena.relations.placement_events import get_rotation_xyzw, solve_a
 from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.relations.relations import get_anchor_objects
-from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw
 
 if TYPE_CHECKING:
     from isaaclab.managers import EventTermCfg
@@ -25,6 +25,7 @@ def solve_and_apply_relation_placement(
     num_envs: int,
     placement_seed: int | None = None,
     resolve_on_reset: bool | None = None,
+    random_yaw_init: bool = False,
 ) -> EventTermCfg | None:
     """Solve relation placement and apply the result to object reset/static state.
 
@@ -35,6 +36,8 @@ def solve_and_apply_relation_placement(
         resolve_on_reset: Optional override for whether to draw fresh layouts from
             the placement pool on reset. When ``False``, fixed per-environment
             initial poses are applied immediately.
+        random_yaw_init: If True, randomly rotates non-anchor objects around the vertical (Z)
+            axis at startup to add visual variety to the scene.
 
     Returns:
         Reset event config to attach to the environment when placement should be
@@ -49,6 +52,7 @@ def solve_and_apply_relation_placement(
         placement_seed=placement_seed,
         apply_positions_to_objects=False,
         solver_params=RelationSolverParams(save_position_history=False, verbose=False),
+        random_yaw_init=random_yaw_init,
     )
     if resolve_on_reset is not None:
         placer_params.resolve_on_reset = resolve_on_reset
@@ -126,7 +130,7 @@ def _apply_dynamic_spawn_pose(
         object_cfg = getattr(obj, "object_cfg", None)
         assert object_cfg is not None, f"Object '{obj.name}' must have object_cfg initialized before placement."
         object_cfg.init_state.pos = pos
-        object_cfg.init_state.rot = get_rotation_xyzw(obj)
+        object_cfg.init_state.rot = rotate_quat_by_yaw(get_rotation_xyzw(obj), layout.orientations.get(obj, 0.0))
 
     return EventTermCfg(
         func=solve_and_place_objects,
@@ -149,7 +153,7 @@ def _apply_static_initial_poses(
     for obj in objects:
         if obj in anchor_objects_set:
             continue
-        rotation_xyzw = get_rotation_xyzw(obj)
+        base_rotation_xyzw = get_rotation_xyzw(obj)
         poses = []
         missing_envs: list[int] = []
         for env_idx in range(num_envs):
@@ -157,6 +161,7 @@ def _apply_static_initial_poses(
             if pos is None:
                 missing_envs.append(env_idx)
             else:
+                rotation_xyzw = rotate_quat_by_yaw(base_rotation_xyzw, layouts[env_idx].orientations.get(obj, 0.0))
                 poses.append(Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw))
         if missing_envs:
             print(

--- a/isaaclab_arena/environments/relation_solver_interface.py
+++ b/isaaclab_arena/environments/relation_solver_interface.py
@@ -127,10 +127,12 @@ def _apply_dynamic_spawn_pose(
         pos = layout.positions.get(obj)
         if pos is None:
             continue
+        yaw = layout.orientations.get(obj, 0.0)
+        rot = rotate_quat_by_yaw(get_rotation_xyzw(obj), yaw)
         object_cfg = getattr(obj, "object_cfg", None)
         assert object_cfg is not None, f"Object '{obj.name}' must have object_cfg initialized before placement."
         object_cfg.init_state.pos = pos
-        object_cfg.init_state.rot = rotate_quat_by_yaw(get_rotation_xyzw(obj), layout.orientations.get(obj, 0.0))
+        object_cfg.init_state.rot = rot
 
     return EventTermCfg(
         func=solve_and_place_objects,
@@ -161,7 +163,8 @@ def _apply_static_initial_poses(
             if pos is None:
                 missing_envs.append(env_idx)
             else:
-                rotation_xyzw = rotate_quat_by_yaw(base_rotation_xyzw, layouts[env_idx].orientations.get(obj, 0.0))
+                yaw = layouts[env_idx].orientations.get(obj, 0.0)
+                rotation_xyzw = rotate_quat_by_yaw(base_rotation_xyzw, yaw)
                 poses.append(Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw))
         if missing_envs:
             print(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import math
 import torch
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -23,6 +22,7 @@ from isaaclab_arena.relations.relations import (
 )
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, wrap_angle_to_pi
+from isaaclab_arena.utils.random import get_random_rotation
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase
@@ -214,7 +214,9 @@ class ObjectPlacer:
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()
         all_validations = [
-            self._validate_placement(positions, self._bbox_row(candidate_bboxes, candidate_idx))
+            self._validate_placement(
+                positions, self._get_bounding_boxes_for_candidate_index(candidate_bboxes, candidate_idx)
+            )
             for candidate_idx, positions in enumerate(all_positions)
         ]
 
@@ -344,8 +346,7 @@ class ObjectPlacer:
         for obj in objects:
             if obj in anchor_objects:
                 continue
-            u = torch.rand(1, generator=generator).item()
-            orientations[obj] = (2.0 * u - 1.0) * math.pi  # uniform in [-pi, pi)
+            orientations[obj] = get_random_rotation(generator)
         return orientations
 
     @staticmethod
@@ -367,8 +368,8 @@ class ObjectPlacer:
             bbox = candidate_bboxes[obj]
             # Only objects that receive a sampled yaw are rotated; anchors never appear here.
             if any(obj in orientations for orientations in orientations_per_candidate):
-                # Enclose marker_rotation + sampled yaw (the applied pose); both are pure-Z.
-                marker_yaw = ObjectPlacer._marker_z_yaw(obj)
+                # Enclose marker_yaw + sampled yaw (the applied pose); both are pure-Z.
+                marker_yaw = ObjectPlacer._get_yaw_from_rotate_around_solution(obj)
                 yaws = [
                     wrap_angle_to_pi(orientations_per_candidate[c].get(obj, 0.0) + marker_yaw)
                     for c in range(num_candidates)
@@ -380,13 +381,13 @@ class ObjectPlacer:
         return rotated
 
     @staticmethod
-    def _marker_z_yaw(obj: ObjectBase) -> float:
+    def _get_yaw_from_rotate_around_solution(obj: ObjectBase) -> float:
         """Z-yaw (radians) of obj's RotateAroundSolution marker, 0.0 if none.
 
         Rejects roll/pitch markers: a Z-rotated box can't enclose them, so they would otherwise
         validate a silently-wrong footprint.
         """
-        marker = next((r for r in obj.get_relations() if isinstance(r, RotateAroundSolution)), None)
+        marker = ObjectPlacer._get_rotate_around_solution(obj)
         if marker is None:
             return 0.0
         assert marker.roll_rad == 0.0 and marker.pitch_rad == 0.0, (
@@ -396,18 +397,12 @@ class ObjectPlacer:
         return marker.yaw_rad
 
     @staticmethod
-    def _bbox_row(
+    def _get_bounding_boxes_for_candidate_index(
         bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
-        row_idx: int,
+        candidate_idx: int,
     ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
         """Slice one candidate's bboxes (each (1, 3)) out of the stacked (num_candidates, 3) boxes."""
-        return {
-            obj: AxisAlignedBoundingBox(
-                min_point=bbox.min_point[row_idx : row_idx + 1],
-                max_point=bbox.max_point[row_idx : row_idx + 1],
-            )
-            for obj, bbox in bboxes.items()
-        }
+        return {obj: bbox[candidate_idx] for obj, bbox in bboxes.items()}
 
     def _get_on_parent_world_bbox(
         self,
@@ -666,7 +661,8 @@ class ObjectPlacer:
                 return rel
         return None
 
-    def _get_rotate_around_solution(self, obj: ObjectBase) -> RotateAroundSolution | None:
+    @staticmethod
+    def _get_rotate_around_solution(obj: ObjectBase) -> RotateAroundSolution | None:
         for rel in obj.get_relations():
             if isinstance(rel, RotateAroundSolution):
                 return rel

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -336,8 +336,7 @@ class ObjectPlacer:
     ) -> dict[ObjectBase, float]:
         """Sample a fixed yaw (radians about Z) per non-anchor object.
 
-        Returns an empty dict when random_yaw_init is off (no RNG consumed). Anchors are
-        never rotated. The yaw is baked into the conservative bbox; it is not optimized.
+        Empty dict (no RNG consumed) when random_yaw_init is off; anchors are never rotated.
         """
         if not self.params.random_yaw_init:
             return {}
@@ -357,22 +356,44 @@ class ObjectPlacer:
     ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
         """Replace each candidate's bbox with the enclosing box of its yaw-rotated object.
 
-        candidate_bboxes hold one row per solver candidate, shape (num_candidates, 3). For each
-        object the per-candidate yaw rotates that row independently. Returns the input unchanged
-        when no candidate rotates the object, so the no-yaw path stays untouched.
+        candidate_bboxes hold one row per candidate (num_candidates, 3); each row is rotated by
+        its own yaw. Returns the input unchanged when no yaw is set, keeping the no-yaw path exact.
         """
         if not any(orientations for orientations in orientations_per_candidate):
             return candidate_bboxes
         num_candidates = len(orientations_per_candidate)
         rotated: dict[ObjectBase, AxisAlignedBoundingBox] = {}
         for obj in objects:
-            yaws = [wrap_angle_to_pi(orientations_per_candidate[c].get(obj, 0.0)) for c in range(num_candidates)]
             bbox = candidate_bboxes[obj]
-            if any(yaw != 0.0 for yaw in yaws):
-                yaw_tensor = torch.tensor(yaws, dtype=torch.float32, device=bbox.min_point.device)
-                bbox = bbox.rotated_around_z(yaw_tensor)
+            # Only objects that receive a sampled yaw are rotated; anchors never appear here.
+            if any(obj in orientations for orientations in orientations_per_candidate):
+                # Enclose marker_rotation + sampled yaw (the applied pose); both are pure-Z.
+                marker_yaw = ObjectPlacer._marker_z_yaw(obj)
+                yaws = [
+                    wrap_angle_to_pi(orientations_per_candidate[c].get(obj, 0.0) + marker_yaw)
+                    for c in range(num_candidates)
+                ]
+                if any(yaw != 0.0 for yaw in yaws):
+                    yaw_tensor = torch.tensor(yaws, dtype=torch.float32, device=bbox.min_point.device)
+                    bbox = bbox.rotated_around_z(yaw_tensor)
             rotated[obj] = bbox
         return rotated
+
+    @staticmethod
+    def _marker_z_yaw(obj: ObjectBase) -> float:
+        """Z-yaw (radians) of obj's RotateAroundSolution marker, 0.0 if none.
+
+        Rejects roll/pitch markers: a Z-rotated box can't enclose them, so they would otherwise
+        validate a silently-wrong footprint.
+        """
+        marker = next((r for r in obj.get_relations() if isinstance(r, RotateAroundSolution)), None)
+        if marker is None:
+            return 0.0
+        assert marker.roll_rad == 0.0 and marker.pitch_rad == 0.0, (
+            f"random_yaw_init cannot enclose a roll/pitch RotateAroundSolution on '{obj.name}' "
+            f"(roll={marker.roll_rad}, pitch={marker.pitch_rad}); only yaw markers are supported."
+        )
+        return marker.yaw_rad
 
     @staticmethod
     def _bbox_row(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -5,8 +5,9 @@
 
 from __future__ import annotations
 
+import math
 import torch
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
@@ -21,7 +22,7 @@ from isaaclab_arena.relations.relations import (
     get_anchor_objects,
 )
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, wrap_angle_to_pi
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase
@@ -39,6 +40,9 @@ class PlacementCandidate:
 
     is_valid: bool
     """Whether the placement passed validation checks."""
+
+    orientations: dict[ObjectBase, float] = field(default_factory=dict)
+    """Per-object yaw (radians about Z) sampled for this candidate. Empty when unrotated."""
 
 
 class ObjectPlacer:
@@ -100,7 +104,8 @@ class ObjectPlacer:
 
         if self.params.apply_positions_to_objects:
             positions_per_env = [r.positions for r in results_per_env]
-            self._apply_positions(positions_per_env, anchor_objects_set)
+            orientations_per_env = [r.orientations for r in results_per_env]
+            self._apply_poses(positions_per_env, anchor_objects_set, orientations_per_env)
 
         if num_envs == 1:
             return results_per_env[0]
@@ -188,6 +193,7 @@ class ObjectPlacer:
         per_env_bboxes = env_bboxes.get_bounding_boxes_for_all_envs()
 
         initial_positions: list[dict[ObjectBase, tuple[float, float, float]]] = []
+        orientations_per_candidate: list[dict[ObjectBase, float]] = []
         for candidate_idx in range(num_candidates):
             cur_env = candidate_idx // candidates_per_env
             if generator is not None:
@@ -196,12 +202,19 @@ class ObjectPlacer:
             initial_positions.append(
                 self._generate_initial_positions(objects, anchor_objects_set, per_env_bboxes[cur_env], generator)
             )
+            orientations_per_candidate.append(
+                self._generate_initial_orientations(objects, anchor_objects_set, generator)
+            )
+
+        # Bake each candidate's yaw into a conservative enclosing bbox; no-op when yaw is disabled.
+        # The solver and validation then treat the rotated object as an axis-aligned box.
+        candidate_bboxes = self._rotate_candidate_bboxes(objects, candidate_bboxes, orientations_per_candidate)
 
         all_positions = self._solver.solve(objects, initial_positions, env_bboxes=candidate_bboxes)
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()
         all_validations = [
-            self._validate_placement(positions, per_env_bboxes[candidate_idx // candidates_per_env])
+            self._validate_placement(positions, self._bbox_row(candidate_bboxes, candidate_idx))
             for candidate_idx, positions in enumerate(all_positions)
         ]
 
@@ -212,6 +225,7 @@ class ObjectPlacer:
                     all_losses[candidate_idx],
                     all_positions[candidate_idx],
                     all_validations[candidate_idx],
+                    orientations_per_candidate[candidate_idx],
                 )
             )
 
@@ -223,6 +237,7 @@ class ObjectPlacer:
                     positions=candidate.positions,
                     final_loss=candidate.loss,
                     attempts=attempts_per_result,
+                    orientations=candidate.orientations,
                 )
                 for candidate in candidate_slice
             ]
@@ -312,6 +327,66 @@ class ObjectPlacer:
             initial_pose, Pose
         ), f"Object '{obj.name}' must have a fixed Pose to use its env bbox, got {type(initial_pose).__name__}."
         return env_bboxes[obj].translated(initial_pose.position_xyz)
+
+    def _generate_initial_orientations(
+        self,
+        objects: list[ObjectBase],
+        anchor_objects: set[ObjectBase],
+        generator: torch.Generator | None = None,
+    ) -> dict[ObjectBase, float]:
+        """Sample a fixed yaw (radians about Z) per non-anchor object.
+
+        Returns an empty dict when random_yaw_init is off (no RNG consumed). Anchors are
+        never rotated. The yaw is baked into the conservative bbox; it is not optimized.
+        """
+        if not self.params.random_yaw_init:
+            return {}
+        orientations: dict[ObjectBase, float] = {}
+        for obj in objects:
+            if obj in anchor_objects:
+                continue
+            u = torch.rand(1, generator=generator).item()
+            orientations[obj] = (2.0 * u - 1.0) * math.pi  # uniform in [-pi, pi)
+        return orientations
+
+    @staticmethod
+    def _rotate_candidate_bboxes(
+        objects: list[ObjectBase],
+        candidate_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
+        orientations_per_candidate: list[dict[ObjectBase, float]],
+    ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
+        """Replace each candidate's bbox with the enclosing box of its yaw-rotated object.
+
+        candidate_bboxes hold one row per solver candidate, shape (num_candidates, 3). For each
+        object the per-candidate yaw rotates that row independently. Returns the input unchanged
+        when no candidate rotates the object, so the no-yaw path stays untouched.
+        """
+        if not any(orientations for orientations in orientations_per_candidate):
+            return candidate_bboxes
+        num_candidates = len(orientations_per_candidate)
+        rotated: dict[ObjectBase, AxisAlignedBoundingBox] = {}
+        for obj in objects:
+            yaws = [wrap_angle_to_pi(orientations_per_candidate[c].get(obj, 0.0)) for c in range(num_candidates)]
+            bbox = candidate_bboxes[obj]
+            if any(yaw != 0.0 for yaw in yaws):
+                yaw_tensor = torch.tensor(yaws, dtype=torch.float32, device=bbox.min_point.device)
+                bbox = bbox.rotated_around_z(yaw_tensor)
+            rotated[obj] = bbox
+        return rotated
+
+    @staticmethod
+    def _bbox_row(
+        bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
+        row_idx: int,
+    ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
+        """Slice one candidate's bboxes (each (1, 3)) out of the stacked (num_candidates, 3) boxes."""
+        return {
+            obj: AxisAlignedBoundingBox(
+                min_point=bbox.min_point[row_idx : row_idx + 1],
+                max_point=bbox.max_point[row_idx : row_idx + 1],
+            )
+            for obj, bbox in bboxes.items()
+        }
 
     def _get_on_parent_world_bbox(
         self,
@@ -523,18 +598,19 @@ class ObjectPlacer:
         """
         return self._validate_no_overlap(positions, env_bboxes) and self._validate_on_relations(positions, env_bboxes)
 
-    def _apply_positions(
+    def _apply_poses(
         self,
         positions_per_env: list[dict[ObjectBase, tuple[float, float, float]]],
         anchor_objects: set[ObjectBase],
+        orientations_per_env: list[dict[ObjectBase, float]],
     ) -> None:
-        """Apply solved positions to objects (skipping anchors).
+        """Apply solved positions and sampled yaw to objects (skipping anchors).
 
         Handles both single-env and multi-env placement:
         - Single-env: sets a fixed Pose or PoseRange (with RandomAroundSolution).
         - Multi-env: sets a PosePerEnv with one Pose per environment.
 
-        Rotation is taken from RotateAroundSolution marker if present, otherwise identity.
+        Rotation is the RotateAroundSolution marker (or identity) with the sampled yaw composed on top.
         """
         num_envs = len(positions_per_env)
         objects = list(positions_per_env[0])
@@ -543,10 +619,11 @@ class ObjectPlacer:
                 continue
 
             rotate_marker = self._get_rotate_around_solution(obj)
-            rotation_xyzw = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
+            base_rotation = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
 
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
+                rotation_xyzw = rotate_quat_by_yaw(base_rotation, orientations_per_env[0].get(obj, 0.0))
                 random_marker = self._get_random_around_solution(obj)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
@@ -554,7 +631,10 @@ class ObjectPlacer:
                     obj.set_initial_pose(Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw))
             else:
                 poses = [
-                    Pose(position_xyz=positions_per_env[env_idx][obj], rotation_xyzw=rotation_xyzw)
+                    Pose(
+                        position_xyz=positions_per_env[env_idx][obj],
+                        rotation_xyzw=rotate_quat_by_yaw(base_rotation, orientations_per_env[env_idx].get(obj, 0.0)),
+                    )
                     for env_idx in range(num_envs)
                 ]
                 obj.set_initial_pose(PosePerEnv(poses=poses))

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -15,6 +15,11 @@ class ObjectPlacerParams:
     solver_params: RelationSolverParams = field(default_factory=RelationSolverParams)
     """Parameters for the underlying RelationSolver."""
 
+    random_yaw_init: bool = False
+    """If True, give each non-anchor object a random fixed yaw about Z (uniform in [-pi, pi))
+    for scene variety. Yaw is not optimized; the solver uses the conservative AABB enclosing
+    the rotated object so the layout stays valid."""
+
     max_placement_attempts: int = 10
     """Number of candidate layouts solved and ranked per result. Higher values raise the chance a valid
     layout is found in the batched solve. Also bounds the refill batches in PooledObjectPlacer."""

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -16,9 +16,8 @@ class ObjectPlacerParams:
     """Parameters for the underlying RelationSolver."""
 
     random_yaw_init: bool = False
-    """If True, give each non-anchor object a random fixed yaw about Z (uniform in [-pi, pi))
-    for scene variety. Yaw is not optimized; the solver uses the conservative AABB enclosing
-    the rotated object so the layout stays valid."""
+    """If True, give each non-anchor object a random fixed yaw about Z (uniform in [-pi, pi)) for
+    scene variety. Not optimized; collisions use the conservative box enclosing the rotated object."""
 
     max_placement_attempts: int = 10
     """Number of candidate layouts solved and ranked per result. Higher values raise the chance a valid

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -12,7 +12,7 @@ from isaaclab.envs import ManagerBasedEnv
 
 from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
 from isaaclab_arena.relations.relations import RotateAroundSolution, get_anchor_objects
-from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.pose import Pose, rotate_quat_by_yaw
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase
@@ -61,7 +61,7 @@ def solve_and_place_objects(
         results_by_env = dict(zip(reset_env_ids, reset_results))
 
     anchor_objects_set = set(get_anchor_objects(objects))
-    rotations = {obj: get_rotation_xyzw(obj) for obj in objects if obj not in anchor_objects_set}
+    base_rotations = {obj: get_rotation_xyzw(obj) for obj in objects if obj not in anchor_objects_set}
 
     zero_velocity = torch.zeros(1, 6, device=env.device)
     for cur_env in reset_env_ids:
@@ -72,12 +72,12 @@ def solve_and_place_objects(
                 "Warning: Writing best-loss fallback placement for "
                 f"env {cur_env}; layout failed strict placement validation."
             )
-        positions = result.positions
-        for obj, pos in positions.items():
+        for obj, pos in result.positions.items():
             if obj in anchor_objects_set:
                 continue
             asset = env.scene[obj.name]
-            pose = Pose(position_xyz=pos, rotation_xyzw=rotations[obj])
+            rotation_xyzw = rotate_quat_by_yaw(base_rotations[obj], result.orientations.get(obj, 0.0))
+            pose = Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw)
             pose_t_xyz_q_xyzw = pose.to_tensor(device=env.device).unsqueeze(0)
             pose_t_xyz_q_xyzw[0, :3] += env.scene.env_origins[cur_env, :]
             asset.write_root_pose_to_sim(pose_t_xyz_q_xyzw, env_ids=env_id_tensor)

--- a/isaaclab_arena/relations/placement_result.py
+++ b/isaaclab_arena/relations/placement_result.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -27,6 +27,10 @@ class PlacementResult:
 
     attempts: int
     """Number of attempts made."""
+
+    orientations: dict[ObjectBase, float] = field(default_factory=dict)
+    """Per-object yaw (radians) about the world up (Z) axis, composed on top of each object's
+    base rotation. Keyed by object, like positions. Empty when unrotated."""
 
 
 @dataclass

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -8,6 +8,8 @@
 import math
 import torch
 
+import pytest
+
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
@@ -84,6 +86,16 @@ def test_rotated_around_z_batched_angles_broadcasts_single_box():
     # Angle 90°: X/Y extents swap for this origin-centered box.
     torch.testing.assert_close(rotated.min_point[1], torch.tensor([-0.1, -0.2, 0.0]), atol=1e-6, rtol=0)
     torch.testing.assert_close(rotated.max_point[1], torch.tensor([0.1, 0.2, 0.5]), atol=1e-6, rtol=0)
+
+
+def test_rotated_around_z_mismatched_box_and_angle_counts_raises():
+    """Multiple boxes paired with a different count of multiple angles is ambiguous and must assert."""
+    boxes = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[-0.2, -0.1, 0.0], [-0.2, -0.1, 0.0]]),
+        max_point=torch.tensor([[0.2, 0.1, 0.5], [0.2, 0.1, 0.5]]),
+    )
+    with pytest.raises(AssertionError):
+        boxes.rotated_around_z(torch.tensor([0.0, math.pi / 2, math.pi]))
 
 
 def test_bounding_box_single_env_overlaps():

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -45,8 +45,7 @@ def test_bounding_box_single_env_transforms():
 
 
 def test_rotated_around_z_single_angle():
-    """90° matches the exact rotated_90_around_z (off-origin box, so center shifts); 45° inflates
-    an origin-centered box to its conservative enclosing AABB (Z extents unchanged)."""
+    """90° matches rotated_90_around_z; 45° inflates a centered box to its conservative enclosure."""
     off_origin = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 1.0, 0.5))
     rot90 = off_origin.rotated_around_z(math.pi / 2)
     torch.testing.assert_close(rot90.min_point, off_origin.rotated_90_around_z(1).min_point, atol=1e-6, rtol=0)
@@ -59,6 +58,18 @@ def test_rotated_around_z_single_angle():
     half = (0.2 + 0.1) * math.cos(math.pi / 4)
     torch.testing.assert_close(rot45.min_point, torch.tensor([[-half, -half, -0.05]]), atol=1e-6, rtol=0)
     torch.testing.assert_close(rot45.max_point, torch.tensor([[half, half, 0.05]]), atol=1e-6, rtol=0)
+
+
+def test_rotated_around_z_off_center_arbitrary_angle():
+    """An off-center box at 30° enclosed by hand-computed corner extents (center shifts, Z fixed)."""
+    box = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 1.0, 0.5))
+    rot = box.rotated_around_z(math.pi / 6)
+    cos, sin = math.cos(math.pi / 6), math.sin(math.pi / 6)
+    corners = [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0)]
+    xs = [x * cos - y * sin for x, y in corners]
+    ys = [x * sin + y * cos for x, y in corners]
+    torch.testing.assert_close(rot.min_point, torch.tensor([[min(xs), min(ys), 0.0]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rot.max_point, torch.tensor([[max(xs), max(ys), 0.5]]), atol=1e-6, rtol=0)
 
 
 def test_rotated_around_z_batched_angles_broadcasts_single_box():

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -5,6 +5,7 @@
 
 """Tests for AxisAlignedBoundingBox with always-tensor API."""
 
+import math
 import torch
 
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
@@ -41,6 +42,37 @@ def test_bounding_box_single_env_transforms():
     rotated = aabb.rotated_90_around_z(1)
     torch.testing.assert_close(rotated.min_point, torch.tensor([[-1.0, 0.0, 0.0]]), atol=1e-6, rtol=0)
     torch.testing.assert_close(rotated.max_point, torch.tensor([[0.0, 2.0, 0.5]]), atol=1e-6, rtol=0)
+
+
+def test_rotated_around_z_single_angle():
+    """90° matches the exact rotated_90_around_z (off-origin box, so center shifts); 45° inflates
+    an origin-centered box to its conservative enclosing AABB (Z extents unchanged)."""
+    off_origin = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(2.0, 1.0, 0.5))
+    rot90 = off_origin.rotated_around_z(math.pi / 2)
+    torch.testing.assert_close(rot90.min_point, off_origin.rotated_90_around_z(1).min_point, atol=1e-6, rtol=0)
+    torch.testing.assert_close(rot90.min_point, torch.tensor([[-1.0, 0.0, 0.0]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rot90.max_point, torch.tensor([[0.0, 2.0, 0.5]]), atol=1e-6, rtol=0)
+
+    # Half-extents (0.2, 0.1); enclosing half-extent = a|cos| + b|sin| = 0.3*cos(45°) on each axis.
+    centered = AxisAlignedBoundingBox(min_point=(-0.2, -0.1, -0.05), max_point=(0.2, 0.1, 0.05))
+    rot45 = centered.rotated_around_z(math.pi / 4)
+    half = (0.2 + 0.1) * math.cos(math.pi / 4)
+    torch.testing.assert_close(rot45.min_point, torch.tensor([[-half, -half, -0.05]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rot45.max_point, torch.tensor([[half, half, 0.05]]), atol=1e-6, rtol=0)
+
+
+def test_rotated_around_z_batched_angles_broadcasts_single_box():
+    """An (M,) angle tensor broadcasts an N=1 box to M enclosing boxes (one per angle)."""
+    aabb = AxisAlignedBoundingBox(min_point=(-0.2, -0.1, 0.0), max_point=(0.2, 0.1, 0.5))
+    angles = torch.tensor([0.0, math.pi / 2])
+    rotated = aabb.rotated_around_z(angles)
+    assert rotated.num_envs == 2
+    # Angle 0: unchanged.
+    torch.testing.assert_close(rotated.min_point[0], torch.tensor([-0.2, -0.1, 0.0]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rotated.max_point[0], torch.tensor([0.2, 0.1, 0.5]), atol=1e-6, rtol=0)
+    # Angle 90°: X/Y extents swap for this origin-centered box.
+    torch.testing.assert_close(rotated.min_point[1], torch.tensor([-0.1, -0.2, 0.0]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rotated.max_point[1], torch.tensor([0.1, 0.2, 0.5]), atol=1e-6, rtol=0)
 
 
 def test_bounding_box_single_env_overlaps():

--- a/isaaclab_arena/tests/test_bounding_box.py
+++ b/isaaclab_arena/tests/test_bounding_box.py
@@ -88,6 +88,25 @@ def test_rotated_around_z_batched_angles_broadcasts_single_box():
     torch.testing.assert_close(rotated.max_point[1], torch.tensor([0.1, 0.2, 0.5]), atol=1e-6, rtol=0)
 
 
+def test_getitem_selects_single_row():
+    """Indexing a batched bbox returns the (N=1) box for that row; out-of-range asserts."""
+    boxes = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]),
+        max_point=torch.tensor([[1.0, 1.0, 1.0], [4.0, 5.0, 6.0]]),
+    )
+    first = boxes[0]
+    assert first.num_envs == 1
+    torch.testing.assert_close(first.min_point, torch.tensor([[0.0, 0.0, 0.0]]))
+    torch.testing.assert_close(first.max_point, torch.tensor([[1.0, 1.0, 1.0]]))
+
+    last = boxes[1]
+    torch.testing.assert_close(last.min_point, torch.tensor([[1.0, 2.0, 3.0]]))
+    torch.testing.assert_close(last.max_point, torch.tensor([[4.0, 5.0, 6.0]]))
+
+    with pytest.raises(AssertionError):
+        _ = boxes[2]
+
+
 def test_rotated_around_z_mismatched_box_and_angle_counts_raises():
     """Multiple boxes paired with a different count of multiple angles is ambiguous and must assert."""
     boxes = AxisAlignedBoundingBox(

--- a/isaaclab_arena/tests/test_no_collision_loss.py
+++ b/isaaclab_arena/tests/test_no_collision_loss.py
@@ -5,6 +5,7 @@
 
 """Tests for NoCollisionLossStrategy and RelationSolver built-in no-overlap behavior."""
 
+import math
 import torch
 
 from isaaclab_arena.assets.dummy_object import DummyObject
@@ -43,6 +44,45 @@ def _create_no_collision_scene() -> tuple[DummyObject, DummyObject, DummyObject]
     box_a.add_relation(On(table, clearance_m=0.01))
     box_b.add_relation(On(table, clearance_m=0.01))
     return table, box_a, box_b
+
+
+def test_solver_uses_rotated_bbox_for_collision():
+    """A yaw-rotated env bbox passed to solve() changes the no-overlap loss, proving the solver uses it."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+
+    # Long box (spans X) and a cube offset in +Y. No On/NextTo relations, so the only loss is
+    # the built-in no-overlap loss between the two non-anchors.
+    long_box = DummyObject(
+        name="long_box",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.3, -0.05, -0.05), max_point=(0.3, 0.05, 0.05)),
+    )
+    cube = DummyObject(
+        name="cube",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.05, -0.05, -0.05), max_point=(0.05, 0.05, 0.05)),
+    )
+    objects = [table, long_box, cube]
+    # Boxes sit high above the table (z=0.5) so neither collides with the table.
+    initial = [{table: (0.0, 0.0, 0.0), long_box: (0.0, 0.0, 0.5), cube: (0.0, 0.2, 0.5)}]
+
+    # max_iters=0: solve() only computes the initial loss and stores last_loss_per_env.
+    solver = RelationSolver(params=RelationSolverParams(max_iters=0, verbose=False))
+
+    solver.solve(objects, initial)
+    assert solver.last_loss_per_env is not None
+    loss_unrotated = solver.last_loss_per_env[0].item()
+
+    # Hand the solver a 90° conservative bbox for the long box via the env_bboxes channel.
+    rotated = {long_box: long_box.get_bounding_box().rotated_around_z(math.pi / 2)}
+    solver.solve(objects, initial, env_bboxes=rotated)
+    assert solver.last_loss_per_env is not None
+    loss_rotated = solver.last_loss_per_env[0].item()
+
+    # Unrotated: long box spans Y [-0.05, 0.05], clear of the cube at Y=0.2 -> no overlap.
+    assert loss_unrotated == 0.0
+    # Rotated 90°: long box now spans Y [-0.3, 0.3], overlapping the cube -> positive loss.
+    assert loss_rotated > 0.0
 
 
 # =============================================================================

--- a/isaaclab_arena/tests/test_no_collision_loss.py
+++ b/isaaclab_arena/tests/test_no_collision_loss.py
@@ -47,7 +47,7 @@ def _create_no_collision_scene() -> tuple[DummyObject, DummyObject, DummyObject]
 
 
 def test_solver_uses_rotated_bbox_for_collision():
-    """A yaw-rotated env bbox passed to solve() changes the no-overlap loss, proving the solver uses it."""
+    """Test that a yaw-rotated env bbox passed to solve() changes the no-overlap loss (solver consumes it)."""
     table = _create_table()
     table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
     table.add_relation(IsAnchor())

--- a/isaaclab_arena/tests/test_object_placer_reproducibility.py
+++ b/isaaclab_arena/tests/test_object_placer_reproducibility.py
@@ -5,6 +5,7 @@
 
 """Tests for ObjectPlacer and RelationSolver reproducibility."""
 
+import math
 
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.object_placer import ObjectPlacer
@@ -12,9 +13,9 @@ from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import MultiEnvPlacementResult, PlacementResult
 from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
-from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, Side
+from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, RotateAroundSolution, Side
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, get_random_pose_within_bounding_box
-from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw
 
 
 def _create_test_objects():
@@ -210,3 +211,63 @@ def test_object_placer_applies_pose_per_env():
         pose = obj.get_initial_pose()
         assert isinstance(pose, PosePerEnv), f"{obj.name} should have PosePerEnv, got {type(pose).__name__}"
         assert len(pose.poses) == num_envs
+
+
+def _is_identity_quat(rotation_xyzw: tuple[float, float, float, float], atol: float = 1e-6) -> bool:
+    """Whether a quaternion is (approximately) the identity (0, 0, 0, 1)."""
+    x, y, z, w = rotation_xyzw
+    return abs(x) < atol and abs(y) < atol and abs(z) < atol and abs(abs(w) - 1.0) < atol
+
+
+def _yaw_rad_from_quat(rotation_xyzw: tuple[float, float, float, float]) -> float:
+    """Z-yaw (radians) of a pure-Z quaternion (x, y, z, w)."""
+    return 2.0 * math.atan2(rotation_xyzw[2], rotation_xyzw[3])
+
+
+def test_random_yaw_init_rotates_non_anchors_only_when_enabled():
+    """Enabled: non-anchors get a non-identity yaw, the anchor never does. Disabled (default,
+    same seed): everything keeps identity."""
+    solver_params = RelationSolverParams(max_iters=10, verbose=False)
+
+    desk, box1, box2 = _create_test_objects()
+    ObjectPlacer(params=ObjectPlacerParams(placement_seed=42, solver_params=solver_params, random_yaw_init=True)).place(
+        objects=[desk, box1, box2], num_envs=1
+    )
+    assert _is_identity_quat(desk.get_initial_pose().rotation_xyzw), "anchor is never rotated"
+    for box in [box1, box2]:
+        assert abs(_yaw_rad_from_quat(box.get_initial_pose().rotation_xyzw)) > 1e-3, f"{box.name} should be rotated"
+
+    desk, box1, box2 = _create_test_objects()
+    ObjectPlacer(params=ObjectPlacerParams(placement_seed=42, solver_params=solver_params)).place(
+        objects=[desk, box1, box2], num_envs=1
+    )
+    for box in [box1, box2]:
+        assert _is_identity_quat(box.get_initial_pose().rotation_xyzw), f"{box.name} should be unrotated"
+
+
+def test_compose_rotation_combines_sampled_yaw_and_marker():
+    """rotate_quat_by_yaw composes the sampled yaw on top of a RotateAroundSolution marker."""
+    marker = RotateAroundSolution(yaw_rad=math.pi / 6)
+    composed = rotate_quat_by_yaw(marker.get_rotation_xyzw(), math.pi / 3)
+    # Both rotations are about Z, so the total yaw is pi/6 + pi/3 = pi/2.
+    assert abs(composed[0]) < 1e-6 and abs(composed[1]) < 1e-6
+    assert abs(_yaw_rad_from_quat(composed) - math.pi / 2) < 1e-5
+
+
+def test_random_yaw_init_multi_env_distinct_yaws():
+    """Multi-env placement with random_yaw_init yields distinct per-env yaws via PosePerEnv."""
+    num_envs = 4
+    solver_params = RelationSolverParams(max_iters=10, verbose=False)
+    desk, box1, box2 = _create_test_objects()
+    objects = [desk, box1, box2]
+    placer = ObjectPlacer(
+        params=ObjectPlacerParams(placement_seed=42, solver_params=solver_params, random_yaw_init=True)
+    )
+    placer.place(objects, num_envs=num_envs)
+
+    pose = box1.get_initial_pose()
+    assert isinstance(pose, PosePerEnv)
+    yaws = [_yaw_rad_from_quat(p.rotation_xyzw) for p in pose.poses]
+    assert any(
+        abs(yaws[i] - yaws[j]) > 1e-6 for i in range(num_envs) for j in range(i + 1, num_envs)
+    ), "Per-env yaws should differ across environments"

--- a/isaaclab_arena/tests/test_object_placer_reproducibility.py
+++ b/isaaclab_arena/tests/test_object_placer_reproducibility.py
@@ -7,6 +7,8 @@
 
 import math
 
+import pytest
+
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
@@ -15,7 +17,7 @@ from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, RotateAroundSolution, Side
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, get_random_pose_within_bounding_box
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, wrap_angle_to_pi
 
 
 def _create_test_objects():
@@ -225,8 +227,7 @@ def _yaw_rad_from_quat(rotation_xyzw: tuple[float, float, float, float]) -> floa
 
 
 def test_random_yaw_init_rotates_non_anchors_only_when_enabled():
-    """Enabled: non-anchors get a non-identity yaw, the anchor never does. Disabled (default,
-    same seed): everything keeps identity."""
+    """Enabled rotates non-anchors (never the anchor); disabled (same seed) keeps identity."""
     solver_params = RelationSolverParams(max_iters=10, verbose=False)
 
     desk, box1, box2 = _create_test_objects()
@@ -271,3 +272,61 @@ def test_random_yaw_init_multi_env_distinct_yaws():
     assert any(
         abs(yaws[i] - yaws[j]) > 1e-6 for i in range(num_envs) for j in range(i + 1, num_envs)
     ), "Per-env yaws should differ across environments"
+
+
+def _placed_yaws(seed: int) -> tuple[float, float]:
+    """Place two boxes with random_yaw_init at the given seed; return their applied yaws."""
+    solver_params = RelationSolverParams(max_iters=10, verbose=False)
+    desk, box1, box2 = _create_test_objects()
+    ObjectPlacer(
+        params=ObjectPlacerParams(placement_seed=seed, solver_params=solver_params, random_yaw_init=True)
+    ).place([desk, box1, box2], num_envs=1)
+    return (
+        _yaw_rad_from_quat(box1.get_initial_pose().rotation_xyzw),
+        _yaw_rad_from_quat(box2.get_initial_pose().rotation_xyzw),
+    )
+
+
+def test_random_yaw_init_seed_determinism():
+    """Same seed -> identical sampled yaws; a different seed -> different yaws."""
+    assert _placed_yaws(42) == _placed_yaws(42), "same seed must reproduce identical yaws"
+    assert _placed_yaws(42) != _placed_yaws(7), "different seeds should produce different yaws"
+
+
+def test_random_yaw_init_applied_yaw_matches_selected_candidate():
+    """Applied yaw equals the selected candidate's recorded orientation (apply stays in sync with validation)."""
+    solver_params = RelationSolverParams(max_iters=10, verbose=False)
+    desk, box1, box2 = _create_test_objects()
+    placer = ObjectPlacer(
+        params=ObjectPlacerParams(placement_seed=11, solver_params=solver_params, random_yaw_init=True)
+    )
+    result = placer.place([desk, box1, box2], num_envs=1)
+    for box in (box1, box2):
+        applied = _yaw_rad_from_quat(box.get_initial_pose().rotation_xyzw)
+        assert abs(wrap_angle_to_pi(applied - result.orientations[box])) < 1e-5
+
+
+def test_random_yaw_init_composes_marker_yaw():
+    """A yaw RotateAroundSolution marker composes with the sampled yaw: applied == marker + sampled."""
+    marker_yaw = math.pi / 6
+    solver_params = RelationSolverParams(max_iters=10, verbose=False)
+    desk, box1, box2 = _create_test_objects()
+    box1.add_relation(RotateAroundSolution(yaw_rad=marker_yaw))
+    placer = ObjectPlacer(
+        params=ObjectPlacerParams(placement_seed=3, solver_params=solver_params, random_yaw_init=True)
+    )
+    result = placer.place([desk, box1, box2], num_envs=1)
+    applied = _yaw_rad_from_quat(box1.get_initial_pose().rotation_xyzw)
+    assert abs(wrap_angle_to_pi(applied - (marker_yaw + result.orientations[box1]))) < 1e-5
+
+
+def test_random_yaw_init_rejects_roll_pitch_marker():
+    """A roll/pitch marker cannot be enclosed by a Z-rotated bbox, so placement must fail loudly."""
+    solver_params = RelationSolverParams(max_iters=5, verbose=False)
+    desk, box1, box2 = _create_test_objects()
+    box1.add_relation(RotateAroundSolution(roll_rad=0.3))
+    placer = ObjectPlacer(
+        params=ObjectPlacerParams(placement_seed=1, solver_params=solver_params, random_yaw_init=True)
+    )
+    with pytest.raises(AssertionError):
+        placer.place([desk, box1, box2], num_envs=1)

--- a/isaaclab_arena/tests/test_placement_events.py
+++ b/isaaclab_arena/tests/test_placement_events.py
@@ -178,6 +178,41 @@ def test_solve_and_place_objects_writes_poses_to_sim():
         assert pose_arg.shape == (1, 7), f"Expected (1,7) pose tensor for {name}, got {pose_arg.shape}"
 
 
+def test_solve_and_place_objects_applies_random_yaw():
+    """With random_yaw_init enabled the runtime path should write yawed (non-identity) poses."""
+
+    from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+    from isaaclab_arena.relations.placement_events import solve_and_place_objects
+    from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
+    from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+
+    desk, box1, box2 = _create_test_objects()
+    objects = [desk, box1, box2]
+
+    env = _make_mock_env(num_envs=1)
+    env_ids = torch.tensor([0])
+
+    solver_params = RelationSolverParams(max_iters=200, convergence_threshold=1e-3)
+    placer_params = ObjectPlacerParams(
+        solver_params=solver_params,
+        placement_seed=123,
+        random_yaw_init=True,
+    )
+    pool = PooledObjectPlacer(objects=objects, placer_params=placer_params, pool_size=10)
+
+    solve_and_place_objects(env, env_ids, objects, pool)
+
+    yawed = False
+    for name in ("box1", "box2"):
+        pose_arg = env._assets[name].write_root_pose_to_sim.call_args[0][0]
+        # Pose tensor layout is (x, y, z, qx, qy, qz, qw); pure-Z yaw shows up as non-zero qz.
+        assert abs(pose_arg[0, 3].item()) < 1e-6, f"{name} should have no roll component"
+        assert abs(pose_arg[0, 4].item()) < 1e-6, f"{name} should have no pitch component"
+        if abs(pose_arg[0, 5].item()) > 1e-6:
+            yawed = True
+    assert yawed, "random_yaw_init should produce at least one yawed object in the written poses"
+
+
 def test_solve_and_place_objects_skips_empty_env_ids():
     """solve_and_place_objects should return immediately for an empty env_ids tensor."""
 

--- a/isaaclab_arena/tests/test_placement_events.py
+++ b/isaaclab_arena/tests/test_placement_events.py
@@ -202,6 +202,9 @@ def test_solve_and_place_objects_applies_random_yaw():
 
     solve_and_place_objects(env, env_ids, objects, pool)
 
+    # Anchor (desk) is never rotated or written, even with random yaw enabled.
+    assert "desk" not in env._assets, "Anchor pose should not be written to sim"
+
     yawed = False
     for name in ("box1", "box2"):
         pose_arg = env._assets[name].write_root_pose_to_sim.call_args[0][0]

--- a/isaaclab_arena/tests/test_pose.py
+++ b/isaaclab_arena/tests/test_pose.py
@@ -3,7 +3,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.utils.pose import Pose, PosePerEnv
+import math
+
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, wrap_angle_to_pi
+
+
+def _yaw_of(quat_xyzw: tuple[float, float, float, float]) -> float:
+    return 2.0 * math.atan2(quat_xyzw[2], quat_xyzw[3])
+
+
+def test_rotate_quat_by_yaw_about_identity():
+    """Yawing the identity gives a pure-Z quaternion with that yaw."""
+    q = rotate_quat_by_yaw((0.0, 0.0, 0.0, 1.0), math.pi / 2)
+    assert abs(q[0]) < 1e-6 and abs(q[1]) < 1e-6
+    assert abs(wrap_angle_to_pi(_yaw_of(q) - math.pi / 2)) < 1e-6
+
+
+def test_rotate_quat_by_yaw_composes_and_wraps():
+    """Yaw composes additively about Z, and out-of-range angles wrap to [-pi, pi)."""
+    base = rotate_quat_by_yaw((0.0, 0.0, 0.0, 1.0), math.pi / 6)
+    composed = rotate_quat_by_yaw(base, math.pi / 3)
+    assert abs(wrap_angle_to_pi(_yaw_of(composed) - math.pi / 2)) < 1e-6
+
+    # yaw == 0 (and full turns) return the base unchanged.
+    assert rotate_quat_by_yaw(base, 0.0) == base
+    assert rotate_quat_by_yaw(base, 2.0 * math.pi) == base
 
 
 def test_pose_composition():

--- a/isaaclab_arena/tests/test_random.py
+++ b/isaaclab_arena/tests/test_random.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import torch
+
+from isaaclab_arena.utils.random import get_random_rotation
+
+
+def test_get_random_rotation_in_range():
+    """Sampled yaws always fall within [-pi, pi)."""
+    generator = torch.Generator().manual_seed(0)
+    samples = [get_random_rotation(generator) for _ in range(1000)]
+    assert all(-math.pi <= yaw < math.pi for yaw in samples)
+
+
+def _sample_sequence(seed: int, n: int = 5) -> list[float]:
+    generator = torch.Generator().manual_seed(seed)
+    return [get_random_rotation(generator) for _ in range(n)]
+
+
+def test_get_random_rotation_seed_determinism():
+    """Equally-seeded generators produce identical sequences; different seeds differ."""
+    assert _sample_sequence(42) == _sample_sequence(42)
+    assert _sample_sequence(42) != _sample_sequence(7)

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -5,6 +5,8 @@
 
 """Tests for ObjectPlacer placement validation (_validate_placement, _validate_no_overlap, _validate_on_relations)."""
 
+import math
+
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
@@ -17,6 +19,13 @@ def _make_box(name: str, size: float = 0.2) -> DummyObject:
     return DummyObject(
         name=name,
         bounding_box=AxisAlignedBoundingBox(min_point=(-half, -half, -half), max_point=(half, half, half)),
+    )
+
+
+def _make_long_box(name: str, half_x: float = 0.3, half_y: float = 0.05, half_z: float = 0.05) -> DummyObject:
+    return DummyObject(
+        name=name,
+        bounding_box=AxisAlignedBoundingBox(min_point=(-half_x, -half_y, -half_z), max_point=(half_x, half_y, half_z)),
     )
 
 
@@ -85,6 +94,19 @@ def test_colocated_siblings_overlap_rejected():
     b = _make_box("b", size=0.2)
     positions = {desk: (0.0, 0.0, 0.0), a: (0.0, 0.0, 0.15), b: (0.0, 0.0, 0.15)}
     assert placer._validate_placement(positions, _env_bboxes(positions)) is False
+
+
+def test_rotation_aware_overlap_uses_yaw():
+    """Validation respects the sampled yaw through the per-env bbox: a long box clears a +Y cube
+    when axis-aligned, but its 90° conservative enclosing box swings into the cube and overlaps."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    a = _make_long_box("a")  # x in [-0.3, 0.3], y in [-0.05, 0.05]
+    b = _make_box("b", size=0.1)
+    positions = {a: (0.0, 0.0, 0.0), b: (0.0, 0.2, 0.0)}
+    axis_aligned = {a: a.get_bounding_box(), b: b.get_bounding_box()}
+    assert placer._validate_placement(positions, axis_aligned) is True
+    rotated = {a: a.get_bounding_box().rotated_around_z(math.pi / 2), b: b.get_bounding_box()}
+    assert placer._validate_placement(positions, rotated) is False
 
 
 def test_on_relation_check_no_relation_returns_true():

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -97,8 +97,7 @@ def test_colocated_siblings_overlap_rejected():
 
 
 def test_rotation_aware_overlap_uses_yaw():
-    """Validation respects the sampled yaw through the per-env bbox: a long box clears a +Y cube
-    when axis-aligned, but its 90° conservative enclosing box swings into the cube and overlaps."""
+    """Test that a long box clears a +Y cube axis-aligned but overlaps it after a 90° conservative rotation."""
     placer = ObjectPlacer(params=ObjectPlacerParams())
     a = _make_long_box("a")  # x in [-0.3, 0.3], y in [-0.05, 0.05]
     b = _make_box("b", size=0.1)

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -114,7 +114,7 @@ def test_rotation_aware_overlap_uses_yaw():
     assert placer._validate_placement(positions, rotated) is False
 
 
-def test_candidate_bbox_row_aligns_with_candidate_yaw():
+def test_candidate_bbox_aligns_with_candidate_yaw():
     """Per-candidate yaw, bbox row, and validation stay index-aligned: only the matched row is collision-free."""
     placer = ObjectPlacer(params=ObjectPlacerParams())
     a = _make_long_box("a")  # long in X
@@ -126,7 +126,10 @@ def test_candidate_bbox_row_aligns_with_candidate_yaw():
     rotated = ObjectPlacer._rotate_candidate_bboxes([a, b], candidate_bboxes, [{a: 0.0}, {a: math.pi / 2}])
 
     # Mirrors _place_ranked: each candidate validates against its own bbox row.
-    validations = [placer._validate_placement(positions, ObjectPlacer._bbox_row(rotated, idx)) for idx in range(2)]
+    validations = [
+        placer._validate_placement(positions, ObjectPlacer._get_bounding_boxes_for_candidate_index(rotated, idx))
+        for idx in range(2)
+    ]
     # Axis-aligned `a` clears b; rotated 90° it sweeps into b. A row/candidate swap would flip both.
     assert validations == [True, False]
 
@@ -145,6 +148,21 @@ def test_rotate_candidate_bboxes_encloses_marker_plus_sampled_yaw():
     # Dropping the marker (sampled yaw only) would enclose an undersized, misaligned footprint.
     sampled_only = box.get_bounding_box().rotated_around_z(sampled_yaw)
     assert not torch.allclose(rotated[box].max_point, sampled_only.max_point, atol=1e-6)
+
+
+def test_on_relation_containment_uses_rotated_bbox():
+    """Test that a child fits the parent rim axis-aligned but spills past it once yaw-inflated 90°."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    desk = _make_desk()  # XY in [-0.5, 0.5]
+    child = _make_long_box("child")  # x in [-0.3, 0.3], y in [-0.05, 0.05]
+    child.add_relation(On(desk, clearance_m=0.01))
+    # Near the +Y rim: axis-aligned half-Y 0.05 stays inside; rotated 90° half-Y 0.3 spills past +0.5.
+    positions = {desk: (0.0, 0.0, 0.0), child: (0.0, 0.44, 0.105)}
+
+    axis_aligned = {desk: desk.get_bounding_box(), child: child.get_bounding_box()}
+    assert placer._validate_on_relations(positions, axis_aligned) is True
+    rotated = {desk: desk.get_bounding_box(), child: child.get_bounding_box().rotated_around_z(math.pi / 2)}
+    assert placer._validate_on_relations(positions, rotated) is False
 
 
 def test_on_relation_check_no_relation_returns_true():

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -6,11 +6,12 @@
 """Tests for ObjectPlacer placement validation (_validate_placement, _validate_no_overlap, _validate_on_relations)."""
 
 import math
+import torch
 
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
-from isaaclab_arena.relations.relations import On
+from isaaclab_arena.relations.relations import On, RotateAroundSolution
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
@@ -38,6 +39,11 @@ def _make_desk() -> DummyObject:
 
 def _env_bboxes(positions: dict[DummyObject, tuple[float, float, float]]):
     return {obj: obj.get_bounding_box() for obj in positions}
+
+
+def _stack_rows(bbox: AxisAlignedBoundingBox, n: int) -> AxisAlignedBoundingBox:
+    """Repeat a single-env bbox into n stacked rows (one per candidate)."""
+    return AxisAlignedBoundingBox(min_point=bbox.min_point.repeat(n, 1), max_point=bbox.max_point.repeat(n, 1))
 
 
 def test_no_overlap_returns_true():
@@ -106,6 +112,39 @@ def test_rotation_aware_overlap_uses_yaw():
     assert placer._validate_placement(positions, axis_aligned) is True
     rotated = {a: a.get_bounding_box().rotated_around_z(math.pi / 2), b: b.get_bounding_box()}
     assert placer._validate_placement(positions, rotated) is False
+
+
+def test_candidate_bbox_row_aligns_with_candidate_yaw():
+    """Per-candidate yaw, bbox row, and validation stay index-aligned: only the matched row is collision-free."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    a = _make_long_box("a")  # long in X
+    b = _make_box("b", size=0.1)
+    positions = {a: (0.0, 0.0, 0.0), b: (0.0, 0.2, 0.0)}
+
+    # Two candidates share positions but assign distinct yaws to `a`.
+    candidate_bboxes = {a: _stack_rows(a.get_bounding_box(), 2), b: _stack_rows(b.get_bounding_box(), 2)}
+    rotated = ObjectPlacer._rotate_candidate_bboxes([a, b], candidate_bboxes, [{a: 0.0}, {a: math.pi / 2}])
+
+    # Mirrors _place_ranked: each candidate validates against its own bbox row.
+    validations = [placer._validate_placement(positions, ObjectPlacer._bbox_row(rotated, idx)) for idx in range(2)]
+    # Axis-aligned `a` clears b; rotated 90° it sweeps into b. A row/candidate swap would flip both.
+    assert validations == [True, False]
+
+
+def test_rotate_candidate_bboxes_encloses_marker_plus_sampled_yaw():
+    """_rotate_candidate_bboxes folds the marker yaw into the box, not just the sampled yaw."""
+    box = _make_long_box("box")
+    marker_yaw, sampled_yaw = math.pi / 6, math.pi / 3
+    box.add_relation(RotateAroundSolution(yaw_rad=marker_yaw))
+
+    rotated = ObjectPlacer._rotate_candidate_bboxes([box], {box: box.get_bounding_box()}, [{box: sampled_yaw}])
+
+    expected = box.get_bounding_box().rotated_around_z(marker_yaw + sampled_yaw)
+    torch.testing.assert_close(rotated[box].min_point, expected.min_point, atol=1e-6, rtol=0)
+    torch.testing.assert_close(rotated[box].max_point, expected.max_point, atol=1e-6, rtol=0)
+    # Dropping the marker (sampled yaw only) would enclose an undersized, misaligned footprint.
+    sampled_only = box.get_bounding_box().rotated_around_z(sampled_yaw)
+    assert not torch.allclose(rotated[box].max_point, sampled_only.max_point, atol=1e-6)
 
 
 def test_on_relation_check_no_relation_returns_true():

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -205,20 +205,25 @@ class AxisAlignedBoundingBox:
             )
 
     def rotated_around_z(self, angle_rad: float | torch.Tensor) -> "AxisAlignedBoundingBox":
-        """Rotate the bounding box by an arbitrary angle around Z, refitting to the enclosing axis-aligned box.
+        """Refit to the axis-aligned box enclosing this box rotated by angle_rad around Z.
 
-        The refit box is conservative (larger than the true rotated box) except at 90°
-        multiples. Z extents are unchanged.
+        Conservative (larger than the true rotated box) except at 90° multiples; Z extents unchanged.
 
         Args:
-            angle_rad: Yaw in radians. A scalar rotates every box by the same angle; a
-                1-D tensor gives per-box angles (or, for a single box, one box per angle).
+            angle_rad: Yaw in radians. A scalar rotates every box equally; a 1-D tensor gives
+                per-box angles (or, for a single box, one box per angle).
 
         Returns:
             New AxisAlignedBoundingBox enclosing the rotated box.
         """
         device = self._min_point.device
         angles = torch.as_tensor(angle_rad, dtype=torch.float32, device=device).reshape(-1)  # (M,)
+
+        num_boxes, num_angles = self._min_point.shape[0], angles.shape[0]
+        assert num_boxes == 1 or num_angles == 1 or num_boxes == num_angles, (
+            "rotated_around_z requires one box, one angle, or equal counts; "
+            f"got {num_boxes} boxes and {num_angles} angles."
+        )
 
         cos = torch.cos(angles).unsqueeze(1)  # (M, 1)
         sin = torch.sin(angles).unsqueeze(1)  # (M, 1)

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -38,6 +38,13 @@ class AxisAlignedBoundingBox:
     def __repr__(self) -> str:
         return f"AxisAlignedBoundingBox(min_point={self._min_point}, max_point={self._max_point})"
 
+    def __getitem__(self, idx: int) -> "AxisAlignedBoundingBox":
+        """Select row idx (one env/candidate), returning a single-box (N=1) bbox."""
+        assert 0 <= idx < self.num_envs, f"index {idx} out of range for bbox with num_envs={self.num_envs}."
+        return AxisAlignedBoundingBox(
+            min_point=self._min_point[idx : idx + 1], max_point=self._max_point[idx : idx + 1]
+        )
+
     @staticmethod
     def _to_batched_tensor(value: tuple[float, float, float] | torch.Tensor) -> torch.Tensor:
         """Convert tuple, 1-D tensor, or (N, 3) tensor to (N, 3) float32 tensor."""

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -204,6 +204,52 @@ class AxisAlignedBoundingBox:
                 max_point=torch.stack([max_y, -min_x, max_z], dim=1),
             )
 
+    def rotated_around_z(self, angle_rad: float | torch.Tensor) -> "AxisAlignedBoundingBox":
+        """Rotate the bounding box by an arbitrary angle around Z, refitting to the enclosing axis-aligned box.
+
+        The refit box is conservative (larger than the true rotated box) except at 90°
+        multiples. Z extents are unchanged.
+
+        Args:
+            angle_rad: Yaw in radians. A scalar rotates every box by the same angle; a
+                1-D tensor gives per-box angles (or, for a single box, one box per angle).
+
+        Returns:
+            New AxisAlignedBoundingBox enclosing the rotated box.
+        """
+        device = self._min_point.device
+        angles = torch.as_tensor(angle_rad, dtype=torch.float32, device=device).reshape(-1)  # (M,)
+
+        cos = torch.cos(angles).unsqueeze(1)  # (M, 1)
+        sin = torch.sin(angles).unsqueeze(1)  # (M, 1)
+
+        # XY footprint corners relative to the object origin: (N, 4).
+        min_x, min_y = self._min_point[:, 0], self._min_point[:, 1]
+        max_x, max_y = self._max_point[:, 0], self._max_point[:, 1]
+        corners_x = torch.stack([min_x, max_x, max_x, min_x], dim=1)  # (N, 4)
+        corners_y = torch.stack([min_y, min_y, max_y, max_y], dim=1)  # (N, 4)
+
+        # Rotate corners (broadcasts (N, 4) with (M, 1)).
+        rot_x = corners_x * cos - corners_y * sin
+        rot_y = corners_x * sin + corners_y * cos
+
+        new_min_x = rot_x.min(dim=1).values  # (L,)
+        new_max_x = rot_x.max(dim=1).values
+        new_min_y = rot_y.min(dim=1).values
+        new_max_y = rot_y.max(dim=1).values
+
+        # Z extents are invariant under Z rotation; broadcast to the output leading dim.
+        out_len = new_min_x.shape[0]
+        min_z, max_z = self._min_point[:, 2], self._max_point[:, 2]
+        if min_z.shape[0] == 1 and out_len > 1:
+            min_z = min_z.expand(out_len)
+            max_z = max_z.expand(out_len)
+
+        return AxisAlignedBoundingBox(
+            min_point=torch.stack([new_min_x, new_min_y, min_z], dim=1),
+            max_point=torch.stack([new_max_x, new_max_y, max_z], dim=1),
+        )
+
 
 def quaternion_to_90_deg_z_quarters(rotation_xyzw: tuple[float, float, float, float], tol_deg: float = 1.0) -> int:
     """Convert a quaternion to 90° rotation quarters around Z axis.

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import torch
 from dataclasses import dataclass
 
@@ -50,6 +51,25 @@ class Pose:
 
     def multiply(self, other: "Pose") -> "Pose":
         return compose_poses(self, other)
+
+
+def wrap_angle_to_pi(angle_rad: float) -> float:
+    """Wrap an angle in radians to [-pi, pi)."""
+    return (angle_rad + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def rotate_quat_by_yaw(
+    base_xyzw: tuple[float, float, float, float], yaw_rad: float
+) -> tuple[float, float, float, float]:
+    """Rotate base_xyzw (xyzw) by an extra yaw about Z. Returns base unchanged when yaw is 0."""
+    yaw_rad = wrap_angle_to_pi(yaw_rad)  # keep half-angle small for precision; canonicalize 2pi -> 0
+    if yaw_rad == 0.0:
+        return base_xyzw
+    bx, by, bz, bw = base_xyzw
+    sz = math.sin(yaw_rad / 2.0)
+    cz = math.cos(yaw_rad / 2.0)
+    # Hamilton product base ⊗ (0, 0, sz, cz) — composes the Z-yaw after the base rotation.
+    return (bx * cz + by * sz, -bx * sz + by * cz, bz * cz + bw * sz, -bz * sz + bw * cz)
 
 
 def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -68,7 +68,7 @@ def rotate_quat_by_yaw(
     bx, by, bz, bw = base_xyzw
     sz = math.sin(yaw_rad / 2.0)
     cz = math.cos(yaw_rad / 2.0)
-    # Hamilton product base ⊗ (0, 0, sz, cz) — composes the Z-yaw after the base rotation.
+    # Hamilton product base ⊗ (0, 0, sz, cz). Both rotations are about Z, so they commute.
     return (bx * cz + by * sz, -bx * sz + by * cz, bz * cz + bw * sz, -bz * sz + bw * cz)
 
 

--- a/isaaclab_arena/utils/random.py
+++ b/isaaclab_arena/utils/random.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gymnasium as gym
+import math
 import numpy as np
 import random
 import torch
@@ -17,3 +18,9 @@ def set_seed(seed: int, env: gym.Env = None):
     random.seed(seed)
     if env is not None:
         env.unwrapped.seed(seed)
+
+
+def get_random_rotation(generator: torch.Generator | None = None) -> float:
+    """Sample a uniform yaw in [-pi, pi) radians (rotation about Z)."""
+    u = torch.rand(1, generator=generator).item()
+    return (2.0 * u - 1.0) * math.pi


### PR DESCRIPTION
## Summary
Add random yaw initialization for placed objects

## Detailed description
- Add `--random_yaw_init` flag for per-object random z-rotation.
- Add conservative rotated-AABB support so collision checks account for yaw.
- Add related tests.
