### PR TITLE
Bringup Env from EnvGraphSpec yaml via CLI

### DIFF
--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -67,6 +67,16 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             "When not set, each environment uses its own default."
         ),
     )
+    arena_group.add_argument(
+        "--resolve_on_reset",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Re-place objects from the pool on each reset (default: True). Use --no-resolve_on_reset to keep the same"
+            " layout."
+        ),
+    )
+
 
 def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add environment graph spec specific command line arguments to the given parser."""
@@ -78,8 +88,8 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         help=(
-            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of a"
-            " registered example-environment name; the env-name subcommand then becomes optional."
+            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
+            " a registered example-environment name; the env-name subcommand then becomes optional."
         ),
     )
 

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -15,6 +15,7 @@ def get_isaaclab_arena_cli_parser() -> argparse.ArgumentParser:
     add_isaac_lab_cli_args(parser)
     add_isaaclab_arena_cli_args(parser)
     add_external_environments_cli_args(parser)
+    add_env_graph_spec_cli_args(parser)
     return parser
 
 
@@ -66,13 +67,19 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             "When not set, each environment uses its own default."
         ),
     )
-    arena_group.add_argument(
-        "--resolve_on_reset",
-        action=argparse.BooleanOptionalAction,
+
+def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add environment graph spec specific command line arguments to the given parser."""
+    env_graph_spec_group = parser.add_argument_group(
+        "Environment Graph Spec Arguments", "Arguments specific to environment graph spec"
+    )
+    env_graph_spec_group.add_argument(
+        "--env_graph_spec_yaml",
+        type=str,
         default=None,
         help=(
-            "Re-place objects from the pool on each reset (default: True). Use --no-resolve_on_reset to keep the same"
-            " layout."
+            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of a"
+            " registered example-environment name; the env-name subcommand then becomes optional."
         ),
     )
 

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -63,10 +63,21 @@ class ArenaEnvGraphSpec:
     tasks: list[ArenaEnvGraphTaskSpec] = field(default_factory=list)
     state_specs: list[ArenaEnvGraphStateSpec] = field(default_factory=list)
 
+    @staticmethod
+    def _load_yaml_dict(path: str | Path) -> dict[str, Any]:
+        """Load a graph YAML into a dict, asserting the path exists with a clear message.
+
+        Centralizes the file read so a missing ``--env_graph_spec_yaml`` fails here with an
+        attributable error instead of an opaque ``FileNotFoundError`` from ``open``.
+        """
+        path = Path(path)
+        assert path.is_file(), f"Env graph spec YAML not found: {path}"
+        with path.open("r", encoding="utf-8") as f:
+            return as_dict(yaml.safe_load(f), "Env graph spec")
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> "ArenaEnvGraphSpec":
-        with Path(path).open("r", encoding="utf-8") as f:
-            return cls.from_dict(yaml.safe_load(f))
+        return cls.from_dict(cls._load_yaml_dict(path))
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ArenaEnvGraphSpec":

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -71,12 +71,8 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
         argparse.Namespace(env_graph_spec_yaml=None, example_environment=None),
         argparse.Namespace(env_graph_spec_yaml=yaml_path, example_environment="lift_object"),
     ):
-        try:
+        with pytest.raises(AssertionError):
             get_arena_builder_from_cli(bad)
-        except AssertionError:
-            pass
-        else:
-            raise AssertionError(f"expected AssertionError for {bad}")
 
     return True
 

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -48,3 +48,43 @@ def test_arena_env_graph_conversion_builds_sequential_pick_and_place_task():
 
     result = run_simulation_app_function(_test_arena_env_graph_conversion_builds_sequential_pick_and_place_task)
     assert result
