### PR TITLE
Derive Docker container name per clone

### DIFF
--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -6,7 +6,19 @@ allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker im
 
 # Dev Container
 
-Arena uses a single Docker container (`isaaclab_arena-latest`) as the dev, test, training, and eval environment. There is no separate dev container.
+Arena uses a single Docker container as the dev, test, training, and eval environment. There is no separate dev container.
+
+Each clone gets its own container so multiple clones run in parallel. The image (`isaaclab_arena:latest`) is shared; only the container name varies: `isaaclab_arena-latest` for the `IsaacLab-Arena` clone, `isaaclab_arena-latest-<suffix>` for an `IsaacLab-Arena_<suffix>` clone. `run_docker.sh` derives the suffix from the clone directory automatically.
+
+## Discover this clone's container
+
+Never hardcode the name. Resolve the container that mounts the current clone, then reuse `$ARENA_CONTAINER`:
+
+```bash
+ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+```
+
+Empty result means no container is running for this clone — start one (below).
 
 ## Start or attach
 
@@ -14,7 +26,7 @@ Arena uses a single Docker container (`isaaclab_arena-latest`) as the dev, test,
 ./docker/run_docker.sh
 ```
 
-Idempotent: builds the image if it does not exist, starts the container if it is not running, then attaches.
+Idempotent: builds the (shared) image if it does not exist, starts this clone's container if it is not running, then attaches. The container name is auto-derived from the clone directory; pass `-s <suffix>` to override it.
 
 ## Common flag combinations
 
@@ -35,7 +47,7 @@ Example with custom mounts:
 ## Run a command in the already-running container
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && <command>"
 ```
 
@@ -50,7 +62,7 @@ Inside the container, `python` is aliased to `/isaac-sim/python.sh`. Both forms 
 A container is up and importable when:
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "/isaac-sim/python.sh -c 'import isaaclab_arena; print(isaaclab_arena.__file__)'"
 ```
 

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -8,17 +8,17 @@ allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker im
 
 Arena uses a single Docker container as the dev, test, training, and eval environment. There is no separate dev container.
 
-Each clone gets its own container so clones run in parallel: the image (`isaaclab_arena:latest`) is shared, but the name is `isaaclab_arena-latest` for `IsaacLab-Arena` and `isaaclab_arena-latest-<suffix>` for `IsaacLab-Arena_<suffix>` (`run_docker.sh` derives the suffix automatically).
+Each clone of the repo on the host machine gets its own container, so separate clones can run in parallel. The image (`isaaclab_arena:latest`) is shared, but the container name is `isaaclab_arena-latest` for the folder named `IsaacLab-Arena` and `isaaclab_arena-latest-<suffix>` for folders named `IsaacLab-Arena_<suffix>` (`run_docker.sh` derives the suffix automatically).
 
-## Discover this clone's container
+## Discover this clone's container (once per session)
 
-Never hardcode the name. Resolve the container mounting this clone (empty result = none running, so start one below):
+Never hardcode the name. At the start of a session, resolve the container mounting this clone into `ARENA_CONTAINER` (empty result = none running, so start one below):
 
 ```bash
-docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1
+ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
 ```
 
-Substitute that name for `$ARENA_CONTAINER` in the commands below — a shell variable won't carry across separate `docker exec` calls, so use the literal name (or set `ARENA_CONTAINER` in the same shell as each command).
+Run the commands below in that same shell so `$ARENA_CONTAINER` stays set (or substitute the literal name).
 
 ## Start or attach
 

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -12,11 +12,13 @@ Each clone gets its own container so clones run in parallel: the image (`isaacla
 
 ## Discover this clone's container
 
-Never hardcode the name. Resolve the container mounting this clone, then reuse `$ARENA_CONTAINER` (empty result = none running, so start one below):
+Never hardcode the name. Resolve the container mounting this clone (empty result = none running, so start one below):
 
 ```bash
-ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1
 ```
+
+Substitute that name for `$ARENA_CONTAINER` in the commands below — a shell variable won't carry across separate `docker exec` calls, so use the literal name (or set `ARENA_CONTAINER` in the same shell as each command).
 
 ## Start or attach
 

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -8,17 +8,15 @@ allowed-tools: Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker im
 
 Arena uses a single Docker container as the dev, test, training, and eval environment. There is no separate dev container.
 
