### PR TITLE
Make AreneEnvGraphSpec pydantic

### DIFF
--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -91,7 +91,7 @@ def _instantiate_assets_from_nodes(node_specs: list[ArenaEnvGraphNodeSpec], asse
     """Return ``{node.id: live_asset}`` after a single pass over ``node_specs``.
 
     Each ``node_spec.params`` is forwarded verbatim to the asset constructor. Assumes parent
-    nodes precede their OBJECT_REFERENCE children — guaranteed by ``assert_references_exist``.
+    nodes precede their OBJECT_REFERENCE children — guaranteed by graph-spec reference validation.
     """
     assets_by_node_id: dict[str, Any] = {}
     for node_spec in node_specs:

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -9,9 +9,8 @@ import yaml
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, field_validator, model_validator
 
-from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphNodeSpec,
     ArenaEnvGraphNodeType,
@@ -22,18 +21,12 @@ from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphTaskConstraintSpec,
     ArenaEnvGraphTaskConstraintType,
     ArenaEnvGraphTaskSpec,
+    _coerce_graph_node,
 )
 from isaaclab_arena.environments.graph_spec_utils import (
-    as_dict,
-    assert_references_exist,
-    assert_spatial_constraint_shapes,
-    assert_unique_ids,
-    optional_dict,
-    optional_str,
-    parse_list,
-    required_enum,
-    required_number_sequence,
-    required_str,
+    validate_references_exist,
+    validate_spatial_constraint_shapes,
+    validate_unique_ids,
 )
 
 if TYPE_CHECKING:
