### PR TITLE
Stop importing object_library from calling the Lightwheel API

### DIFF
--- a/isaaclab_arena/assets/lightwheel_lazy.py
+++ b/isaaclab_arena/assets/lightwheel_lazy.py
@@ -46,9 +46,14 @@ silently corrupting unrelated registrations.
 Caching is per-descriptor: the resolved path is stored on the descriptor instance
 after the first successful resolution, so subsequent accesses are free and the
 underlying SDK call is made at most once per process.
+
+The actual SDK call is routed through :func:`isaaclab_arena.assets.lightwheel_utils.acquire_lightwheel_asset`,
+which applies a longer scoped timeout and retries transient timeout failures.
 """
 
 from __future__ import annotations
+
+from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 
 
 class LightwheelLazyPath:
@@ -100,18 +105,22 @@ class LightwheelLazyPath:
             return self._cached_path
         from lightwheel_sdk.loader import object_loader
 
+        identifier = self._file_name if self._file_name is not None else self._registry_name
         query_kwargs: dict = {"registry_type": self._registry_type, "file_type": self._file_type}
         if self._file_name is not None:
             query_kwargs["file_name"] = self._file_name
         else:
             query_kwargs["registry_name"] = self._registry_name
         try:
-            file_path, _, _ = object_loader.acquire_by_registry(**query_kwargs)
+            file_path, _, _ = acquire_lightwheel_asset(
+                object_loader,
+                object_loader.acquire_by_registry,
+                description=f"Lightwheel asset {identifier!r}",
+                **query_kwargs,
+            )
         except Exception as error:
-            identifier = self._file_name if self._file_name is not None else self._registry_name
             raise RuntimeError(
-                f"Failed to resolve Lightwheel asset {identifier!r}"
-                f" (registry_type={self._registry_type!r}): {error}"
+                f"Failed to resolve Lightwheel asset {identifier!r} (registry_type={self._registry_type!r}): {error}"
             ) from error
         self._cached_path = file_path
         return file_path

--- a/isaaclab_arena/assets/lightwheel_lazy.py
+++ b/isaaclab_arena/assets/lightwheel_lazy.py
@@ -71,10 +71,6 @@ class LightwheelLazyPath:
     issues the registry query, caches the resolved path on the descriptor, and
     returns it. Subsequent accesses return the cached value without further work.
 
-    Resolution failures are re-raised with a message that names the asset and
-    registry parameters, so the caller can tell *which* Lightwheel asset failed
-    rather than getting a bare SDK exception.
-
     Args:
         registry_type: Lightwheel registry partition (``"fixtures"``, ``"objects"``, …).
         file_name: File-name lookup key. Mutually exclusive with ``registry_name``;
@@ -94,10 +90,13 @@ class LightwheelLazyPath:
         assert (file_name is None) != (
             registry_name is None
         ), "Provide exactly one of file_name= or registry_name= (matches acquire_by_registry's signature)."
-        self._registry_type = registry_type
-        self._file_name = file_name
-        self._registry_name = registry_name
-        self._file_type = file_type
+        identifier = file_name if file_name is not None else registry_name
+        self._description = f"Lightwheel asset {identifier!r}"
+        self._query_kwargs: dict = {"registry_type": registry_type, "file_type": file_type}
+        if file_name is not None:
+            self._query_kwargs["file_name"] = file_name
+        else:
+            self._query_kwargs["registry_name"] = registry_name
         self._cached_path: str | None = None
 
     def __get__(self, instance, owner):
@@ -105,22 +104,11 @@ class LightwheelLazyPath:
             return self._cached_path
         from lightwheel_sdk.loader import object_loader
 
-        identifier = self._file_name if self._file_name is not None else self._registry_name
-        query_kwargs: dict = {"registry_type": self._registry_type, "file_type": self._file_type}
-        if self._file_name is not None:
-            query_kwargs["file_name"] = self._file_name
-        else:
-            query_kwargs["registry_name"] = self._registry_name
-        try:
-            file_path, _, _ = acquire_lightwheel_asset(
-                object_loader,
-                object_loader.acquire_by_registry,
-                description=f"Lightwheel asset {identifier!r}",
-                **query_kwargs,
-            )
-        except Exception as error:
-            raise RuntimeError(
-                f"Failed to resolve Lightwheel asset {identifier!r} (registry_type={self._registry_type!r}): {error}"
-            ) from error
+        file_path, _, _ = acquire_lightwheel_asset(
+            object_loader,
+            object_loader.acquire_by_registry,
+            description=self._description,
+            **self._query_kwargs,
+        )
         self._cached_path = file_path
         return file_path

--- a/isaaclab_arena/assets/lightwheel_lazy.py
+++ b/isaaclab_arena/assets/lightwheel_lazy.py
@@ -3,82 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Lazy resolver for Lightwheel-SDK-backed USD paths.
-
-Background
-----------
-Several asset classes in :mod:`isaaclab_arena.assets.object_library` were initially
-defined with eager Lightwheel SDK calls in their *class body*::
-
-    @register_asset
-    class Microwave(LibraryObject, Openable):
-        from lightwheel_sdk.loader import object_loader  # class-body import
-        file_path, _, _ = object_loader.acquire_by_registry(  # class-body HTTP
-            registry_type="fixtures", file_name="Microwave039", file_type="USD"
-        )
-        usd_path = file_path
-
-Class bodies are evaluated **at module import time**, which means importing
-``object_library`` makes a synchronous HTTP request to the Lightwheel API. If the
-request times out or fails (the SDK has a 10-second read timeout), the class body
-raises and the module import / reload fails — *every* class defined below the failing
-one in that module is left undefined and unregistered, including unrelated assets
-like ``RubiksCubeHot3DRobolab``. This was the root cause of a registry-loss bug we
-hit during a long multi-job eval sweep: a transient Lightwheel API stall broke an
-``importlib.reload(object_library)`` call, ``rubiks_cube_hot3d_robolab`` failed to
-re-register, and subsequent jobs crashed with a misleading "asset not found" error.
-
-What this module provides
--------------------------
-:class:`LightwheelLazyPath` is a class-attribute descriptor that **defers** the
-Lightwheel SDK call from class-body evaluation to first attribute access. After the
-fix the same class looks like::
-
-    @register_asset
-    class Microwave(LibraryObject, Openable):
-        usd_path = LightwheelLazyPath("fixtures", "Microwave039")
-        # ... no class-body network call ...
-
-Import / reload of ``object_library`` no longer touches the network. Failures, when
-they happen, surface at the moment the asset is actually instantiated rather than
-silently corrupting unrelated registrations.
-
-Caching is per-descriptor: the resolved path is stored on the descriptor instance
-after the first successful resolution, so subsequent accesses are free and the
-underlying SDK call is made at most once per process.
-
-The actual SDK call is routed through :func:`isaaclab_arena.assets.lightwheel_utils.acquire_lightwheel_asset`,
-which applies a longer scoped timeout and retries transient timeout failures.
-"""
-
 from __future__ import annotations
 
 from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 
 
 class LightwheelLazyPath:
-    """Descriptor that defers a Lightwheel ``object_loader`` call to first access.
-
-    Instantiate as a class attribute on a Lightwheel-backed asset::
-
-        usd_path = LightwheelLazyPath("fixtures", "Microwave039")
-
-    or, for the list-style registry signature used by a couple of object classes::
-
-        usd_path = LightwheelLazyPath("objects", registry_name=["broccoli"])
-
-    The first access (``instance.usd_path`` or ``Class.usd_path``) imports the SDK,
-    issues the registry query, caches the resolved path on the descriptor, and
-    returns it. Subsequent accesses return the cached value without further work.
-
-    Args:
-        registry_type: Lightwheel registry partition (``"fixtures"``, ``"objects"``, …).
-        file_name: File-name lookup key. Mutually exclusive with ``registry_name``;
-            exactly one must be supplied.
-        registry_name: List-style lookup key. Mutually exclusive with ``file_name``.
-        file_type: Asset file format passed through to ``acquire_by_registry``.
-            Defaults to ``"USD"`` which is what every existing call site uses.
-    """
+    """Class-attribute descriptor that resolves a Lightwheel USD path on first access and caches it."""
 
     def __init__(
         self,

--- a/isaaclab_arena/assets/lightwheel_lazy.py
+++ b/isaaclab_arena/assets/lightwheel_lazy.py
@@ -11,23 +11,8 @@ from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 class LightwheelLazyPath:
     """Class-attribute descriptor that resolves a Lightwheel USD path on first access and caches it."""
 
-    def __init__(
-        self,
-        registry_type: str,
-        file_name: str | None = None,
-        registry_name: list[str] | None = None,
-        file_type: str = "USD",
-    ):
-        assert (file_name is None) != (
-            registry_name is None
-        ), "Provide exactly one of file_name= or registry_name= (matches acquire_by_registry's signature)."
-        identifier = file_name if file_name is not None else registry_name
-        self._description = f"Lightwheel asset {identifier!r}"
-        self._query_kwargs: dict = {"registry_type": registry_type, "file_type": file_type}
-        if file_name is not None:
-            self._query_kwargs["file_name"] = file_name
-        else:
-            self._query_kwargs["registry_name"] = registry_name
+    def __init__(self, **acquire_by_registry_kwargs):
+        self._kwargs = acquire_by_registry_kwargs
         self._cached_path: str | None = None
 
     def __get__(self, instance, owner):
@@ -38,8 +23,8 @@ class LightwheelLazyPath:
         file_path, _, _ = acquire_lightwheel_asset(
             object_loader,
             object_loader.acquire_by_registry,
-            description=self._description,
-            **self._query_kwargs,
+            description=f"Lightwheel asset {self._kwargs}",
+            **self._kwargs,
         )
         self._cached_path = file_path
         return file_path

--- a/isaaclab_arena/assets/lightwheel_lazy.py
+++ b/isaaclab_arena/assets/lightwheel_lazy.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lazy resolver for Lightwheel-SDK-backed USD paths.
+
+Background
+----------
+Several asset classes in :mod:`isaaclab_arena.assets.object_library` were initially
+defined with eager Lightwheel SDK calls in their *class body*::
+
+    @register_asset
+    class Microwave(LibraryObject, Openable):
+        from lightwheel_sdk.loader import object_loader  # class-body import
+        file_path, _, _ = object_loader.acquire_by_registry(  # class-body HTTP
+            registry_type="fixtures", file_name="Microwave039", file_type="USD"
+        )
+        usd_path = file_path
+
+Class bodies are evaluated **at module import time**, which means importing
+``object_library`` makes a synchronous HTTP request to the Lightwheel API. If the
+request times out or fails (the SDK has a 10-second read timeout), the class body
+raises and the module import / reload fails — *every* class defined below the failing
+one in that module is left undefined and unregistered, including unrelated assets
+like ``RubiksCubeHot3DRobolab``. This was the root cause of a registry-loss bug we
+hit during a long multi-job eval sweep: a transient Lightwheel API stall broke an
+``importlib.reload(object_library)`` call, ``rubiks_cube_hot3d_robolab`` failed to
+re-register, and subsequent jobs crashed with a misleading "asset not found" error.
+
+What this module provides
+-------------------------
+:class:`LightwheelLazyPath` is a class-attribute descriptor that **defers** the
+Lightwheel SDK call from class-body evaluation to first attribute access. After the
+fix the same class looks like::
+
+    @register_asset
+    class Microwave(LibraryObject, Openable):
+        usd_path = LightwheelLazyPath("fixtures", "Microwave039")
+        # ... no class-body network call ...
+
+Import / reload of ``object_library`` no longer touches the network. Failures, when
+they happen, surface at the moment the asset is actually instantiated rather than
+silently corrupting unrelated registrations.
+
+Caching is per-descriptor: the resolved path is stored on the descriptor instance
+after the first successful resolution, so subsequent accesses are free and the
+underlying SDK call is made at most once per process.
+"""
+
+from __future__ import annotations
+
+
+class LightwheelLazyPath:
+    """Descriptor that defers a Lightwheel ``object_loader`` call to first access.
+
+    Instantiate as a class attribute on a Lightwheel-backed asset::
+
+        usd_path = LightwheelLazyPath("fixtures", "Microwave039")
+
+    or, for the list-style registry signature used by a couple of object classes::
+
+        usd_path = LightwheelLazyPath("objects", registry_name=["broccoli"])
+
+    The first access (``instance.usd_path`` or ``Class.usd_path``) imports the SDK,
+    issues the registry query, caches the resolved path on the descriptor, and
+    returns it. Subsequent accesses return the cached value without further work.
+
+    Resolution failures are re-raised with a message that names the asset and
+    registry parameters, so the caller can tell *which* Lightwheel asset failed
+    rather than getting a bare SDK exception.
+
+    Args:
+        registry_type: Lightwheel registry partition (``"fixtures"``, ``"objects"``, …).
+        file_name: File-name lookup key. Mutually exclusive with ``registry_name``;
+            exactly one must be supplied.
+        registry_name: List-style lookup key. Mutually exclusive with ``file_name``.
+        file_type: Asset file format passed through to ``acquire_by_registry``.
+            Defaults to ``"USD"`` which is what every existing call site uses.
+    """
+
+    def __init__(
+        self,
+        registry_type: str,
+        file_name: str | None = None,
+        registry_name: list[str] | None = None,
+        file_type: str = "USD",
+    ):
+        assert (file_name is None) != (
+            registry_name is None
+        ), "Provide exactly one of file_name= or registry_name= (matches acquire_by_registry's signature)."
+        self._registry_type = registry_type
+        self._file_name = file_name
+        self._registry_name = registry_name
+        self._file_type = file_type
+        self._cached_path: str | None = None
+
+    def __get__(self, instance, owner):
+        if self._cached_path is not None:
+            return self._cached_path
+        from lightwheel_sdk.loader import object_loader
+
+        query_kwargs: dict = {"registry_type": self._registry_type, "file_type": self._file_type}
+        if self._file_name is not None:
+            query_kwargs["file_name"] = self._file_name
+        else:
+            query_kwargs["registry_name"] = self._registry_name
+        try:
+            file_path, _, _ = object_loader.acquire_by_registry(**query_kwargs)
+        except Exception as error:
+            identifier = self._file_name if self._file_name is not None else self._registry_name
+            raise RuntimeError(
+                f"Failed to resolve Lightwheel asset {identifier!r}"
+                f" (registry_type={self._registry_type!r}): {error}"
+            ) from error
+        self._cached_path = file_path
+        return file_path

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -10,6 +10,7 @@ import isaaclab.sim as sim_utils
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.hdr_image import HDRImage
+
 from isaaclab.assets import RigidObjectCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
@@ -18,6 +19,7 @@ from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.affordances.placeable import Placeable
 from isaaclab_arena.affordances.pressable import Pressable
 from isaaclab_arena.affordances.turnable import Turnable
+from isaaclab_arena.assets.lightwheel_lazy import LightwheelLazyPath
 from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_utils import (
@@ -25,7 +27,6 @@ from isaaclab_arena.assets.object_utils import (
     RIGID_BODY_PROPS_HIGH_PRECISION,
     RIGID_BODY_PROPS_MEDIUM_PRECISION,
 )
-from isaaclab_arena.assets.lightwheel_lazy import LightwheelLazyPath
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
 
@@ -175,7 +176,7 @@ class Microwave(LibraryObject, Openable):
     name = "microwave"
     tags = ["object", "openable"]
     # Resolved lazily on first attribute access — see isaaclab_arena.assets.lightwheel_lazy.
-    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="Microwave039")
+    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="Microwave039", file_type="USD")
     object_type = ObjectType.ARTICULATION
 
     # Openable affordance parameters
@@ -202,7 +203,7 @@ class CoffeeMachine(LibraryObject, Pressable):
 
     name = "coffee_machine"
     tags = ["object", "pressable"]
-    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="CoffeeMachine108")
+    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="CoffeeMachine108", file_type="USD")
     object_type = ObjectType.ARTICULATION
 
     # Openable affordance parameters
@@ -664,7 +665,7 @@ class Broccoli(LibraryObject):
 
     name = "broccoli"
     tags = ["object", "vegetable", "graspable"]
-    usd_path = LightwheelLazyPath(registry_type="objects", registry_name=["broccoli"])
+    usd_path = LightwheelLazyPath(registry_type="objects", registry_name=["broccoli"], file_type="USD")
     object_type = ObjectType.RIGID
 
     def __init__(
@@ -685,7 +686,7 @@ class SweetPotato(LibraryObject):
 
     name = "sweet_potato"
     tags = ["object", "vegetable", "graspable"]
-    usd_path = LightwheelLazyPath(registry_type="objects", file_name="SweetPotato005")
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="SweetPotato005", file_type="USD")
     object_type = ObjectType.RIGID
     scale = (1.5, 1.5, 1.5)
 
@@ -707,7 +708,7 @@ class Jug(LibraryObject):
 
     name = "jug"
     tags = ["object", "graspable"]
-    usd_path = LightwheelLazyPath(registry_type="objects", file_name="Jug005")
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="Jug005", file_type="USD")
     object_type = ObjectType.RIGID
     scale = (2.0, 2.0, 2.0)
 
@@ -729,7 +730,7 @@ class BeerBottle(LibraryObject):
 
     name = "beer_bottle"
     tags = ["object", "graspable"]
-    usd_path = LightwheelLazyPath(registry_type="objects", file_name="beer016")
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="beer016", file_type="USD")
     object_type = ObjectType.RIGID
     scale = (1.2, 1.2, 1.2)
 

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -18,7 +18,6 @@ from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.affordances.placeable import Placeable
 from isaaclab_arena.affordances.pressable import Pressable
 from isaaclab_arena.affordances.turnable import Turnable
-from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_utils import (
@@ -26,6 +25,7 @@ from isaaclab_arena.assets.object_utils import (
     RIGID_BODY_PROPS_HIGH_PRECISION,
     RIGID_BODY_PROPS_MEDIUM_PRECISION,
 )
+from isaaclab_arena.assets.lightwheel_lazy import LightwheelLazyPath
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
 
@@ -172,20 +172,10 @@ class PowerDrill(LibraryObject):
 class Microwave(LibraryObject, Openable):
     """A microwave oven."""
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "microwave"
     tags = ["object", "openable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="microwave asset",
-        registry_type="fixtures",
-        file_name="Microwave039",
-        file_type="USD",
-    )
-    usd_path = file_path
+    # Resolved lazily on first attribute access — see isaaclab_arena.assets.lightwheel_lazy.
+    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="Microwave039")
     object_type = ObjectType.ARTICULATION
 
     # Openable affordance parameters
@@ -210,20 +200,9 @@ class CoffeeMachine(LibraryObject, Pressable):
     Encapsulates the pick-up object config for a pick-and-place environment.
     """
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "coffee_machine"
     tags = ["object", "pressable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="coffee_machine asset",
-        registry_type="fixtures",
-        file_name="CoffeeMachine108",
-        file_type="USD",
-    )
-    usd_path = file_path
+    usd_path = LightwheelLazyPath(registry_type="fixtures", file_name="CoffeeMachine108")
     object_type = ObjectType.ARTICULATION
 
     # Openable affordance parameters
@@ -683,20 +662,9 @@ class Broccoli(LibraryObject):
     Brocolli
     """
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "broccoli"
     tags = ["object", "vegetable", "graspable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="broccoli asset",
-        registry_type="objects",
-        registry_name=["broccoli"],
-        file_type="USD",
-    )
-    usd_path = file_path
+    usd_path = LightwheelLazyPath(registry_type="objects", registry_name=["broccoli"])
     object_type = ObjectType.RIGID
 
     def __init__(
@@ -715,20 +683,9 @@ class SweetPotato(LibraryObject):
     SweetPotato
     """
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "sweet_potato"
     tags = ["object", "vegetable", "graspable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="sweet_potato asset",
-        registry_type="objects",
-        file_name="SweetPotato005",
-        file_type="USD",
-    )
-    usd_path = file_path
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="SweetPotato005")
     object_type = ObjectType.RIGID
     scale = (1.5, 1.5, 1.5)
 