-Each clone gets its own container so multiple clones run in parallel. The image (`isaaclab_arena:latest`) is shared; only the container name varies: `isaaclab_arena-latest` for the `IsaacLab-Arena` clone, `isaaclab_arena-latest-<suffix>` for an `IsaacLab-Arena_<suffix>` clone. `run_docker.sh` derives the suffix from the clone directory automatically.
+Each clone gets its own container so clones run in parallel: the image (`isaaclab_arena:latest`) is shared, but the name is `isaaclab_arena-latest` for `IsaacLab-Arena` and `isaaclab_arena-latest-<suffix>` for `IsaacLab-Arena_<suffix>` (`run_docker.sh` derives the suffix automatically).
 
 ## Discover this clone's container
 
-Never hardcode the name. Resolve the container that mounts the current clone, then reuse `$ARENA_CONTAINER`:
+Never hardcode the name. Resolve the container mounting this clone, then reuse `$ARENA_CONTAINER` (empty result = none running, so start one below):
 
 ```bash
 ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
 ```
-
-Empty result means no container is running for this clone — start one (below).
 
 ## Start or attach
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -14,13 +14,13 @@ allowed-tools: Bash(docker exec *) Bash(docker ps *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one mounting this clone (empty = none running, use the `dev-container` skill first):
+All commands run inside the already-running container via `docker exec`. Each clone of the repo on the host system has its own container, so at the start of a session resolve the one mounting this clone into `ARENA_CONTAINER` (empty = none running — use the `dev-container` skill first):
 
 ```bash
-docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1
+ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
 ```
 
-Substitute that name for `$ARENA_CONTAINER` in the commands below — a shell variable won't carry across separate `docker exec` calls, so use the literal name (or set `ARENA_CONTAINER` in the same shell as each command).
+Run the phase commands below in that same shell so `$ARENA_CONTAINER` stays set (or substitute the literal name).
 
 ## Phase 1 — no cameras, no subprocess
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -2,7 +2,7 @@
 name: run-tests
 description: Runs the Isaac Lab-Arena pytest suite across its three required phases (no-cameras, with-cameras, with-subprocess) inside the running isaaclab_arena Docker container. Use when the user asks to run the tests, test their changes, verify the test suite passes, check whether a change broke anything (e.g. "did I break anything", "do the tests still pass", "is everything still working"), run only one specific phase (e.g. "run Phase 1", "run only the no-camera tests", "skip the camera and subprocess tests"), or run coverage for a specific module.
 argument-hint: "[phase1|phase2|phase3]"
-allowed-tools: Bash(docker exec *)
+allowed-tools: Bash(docker exec *) Bash(docker ps *)
 ---
 
 # Run Tests
@@ -14,14 +14,20 @@ allowed-tools: Bash(docker exec *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`. If the container is not running, use the `dev-container` skill first.
+All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one serving this clone by its mount and reuse `$ARENA_CONTAINER` in every command below:
+
+```bash
+ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+```
+
+If the result is empty, no container is running for this clone — use the `dev-container` skill first.
 
 ## Phase 1 — no cameras, no subprocess
 
 The fastest of the three. Useful on its own when iterating on changes that don't touch rendering or subprocess paths.
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'not with_cameras and not with_subprocess' isaaclab_arena/tests"
@@ -30,7 +36,7 @@ docker exec isaaclab_arena-latest bash -c \
 ## Phase 2 — with cameras
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'with_cameras and not with_subprocess' isaaclab_arena/tests"
@@ -39,7 +45,7 @@ docker exec isaaclab_arena-latest bash -c \
 ## Phase 3 — with subprocess
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'with_subprocess' isaaclab_arena/tests"
@@ -49,12 +55,12 @@ docker exec isaaclab_arena-latest bash -c \
 
 ```bash
 # single file
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py"
 
 # single function
-docker exec isaaclab_arena-latest bash -c \
+docker exec "$ARENA_CONTAINER" bash -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py::test_default_assets_registered"
 ```

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -14,11 +14,13 @@ allowed-tools: Bash(docker exec *) Bash(docker ps *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one mounting this clone and reuse `$ARENA_CONTAINER` below (empty = none running, use the `dev-container` skill first):
+All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one mounting this clone (empty = none running, use the `dev-container` skill first):
 
 ```bash
-ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1
 ```
+
+Substitute that name for `$ARENA_CONTAINER` in the commands below — a shell variable won't carry across separate `docker exec` calls, so use the literal name (or set `ARENA_CONTAINER` in the same shell as each command).
 
 ## Phase 1 — no cameras, no subprocess
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -14,13 +14,11 @@ allowed-tools: Bash(docker exec *) Bash(docker ps *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one serving this clone by its mount and reuse `$ARENA_CONTAINER` in every command below:
+All commands run inside the already-running container via `docker exec`. Each clone has its own container, so first resolve the one mounting this clone and reuse `$ARENA_CONTAINER` below (empty = none running, use the `dev-container` skill first):
 
 ```bash
 ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
 ```
-
-If the result is empty, no container is running for this clone — use the `dev-container` skill first.
 
 ## Phase 1 — no cameras, no subprocess
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside this clone's Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
-Each clone gets its own container so multiple clones can run in parallel. The image (`isaaclab_arena:latest`) is shared; only the container name varies. The name is `isaaclab_arena-latest` plus a suffix derived from the clone directory: `IsaacLab-Arena` keeps the bare name, `IsaacLab-Arena_<suffix>` becomes `isaaclab_arena-latest-<suffix>`. **Do not hardcode the container name** — discover the one serving this clone by its mount, then exec into it:
+Each clone gets its own container (shared image, per-clone name), so clones run in parallel. **Don't hardcode the container name** — discover the one mounting this clone, then exec into it (see the `dev-container` skill for the naming rule):
 
 ```bash
 ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,16 +22,9 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside this clone's Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
-Each clone gets its own container (shared image, per-clone name), so clones run in parallel. **Don't hardcode the container name** — discover the one mounting this clone, then exec into it (see the `dev-container` skill for the naming rule):
-
-```bash
-ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
-docker exec "$ARENA_CONTAINER" bash -c '/isaac-sim/python.sh ...'
-```
+Each clone gets its own container (shared image, per-clone name), so clones run in parallel. **Don't hardcode the container name** — use the `dev-container` skill to build, start, attach to, discover, or exec into this clone's container.
 
 Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, isort, pyupgrade, codespell) runs **on the host**.
-
-Use the `dev-container` skill for build, start, attach, and exec inside the container.
 
 ## Repository layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,14 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 ## Docker environment
 
-Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
+Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside this clone's Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
+
+Each clone gets its own container so multiple clones can run in parallel. The image (`isaaclab_arena:latest`) is shared; only the container name varies. The name is `isaaclab_arena-latest` plus a suffix derived from the clone directory: `IsaacLab-Arena` keeps the bare name, `IsaacLab-Arena_<suffix>` becomes `isaaclab_arena-latest-<suffix>`. **Do not hardcode the container name** — discover the one serving this clone by its mount, then exec into it:
+
+```bash
+ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+docker exec "$ARENA_CONTAINER" bash -c '/isaac-sim/python.sh ...'
+```
 
 Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, isort, pyupgrade, codespell) runs **on the host**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,9 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 ## Docker environment
 
-Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside this clone's Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
+Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the local repo clone's Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
-Each clone gets its own container (shared image, per-clone name), so clones run in parallel. **Don't hardcode the container name** — use the `dev-container` skill to build, start, attach to, discover, or exec into this clone's container.
+Each clone gets its own container (shared image, per-clone name), so clones run in parallel. **Don't hardcode the container name** — use the `dev-container` skill to build, start, attach to, discover, or exec into the local clone's container.
 
 Run as the host user, not root.
 

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -18,8 +18,11 @@ INSTALL_GROOT="false"
 # Whether to forcefully rebuild the docker image
 # (it takes a while to re-build, but for testing is not really necessary)
 FORCE_REBUILD=false
-# Optional suffix appended to the container name to allow multiple containers
+# Optional suffix appended to the container name to allow multiple containers.
+# When not set explicitly via -s, it is derived from the repo directory name
+# (see below) so each clone gets its own container automatically.
 CONTAINER_SUFFIX=""
+CONTAINER_SUFFIX_EXPLICIT=false
 
 while getopts ":d:m:e:hn:rn:Rn:vn:gn:s:" OPTION; do
     case $OPTION in
@@ -53,6 +56,7 @@ while getopts ":d:m:e:hn:rn:Rn:vn:gn:s:" OPTION; do
             ;;
         s)
             CONTAINER_SUFFIX="-${OPTARG}"