@@ -56,53 +49,60 @@ __all__ = [
 
 
 class ArenaEnvGraphSpec(BaseModel):
-    """Typed representation of an environment graph YAML file.
-
-    It defines the nodes, tasks, and state specs of the environment graph.
-    """
+    """Typed representation of an environment graph YAML file."""
 
     model_config = ConfigDict(extra="ignore")
 
-    env_name: str
-    nodes: list[ArenaEnvGraphNodeSpec] = Field(default_factory=list)
+    env_name: str = Field(min_length=1)
+    nodes: list[SerializeAsAny[ArenaEnvGraphNodeSpec]] = Field(default_factory=list)
     tasks: list[ArenaEnvGraphTaskSpec] = Field(default_factory=list)
     state_specs: list[ArenaEnvGraphStateSpec] = Field(default_factory=list)
 
+    @field_validator("nodes", mode="before")
+    @classmethod
+    def _parse_nodes(cls, nodes: Any) -> list[Any]:
+        if nodes is None:
+            return []
+        if not isinstance(nodes, list):
+            raise ValueError("Field 'nodes' must be a list")
+        return [_coerce_graph_node(node) for node in nodes]
+
+    @model_validator(mode="after")
+    def _validate_graph_invariants(self) -> ArenaEnvGraphSpec:
+        self._check_graph_invariants()
+        return self
+
+    def _check_graph_invariants(self) -> None:
+        validate_unique_ids(self.nodes, self.tasks, self.state_specs)
+        validate_references_exist(self.nodes, self.tasks, self.state_specs)
+        validate_spatial_constraint_shapes(self.state_specs)
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> ArenaEnvGraphSpec:
-        with Path(path).open("r", encoding="utf-8") as f:
+        path = Path(path)
+        if not path.is_file():
+            raise ValueError(f"Env graph spec YAML not found: {path}")
+        with path.open("r", encoding="utf-8") as f:
             return cls.from_dict(yaml.safe_load(f))
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ArenaEnvGraphSpec:
-        data = as_dict(data, "Env graph spec")
-        nodes = parse_list(data, "nodes", _parse_node)
-        tasks = parse_list(data, "tasks", _parse_task)
-        state_specs = parse_list(data, "state_specs", _parse_state_spec)
-
-        spec = cls(
-            env_name=required_str(data, "env_name"),
-            nodes=nodes,
-            tasks=tasks,
-            state_specs=state_specs,
-        )
-        spec.validate()
-        return spec
+        if not isinstance(data, dict):
+            raise ValueError(f"Env graph spec must be a dict, got {type(data).__name__}")
+        return cls.model_validate(data)
 
     def validate(self) -> None:
-        """Validate graph-level ids, references, and relationship shapes."""
-        assert_unique_ids(self.nodes, self.tasks, self.state_specs)
-        assert_references_exist(self.nodes, self.tasks, self.state_specs)
-        assert_spatial_constraint_shapes(self.state_specs)
+        """Re-run graph-level validators (e.g. after mutating a loaded spec)."""
+        self._check_graph_invariants()
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to the plain YAML mapping — the inverse of ``from_dict``."""
-        return {
-            "env_name": self.env_name,
-            "nodes": [_node_to_dict(node) for node in self.nodes],
-            "tasks": [_task_to_dict(task) for task in self.tasks],
-            "state_specs": [_state_spec_to_dict(state) for state in self.state_specs],
-        }
+        """Serialize to the plain YAML mapping — the inverse of ``from_dict``.
+
+        Uses Pydantic's JSON dump mode so enums become strings, ``None`` is omitted,
+        tuples become lists, and ``object_reference`` nodes retain their extra fields
+        (via :class:`~pydantic.SerializeAsAny`).
+        """
+        return self.model_dump(mode="json", exclude_none=True)
 
     def write_yaml(self, path: str | Path) -> None:
         """Validate this spec and write it to ``path`` as YAML."""
@@ -127,133 +127,6 @@ class ArenaEnvGraphSpec(BaseModel):
 
         The first ``state_spec`` is used as the scene's initial state.
         """
-        # Lazy import: build_arena_env_from_graph_spec pulls in Scene -> phyx_utils ->
-        # pxr.PhysxSchema, which requires SimulationApp. Keeping the import here lets
-        # data-only consumers of the spec (parsers, tests) import this module before
-        # SimulationApp is started.
-        # TODO(xinjieyao, 2026-05-26): once `build_arena_env_from_graph_spec` aggregates across all state_specs,
-        # this wrapper stays single-arg — no caller-side selection is needed.
         from isaaclab_arena.environments.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
 
         return build_arena_env_from_graph_spec(self)
-
-
-def _parse_node(data: Any) -> ArenaEnvGraphNodeSpec:
-    data = as_dict(data, "Node spec")
-    node_type = required_enum(data, "type", ArenaEnvGraphNodeType)
-    common = dict(
-        id=required_str(data, "id"),
-        name=required_str(data, "name"),
-        type=node_type,
-        params=optional_dict(data, "params"),
-    )
-    if node_type == ArenaEnvGraphNodeType.OBJECT_REFERENCE:
-        return ArenaEnvGraphObjectReferenceNodeSpec(
-            **common,
-            parent=required_str(data, "parent"),
-            prim_path=required_str(data, "prim_path"),
-            object_type=required_enum(data, "object_type", ObjectType),
-        )
-    return ArenaEnvGraphNodeSpec(**common)
-
-
-def _parse_spatial_constraint(data: Any) -> ArenaEnvGraphSpatialConstraintSpec:
-    data = as_dict(data, "Spatial constraint spec")
-    constraint_type = required_enum(data, "type", ArenaEnvGraphSpatialConstraintType)
-    params = optional_dict(data, "params")
-    # Parse optional position_xyz and rotation_xyzw fields and check their lengths.
-    if params and "position_xyz" in params:
-        params["position_xyz"] = required_number_sequence(params, "position_xyz", 3)
-    if params and "rotation_xyzw" in params:
-        params["rotation_xyzw"] = required_number_sequence(params, "rotation_xyzw", 4)
-
-    return ArenaEnvGraphSpatialConstraintSpec(
-        id=required_str(data, "id"),
-        type=constraint_type,
-        parent=required_str(data, "parent"),
-        child=optional_str(data, "child"),
-        params=params,
-    )
-
-
-def _parse_task_constraint(data: Any) -> ArenaEnvGraphTaskConstraintSpec:
-    data = as_dict(data, "Task constraint spec")
-    return ArenaEnvGraphTaskConstraintSpec(
-        id=required_str(data, "id"),
-        type=required_enum(data, "type", ArenaEnvGraphTaskConstraintType),
-        parent=required_str(data, "parent"),
-        child=optional_str(data, "child"),
-        params=optional_dict(data, "params"),
-    )
-
-
-def _parse_state_spec(data: Any) -> ArenaEnvGraphStateSpec:
-    data = as_dict(data, "State spec")
-    assert "edges" not in data, "State spec must define spatial_constraints and task_constraints directly"
-    return ArenaEnvGraphStateSpec(
-        id=required_str(data, "id"),
-        spatial_constraints=parse_list(data, "spatial_constraints", _parse_spatial_constraint),
-        task_constraints=parse_list(data, "task_constraints", _parse_task_constraint),
-    )
-
-
-def _parse_task(data: Any) -> ArenaEnvGraphTaskSpec:
-    data = as_dict(data, "Task spec")
-    for old_key in ("state_specs", "initial_state_spec", "success_state_spec"):
-        assert old_key not in data, "Task spec must use initial_state_spec_id and success_state_spec_id"
-    return ArenaEnvGraphTaskSpec(
-        id=required_str(data, "id"),
-        type=required_str(data, "type"),
-        initial_state_spec_id=required_str(data, "initial_state_spec_id"),
-        success_state_spec_id=required_str(data, "success_state_spec_id"),
-        task_args=optional_dict(data, "task_args"),
-    )
-
-
-def _yaml_safe(value: Any) -> Any:
-    """Coerce parsed values into YAML-dumpable primitives (tuples -> lists, recursively)."""
-    if isinstance(value, (list, tuple)):
-        return [_yaml_safe(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _yaml_safe(item) for key, item in value.items()}
-    return value
-
-
-def _node_to_dict(node: ArenaEnvGraphNodeSpec) -> dict[str, Any]:
-    data: dict[str, Any] = {"id": node.id, "name": node.name, "type": node.type.value}
-    if isinstance(node, ArenaEnvGraphObjectReferenceNodeSpec):
-        data["parent"] = node.parent
-        data["prim_path"] = node.prim_path
-        data["object_type"] = node.object_type.value
-    if node.params:
-        data["params"] = _yaml_safe(node.params)
-    return data
-
-
-def _task_to_dict(task: ArenaEnvGraphTaskSpec) -> dict[str, Any]:
-    return {
-        "id": task.id,
-        "type": task.type,
-        "initial_state_spec_id": task.initial_state_spec_id,
-        "success_state_spec_id": task.success_state_spec_id,
-        "task_args": _yaml_safe(task.task_args),
-    }
-
-
-def _state_spec_to_dict(state: ArenaEnvGraphStateSpec) -> dict[str, Any]:
-    return {
-        "id": state.id,
-        "spatial_constraints": [_constraint_to_dict(c) for c in state.spatial_constraints],
-        "task_constraints": [_constraint_to_dict(c) for c in state.task_constraints],
-    }
-
-
-def _constraint_to_dict(
-    constraint: ArenaEnvGraphSpatialConstraintSpec | ArenaEnvGraphTaskConstraintSpec,
-) -> dict[str, Any]:
-    data: dict[str, Any] = {"id": constraint.id, "type": constraint.type.value, "parent": constraint.parent}
-    if constraint.child is not None:
-        data["child"] = constraint.child
-    if constraint.params:
-        data["params"] = _yaml_safe(constraint.params)
-    return data

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -3,10 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import yaml
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environments.arena_env_graph_types import (
@@ -52,24 +55,26 @@ __all__ = [
 ]
 
 
-@dataclass
-class ArenaEnvGraphSpec:
+class ArenaEnvGraphSpec(BaseModel):
     """Typed representation of an environment graph YAML file.
+
     It defines the nodes, tasks, and state specs of the environment graph.
     """
 
+    model_config = ConfigDict(extra="ignore")
+
     env_name: str
-    nodes: list[ArenaEnvGraphNodeSpec] = field(default_factory=list)
-    tasks: list[ArenaEnvGraphTaskSpec] = field(default_factory=list)
-    state_specs: list[ArenaEnvGraphStateSpec] = field(default_factory=list)
+    nodes: list[ArenaEnvGraphNodeSpec] = Field(default_factory=list)
+    tasks: list[ArenaEnvGraphTaskSpec] = Field(default_factory=list)
+    state_specs: list[ArenaEnvGraphStateSpec] = Field(default_factory=list)
 
     @classmethod
-    def from_yaml(cls, path: str | Path) -> "ArenaEnvGraphSpec":
+    def from_yaml(cls, path: str | Path) -> ArenaEnvGraphSpec:
         with Path(path).open("r", encoding="utf-8") as f:
             return cls.from_dict(yaml.safe_load(f))
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "ArenaEnvGraphSpec":
+    def from_dict(cls, data: dict[str, Any]) -> ArenaEnvGraphSpec:
         data = as_dict(data, "Env graph spec")
         nodes = parse_list(data, "nodes", _parse_node)
         tasks = parse_list(data, "tasks", _parse_task)
@@ -90,6 +95,21 @@ class ArenaEnvGraphSpec:
         assert_references_exist(self.nodes, self.tasks, self.state_specs)
         assert_spatial_constraint_shapes(self.state_specs)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the plain YAML mapping — the inverse of ``from_dict``."""
+        return {
+            "env_name": self.env_name,
+            "nodes": [_node_to_dict(node) for node in self.nodes],
+            "tasks": [_task_to_dict(task) for task in self.tasks],
+            "state_specs": [_state_spec_to_dict(state) for state in self.state_specs],
+        }
+
+    def write_yaml(self, path: str | Path) -> None:
+        """Validate this spec and write it to ``path`` as YAML."""
+        self.validate()
+        with Path(path).open("w", encoding="utf-8") as f:
+            yaml.safe_dump(self.to_dict(), f, sort_keys=False)
+
     @property
     def nodes_by_id(self) -> dict[str, ArenaEnvGraphNodeSpec]:
         return {node.id: node for node in self.nodes}
@@ -102,7 +122,7 @@ class ArenaEnvGraphSpec:
     def state_specs_by_id(self) -> dict[str, ArenaEnvGraphStateSpec]:
         return {state_spec.id: state_spec for state_spec in self.state_specs}
 
-    def to_arena_env(self) -> "IsaacLabArenaEnvironment":
+    def to_arena_env(self) -> IsaacLabArenaEnvironment:
         """Convert this graph spec into an `IsaacLabArenaEnvironment`.
 
         The first ``state_spec`` is used as the scene's initial state.
@@ -188,3 +208,52 @@ def _parse_task(data: Any) -> ArenaEnvGraphTaskSpec:
         success_state_spec_id=required_str(data, "success_state_spec_id"),
         task_args=optional_dict(data, "task_args"),
     )
+
+
+def _yaml_safe(value: Any) -> Any:
+    """Coerce parsed values into YAML-dumpable primitives (tuples -> lists, recursively)."""
+    if isinstance(value, (list, tuple)):
+        return [_yaml_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _yaml_safe(item) for key, item in value.items()}
+    return value
+
+
+def _node_to_dict(node: ArenaEnvGraphNodeSpec) -> dict[str, Any]:
+    data: dict[str, Any] = {"id": node.id, "name": node.name, "type": node.type.value}
+    if isinstance(node, ArenaEnvGraphObjectReferenceNodeSpec):
+        data["parent"] = node.parent
+        data["prim_path"] = node.prim_path
+        data["object_type"] = node.object_type.value
+    if node.params:
+        data["params"] = _yaml_safe(node.params)
+    return data
+
+
+def _task_to_dict(task: ArenaEnvGraphTaskSpec) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "type": task.type,
+        "initial_state_spec_id": task.initial_state_spec_id,
+        "success_state_spec_id": task.success_state_spec_id,
+        "task_args": _yaml_safe(task.task_args),
+    }
+
+
+def _state_spec_to_dict(state: ArenaEnvGraphStateSpec) -> dict[str, Any]:
+    return {
+        "id": state.id,
+        "spatial_constraints": [_constraint_to_dict(c) for c in state.spatial_constraints],
+        "task_constraints": [_constraint_to_dict(c) for c in state.task_constraints],
+    }
+
+
+def _constraint_to_dict(
+    constraint: ArenaEnvGraphSpatialConstraintSpec | ArenaEnvGraphTaskConstraintSpec,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {"id": constraint.id, "type": constraint.type.value, "parent": constraint.parent}
+    if constraint.child is not None:
+        data["child"] = constraint.child
+    if constraint.params:
+        data["params"] = _yaml_safe(constraint.params)
+    return data

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -3,24 +3,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Lightweight schema for the env-graph spec.
+"""Pydantic schema for the env-graph spec.
 
-Pydantic models with no parsing or conversion behavior. YAML loading, validation, and
-conversion entry points live in ``arena_env_graph_spec``.
-
-Lives in its own module so that conversion-utilities can import these names at module
-level without creating a circular import back into ``arena_env_graph_spec`` (which itself
-depends on the conversion module).
+Graph-level validation (unique ids, cross-references, relation arity) runs on
+:class:`~isaaclab_arena.environments.arena_env_graph_spec.ArenaEnvGraphSpec` via
+``model_validator``. Lives in its own module so conversion utilities can import
+these names without a circular import through ``arena_env_graph_spec``.
 """
 
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Literal
+from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from isaaclab_arena.assets.object_type import ObjectType
+from isaaclab_arena.environments.graph_spec_utils import coerce_number_sequence
 
 
 class ArenaEnvGraphNodeType(Enum):
@@ -29,6 +28,25 @@ class ArenaEnvGraphNodeType(Enum):
     OBJECT = "object"
     OBJECT_REFERENCE = "object_reference"
     LIGHTING = "lighting"
+
+
+_OBJECT_REFERENCE_VALUES = frozenset({
+    ArenaEnvGraphNodeType.OBJECT_REFERENCE,
+    ArenaEnvGraphNodeType.OBJECT_REFERENCE.value,
+})
+
+
+def _is_object_reference_type(node_type: Any) -> bool:
+    return node_type in _OBJECT_REFERENCE_VALUES
+
+
+def _coerce_graph_node(data: Any) -> Any:
+    """Route ``object_reference`` dicts to :class:`ArenaEnvGraphObjectReferenceNodeSpec`."""
+    if isinstance(data, ArenaEnvGraphNodeSpec):
+        return data
+    if isinstance(data, dict) and _is_object_reference_type(data.get("type")):
+        return ArenaEnvGraphObjectReferenceNodeSpec.model_validate(data)
+    return data
 
 
 class ArenaEnvGraphSpatialConstraintType(Enum):
@@ -49,54 +67,56 @@ class ArenaEnvGraphTaskConstraintType(Enum):
 
 
 class ArenaEnvGraphNodeSpec(BaseModel):
-    """Node in an environment graph.
-
-    Could be an object, an embodiment, a background, etc. Object references — USD prims
-    inside a parent background asset — are represented by the
-    :class:`ArenaEnvGraphObjectReferenceNodeSpec` subclass, which adds the extra fields
-    needed to locate and type the referenced prim.
-    """
+    """Node in an environment graph (all types except ``object_reference``)."""
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str
-    name: str  # Name registered in the asset registry
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
     type: ArenaEnvGraphNodeType
-    # Asset-type specific optional kwargs (e.g. scale, spawn_cfg_addon) — distinct from
-    # the typed graph metadata above. The Arena environment builder forwards these when
-    # instantiating the asset class.
     params: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _reject_object_reference_without_extra_fields(self) -> ArenaEnvGraphNodeSpec:
+        if type(self) is ArenaEnvGraphNodeSpec and self.type == ArenaEnvGraphNodeType.OBJECT_REFERENCE:
+            raise ValueError("object_reference nodes require parent, prim_path, and object_type fields")
+        return self
 
 
 class ArenaEnvGraphObjectReferenceNodeSpec(ArenaEnvGraphNodeSpec):
-    """Object-reference node: a USD prim inside a parent background asset.
+    """Object-reference node: a USD prim inside a parent background asset."""
 
-    All three extra fields are required for this node type — without them the
-    builder cannot bind to the referenced prim or know how to wrap it.
-    """
+    type: ArenaEnvGraphNodeType = ArenaEnvGraphNodeType.OBJECT_REFERENCE
+    parent: str = Field(min_length=1)
+    prim_path: str = Field(min_length=1)
+    object_type: ObjectType
 
-    type: Literal[ArenaEnvGraphNodeType.OBJECT_REFERENCE] = ArenaEnvGraphNodeType.OBJECT_REFERENCE
-    parent: str  # id of the parent (typically background) node that owns the prim
-    prim_path: str  # USD prim path of the referenced prim (may contain {ENV_REGEX_NS})
-    object_type: ObjectType  # how to wrap the prim (rigid, articulation, etc.)
+    @model_validator(mode="after")
+    def _must_be_object_reference(self) -> ArenaEnvGraphObjectReferenceNodeSpec:
+        assert self.type == ArenaEnvGraphNodeType.OBJECT_REFERENCE, "internal invariant"
+        return self
 
 
 class ArenaEnvGraphSpatialConstraintSpec(BaseModel):
-    """Spatial constraint edge in an environment graph state spec.
-
-    It defines a relation between two nodes.
-    """
+    """Spatial constraint edge in an environment graph state spec."""
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str
+    id: str = Field(min_length=1)
     type: ArenaEnvGraphSpatialConstraintType
-    parent: str
-    child: str | None = None  # Optional, e.g. is_anchor constraint does not have a child
-    # Type-specific optional kwargs for the underlying RelationBase subclass selected by `type`
-    # (e.g. {x_min, x_max, y_min, y_max} for position_limits; {side, distance} for next_to etc.).
-    # The Arena environment builder forwards these when constructing the Relation instance.
+    parent: str = Field(min_length=1)
+    child: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("params", mode="after")
+    @classmethod
+    def _normalize_pose_params(cls, params: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(params)
+        if "position_xyz" in normalized:
+            normalized["position_xyz"] = coerce_number_sequence(normalized["position_xyz"], 3, "position_xyz")
+        if "rotation_xyzw" in normalized:
+            normalized["rotation_xyzw"] = coerce_number_sequence(normalized["rotation_xyzw"], 4, "rotation_xyzw")
+        return normalized
 
 
 class ArenaEnvGraphTaskConstraintSpec(BaseModel):
@@ -104,27 +124,28 @@ class ArenaEnvGraphTaskConstraintSpec(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str
+    id: str = Field(min_length=1)
     type: ArenaEnvGraphTaskConstraintType
-    parent: str
-    child: str | None = None  # Optional, could be a robot keeps gripper open or closed, or a single object
-    # Type-specific optional kwargs for the underlying TaskConstraintBase subclass selected by `type`
-    # (e.g. grasp pose offset the reach constraint.).
-    # The Arena environment builder forwards these when constructing the TaskConstraint instance.
+    parent: str = Field(min_length=1)
+    child: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
 
 
 class ArenaEnvGraphStateSpec(BaseModel):
-    """Snapshot of the environment state in the graph.
-
-    Could be an initial, intermediate, or final state.
-    """
+    """Snapshot of the environment state in the graph."""
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str
+    id: str = Field(min_length=1)
     spatial_constraints: list[ArenaEnvGraphSpatialConstraintSpec] = Field(default_factory=list)
     task_constraints: list[ArenaEnvGraphTaskConstraintSpec] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_edges_wrapper(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "edges" in data:
+            raise ValueError("State spec must define spatial_constraints and task_constraints directly")
+        return data
 
 
 class ArenaEnvGraphTaskSpec(BaseModel):
@@ -132,8 +153,17 @@ class ArenaEnvGraphTaskSpec(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str
-    type: str  # Task class name, could be a custom task class or a built-in task class
-    initial_state_spec_id: str
-    success_state_spec_id: str
+    id: str = Field(min_length=1)
+    type: str = Field(min_length=1)
+    initial_state_spec_id: str = Field(min_length=1)
+    success_state_spec_id: str = Field(min_length=1)
     task_args: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_legacy_state_keys(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for old_key in ("state_specs", "initial_state_spec", "success_state_spec"):
+                if old_key in data:
+                    raise ValueError("Task spec must use initial_state_spec_id and success_state_spec_id")
+        return data

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -5,8 +5,8 @@
 
 """Lightweight schema for the env-graph spec.
 
-Pure data: enums and dataclasses with no parsing or conversion behavior. Behavior (YAML
-loading, validation, conversion entry point) lives in ``arena_env_graph_spec``.
+Pydantic models with no parsing or conversion behavior. YAML loading, validation, and
+conversion entry points live in ``arena_env_graph_spec``.
 
 Lives in its own module so that conversion-utilities can import these names at module
 level without creating a circular import back into ``arena_env_graph_spec`` (which itself
@@ -15,9 +15,10 @@ depends on the conversion module).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from isaaclab_arena.assets.object_type import ObjectType
 
@@ -47,8 +48,7 @@ class ArenaEnvGraphTaskConstraintType(Enum):
     REACH = "reach"
 
 
-@dataclass
-class ArenaEnvGraphNodeSpec:
+class ArenaEnvGraphNodeSpec(BaseModel):
     """Node in an environment graph.
 
     Could be an object, an embodiment, a background, etc. Object references — USD prims
@@ -57,20 +57,17 @@ class ArenaEnvGraphNodeSpec:
     needed to locate and type the referenced prim.
     """
 
+    model_config = ConfigDict(extra="ignore")
+
     id: str
     name: str  # Name registered in the asset registry
     type: ArenaEnvGraphNodeType
     # Asset-type specific optional kwargs (e.g. scale, spawn_cfg_addon) — distinct from
     # the typed graph metadata above. The Arena environment builder forwards these when
     # instantiating the asset class.
-    params: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
 
 
-# kw_only=True forces the three new fields to be keyword-only in __init__. Required because
-# the base class ends with a defaulted field (`params`) and Python forbids non-default args
-# from following default ones — placing the new required fields after `*` sidesteps that rule
-# and lets us declare them as required (no default) instead of Optional with runtime checks.
-@dataclass(kw_only=True)
 class ArenaEnvGraphObjectReferenceNodeSpec(ArenaEnvGraphNodeSpec):
     """Object-reference node: a USD prim inside a parent background asset.
 
@@ -78,17 +75,19 @@ class ArenaEnvGraphObjectReferenceNodeSpec(ArenaEnvGraphNodeSpec):
     builder cannot bind to the referenced prim or know how to wrap it.
     """
 
+    type: Literal[ArenaEnvGraphNodeType.OBJECT_REFERENCE] = ArenaEnvGraphNodeType.OBJECT_REFERENCE
     parent: str  # id of the parent (typically background) node that owns the prim
     prim_path: str  # USD prim path of the referenced prim (may contain {ENV_REGEX_NS})
     object_type: ObjectType  # how to wrap the prim (rigid, articulation, etc.)
 
 
-@dataclass
-class ArenaEnvGraphSpatialConstraintSpec:
+class ArenaEnvGraphSpatialConstraintSpec(BaseModel):
     """Spatial constraint edge in an environment graph state spec.
 
     It defines a relation between two nodes.
     """
+
+    model_config = ConfigDict(extra="ignore")
 
     id: str
     type: ArenaEnvGraphSpatialConstraintType
@@ -97,12 +96,13 @@ class ArenaEnvGraphSpatialConstraintSpec:
     # Type-specific optional kwargs for the underlying RelationBase subclass selected by `type`
     # (e.g. {x_min, x_max, y_min, y_max} for position_limits; {side, distance} for next_to etc.).
     # The Arena environment builder forwards these when constructing the Relation instance.
-    params: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class ArenaEnvGraphTaskConstraintSpec:
+class ArenaEnvGraphTaskConstraintSpec(BaseModel):
     """Task-dependent constraint edge in an environment graph state spec."""
+
+    model_config = ConfigDict(extra="ignore")
 
     id: str
     type: ArenaEnvGraphTaskConstraintType
@@ -111,27 +111,29 @@ class ArenaEnvGraphTaskConstraintSpec:
     # Type-specific optional kwargs for the underlying TaskConstraintBase subclass selected by `type`
     # (e.g. grasp pose offset the reach constraint.).
     # The Arena environment builder forwards these when constructing the TaskConstraint instance.
-    params: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
 
 
-@dataclass
-class ArenaEnvGraphStateSpec:
+class ArenaEnvGraphStateSpec(BaseModel):
     """Snapshot of the environment state in the graph.
 
     Could be an initial, intermediate, or final state.
     """
 
+    model_config = ConfigDict(extra="ignore")
+
     id: str
-    spatial_constraints: list[ArenaEnvGraphSpatialConstraintSpec] = field(default_factory=list)
-    task_constraints: list[ArenaEnvGraphTaskConstraintSpec] = field(default_factory=list)
+    spatial_constraints: list[ArenaEnvGraphSpatialConstraintSpec] = Field(default_factory=list)
+    task_constraints: list[ArenaEnvGraphTaskConstraintSpec] = Field(default_factory=list)
 
 
-@dataclass
-class ArenaEnvGraphTaskSpec:
+class ArenaEnvGraphTaskSpec(BaseModel):
     """Task entry in an environment graph."""
+
+    model_config = ConfigDict(extra="ignore")
 
     id: str
     type: str  # Task class name, could be a custom task class or a built-in task class
     initial_state_spec_id: str
     success_state_spec_id: str
-    task_args: dict[str, Any] = field(default_factory=dict)
+    task_args: dict[str, Any] = Field(default_factory=dict)

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -4,89 +4,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable, Iterator
-from enum import Enum
 from numbers import Real
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 
 if TYPE_CHECKING:
-    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpatialConstraintType
+    from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphSpatialConstraintType
     from isaaclab_arena.relations.relations import RelationBase
 
 
-def as_dict(data: Any, spec_name: str) -> dict[str, Any]:
-    """Require a YAML section to be a mapping before parsing it."""
-    assert isinstance(data, dict), f"{spec_name} must be a dict, got {type(data).__name__}"
-    return data
-
-
-def parse_list(data: dict[str, Any], key: str, parser: Callable[[Any], Any]) -> list[Any]:
-    """Parse a list field, treating a missing field as an empty list."""
-    values = data.get(key, [])
-    assert isinstance(values, list), f"Field '{key}' must be a list"
-    return [parser(value) for value in values]
-
-
-def required_str(data: dict[str, Any], key: str) -> str:
-    """Read a required non-empty string field."""
-    value = data.get(key)
-    assert isinstance(value, str) and value, f"Missing required string field '{key}'"
-    return value
-
-
-def optional_str(data: dict[str, Any], key: str) -> str | None:
-    """Read an optional string field without inventing a default value."""
-    value = data.get(key)
-    assert value is None or isinstance(value, str), f"Optional field '{key}' must be a string when set"
-    return value
-
-
-def optional_dict(data: dict[str, Any], key: str) -> dict[str, Any]:
-    """Read an optional mapping field and return a mutable copy."""
-    value = data.get(key, {})
-    assert value is None or isinstance(value, dict), f"Optional field '{key}' must be a dict when set"
-    return dict(value or {})
-
-
-def required_number_sequence(data: dict[str, Any], key: str, length: int) -> tuple[float, ...]:
-    """Read a fixed-length numeric list such as a position or quaternion."""
-    value = data.get(key)
-    assert isinstance(value, (list, tuple)), f"Missing required numeric sequence field '{key}'"
-    assert len(value) == length, f"Field '{key}' must contain {length} numbers"
-    assert all(
-        isinstance(item, Real) and not isinstance(item, bool) for item in value
-    ), f"Field '{key}' must contain only numbers"
+def coerce_number_sequence(value: Any, length: int, field_name: str) -> tuple[float, ...]:
+    """Coerce a fixed-length numeric list or tuple (e.g. position or quaternion)."""
+    if not isinstance(value, (list, tuple)):
+        raise ValueError(f"Field '{field_name}' must contain {length} numbers")
+    if len(value) != length:
+        raise ValueError(f"Field '{field_name}' must contain {length} numbers")
+    if not all(isinstance(item, Real) and not isinstance(item, bool) for item in value):
+        raise ValueError(f"Field '{field_name}' must contain only numbers")
     return tuple(float(item) for item in value)
 
 
-def required_enum(data: dict[str, Any], key: str, enum_type: type[Enum]) -> Enum:
-    """Read a required enum field from its YAML string value."""
-    value = data.get(key)
-    assert value is not None, f"Missing required field '{key}'"
-    parsed = parse_enum(value, key, enum_type)
-    assert parsed is not None
-    return parsed
-
-
-def optional_enum(data: dict[str, Any], key: str, enum_type: type[Enum]) -> Enum | None:
-    """Read an optional enum field from its YAML string value."""
-    return parse_enum(data.get(key), key, enum_type)
-
-
-def parse_enum(value: Any, key: str, enum_type: type[Enum]) -> Enum | None:
-    """Convert a YAML string to an enum value and show valid options on failure."""
-    if value is None or isinstance(value, enum_type):
-        return value
-    assert isinstance(value, str), f"Field '{key}' must be a string when set"
-    try:
-        return enum_type(value)
-    except ValueError:
-        valid_values = [enum_value.value for enum_value in enum_type]
-        raise AssertionError(f"Unknown {key} '{value}'. Expected one of {valid_values}") from None
-
-
-def assert_unique_ids(nodes: list[Any], tasks: list[Any], state_specs: list[Any]) -> None:
+def validate_unique_ids(nodes: list[Any], tasks: list[Any], state_specs: list[Any]) -> None:
     """Ensure every graph id is unique, including constraint ids inside states."""
     id_locations: dict[str, list[str]] = {}
     for node in nodes:
@@ -101,89 +40,81 @@ def assert_unique_ids(nodes: list[Any], tasks: list[Any], state_specs: list[Any]
             _add_id_location(id_locations, constraint.id, f"task constraint '{constraint.id}'")
 
     duplicates = {spec_id: locations for spec_id, locations in id_locations.items() if len(locations) > 1}
-    assert not duplicates, f"Duplicate env graph ids found: {duplicates}"
+    if duplicates:
+        raise ValueError(f"Duplicate env graph ids found: {duplicates}")
 
 
-def assert_references_exist(nodes: list[Any], tasks: list[Any], state_specs: list[Any]) -> None:
+def validate_references_exist(
+    nodes: list[Any], tasks: list[Any], state_specs: list[Any], *, check_task_wiring: bool = True
+) -> None:
     """Ensure every graph reference points to a node or state spec that exists."""
     node_ids = {node.id for node in nodes}
     state_spec_ids = {state_spec.id for state_spec in state_specs}
 
-    # Track ids seen so far so a node's parent must be defined *earlier* in the list. The
-    # conversion process (_instantiate_assets_from_nodes) materializes nodes in order and looks
-    # up the parent, so a parent listed after its reference would otherwise only fail
-    # there with a raw KeyError.
     seen_node_ids: set[str] = set()
     for node in nodes:
         parent = getattr(node, "parent", None)
         if parent is not None:
-            assert parent in node_ids, f"Node '{node.id}' references unknown parent '{parent}'"
-            assert parent in seen_node_ids, (
-                f"Node '{node.id}' references parent '{parent}' defined later in the node list; "
-                "a parent must appear before any node that references it"
-            )
+            if parent not in node_ids:
+                raise ValueError(f"Node '{node.id}' references unknown parent '{parent}'")
+            if parent not in seen_node_ids:
+                raise ValueError(
+                    f"Node '{node.id}' references parent '{parent}' defined later in the node list; "
+                    "a parent must appear before any node that references it"
+                )
         seen_node_ids.add(node.id)
 
-    for task in tasks:
-        for label, state_spec_id in (
-            ("initial_state_spec_id", task.initial_state_spec_id),
-            ("success_state_spec_id", task.success_state_spec_id),
-        ):
-            assert (
-                state_spec_id in state_spec_ids
-            ), f"Task '{task.id}' references unknown state spec '{state_spec_id}' for '{label}'"
+    if check_task_wiring:
+        for task in tasks:
+            for label, state_spec_id in (
+                ("initial_state_spec_id", task.initial_state_spec_id),
+                ("success_state_spec_id", task.success_state_spec_id),
+            ):
+                if state_spec_id not in state_spec_ids:
+                    raise ValueError(f"Task '{task.id}' references unknown state spec '{state_spec_id}' for '{label}'")
 
     for state_spec in state_specs:
         for constraint in state_spec.spatial_constraints:
-            assert (
-                constraint.parent in node_ids
-            ), f"Constraint '{constraint.id}' references unknown parent node '{constraint.parent}'"
-            if constraint.child is not None:
-                assert (
-                    constraint.child in node_ids
-                ), f"Constraint '{constraint.id}' references unknown child node '{constraint.child}'"
+            if constraint.parent not in node_ids:
+                raise ValueError(f"Constraint '{constraint.id}' references unknown parent node '{constraint.parent}'")
+            if constraint.child is not None and constraint.child not in node_ids:
+                raise ValueError(f"Constraint '{constraint.id}' references unknown child node '{constraint.child}'")
 
         for constraint in state_spec.task_constraints:
-            if constraint.parent is not None:
-                assert (
-                    constraint.parent in node_ids
-                ), f"Constraint '{constraint.id}' references unknown parent node '{constraint.parent}'"
-            if constraint.child is not None:
-                assert (
-                    constraint.child in node_ids
-                ), f"Constraint '{constraint.id}' references unknown child node '{constraint.child}'"
+            if constraint.parent is not None and constraint.parent not in node_ids:
+                raise ValueError(f"Constraint '{constraint.id}' references unknown parent node '{constraint.parent}'")
+            if constraint.child is not None and constraint.child not in node_ids:
+                raise ValueError(f"Constraint '{constraint.id}' references unknown child node '{constraint.child}'")
 
 
-def assert_spatial_constraint_shapes(state_specs: list[Any]) -> None:
+def validate_spatial_constraint_shapes(state_specs: list[Any]) -> None:
     """Check each spatial constraint has the parent/child shape its relation expects."""
     for state_spec in state_specs:
         for constraint in state_spec.spatial_constraints:
             constraint_type = _enum_value(constraint.type)
             if constraint_type == "at_pose":
-                # Special: no relation class; pose is supplied directly via params.
-                assert (
-                    "position_xyz" in constraint.params
-                ), f"Spatial constraint '{constraint.id}' of type 'at_pose' requires params.position_xyz"
+                if "position_xyz" not in constraint.params:
+                    raise ValueError(
+                        f"Spatial constraint '{constraint.id}' of type 'at_pose' requires params.position_xyz"
+                    )
                 is_unary = True
             elif constraint_type == "in":
-                # Special: no relation class; semantically a binary parent/child constraint.
-                # TODO(xinjieyao, 2026-05-27): add an `In` relation class so this can resolve through the registry.
                 is_unary = False
             else:
                 relation_cls = relation_class_for_spatial_constraint_type(constraint.type)
-                assert (
-                    relation_cls is not None
-                ), f"Spatial constraint type '{constraint_type}' is not mapped to a relation class"
+                if relation_cls is None:
+                    raise ValueError(f"Spatial constraint type '{constraint_type}' is not mapped to a relation class")
                 is_unary = relation_cls.is_unary()
 
             if is_unary:
-                assert (
-                    constraint.child is None
-                ), f"Spatial constraint '{constraint.id}' of type '{constraint_type}' must not define a child node"
-            else:
-                assert (
-                    constraint.child is not None
-                ), f"Spatial constraint '{constraint.id}' of type '{constraint_type}' requires a child node"
+                if constraint.child is not None:
+                    raise ValueError(
+                        f"Spatial constraint '{constraint.id}' of type '{constraint_type}' must not define a child node"
+                    )
+            elif constraint.child is None:
+                raise ValueError(
+                    f"Spatial constraint '{constraint.id}' of type '{constraint_type}' requires a child node"
+                )
 
 
 def _add_id_location(id_locations: dict[str, list[str]], spec_id: str, location: str) -> None:

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -6,6 +6,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
@@ -99,15 +100,7 @@ def test_arena_env_graph_spec_loads_pick_and_place_yaml():
 
 
 def test_registered_relations_match_spatial_constraint_enum():
-    """Registered relations and the spatial-constraint enum must stay in one-to-one sync.
-
-    Each registered RelationBase subclass is keyed by its `name`, which must equal the
-    `value` of a ArenaEnvGraphSpatialConstraintType member (so spec lookups resolve), and
-    every solver-backed enum member must have a relation. AT_POSE and IN are excluded —
-    see _RELATIONLESS_CONSTRAINT_TYPES. This guards against adding one side without the
-    other.
-    """
-    # Importing the module ran the @register_object_relation decorators at file top.
+    """Registered relations and the spatial-constraint enum must stay in one-to-one sync."""
     registered_names = set(ObjectRelationLibraryRegistry().get_all_keys())
     enum_values = {
         constraint.value
@@ -143,7 +136,7 @@ def test_arena_env_graph_spec_validate_rejects_mutated_missing_reference():
     spec = ArenaEnvGraphSpec.from_dict(_minimal_env_graph_data())
     spec.state_specs[0].spatial_constraints[0].parent = "missing_table"
 
-    with pytest.raises(AssertionError, match="unknown parent node 'missing_table'"):
+    with pytest.raises(ValueError, match="unknown parent node 'missing_table'"):
         spec.validate()
 
 
@@ -152,8 +145,13 @@ def test_arena_env_graph_spec_validate_rejects_mutated_invalid_relationship_shap
     constraint = spec.state_specs[0].spatial_constraints[0]
     constraint.type = ArenaEnvGraphSpatialConstraintType.ON
 
-    with pytest.raises(AssertionError, match="requires a child node"):
+    with pytest.raises(ValueError, match="requires a child node"):
         spec.validate()
+
+
+def test_from_yaml_rejects_missing_path_with_clear_message():
+    with pytest.raises(ValueError, match="Env graph spec YAML not found"):
+        ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "does_not_exist.yaml")
 
 
 def test_arena_env_graph_spec_rejects_invalid_data():
@@ -181,7 +179,7 @@ def test_arena_env_graph_spec_rejects_invalid_data():
         (
             "missing required task state spec id",
             lambda data: data["tasks"][0].pop("success_state_spec_id"),
-            "Missing required string field 'success_state_spec_id'",
+            "success_state_spec_id",
         ),
         (
             "old task state map",
@@ -201,7 +199,7 @@ def test_arena_env_graph_spec_rejects_invalid_data():
         (
             "missing spatial parent",
             lambda data: data["state_specs"][0]["spatial_constraints"][0].pop("parent"),
-            "Missing required string field 'parent'",
+            "parent",
         ),
         (
             "relationship missing child",
@@ -226,44 +224,44 @@ def test_arena_env_graph_spec_rejects_invalid_data():
         (
             "unknown object type",
             lambda data: data["nodes"][2].__setitem__("object_type", "unknown"),
-            "Unknown object_type 'unknown'",
+            "object_type",
         ),
         (
             "object_reference missing parent",
             lambda data: data["nodes"][2].pop("parent"),
-            "Missing required string field 'parent'",
+            "parent",
         ),
         (
             "object_reference missing prim_path",
             lambda data: data["nodes"][2].pop("prim_path"),
-            "Missing required string field 'prim_path'",
+            "prim_path",
         ),
         (
             "object_reference missing object_type",
             lambda data: data["nodes"][2].pop("object_type"),
-            "Missing required field 'object_type'",
+            "object_type",
         ),
         (
             "unknown node type",
             lambda data: data["nodes"][0].__setitem__("type", "unknown"),
-            "Unknown type 'unknown'",
+            "type",
         ),
         (
             "unknown spatial constraint type",
             lambda data: data["state_specs"][0]["spatial_constraints"][0].__setitem__("type", "unknown"),
-            "Unknown type 'unknown'",
+            "type",
         ),
         (
             "unknown task constraint type",
             lambda data: data["state_specs"][0]["task_constraints"][0].__setitem__("type", "unknown"),
-            "Unknown type 'unknown'",
+            "type",
         ),
         (
             "invalid at_pose position",
             lambda data: data["state_specs"][0]["spatial_constraints"].append(
                 _at_pose_constraint(position_xyz=[0.1, 0.2])
             ),
-            "Field 'position_xyz' must contain 3 numbers",
+            "position_xyz",
         ),
     ]
 
@@ -271,12 +269,9 @@ def test_arena_env_graph_spec_rejects_invalid_data():
         data = _minimal_env_graph_data()
         mutate(data)
 
-        try:
+        with pytest.raises(ValidationError) as exc_info:
             ArenaEnvGraphSpec.from_dict(data)
-        except AssertionError as exc:
-            assert error_match in str(exc), label
-        else:
-            raise AssertionError(f"{label}: expected AssertionError")
+        assert error_match in str(exc_info.value), label
 
 
 def _minimal_env_graph_data():
@@ -285,8 +280,6 @@ def _minimal_env_graph_data():
         "nodes": [
             {"id": "robot", "name": "robot", "type": "embodiment"},
             {"id": "background", "name": "background", "type": "background"},
-            # Kept at index 2 (after its parent at index 1) so the bad-data mutation lambdas
-            # below can address it, and so the order satisfies the upstream ordering contract.
             {
                 "id": "table",
                 "name": "table",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ RUNTIME_DEPS = [
     "vuer[all]",
     "lightwheel-sdk",
     "pytest",
+    "pydantic>=2.0",
 ]
 
 DEV_DEPS = [


### PR DESCRIPTION
## Summary
This refactor makes the relation/task spec reusable for AgentIntentSpec

## Detailed description
- What was the reason for the change?
Pydantic forces strict field validations and provide built-in support for generation json schema and serialziation/deserialization. It's basically required for the agentic inference to enforce structured output. Moving  AreneEnvGraphSpec to pydantic basemode makes it reusable by the env gen agent.
- What has been changed?
Refactor AreneEnvGraphSpec and its subclasses from dataclass to pydantic. Use pydantic default serialization and validation methods.
- What is the impact of this change?
Should be no-op to outside interfaces.