### PR TITLE
Allow CLI overrides with Env Graph Spec yaml

### DIFF
--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -67,13 +67,19 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             "When not set, each environment uses its own default."
         ),
     )
-    arena_group.add_argument(
-        "--resolve_on_reset",
-        action=argparse.BooleanOptionalAction,
+
+def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
+    """Add environment graph spec specific command line arguments to the given parser."""
+    env_graph_spec_group = parser.add_argument_group(
+        "Environment Graph Spec Arguments", "Arguments specific to environment graph spec"
+    )
+    env_graph_spec_group.add_argument(
+        "--env_graph_spec_yaml",
+        type=str,
         default=None,
         help=(
-            "Re-place objects from the pool on each reset (default: True). Use --no-resolve_on_reset to keep the same"
-            " layout."
+            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of a"
+            " registered example-environment name; the env-name subcommand then becomes optional."
         ),
     )
     arena_group.add_argument(

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -76,6 +76,16 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             " layout."
         ),
     )
+    arena_group.add_argument(
+        "--random_yaw_init",
+        action="store_true",
+        default=False,
+        help=(
+            "Randomly rotate objects (except anchors) around the Z-axis for scene variety. "
+            "Collisions use a larger enclosing box; the solver won't optimize this rotation. "
+            "Only affects objects positioned by the placement solver; manually-placed objects are unaffected."
+        ),
+    )
 
 
 def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
@@ -91,16 +101,6 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
             "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
             " a registered example-environment name; the env-name subcommand then becomes optional. Any override flags"
             " the YAML declares under `cli_override_specs` are added to the parser dynamically."
-        ),
-    )
-    env_graph_spec_group.add_argument(
-        "--random_yaw_init",
-        action="store_true",
-        default=False,
-        help=(
-            "Randomly rotate objects (except anchors) around the Z-axis for scene variety. "
-            "Collisions use a larger enclosing box; the solver won't optimize this rotation. "
-            "Only affects objects positioned by the placement solver; manually-placed objects are unaffected."
         ),
     )
 

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -90,10 +90,10 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
             " a registered example-environment name; the env-name subcommand then becomes optional. Any override flags"
-            " the YAML declares under `cli_overrides` are added to the parser dynamically."
+            " the YAML declares under `cli_override_specs` are added to the parser dynamically."
         ),
     )
