### PR TITLE
Add chunked-dispatch mode to eval_runner

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -7,6 +7,7 @@ import argparse
 import dataclasses
 import gc
 import json
+import math
 import os
 import subprocess
 import sys
@@ -129,34 +130,43 @@ def _close_job_resources(policy: "PolicyBase | None", env) -> None:
         _close_env(env)
 
 
+def _run_chunk(chunk_label: str, chunk_jobs: list[dict]) -> int:
+    """Run ``chunk_jobs`` in a fresh ``eval_runner`` subprocess and return its exit code."""
+    print(f"[eval_runner] {chunk_label}", flush=True)
+    # Serialize this chunk's jobs to a temp config the child loads via --eval_jobs_config.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        json.dump({"jobs": chunk_jobs}, tmp)
+        chunk_path = Path(tmp.name)
+    # Re-run this invocation in the child, with --eval_jobs_config appended so it wins over
+    # the master config (argparse keeps the last value).
+    this_invocation = sys.argv
+    config_override = ["--eval_jobs_config", str(chunk_path)]
+    child_cmd = [sys.executable, *this_invocation, *config_override]
+    try:
+        result = subprocess.run(child_cmd, check=False)
+    finally:
+        # Remove the temp chunk config now that the child has loaded it.
+        chunk_path.unlink(missing_ok=True)
+    return result.returncode
+
+
 def _run_in_chunks(args_cli: argparse.Namespace, master_cfg: dict) -> None:
     """Run each chunk of ``master_cfg['jobs']`` in a fresh ``eval_runner`` subprocess."""
     jobs = master_cfg["jobs"]
     chunk_size = args_cli.chunk_size
     if chunk_size <= 0:
         raise ValueError(f"--chunk_size must be positive, got {chunk_size}")
-    n_chunks = (len(jobs) + chunk_size - 1) // chunk_size
+    n_chunks = math.ceil(len(jobs) / chunk_size)
     print(f"[eval_runner] {len(jobs)} jobs → {n_chunks} chunks of <= {chunk_size}", flush=True)
 
     for chunk_idx in range(n_chunks):
         start = chunk_idx * chunk_size
         end = min(start + chunk_size, len(jobs))
-        print(f"[eval_runner] chunk {chunk_idx + 1}/{n_chunks}: jobs {start}..{end - 1}", flush=True)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-            json.dump({"jobs": jobs[start:end]}, tmp)
-            chunk_path = Path(tmp.name)
-        # Appended ``--eval_jobs_config`` overrides the one in sys.argv (argparse keeps
-        # the last). Forwarded ``--chunk_size`` is inert in the child (jobs <= chunk_size).
-        try:
-            result = subprocess.run(
-                [sys.executable, sys.argv[0], *sys.argv[1:], "--eval_jobs_config", str(chunk_path)],
-                check=False,
-            )
-        finally:
-            chunk_path.unlink(missing_ok=True)
-        if result.returncode != 0:
-            print(f"[eval_runner] chunk {chunk_idx} failed (exit {result.returncode}).", flush=True)
-            sys.exit(result.returncode)
+        chunk_label = f"chunk {chunk_idx + 1}/{n_chunks}: jobs {start}..{end - 1}"
+        returncode = _run_chunk(chunk_label, jobs[start:end])
+        if returncode != 0:
+            print(f"[eval_runner] chunk {chunk_idx} failed (exit {returncode}).", flush=True)
+            sys.exit(returncode)
 
 
 def main():
@@ -176,8 +186,9 @@ def main():
         eval_jobs_config = json.load(f)
 
     # Chunked dispatch (--chunk_size N). Splits this config across subprocesses so each
-    # gets a fresh SimulationApp. Required for long sweeps to reclaim residual host-RSS
-    # leaks the in-process teardown can't release.
+    # gets a fresh SimulationApp. Required for long sweeps because some host memory leaks
+    # each cycle and is only reclaimed when the process exits — in-process teardown can't
+    # release it.
     if args_cli.chunk_size is not None and len(eval_jobs_config["jobs"]) > args_cli.chunk_size:
         # TODO(cvolk): aggregate per-chunk metrics into one centralized view. Each chunk
         # subprocess currently prints its own MetricsLogger summary and nothing is merged

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -179,6 +179,10 @@ def main():
     # gets a fresh SimulationApp. Required for long sweeps to reclaim residual host-RSS
     # leaks the in-process teardown can't release.
     if args_cli.chunk_size is not None and len(eval_jobs_config["jobs"]) > args_cli.chunk_size:
