### PR TITLE
Move isaaclab_arena_environment out of IsaacLabArenaManagerBasedRLEnvCfg

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -178,11 +178,11 @@ class ArenaEnvBuilder:
             task.get_commands_cfg(),
         )
 
-        isaaclab_arena_env = self.arena_env
-
         viewer_cfg = task.get_viewer_cfg()
 
         episode_length_s = task.get_episode_length_s()
+
+        task_description = task.get_task_description()
 
         # Build the environment configuration
         if not self.args.mimic:
@@ -200,7 +200,7 @@ class ArenaEnvBuilder:
                 teleop_devices=teleop_devices_cfg,
                 recorders=recorder_manager_cfg,
                 metrics=metrics_cfg,
-                isaaclab_arena_env=isaaclab_arena_env,
+                task_description=task_description,
                 viewer=viewer_cfg,
             )
             if episode_length_s is not None:
@@ -230,7 +230,7 @@ class ArenaEnvBuilder:
                 # I assume that they're not needed for the mimic env.
                 # recorders=recorder_manager_cfg,
                 # metrics=metrics_cfg,
-                isaaclab_arena_env=isaaclab_arena_env,
+                task_description=task_description,
                 viewer=viewer_cfg,
             )
 

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -13,8 +13,6 @@ from isaaclab_newton.physics.newton_manager_cfg import MJWarpSolverCfg, NewtonCf
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_tasks.utils import PresetCfg
 
-from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-
 
 @configclass
 class ArenaPhysicsCfg(PresetCfg):
@@ -66,8 +64,8 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
 
     metrics: object | None = None
 
-    # Isaaclab Arena Env. Held as a member to allow use of internal functions
-    isaaclab_arena_env: IsaacLabArenaEnvironment | None = None
+    # Task language description
+    task_description: str | None = None
 
     # Override the RTX renderer's built-in scene ambient (carb /rtx/sceneDb/ambientLightIntensity, default 1.0 with
     # color [0.1, 0.1, 0.1]) so that USD light prims fully control scene illumination.

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -73,7 +73,7 @@ def rollout_policy(
         policy.reset()
         # Determine language instruction: CLI/job-level override takes precedence over the task's own
         # description. Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing).
-        task_description = language_instruction or env.unwrapped.cfg.isaaclab_arena_env.task.get_task_description()
+        task_description = language_instruction or env.unwrapped.cfg.task_description
         policy.set_task_description(task_description)
 
         # Setup progress bar based on num_steps or num_episodes


### PR DESCRIPTION
## Summary
Part of a refactor started in #733 to get run-time objects out of `IsaacLabArenaManagerBasedRLEnvCfg`

## Detailed description
- IsaacLab expects only configuration objects in this struct.
- Our non-adherence to this has started to cause problems in later commits.
- This removes the last run-time objects on `main`