@@ -748,20 +705,9 @@ class Jug(LibraryObject):
     Jug
     """
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "jug"
     tags = ["object", "graspable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="jug asset",
-        registry_type="objects",
-        file_name="Jug005",
-        file_type="USD",
-    )
-    usd_path = file_path
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="Jug005")
     object_type = ObjectType.RIGID
     scale = (2.0, 2.0, 2.0)
 
@@ -781,20 +727,9 @@ class BeerBottle(LibraryObject):
     Beer Bottle
     """
 
-    # Only required when using Lightwheel SDK
-    from lightwheel_sdk.loader import object_loader
-
     name = "beer_bottle"
     tags = ["object", "graspable"]
-    file_path, object_name, metadata = acquire_lightwheel_asset(
-        object_loader,
-        object_loader.acquire_by_registry,
-        description="beer_bottle asset",
-        registry_type="objects",
-        file_name="beer016",
-        file_type="USD",
-    )
-    usd_path = file_path
+    usd_path = LightwheelLazyPath(registry_type="objects", file_name="beer016")
     object_type = ObjectType.RIGID
     scale = (1.2, 1.2, 1.2)
 


### PR DESCRIPTION
## Summary

Importing `isaaclab_arena.assets.object_library` — anyone instantiating an Arena asset, Lightwheel or not — made six unconditional HTTPS calls to the Lightwheel API at module-import time.

This PR introduces `LightwheelLazyPath`: a class-attribute descriptor that defers the SDK call to first access.
