### PR TITLE
[main] [cp #722 from release/0.2.1] Change the prompt for the finetuning

### DIFF
--- a/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
+++ b/docs/pages/example_workflows/static_apple/step_3_policy_training.rst
@@ -93,7 +93,7 @@ The converter is controlled by a config file at
       hdf5_name: "arena_g1_static_apple_dataset_recorded.hdf5"
 
       # Task description
-      language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+      language_instruction: "move the apple to the plate"
       task_index: 3
 
       # Data field mappings

--- a/isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml
+++ b/isaaclab_arena_gr00t/lerobot/config/g1_static_apple_config.yaml
@@ -11,7 +11,7 @@
 data_root: "/datasets/isaaclab_arena/static_apple_tutorial"
 
 # Instruction given to the policy in natural language
-language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+language_instruction: "move the apple to the plate"
 task_index: 3
 
 # Name of the HDF5 file to use for the dataset (matches the recorder output from

--- a/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
+++ b/isaaclab_arena_gr00t/policy/config/g1_static_apple_gr00t_closedloop_config.yaml
@@ -8,7 +8,7 @@
 # Used with Arena's remote-policy server stack (docs: example_workflows/static_apple/step_4_evaluation).
 # The matching client is `isaaclab_arena.policy.action_chunking_client.ActionChunkingClientSidePolicy`.
 # The model is finetuned from `nvidia/GR00T-N1.7-3B` per `static_apple/step_3_policy_training`.
-language_instruction: "Pick up the apple from the shelf and place it onto the plate on the same shelf next to it."
+language_instruction: "move the apple to the plate"
 
 # Must match the diffusion head's action_horizon baked into the finetuned checkpoint
 # (set via the action modality's `delta_indices=list(range(N))` in


### PR DESCRIPTION
cp #722  from release/0.2.1

Align static apple prompt

- Reason: align the simulated static apple workflow with the same prompt used for the real setup.
- Changed the GR00T LeRobot training config prompt to `move the apple to the plate`.
- Updated the closed-loop evaluation config to use the same prompt.
- Updated the static apple policy-training docs snippet so users finetune with the matching prompt.
- Impact: training and evaluation now use consistent language conditioning across sim and real workflows.

---------

## Summary
Short description of the change (max 50 chars)

## Detailed description
- What was the reason for the change?
- What has been changed?
- What is the impact of this change?