-    arena_group.add_argument(
+    env_graph_spec_group.add_argument(
         "--random_yaw_init",
         action="store_true",
         default=False,

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -105,22 +105,6 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
-    """Add environment graph spec specific command line arguments to the given parser."""
-    env_graph_spec_group = parser.add_argument_group(
-        "Environment Graph Spec Arguments", "Arguments specific to environment graph spec"
-    )
-    env_graph_spec_group.add_argument(
-        "--env_graph_spec_yaml",
-        type=str,
-        default=None,
-        help=(
-            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
-            " a registered example-environment name; the env-name subcommand then becomes optional."
-        ),
-    )
-
-
 def add_external_environments_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add external environments specific command line arguments to the given parser."""
     external_environments_group = parser.add_argument_group(

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -89,7 +89,8 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
-            " a registered example-environment name; the env-name subcommand then becomes optional."
+            " a registered example-environment name; the env-name subcommand then becomes optional. Any override flags"
+            " the YAML declares under `cli_overrides` are added to the parser dynamically."
         ),
     )
     arena_group.add_argument(

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -67,6 +67,16 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
             "When not set, each environment uses its own default."
         ),
     )
+    arena_group.add_argument(
+        "--resolve_on_reset",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Re-place objects from the pool on each reset (default: True). Use --no-resolve_on_reset to keep the same"
+            " layout."
+        ),
+    )
+
 
 def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
     """Add environment graph spec specific command line arguments to the given parser."""
@@ -78,8 +88,8 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         help=(
-            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of a"
-            " registered example-environment name; the env-name subcommand then becomes optional."
+            "Path to an environment graph spec YAML. When set, the environment is built from the graph spec instead of"
+            " a registered example-environment name; the env-name subcommand then becomes optional."
         ),
     )
     arena_group.add_argument(

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -23,11 +23,13 @@ from isaaclab_arena.environments.arena_env_graph_types import (
 )
 from isaaclab_arena.environments.graph_spec_utils import (
     as_dict,
+    assert_cli_overrides_reference_nodes,
     assert_references_exist,
     assert_spatial_constraint_shapes,
     assert_unique_ids,
     optional_dict,
     optional_str,
+    parse_cli_override,
     parse_list,
     required_enum,
     required_number_sequence,
@@ -53,7 +55,6 @@ __all__ = [
     "ArenaEnvGraphTaskConstraintSpec",
     "ArenaEnvGraphTaskConstraintType",
     "ArenaEnvGraphTaskSpec",
-    "add_cli_override_args",
 ]
 
 
@@ -97,7 +98,7 @@ class ArenaEnvGraphSpec:
             nodes=nodes,
             tasks=tasks,
             state_specs=state_specs,
-            cli_overrides=parse_list(data, "cli_overrides", _parse_cli_override),
+            cli_overrides=parse_list(data, "cli_overrides", parse_cli_override),
         )
         spec.validate()
         return spec
@@ -111,25 +112,14 @@ class ArenaEnvGraphSpec:
         importing ``pxr`` (relation-class resolution) too early. This skips graph construction
         and validation entirely, touching only the override declarations.
         """
-        return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_overrides", _parse_cli_override)
+        return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_overrides", parse_cli_override)
 
     def validate(self) -> None:
         """Validate graph-level ids, references, and relationship shapes."""
         assert_unique_ids(self.nodes, self.tasks, self.state_specs)
         assert_references_exist(self.nodes, self.tasks, self.state_specs)
         assert_spatial_constraint_shapes(self.state_specs)
-        self._validate_cli_overrides()
-
-    def _validate_cli_overrides(self) -> None:
-        """Ensure each declared override binds a unique flag to an existing node."""
-        node_ids = {node.id for node in self.nodes}
-        seen_args: set[str] = set()
-        for override in self.cli_overrides:
-            assert override.arg not in seen_args, f"Duplicate cli_override arg '--{override.arg}'"
-            seen_args.add(override.arg)
-            assert (
-                override.target_node_id in node_ids
-            ), f"CLI override '--{override.arg}' targets unknown node '{override.target_node_id}'"
+        assert_cli_overrides_reference_nodes(self.nodes, self.cli_overrides)
 
     def apply_cli_overrides(self, args_cli: "argparse.Namespace") -> None:
         """Swap target-node asset names from parsed CLI args, in place.
@@ -170,29 +160,6 @@ class ArenaEnvGraphSpec:
         from isaaclab_arena.environments.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
 
         return build_arena_env_from_graph_spec(self)
-
-
-def add_cli_override_args(
-    parser: "argparse.ArgumentParser", override_specs: list[ArenaEnvGraphCliOverrideSpec]
-) -> None:
-    """Register a graph's declared override fields onto ``CLI parser``."""
-    for override in override_specs:
-        parser.add_argument(
-            f"--{override.arg}",
-            type=str,
-            default=override.default,
-            help=override.help or f"Override the asset behind graph node '{override.target_node_id}'.",
-        )
-
-
-def _parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
-    data = as_dict(data, "CLI override spec")
-    return ArenaEnvGraphCliOverrideSpec(
-        arg=required_str(data, "arg"),
-        target_node_id=required_str(data, "target_node_id"),
-        default=optional_str(data, "default"),
-        help=optional_str(data, "help"),
-    )
 
 
 def _parse_node(data: Any) -> ArenaEnvGraphNodeSpec:

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -22,14 +22,13 @@ from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphTaskSpec,
 )
 from isaaclab_arena.environments.graph_spec_utils import (
-    as_dict,
-    assert_cli_overrides_reference_nodes,
+    assert_cli_override_specs_reference_nodes,
+    assert_dict,
     assert_references_exist,
     assert_spatial_constraint_shapes,
     assert_unique_ids,
     optional_dict,
     optional_str,
-    parse_cli_override,
     parse_list,
     required_enum,
     required_number_sequence,
@@ -68,7 +67,7 @@ class ArenaEnvGraphSpec:
     nodes: list[ArenaEnvGraphNodeSpec] = field(default_factory=list)
     tasks: list[ArenaEnvGraphTaskSpec] = field(default_factory=list)
     state_specs: list[ArenaEnvGraphStateSpec] = field(default_factory=list)
-    cli_overrides: list[ArenaEnvGraphCliOverrideSpec] = field(default_factory=list)
+    cli_override_specs: list[ArenaEnvGraphCliOverrideSpec] = field(default_factory=list)
 
     @staticmethod
     def _load_yaml_dict(path: str | Path) -> dict[str, Any]:
@@ -76,7 +75,7 @@ class ArenaEnvGraphSpec:
         path = Path(path)
         assert path.is_file(), f"Env graph spec YAML not found: {path}"
         with path.open("r", encoding="utf-8") as f:
-            return as_dict(yaml.safe_load(f), "Env graph spec")
+            return assert_dict(yaml.safe_load(f), "Env graph spec")
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "ArenaEnvGraphSpec":
@@ -84,7 +83,7 @@ class ArenaEnvGraphSpec:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ArenaEnvGraphSpec":
-        data = as_dict(data, "Env graph spec")
+        data = assert_dict(data, "Env graph spec")
         nodes = parse_list(data, "nodes", _parse_node)
         tasks = parse_list(data, "tasks", _parse_task)
         state_specs = parse_list(data, "state_specs", _parse_state_spec)
@@ -94,35 +93,35 @@ class ArenaEnvGraphSpec:
             nodes=nodes,
             tasks=tasks,
             state_specs=state_specs,
-            cli_overrides=parse_list(data, "cli_overrides", parse_cli_override),
+            cli_override_specs=parse_list(data, "cli_override_specs", _parse_cli_override),
         )
         spec.validate()
         return spec
 
     @staticmethod
     def read_cli_override_specs(path: str | Path) -> list[ArenaEnvGraphCliOverrideSpec]:
-        """Read just the ``cli_overrides`` section of a graph YAML, skipping the rest.
+        """Read just the ``cli_override_specs`` section of a graph YAML, skipping the rest.
 
         The CLI flags need to be registered before the simulator starts. Loading the full
         graph would import ``pxr`` too early, so this only reads the override entries.
         """
-        return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_overrides", parse_cli_override)
+        return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_override_specs", _parse_cli_override)
 
     def validate(self) -> None:
         """Validate graph-level ids, references, and relationship shapes."""
         assert_unique_ids(self.nodes, self.tasks, self.state_specs)
         assert_references_exist(self.nodes, self.tasks, self.state_specs)
         assert_spatial_constraint_shapes(self.state_specs)
-        assert_cli_overrides_reference_nodes(self.nodes, self.cli_overrides)
+        assert_cli_override_specs_reference_nodes(self.nodes, self.cli_override_specs)
 
-    def apply_cli_overrides(self, args_cli: "argparse.Namespace") -> None:
+    def apply_cli_override_args(self, args_cli: "argparse.Namespace") -> None:
         """Apply the CLI override flags to this graph, in place.
 
         For each override, set the target node's asset ``name`` to the value passed on the
         command line. Flags left unset are skipped, so an untouched graph stays the same.
         """
         nodes_by_id = self.nodes_by_id
-        for override in self.cli_overrides:
+        for override in self.cli_override_specs:
             new_name = getattr(args_cli, override.dest, None)
             if new_name is not None:
                 nodes_by_id[override.target_node_id].name = new_name
@@ -156,7 +155,7 @@ class ArenaEnvGraphSpec:
 
 
 def _parse_node(data: Any) -> ArenaEnvGraphNodeSpec:
-    data = as_dict(data, "Node spec")
+    data = assert_dict(data, "Node spec")
     node_type = required_enum(data, "type", ArenaEnvGraphNodeType)
     common = dict(
         id=required_str(data, "id"),
@@ -174,8 +173,17 @@ def _parse_node(data: Any) -> ArenaEnvGraphNodeSpec:
     return ArenaEnvGraphNodeSpec(**common)
 
 
+def _parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
+    """Parse one entry from the YAML ``cli_override_specs`` list."""
+    data = assert_dict(data, "CLI override spec")
+    return ArenaEnvGraphCliOverrideSpec(
+        arg=required_str(data, "arg"),
+        target_node_id=required_str(data, "target_node_id"),
+    )
+
+
 def _parse_spatial_constraint(data: Any) -> ArenaEnvGraphSpatialConstraintSpec:
-    data = as_dict(data, "Spatial constraint spec")
+    data = assert_dict(data, "Spatial constraint spec")
     constraint_type = required_enum(data, "type", ArenaEnvGraphSpatialConstraintType)
     params = optional_dict(data, "params")
     # Parse optional position_xyz and rotation_xyzw fields and check their lengths.
@@ -194,7 +202,7 @@ def _parse_spatial_constraint(data: Any) -> ArenaEnvGraphSpatialConstraintSpec:
 
 
 def _parse_task_constraint(data: Any) -> ArenaEnvGraphTaskConstraintSpec:
-    data = as_dict(data, "Task constraint spec")
+    data = assert_dict(data, "Task constraint spec")
     return ArenaEnvGraphTaskConstraintSpec(
         id=required_str(data, "id"),
         type=required_enum(data, "type", ArenaEnvGraphTaskConstraintType),
@@ -205,7 +213,7 @@ def _parse_task_constraint(data: Any) -> ArenaEnvGraphTaskConstraintSpec:
 
 
 def _parse_state_spec(data: Any) -> ArenaEnvGraphStateSpec:
-    data = as_dict(data, "State spec")
+    data = assert_dict(data, "State spec")
     assert "edges" not in data, "State spec must define spatial_constraints and task_constraints directly"
     return ArenaEnvGraphStateSpec(
         id=required_str(data, "id"),
@@ -215,7 +223,7 @@ def _parse_state_spec(data: Any) -> ArenaEnvGraphStateSpec:
 
 
 def _parse_task(data: Any) -> ArenaEnvGraphTaskSpec:
-    data = as_dict(data, "Task spec")
+    data = assert_dict(data, "Task spec")
     for old_key in ("state_specs", "initial_state_spec", "success_state_spec"):
         assert old_key not in data, "Task spec must use initial_state_spec_id and success_state_spec_id"
     return ArenaEnvGraphTaskSpec(

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environments.arena_env_graph_types import (
+    ArenaEnvGraphCliOverrideSpec,
     ArenaEnvGraphNodeSpec,
     ArenaEnvGraphNodeType,
     ArenaEnvGraphObjectReferenceNodeSpec,
@@ -34,11 +35,14 @@ from isaaclab_arena.environments.graph_spec_utils import (
 )
 
 if TYPE_CHECKING:
+    import argparse
+
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 
 
 # Re-exported for callers that already import these names from this module.
 __all__ = [
+    "ArenaEnvGraphCliOverrideSpec",
     "ArenaEnvGraphNodeSpec",
     "ArenaEnvGraphNodeType",
     "ArenaEnvGraphObjectReferenceNodeSpec",
@@ -49,6 +53,7 @@ __all__ = [
     "ArenaEnvGraphTaskConstraintSpec",
     "ArenaEnvGraphTaskConstraintType",
     "ArenaEnvGraphTaskSpec",
+    "add_cli_override_args",
 ]
 
 
@@ -62,6 +67,7 @@ class ArenaEnvGraphSpec:
     nodes: list[ArenaEnvGraphNodeSpec] = field(default_factory=list)
     tasks: list[ArenaEnvGraphTaskSpec] = field(default_factory=list)
     state_specs: list[ArenaEnvGraphStateSpec] = field(default_factory=list)
+    cli_overrides: list[ArenaEnvGraphCliOverrideSpec] = field(default_factory=list)
 
     @staticmethod
     def _load_yaml_dict(path: str | Path) -> dict[str, Any]:
@@ -91,15 +97,52 @@ class ArenaEnvGraphSpec:
             nodes=nodes,
             tasks=tasks,
             state_specs=state_specs,
+            cli_overrides=parse_list(data, "cli_overrides", _parse_cli_override),
         )
         spec.validate()
         return spec
+
+    @staticmethod
+    def read_cli_override_specs(path: str | Path) -> list[ArenaEnvGraphCliOverrideSpec]:
+        """Read only the ``cli_overrides`` section of a graph YAML, without building the graph.
+
+        CLI flags must be registered on the parser before args are parsed, which happens before
+        ``SimulationApp`` starts; a full ``from_yaml`` would run ``validate()``, transitively
+        importing ``pxr`` (relation-class resolution) too early. This skips graph construction
+        and validation entirely, touching only the override declarations.
+        """
+        return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_overrides", _parse_cli_override)
 
     def validate(self) -> None:
         """Validate graph-level ids, references, and relationship shapes."""
         assert_unique_ids(self.nodes, self.tasks, self.state_specs)
         assert_references_exist(self.nodes, self.tasks, self.state_specs)
         assert_spatial_constraint_shapes(self.state_specs)
+        self._validate_cli_overrides()
+
+    def _validate_cli_overrides(self) -> None:
+        """Ensure each declared override binds a unique flag to an existing node."""
+        node_ids = {node.id for node in self.nodes}
+        seen_args: set[str] = set()
+        for override in self.cli_overrides:
+            assert override.arg not in seen_args, f"Duplicate cli_override arg '--{override.arg}'"
+            seen_args.add(override.arg)
+            assert (
+                override.target_node_id in node_ids
+            ), f"CLI override '--{override.arg}' targets unknown node '{override.target_node_id}'"
+
+    def apply_cli_overrides(self, args_cli: "argparse.Namespace") -> None:
+        """Swap target-node asset names from parsed CLI args, in place.
+
+        Reads each declared override (see :class:`ArenaEnvGraphCliOverrideSpec`) from the
+        namespace and replaces its target node's ``name``. A flag left at its default of
+        ``None`` leaves that node as authored, so this is a no-op for an untouched graph.
+        """
+        nodes_by_id = self.nodes_by_id
+        for override in self.cli_overrides:
+            new_name = getattr(args_cli, override.dest, None)
+            if new_name is not None:
+                nodes_by_id[override.target_node_id].name = new_name
 
     @property
     def nodes_by_id(self) -> dict[str, ArenaEnvGraphNodeSpec]:
@@ -127,6 +170,29 @@ class ArenaEnvGraphSpec:
         from isaaclab_arena.environments.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
 
         return build_arena_env_from_graph_spec(self)
+
+
+def add_cli_override_args(
+    parser: "argparse.ArgumentParser", override_specs: list[ArenaEnvGraphCliOverrideSpec]
+) -> None:
+    """Register a graph's declared override fields onto ``CLI parser``."""
+    for override in override_specs:
+        parser.add_argument(
+            f"--{override.arg}",
+            type=str,
+            default=override.default,
+            help=override.help or f"Override the asset behind graph node '{override.target_node_id}'.",
+        )
+
+
+def _parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
+    data = as_dict(data, "CLI override spec")
+    return ArenaEnvGraphCliOverrideSpec(
+        arg=required_str(data, "arg"),
+        target_node_id=required_str(data, "target_node_id"),
+        default=optional_str(data, "default"),
+        help=optional_str(data, "help"),
+    )
 
 
 def _parse_node(data: Any) -> ArenaEnvGraphNodeSpec:

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -72,11 +72,7 @@ class ArenaEnvGraphSpec:
 
     @staticmethod
     def _load_yaml_dict(path: str | Path) -> dict[str, Any]:
-        """Load a graph YAML into a dict, asserting the path exists with a clear message.
-
-        Centralizes the file read so a missing ``--env_graph_spec_yaml`` fails here with an
-        attributable error instead of an opaque ``FileNotFoundError`` from ``open``.
-        """
+        """Load a graph YAML into a dict. Fail with a clear message if the file is missing."""
         path = Path(path)
         assert path.is_file(), f"Env graph spec YAML not found: {path}"
         with path.open("r", encoding="utf-8") as f:
@@ -105,12 +101,10 @@ class ArenaEnvGraphSpec:
 
     @staticmethod
     def read_cli_override_specs(path: str | Path) -> list[ArenaEnvGraphCliOverrideSpec]:
-        """Read only the ``cli_overrides`` section of a graph YAML, without building the graph.
+        """Read just the ``cli_overrides`` section of a graph YAML, skipping the rest.
 
-        CLI flags must be registered on the parser before args are parsed, which happens before
-        ``SimulationApp`` starts; a full ``from_yaml`` would run ``validate()``, transitively
-        importing ``pxr`` (relation-class resolution) too early. This skips graph construction
-        and validation entirely, touching only the override declarations.
+        The CLI flags need to be registered before the simulator starts. Loading the full
+        graph would import ``pxr`` too early, so this only reads the override entries.
         """
         return parse_list(ArenaEnvGraphSpec._load_yaml_dict(path), "cli_overrides", parse_cli_override)
 
@@ -122,11 +116,10 @@ class ArenaEnvGraphSpec:
         assert_cli_overrides_reference_nodes(self.nodes, self.cli_overrides)
 
     def apply_cli_overrides(self, args_cli: "argparse.Namespace") -> None:
-        """Swap target-node asset names from parsed CLI args, in place.
+        """Apply the CLI override flags to this graph, in place.
 
-        Reads each declared override (see :class:`ArenaEnvGraphCliOverrideSpec`) from the
-        namespace and replaces its target node's ``name``. A flag left at its default of
-        ``None`` leaves that node as authored, so this is a no-op for an untouched graph.
+        For each override, set the target node's asset ``name`` to the value passed on the
+        command line. Flags left unset are skipped, so an untouched graph stays the same.
         """
         nodes_by_id = self.nodes_by_id
         for override in self.cli_overrides:

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -129,17 +129,14 @@ class ArenaEnvGraphStateSpec:
 
 @dataclass
 class ArenaEnvGraphCliOverrideSpec:
-    """A swap the YAML author exposes on the command line.
+    """Set of override fields on a CLI parser defined in a graph spec YAML.
 
-    The graph declares which knobs are tunable from the CLI — the data-driven analogue of a
-    registered environment's ``add_cli_args``. Each entry binds a flag (``--{arg}``) to a
-    graph node; passing the flag replaces that node's ``name`` (the registered asset). The
-    node's ``id`` — and every edge and task that references it — is left intact, so one graph
+    The graph declares which knobs are tunable from the CLI. One graph
     YAML serves many object/embodiment variants without edits.
     """
 
     arg: str  # flag name without leading dashes; "object" -> --object
-    target_node_id: str  # id of the node whose `name` the flag overrides
+    target_node_id: str  # whose `name` the flag overrides
     default: str | None = None  # asset name when the flag is omitted; None leaves node as authored
     help: str | None = None  # argparse help text; a sensible default is derived when unset
 

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -136,8 +136,6 @@ class ArenaEnvGraphCliOverrideSpec:
 
     arg: str  # flag name without leading dashes; "object" -> --object
     target_node_id: str  # whose `name` the flag overrides
-    default: str | None = None  # asset name when the flag is omitted; None leaves node as authored
-    help: str | None = None  # argparse help text; a sensible default is derived when unset
 
     @property
     def dest(self) -> str:

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -129,10 +129,9 @@ class ArenaEnvGraphStateSpec:
 
 @dataclass
 class ArenaEnvGraphCliOverrideSpec:
-    """Set of override fields on a CLI parser defined in a graph spec YAML.
+    """One CLI flag that swaps a graph node's asset, declared in the graph YAML.
 
-    The graph declares which knobs are tunable from the CLI. One graph
-    YAML serves many object/embodiment variants without edits.
+    Lets one graph YAML serve many variants without editing it.
     """
 
     arg: str  # flag name without leading dashes; "object" -> --object
@@ -142,7 +141,7 @@ class ArenaEnvGraphCliOverrideSpec:
 
     @property
     def dest(self) -> str:
-        """argparse namespace attribute for this flag (mirrors argparse's dash-to-underscore)."""
+        """The argparse attribute name for this flag (dashes become underscores)."""
         return self.arg.replace("-", "_")
 
 

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -128,6 +128,28 @@ class ArenaEnvGraphStateSpec:
 
 
 @dataclass
+class ArenaEnvGraphCliOverrideSpec:
+    """A swap the YAML author exposes on the command line.
+
+    The graph declares which knobs are tunable from the CLI — the data-driven analogue of a
+    registered environment's ``add_cli_args``. Each entry binds a flag (``--{arg}``) to a
+    graph node; passing the flag replaces that node's ``name`` (the registered asset). The
+    node's ``id`` — and every edge and task that references it — is left intact, so one graph
+    YAML serves many object/embodiment variants without edits.
+    """
+
+    arg: str  # flag name without leading dashes; "object" -> --object
+    target_node_id: str  # id of the node whose `name` the flag overrides
+    default: str | None = None  # asset name when the flag is omitted; None leaves node as authored
+    help: str | None = None  # argparse help text; a sensible default is derived when unset
+
+    @property
+    def dest(self) -> str:
+        """argparse namespace attribute for this flag (mirrors argparse's dash-to-underscore)."""
+        return self.arg.replace("-", "_")
+
+
+@dataclass
 class ArenaEnvGraphTaskSpec:
     """Task entry in an environment graph."""
 

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
     import argparse
 
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpatialConstraintType
+    from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphNodeSpec
     from isaaclab_arena.relations.relations import RelationBase
 
 
-def as_dict(data: Any, spec_name: str) -> dict[str, Any]:
+def assert_dict(data: Any, spec_name: str) -> dict[str, Any]:
     """Require a YAML section to be a mapping before parsing it."""
     assert isinstance(data, dict), f"{spec_name} must be a dict, got {type(data).__name__}"
     return data
@@ -189,25 +190,18 @@ def assert_spatial_constraint_shapes(state_specs: list[Any]) -> None:
                 ), f"Spatial constraint '{constraint.id}' of type '{constraint_type}' requires a child node"
 
 