+
+
+def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
+    import argparse
+    import sys
+
+    from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
+
+    yaml_path = str(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
+
+    # --env_graph_spec_yaml with no example-environment subcommand: parses (subcommand is
+    # optional) and the runner builds the env from the graph spec instead of the registry.
+    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path]
+    args = get_isaaclab_arena_environments_cli_parser().parse_args()
+    assert args.example_environment is None
+    builder = get_arena_builder_from_cli(args)
+    assert builder.arena_env.name == "pick_and_place_maple_table_default"
+
+    # Neither source, or both at once, is rejected by the exactly-one-source assert.
+    for bad in (
+        argparse.Namespace(env_graph_spec_yaml=None, example_environment=None),
+        argparse.Namespace(env_graph_spec_yaml=yaml_path, example_environment="lift_object"),
+    ):
+        try:
+            get_arena_builder_from_cli(bad)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(f"expected AssertionError for {bad}")
+
+    return True
+
+
+def test_get_arena_builder_from_cli_builds_env_from_graph_yaml():
+    pytest.importorskip("isaaclab.app")
+
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    result = run_simulation_app_function(_test_get_arena_builder_from_cli_builds_env_from_graph_yaml)
+    assert result

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -156,6 +156,11 @@ def test_arena_env_graph_spec_validate_rejects_mutated_invalid_relationship_shap
         spec.validate()
 
 
+def test_from_yaml_rejects_missing_path_with_clear_message():
+    with pytest.raises(AssertionError, match="Env graph spec YAML not found"):
+        ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "does_not_exist.yaml")
+
+
 def test_arena_env_graph_spec_rejects_invalid_data():
     cases = [
         (

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -72,8 +72,10 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
         name, cls = parse_and_return_external_environment_from_string(environment)
         env_registry.register(cls, name)
 
+    # The subcommand is optional: the env may instead come from a graph spec YAML
+    # (--env_graph_spec_yaml).
     subparsers = args_parser.add_subparsers(
-        dest="example_environment", required=True, help="Example environment to run"
+        dest="example_environment", required=False, help="Example environment to run"
     )
     for env_name in env_registry.get_all_keys():
         env_cls = env_registry.get_component_by_name(env_name)
@@ -97,14 +99,25 @@ def get_isaaclab_arena_environments_cli_parser(
 def get_arena_builder_from_cli(args_cli: argparse.Namespace) -> ArenaEnvBuilder:
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
+    # The env comes from exactly one source: a graph spec YAML (--env_graph_spec_yaml) or a
+    # registered example-environment name (subcommand).
+    env_graph_spec_yaml = getattr(args_cli, "env_graph_spec_yaml", None)
+    example_environment = getattr(args_cli, "example_environment", None)
+    assert (env_graph_spec_yaml is None) != (example_environment is None), (
+        "Specify exactly one environment source: an example-environment name or --env_graph_spec_yaml"
+        f" (got example_environment={example_environment!r}, env_graph_spec_yaml={env_graph_spec_yaml!r})"
+    )
+
+    if env_graph_spec_yaml is not None:
+        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+
+        arena_env = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml).to_arena_env()
+        return ArenaEnvBuilder(arena_env, args_cli)
+
     ensure_environments_registered()
     env_registry = EnvironmentRegistry()
-
-    assert hasattr(args_cli, "example_environment"), "Example environment must be specified"
     assert env_registry.is_registered(
-        args_cli.example_environment
-    ), f"Example environment type {args_cli.example_environment} not supported"
-    example_env = env_registry.get_component_by_name(args_cli.example_environment)()
-
-    env_builder = ArenaEnvBuilder(example_env.get_env(args_cli), args_cli)
-    return env_builder
+        example_environment
+    ), f"Example environment type {example_environment} not supported"
+    example_env = env_registry.get_component_by_name(example_environment)()
+    return ArenaEnvBuilder(example_env.get_env(args_cli), args_cli)


### PR DESCRIPTION
## Summary
Bringup Env from EnvGraphSpec yaml via CLI

## Detailed description
- Why: allow evaluation directly from env graph spec yaml, without a registered env name
- What: Added -env_graph_spec_yaml CLI args and made example_env args optional
- Impact: Env can come from a graph spec yaml or a registered name

## TODO
- Allow varying object/embodiment etc. thur CLI like current --embodiment/--object used in env.py