+        # TODO(cvolk): aggregate per-chunk metrics into one centralized view. Each chunk
+        # subprocess currently prints its own MetricsLogger summary and nothing is merged
+        # or persisted (save_metrics_to_file() is unused). Follow-up: have each chunk write
+        # metrics JSON to a temp file (forward --metrics_file), then merge + print/save here.
         _run_in_chunks(args_cli, eval_jobs_config)
         return
 

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -8,9 +8,13 @@ import dataclasses
 import gc
 import json
 import os
+import subprocess
+import sys
+import tempfile
 import torch
 import traceback
 from gymnasium.wrappers import RecordVideo
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
@@ -125,6 +129,36 @@ def _close_job_resources(policy: "PolicyBase | None", env) -> None:
         _close_env(env)
 
 
+def _run_in_chunks(args_cli: argparse.Namespace, master_cfg: dict) -> None:
+    """Run each chunk of ``master_cfg['jobs']`` in a fresh ``eval_runner`` subprocess."""
+    jobs = master_cfg["jobs"]
+    chunk_size = args_cli.chunk_size
+    if chunk_size <= 0:
+        raise ValueError(f"--chunk_size must be positive, got {chunk_size}")
+    n_chunks = (len(jobs) + chunk_size - 1) // chunk_size
+    print(f"[eval_runner] {len(jobs)} jobs → {n_chunks} chunks of <= {chunk_size}", flush=True)
+
+    for chunk_idx in range(n_chunks):
+        start = chunk_idx * chunk_size
+        end = min(start + chunk_size, len(jobs))
+        print(f"[eval_runner] chunk {chunk_idx + 1}/{n_chunks}: jobs {start}..{end - 1}", flush=True)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+            json.dump({"jobs": jobs[start:end]}, tmp)
+            chunk_path = Path(tmp.name)
+        # Appended ``--eval_jobs_config`` overrides the one in sys.argv (argparse keeps
+        # the last). Forwarded ``--chunk_size`` is inert in the child (jobs <= chunk_size).
+        try:
+            result = subprocess.run(
+                [sys.executable, sys.argv[0], *sys.argv[1:], "--eval_jobs_config", str(chunk_path)],
+                check=False,
+            )
+        finally:
+            chunk_path.unlink(missing_ok=True)
+        if result.returncode != 0:
+            print(f"[eval_runner] chunk {chunk_idx} failed (exit {result.returncode}).", flush=True)
+            sys.exit(result.returncode)
+
+
 def main():
     args_parser = get_isaaclab_arena_cli_parser()
     args_cli, unknown = args_parser.parse_known_args()
@@ -140,6 +174,13 @@ def main():
 
     with open(args_cli.eval_jobs_config, encoding="utf-8") as f:
         eval_jobs_config = json.load(f)
+
+    # Chunked dispatch (--chunk_size N). Splits this config across subprocesses so each
+    # gets a fresh SimulationApp. Required for long sweeps to reclaim residual host-RSS
+    # leaks the in-process teardown can't release.
+    if args_cli.chunk_size is not None and len(eval_jobs_config["jobs"]) > args_cli.chunk_size:
+        _run_in_chunks(args_cli, eval_jobs_config)
+        return
 
     # Check if any job requires cameras and enable them if needed before starting simulation
     enable_cameras_if_required(eval_jobs_config, args_cli)

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -27,3 +27,13 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default=False,
         help="Continue evaluation with remaining jobs when a job fails instead of stopping immediately.",
     )
+    parser.add_argument(
+        "--chunk_size",
+        type=int,
+        default=None,
+        help=(
+            "Run jobs in chunks of at most this many, one fresh subprocess per chunk."
+            " Each restart lets the OS reclaim accumulated memory, avoiding OOM on"
+            " long sweeps. Default unset — single process."
+        ),
+    )

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -34,6 +34,7 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         help=(
             "Run jobs in chunks of at most this many, one fresh subprocess per chunk."
             " Each restart lets the OS reclaim accumulated memory, avoiding OOM on"
-            " long sweeps. Default unset — single process."
+            " long sweeps. Default unset — single process. Leave unset for normal runs;"
+            " set only if a long sweep grows in host memory or gets OOM-killed."
         ),
     )


### PR DESCRIPTION
## Summary

Adds `--chunk_size N` to `eval_runner`. When set and the jobs config has more than N jobs, the runner splits the config into chunks and launches one fresh subprocess per chunk. Unset → unchanged single-process behavior.

## Why

Long evaluation sweeps OOM. Each env build/teardown cycle leaves ~72 MB of host memory unreclaimable from Python. Restarting the process is the only way to reclaim that memory

The in-process leak will be partly fixed upstream ([isaac-sim/IsaacLab#5896](https://github.com/isaac-sim/IsaacLab/pull/5896) cutting it from ~540 MB/cycle to ~72 MB/cycle). 
Chunking is the workaround until what's left is identified and fixed.