+            CONTAINER_SUFFIX_EXPLICIT=true
             ;;
         h)
             script_name=$(basename "$0")
@@ -70,7 +74,8 @@ while getopts ":d:m:e:hn:rn:Rn:vn:gn:s:" OPTION; do
             echo "  -r (Force rebuilding of the docker image.)"
             echo "  -R (Force rebuilding of the docker image, without cache.)"
             echo "  -g (Install GR00T N1.6 dependencies.)"
-            echo "  -s <suffix> (Suffix appended to the container name, allowing multiple containers to run simultaneously.)"
+            echo "  -s <suffix> (Suffix appended to the container name, allowing multiple containers to run simultaneously."
+            echo "      Defaults to the repo directory name after 'IsaacLab-Arena', so each clone gets its own container.)"
             exit 0
             ;;
         \?)
@@ -86,6 +91,16 @@ done
 
 # Shift off the processed options so that $@ has a command to pass to docker run
 shift $((OPTIND-1))
+
+# Derive the container suffix from the repo directory name when not set via -s,
+# so each clone gets its own container (e.g. IsaacLab-Arena_foo -> "-foo").
+# The canonical "IsaacLab-Arena" clone keeps the bare "isaaclab_arena-latest" name.
+if [ "$CONTAINER_SUFFIX_EXPLICIT" = false ]; then
+    repo_dir=$(basename "$(cd "$SCRIPT_DIR/.." && pwd)")
+    derived=${repo_dir#IsaacLab-Arena}
+    derived=${derived#[-_]}
+    [ -n "$derived" ] && CONTAINER_SUFFIX="-${derived}"
+fi
 
 # Display the values being used
 echo "Using Docker image: $DOCKER_IMAGE_NAME:$DOCKER_VERSION_TAG"


### PR DESCRIPTION
## Summary
Per-clone Docker container names. Enables working in several IsaacLab-Arena clones in parallel.

## Detailed description
- `run_docker.sh` defaulted every clone to the bare container name `isaaclab_arena-latest`. With a container already running, launching a second clone execed into the first clone's container instead of mounting its own tree, so _tests/builds silently ran the wrong code_.

- Auto-derive the container suffix from the repo directory name when `-s` is not given: 
`~/IsaacLab-Arena` keeps the bare name, `~/IsaacLab-Arena_<x>` becomes `isaaclab_arena-latest-<x>`.


## Example

**Before this PR — both clones compute the same name `isaaclab_arena-latest`:**

```
~/workspaces/IsaacLab-Arena    $ ./docker/run_docker.sh
   # name not running -> docker run, mounts . (IsaacLab-Arena) at /workspaces/isaaclab_arena

~/workspaces/IsaacLab-Arena_B  $ ./docker/run_docker.sh
   # name isaaclab_arena-latest is ALREADY running (clone A's)
   #   -> takes the "attach" branch: docker exec -it isaaclab_arena-latest ...
   #   -> the `-v .` mount line never runs
   #   -> inside, /workspaces/isaaclab_arena is still IsaacLab-Arena, NOT _B
```

**After this PR — the name is derived from the directory, so the clones never collide:**

```
~/workspaces/IsaacLab-Arena    $ ./docker/run_docker.sh   # -> isaaclab_arena-latest     (mounts IsaacLab-Arena)
~/workspaces/IsaacLab-Arena_B  $ ./docker/run_docker.sh   # -> isaaclab_arena-latest-B   (mounts IsaacLab-Arena_B)
```

Each clone gets its own container mounting its own tree, and the two run in parallel.

Agents/docs resolve their container by mount instead of a hardcoded name:

```
ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
```