-def assert_cli_overrides_reference_nodes(nodes: list[Any], cli_overrides: list[ArenaEnvGraphCliOverrideSpec]) -> None:
+def assert_cli_override_specs_reference_nodes(
+    nodes: list["ArenaEnvGraphNodeSpec"], cli_override_specs: list[ArenaEnvGraphCliOverrideSpec]
+) -> None:
     """Check each CLI override uses a unique flag and points to a real node."""
     node_ids = {node.id for node in nodes}
     seen_args: set[str] = set()
-    for override in cli_overrides:
+    for override in cli_override_specs:
         assert override.arg not in seen_args, f"Duplicate cli_override arg '--{override.arg}'"
         seen_args.add(override.arg)
         assert (
             override.target_node_id in node_ids
         ), f"CLI override '--{override.arg}' targets unknown node '{override.target_node_id}'"
-
-
-def parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
-    """Parse one entry from the YAML ``cli_overrides`` list."""
-    data = as_dict(data, "CLI override spec")
-    return ArenaEnvGraphCliOverrideSpec(
-        arg=required_str(data, "arg"),
-        target_node_id=required_str(data, "target_node_id"),
-    )
 
 
 def add_cli_override_args(

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -9,8 +9,11 @@ from numbers import Real
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
+from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphCliOverrideSpec
 
 if TYPE_CHECKING:
+    import argparse
+
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpatialConstraintType
     from isaaclab_arena.relations.relations import RelationBase
 
@@ -184,6 +187,42 @@ def assert_spatial_constraint_shapes(state_specs: list[Any]) -> None:
                 assert (
                     constraint.child is not None
                 ), f"Spatial constraint '{constraint.id}' of type '{constraint_type}' requires a child node"
+
+
+def assert_cli_overrides_reference_nodes(nodes: list[Any], cli_overrides: list[ArenaEnvGraphCliOverrideSpec]) -> None:
+    """Ensure each declared CLI override binds a unique flag to an existing node."""
+    node_ids = {node.id for node in nodes}
+    seen_args: set[str] = set()
+    for override in cli_overrides:
+        assert override.arg not in seen_args, f"Duplicate cli_override arg '--{override.arg}'"
+        seen_args.add(override.arg)
+        assert (
+            override.target_node_id in node_ids
+        ), f"CLI override '--{override.arg}' targets unknown node '{override.target_node_id}'"
+
+
+def parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
+    """Parse a single ``cli_overrides`` YAML entry into a typed spec."""
+    data = as_dict(data, "CLI override spec")
+    return ArenaEnvGraphCliOverrideSpec(
+        arg=required_str(data, "arg"),
+        target_node_id=required_str(data, "target_node_id"),
+        default=optional_str(data, "default"),
+        help=optional_str(data, "help"),
+    )
+
+
+def add_cli_override_args(
+    parser: "argparse.ArgumentParser", override_specs: list[ArenaEnvGraphCliOverrideSpec]
+) -> None:
+    """Register a graph's declared override flags onto a CLI ``parser``."""
+    for override in override_specs:
+        parser.add_argument(
+            f"--{override.arg}",
+            type=str,
+            default=override.default,
+            help=override.help or f"Override the asset behind graph node '{override.target_node_id}'.",
+        )
 
 
 def _add_id_location(id_locations: dict[str, list[str]], spec_id: str, location: str) -> None:

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -219,7 +219,7 @@ def add_cli_override_args(
         # _option_string_actions maps every registered option string ('--num_envs') to its action
         assert flag not in parser._option_string_actions, (  # noqa: SLF001 (introspect registered flags)
             f"CLI override flag '{flag}' (node '{override.target_node_id}') is already a parser flag "
-            f"(e.g. --num_envs/--seed or an AppLauncher flag); rename its 'arg' in the YAML."
+            "(e.g. --num_envs/--seed or an AppLauncher flag); rename its 'arg' in the YAML."
         )
         parser.add_argument(
             flag,

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -190,7 +190,7 @@ def assert_spatial_constraint_shapes(state_specs: list[Any]) -> None:
 
 
 def assert_cli_overrides_reference_nodes(nodes: list[Any], cli_overrides: list[ArenaEnvGraphCliOverrideSpec]) -> None:
-    """Ensure each declared CLI override binds a unique flag to an existing node."""
+    """Check each CLI override uses a unique flag and points to a real node."""
     node_ids = {node.id for node in nodes}
     seen_args: set[str] = set()
     for override in cli_overrides:
@@ -202,7 +202,7 @@ def assert_cli_overrides_reference_nodes(nodes: list[Any], cli_overrides: list[A
 
 
 def parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
-    """Parse a single ``cli_overrides`` YAML entry into a typed spec."""
+    """Parse one entry from the YAML ``cli_overrides`` list."""
     data = as_dict(data, "CLI override spec")
     return ArenaEnvGraphCliOverrideSpec(
         arg=required_str(data, "arg"),
@@ -215,7 +215,7 @@ def parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
 def add_cli_override_args(
     parser: "argparse.ArgumentParser", override_specs: list[ArenaEnvGraphCliOverrideSpec]
 ) -> None:
-    """Register a graph's declared override flags onto a CLI ``parser``."""
+    """Add each declared override to the CLI ``parser`` as a ``--flag``."""
     for override in override_specs:
         parser.add_argument(
             f"--{override.arg}",

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -207,21 +207,22 @@ def parse_cli_override(data: Any) -> ArenaEnvGraphCliOverrideSpec:
     return ArenaEnvGraphCliOverrideSpec(
         arg=required_str(data, "arg"),
         target_node_id=required_str(data, "target_node_id"),
-        default=optional_str(data, "default"),
-        help=optional_str(data, "help"),
     )
 
 
 def add_cli_override_args(
     parser: "argparse.ArgumentParser", override_specs: list[ArenaEnvGraphCliOverrideSpec]
 ) -> None:
-    """Add each declared override to the CLI ``parser`` as a ``--flag``."""
+    """Add each declared override to the CLI ``parser`` as a ``--flag``.
+
+    Each flag defaults to `None`, so an omitted flag falls back to the node's YAML-specified asset.
+    """
     for override in override_specs:
         parser.add_argument(
             f"--{override.arg}",
             type=str,
-            default=override.default,
-            help=override.help or f"Override the asset behind graph node '{override.target_node_id}'.",
+            default=None,
+            help=f"Override the asset behind graph node '{override.target_node_id}'.",
         )
 
 

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -210,10 +210,19 @@ def add_cli_override_args(
     """Add each declared override to the CLI ``parser`` as a ``--flag``.
 
     Each flag defaults to `None`, so an omitted flag falls back to the node's YAML-specified asset.
+
+    A declared flag that collides with one already on the parser (a built-in like ``--num_envs``
+    or ``--seed``, or any flag added by ``AppLauncher.add_app_launcher_args``) is rejected.
     """
     for override in override_specs:
+        flag = f"--{override.arg}"
+        # _option_string_actions maps every registered option string ('--num_envs') to its action
+        assert flag not in parser._option_string_actions, (  # noqa: SLF001 (introspect registered flags)
+            f"CLI override flag '{flag}' (node '{override.target_node_id}') is already a parser flag "
+            f"(e.g. --num_envs/--seed or an AppLauncher flag); rename its 'arg' in the YAML."
+        )
         parser.add_argument(
-            f"--{override.arg}",
+            flag,
             type=str,
             default=None,
             help=f"Override the asset behind graph node '{override.target_node_id}'.",

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -66,16 +66,16 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     builder = get_arena_builder_from_cli(args)
     assert builder.arena_env.name == "pick_and_place_maple_table_default"
 
-    # The flags the YAML declares under `cli_overrides` are registered dynamically by the
+    # The flags the YAML declares under `cli_override_specs` are registered dynamically by the
     # environments parser (not hardcoded). Confirm --object parses through that real parser
-    # path and that apply_cli_overrides swaps the declared target node's asset name.
+    # path and that apply_cli_override_args swaps the declared target node's asset name.
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 
     sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path, "--object", "dex_cube"]
     args = get_isaaclab_arena_environments_cli_parser().parse_args()
     assert args.object == "dex_cube"
     spec = ArenaEnvGraphSpec.from_yaml(yaml_path)
-    spec.apply_cli_overrides(args)
+    spec.apply_cli_override_args(args)
     assert spec.nodes_by_id["rubiks_cube_hot3d_robolab"].name == "dex_cube"
 
     # A non-existent --env_graph_spec_yaml fails with a clear "not found" assertion from the YAML

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -82,12 +82,8 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     # loader, not an opaque FileNotFoundError. The parser hits it while building, when it reads the
     # graph's declared override flags.
     sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", "/no/such/env_graph.yaml"]
-    try:
+    with pytest.raises(AssertionError, match="not found"):
         get_isaaclab_arena_environments_cli_parser()
-    except AssertionError as error:
-        assert "not found" in str(error)
-    else:
-        raise AssertionError("expected AssertionError for a non-existent --env_graph_spec_yaml")
 
     # Neither source, or both at once, is rejected by the exactly-one-source assert.
     for bad in (

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -66,6 +66,29 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     builder = get_arena_builder_from_cli(args)
     assert builder.arena_env.name == "pick_and_place_maple_table_default"
 
+    # The flags the YAML declares under `cli_overrides` are registered dynamically by the
+    # environments parser (not hardcoded). Confirm --object parses through that real parser
+    # path and that apply_cli_overrides swaps the declared target node's asset name.
+    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+
+    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path, "--object", "dex_cube"]
+    args = get_isaaclab_arena_environments_cli_parser().parse_args()
+    assert args.object == "dex_cube"
+    spec = ArenaEnvGraphSpec.from_yaml(yaml_path)
+    spec.apply_cli_overrides(args)
+    assert spec.nodes_by_id["rubiks_cube_hot3d_robolab"].name == "dex_cube"
+
+    # A non-existent --env_graph_spec_yaml fails with a clear "not found" assertion from the YAML
+    # loader, not an opaque FileNotFoundError. The parser hits it while building, when it reads the
+    # graph's declared override flags.
+    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", "/no/such/env_graph.yaml"]
+    try:
+        get_isaaclab_arena_environments_cli_parser()
+    except AssertionError as error:
+        assert "not found" in str(error)
+    else:
+        raise AssertionError("expected AssertionError for a non-existent --env_graph_spec_yaml")
+
     # Neither source, or both at once, is rejected by the exactly-one-source assert.
     for bad in (
         argparse.Namespace(env_graph_spec_yaml=None, example_environment=None),

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -156,9 +156,87 @@ def test_arena_env_graph_spec_validate_rejects_mutated_invalid_relationship_shap
         spec.validate()
 
 
+def test_cli_overrides_parsed_from_yaml():
+    spec = ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
+
+    overrides = {override.arg: override for override in spec.cli_overrides}
+    assert overrides["embodiment"].target_node_id == "droid_abs_joint_pos"
+    assert overrides["object"].target_node_id == "rubiks_cube_hot3d_robolab"
+
+
+def test_add_cli_override_args_registers_declared_flags():
+    import argparse
+
+    from isaaclab_arena.environments.arena_env_graph_spec import add_cli_override_args
+
+    parser = argparse.ArgumentParser()
+    specs = ArenaEnvGraphSpec.read_cli_override_specs(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
+    add_cli_override_args(parser, specs)
+
+    args = parser.parse_args(["--object", "dex_cube"])
+    assert args.object == "dex_cube"
+    # Unset flags fall back to their declared default of None (a later no-op in apply_cli_overrides).
+    assert args.embodiment is None
+
+
+def test_apply_cli_overrides_swaps_declared_target_node_names():
+    import argparse
+
+    data = _minimal_env_graph_data()
+    data["cli_overrides"] = [
+        {"arg": "object", "target_node_id": "cube"},
+        {"arg": "embodiment", "target_node_id": "robot"},
+    ]
+    spec = ArenaEnvGraphSpec.from_dict(data)
+
+    spec.apply_cli_overrides(argparse.Namespace(object="dex_cube", embodiment="franka_ik"))
+
+    # The asset `name` is swapped; the `id` (and every edge that references it) is untouched.
+    assert spec.nodes_by_id["cube"].name == "dex_cube"
+    assert spec.nodes_by_id["robot"].name == "franka_ik"
+    assert spec.state_specs[0].task_constraints[0].child == "cube"
+    assert spec.state_specs[0].task_constraints[0].parent == "robot"
+
+
+def test_apply_cli_overrides_leaves_unset_flags_as_authored():
+    import argparse
+
+    data = _minimal_env_graph_data()
+    data["cli_overrides"] = [{"arg": "object", "target_node_id": "cube"}]
+    spec = ArenaEnvGraphSpec.from_dict(data)
+
+    spec.apply_cli_overrides(argparse.Namespace(object=None))
+
+    assert spec.nodes_by_id["cube"].name == "cube"
+
+
+def test_validate_rejects_cli_override_targeting_unknown_node():
+    data = _minimal_env_graph_data()
+    data["cli_overrides"] = [{"arg": "object", "target_node_id": "missing_node"}]
+
+    with pytest.raises(AssertionError, match="targets unknown node 'missing_node'"):
+        ArenaEnvGraphSpec.from_dict(data)
+
+
+def test_validate_rejects_duplicate_cli_override_args():
+    data = _minimal_env_graph_data()
+    data["cli_overrides"] = [
+        {"arg": "object", "target_node_id": "cube"},
+        {"arg": "object", "target_node_id": "robot"},
+    ]
+
+    with pytest.raises(AssertionError, match="Duplicate cli_override arg '--object'"):
+        ArenaEnvGraphSpec.from_dict(data)
+
+
 def test_from_yaml_rejects_missing_path_with_clear_message():
     with pytest.raises(AssertionError, match="Env graph spec YAML not found"):
         ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "does_not_exist.yaml")
+
+
+def test_read_cli_override_specs_rejects_missing_path_with_clear_message():
+    with pytest.raises(AssertionError, match="Env graph spec YAML not found"):
+        ArenaEnvGraphSpec.read_cli_override_specs(TEST_DATA_DIR / "does_not_exist.yaml")
 
 
 def test_arena_env_graph_spec_rejects_invalid_data():

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -175,7 +175,7 @@ def test_add_cli_override_args_registers_declared_flags():
 
     args = parser.parse_args(["--object", "dex_cube"])
     assert args.object == "dex_cube"
-    # Unset flags fall back to their declared default of None (a later no-op in apply_cli_overrides).
+    # Unset flags default to None.
     assert args.embodiment is None
 
 

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -156,10 +156,10 @@ def test_arena_env_graph_spec_validate_rejects_mutated_invalid_relationship_shap
         spec.validate()
 
 
-def test_cli_overrides_parsed_from_yaml():
+def test_cli_override_specs_parsed_from_yaml():
     spec = ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
 
-    overrides = {override.arg: override for override in spec.cli_overrides}
+    overrides = {override.arg: override for override in spec.cli_override_specs}
     assert overrides["embodiment"].target_node_id == "droid_abs_joint_pos"
     assert overrides["object"].target_node_id == "rubiks_cube_hot3d_robolab"
 
@@ -179,17 +179,17 @@ def test_add_cli_override_args_registers_declared_flags():
     assert args.embodiment is None
 
 
-def test_apply_cli_overrides_swaps_declared_target_node_names():
+def test_apply_cli_override_args_swaps_declared_target_node_names():
     import argparse
 
     data = _minimal_env_graph_data()
-    data["cli_overrides"] = [
+    data["cli_override_specs"] = [
         {"arg": "object", "target_node_id": "cube"},
         {"arg": "embodiment", "target_node_id": "robot"},
     ]
     spec = ArenaEnvGraphSpec.from_dict(data)
 
-    spec.apply_cli_overrides(argparse.Namespace(object="dex_cube", embodiment="franka_ik"))
+    spec.apply_cli_override_args(argparse.Namespace(object="dex_cube", embodiment="franka_ik"))
 
     # The asset `name` is swapped; the `id` (and every edge that references it) is untouched.
     assert spec.nodes_by_id["cube"].name == "dex_cube"
@@ -198,21 +198,21 @@ def test_apply_cli_overrides_swaps_declared_target_node_names():
     assert spec.state_specs[0].task_constraints[0].parent == "robot"
 
 
-def test_apply_cli_overrides_leaves_unset_flags_as_authored():
+def test_apply_cli_override_args_leaves_unset_flags_as_authored():
     import argparse
 
     data = _minimal_env_graph_data()
-    data["cli_overrides"] = [{"arg": "object", "target_node_id": "cube"}]
+    data["cli_override_specs"] = [{"arg": "object", "target_node_id": "cube"}]
     spec = ArenaEnvGraphSpec.from_dict(data)
 
-    spec.apply_cli_overrides(argparse.Namespace(object=None))
+    spec.apply_cli_override_args(argparse.Namespace(object=None))
 
     assert spec.nodes_by_id["cube"].name == "cube"
 
 
 def test_validate_rejects_cli_override_targeting_unknown_node():
     data = _minimal_env_graph_data()
-    data["cli_overrides"] = [{"arg": "object", "target_node_id": "missing_node"}]
+    data["cli_override_specs"] = [{"arg": "object", "target_node_id": "missing_node"}]
 
     with pytest.raises(AssertionError, match="targets unknown node 'missing_node'"):
         ArenaEnvGraphSpec.from_dict(data)
@@ -220,7 +220,7 @@ def test_validate_rejects_cli_override_targeting_unknown_node():
 
 def test_validate_rejects_duplicate_cli_override_args():
     data = _minimal_env_graph_data()
-    data["cli_overrides"] = [
+    data["cli_override_specs"] = [
         {"arg": "object", "target_node_id": "cube"},
         {"arg": "object", "target_node_id": "robot"},
     ]

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -167,7 +167,7 @@ def test_cli_overrides_parsed_from_yaml():
 def test_add_cli_override_args_registers_declared_flags():
     import argparse
 
-    from isaaclab_arena.environments.arena_env_graph_spec import add_cli_override_args
+    from isaaclab_arena.environments.graph_spec_utils import add_cli_override_args
 
     parser = argparse.ArgumentParser()
     specs = ArenaEnvGraphSpec.read_cli_override_specs(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")

--- a/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+++ b/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
@@ -6,7 +6,7 @@
 env_name: pick_and_place_maple_table_default
 
 # Optional CLI overrides.
-cli_overrides:
+cli_override_specs:
   - arg: embodiment
     target_node_id: droid_abs_joint_pos
   - arg: object

--- a/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+++ b/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
@@ -5,6 +5,14 @@
 
 env_name: pick_and_place_maple_table_default
 
+# Optional CLI overrides.
+cli_overrides:
+  - arg: embodiment
+    target_node_id: droid_abs_joint_pos
+  - arg: object
+    target_node_id: rubiks_cube_hot3d_robolab
+    help: "Asset to pick first (the rubik's cube node)."
+
 nodes:
   - id: droid_abs_joint_pos
     name: droid_abs_joint_pos

--- a/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+++ b/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
@@ -11,7 +11,6 @@ cli_overrides:
     target_node_id: droid_abs_joint_pos
   - arg: object
     target_node_id: rubiks_cube_hot3d_robolab
-    help: "Asset to pick first (the rubik's cube node)."
 
 nodes:
   - id: droid_abs_joint_pos

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -74,11 +74,12 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
         name, cls = parse_and_return_external_environment_from_string(environment)
         env_registry.register(cls, name)
 
-    # A graph spec YAML may declare its own swappable flags under `cli_overrides`. Register them
+    # A graph spec YAML may declare its own swappable flags under `cli_override_specs`. Register them
     # here, before parsing, so they appear in --help and parse like any other flag.
     env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
     if env_graph_spec_yaml is not None:
-        add_cli_override_args(args_parser, ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml))
+        cli_override_specs_from_yaml = ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml)
+        add_cli_override_args(args_parser, cli_override_specs_from_yaml)
 
     # The subcommand is optional: the env may instead come from a graph spec YAML
     # (--env_graph_spec_yaml).
@@ -118,8 +119,8 @@ def get_arena_builder_from_cli(args_cli: argparse.Namespace) -> ArenaEnvBuilder:
 
     if env_graph_spec_yaml is not None:
         spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
-        # YAML can declare its own swappable flags under `cli_overrides`. Apply them here.
-        spec.apply_cli_overrides(args_cli)
+        # YAML can declare its own swappable flags under `cli_override_specs`. Apply them here.
+        spec.apply_cli_override_args(args_cli)
         return ArenaEnvBuilder(spec.to_arena_env(), args_cli)
 
     ensure_environments_registered()

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -73,11 +73,11 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
         env_registry.register(cls, name)
 
     # A graph spec YAML may declare its own swappable flags under `cli_overrides`. Register them
-    # here, before parsing, so they appear in --help and parse like any other flag. Read only the
-    # override section (not the full graph) to keep the pxr import out of the pre-SimulationApp path.
+    # here, before parsing, so they appear in --help and parse like any other flag.
     env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
     if env_graph_spec_yaml is not None:
-        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec, add_cli_override_args
+        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+        from isaaclab_arena.environments.graph_spec_utils import add_cli_override_args
 
         add_cli_override_args(args_parser, ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml))
 
@@ -121,8 +121,7 @@ def get_arena_builder_from_cli(args_cli: argparse.Namespace) -> ArenaEnvBuilder:
         from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 
         spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
-        # Swap the registry asset behind any node the YAML exposed under `cli_overrides`, using the
-        # flags registered in add_example_environments_cli_args. A no-op when none were passed.
+        # YAML can declare its own swappable flags under `cli_overrides`. Apply them here.
         spec.apply_cli_overrides(args_cli)
         return ArenaEnvBuilder(spec.to_arena_env(), args_cli)
 

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environments.graph_spec_utils import add_cli_override_args
 from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
 
 if TYPE_CHECKING:
@@ -76,9 +78,6 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
     # here, before parsing, so they appear in --help and parse like any other flag.
     env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
     if env_graph_spec_yaml is not None:
-        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-        from isaaclab_arena.environments.graph_spec_utils import add_cli_override_args
-
         add_cli_override_args(args_parser, ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml))
 
     # The subcommand is optional: the env may instead come from a graph spec YAML
@@ -118,8 +117,6 @@ def get_arena_builder_from_cli(args_cli: argparse.Namespace) -> ArenaEnvBuilder:
     )
 
     if env_graph_spec_yaml is not None:
-        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-
         spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
         # YAML can declare its own swappable flags under `cli_overrides`. Apply them here.
         spec.apply_cli_overrides(args_cli)

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -72,6 +72,15 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
         name, cls = parse_and_return_external_environment_from_string(environment)
         env_registry.register(cls, name)
 
+    # A graph spec YAML may declare its own swappable flags under `cli_overrides`. Register them
+    # here, before parsing, so they appear in --help and parse like any other flag. Read only the
+    # override section (not the full graph) to keep the pxr import out of the pre-SimulationApp path.
+    env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
+    if env_graph_spec_yaml is not None:
+        from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec, add_cli_override_args
+
+        add_cli_override_args(args_parser, ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml))
+
     # The subcommand is optional: the env may instead come from a graph spec YAML
     # (--env_graph_spec_yaml).
     subparsers = args_parser.add_subparsers(
@@ -111,8 +120,11 @@ def get_arena_builder_from_cli(args_cli: argparse.Namespace) -> ArenaEnvBuilder:
     if env_graph_spec_yaml is not None:
         from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 
-        arena_env = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml).to_arena_env()
-        return ArenaEnvBuilder(arena_env, args_cli)
+        spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
+        # Swap the registry asset behind any node the YAML exposed under `cli_overrides`, using the
+        # flags registered in add_example_environments_cli_args. A no-op when none were passed.
+        spec.apply_cli_overrides(args_cli)
+        return ArenaEnvBuilder(spec.to_arena_env(), args_cli)
 
     ensure_environments_registered()
     env_registry = EnvironmentRegistry()


### PR DESCRIPTION
## Summary
Allow CLI overrides with Env Graph Spec yaml

## Detailed description
- Why: Users may swap object/embodiment/background thru CLI when running policy_runner
- What: Added `EnvGraphCliOverrideSpec` class and a section in yaml to let user specify what could be swapped
- Impact: Eval env with swapping objects/embodiment with graph yaml

`python policy_runner.py --env_graph_yaml xxx.yaml --object apple`
