### PR TITLE
Run in-container agent commands as the host user

### DIFF
--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -34,16 +34,12 @@ Example with custom mounts:
 
 ## Run a command in the already-running container
 
-Run as the **host user**, not root — mirror how `run_docker.sh` attaches (`docker exec -it <container> su $(id -un)`):
-
 ```bash
 docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && <command>"
 ```
 
 The repo root is mounted at `/workspaces/isaaclab_arena` inside the container.
-
-**Never** use a bare `docker exec <container> bash -c "…"` for commands that read or write shared state — that runs as **root** and leaves root-owned files in caches the host user shares (`/tmp/Assets`, `~/.config`, …), which then fail to read on the user's own runs. `su $(id -un) -c` runs as the host user (the account `docker/setup/entrypoint.sh` provisions) with `HOME` set correctly; `$(id -un)` is evaluated on the host and matches the in-container account.
 
 ## Python invocation
 

--- a/.agents/skills/dev-container/SKILL.md
+++ b/.agents/skills/dev-container/SKILL.md
@@ -34,12 +34,16 @@ Example with custom mounts:
 
 ## Run a command in the already-running container
 
+Run as the **host user**, not root — mirror how `run_docker.sh` attaches (`docker exec -it <container> su $(id -un)`):
+
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && <command>"
 ```
 
 The repo root is mounted at `/workspaces/isaaclab_arena` inside the container.
+
+**Never** use a bare `docker exec <container> bash -c "…"` for commands that read or write shared state — that runs as **root** and leaves root-owned files in caches the host user shares (`/tmp/Assets`, `~/.config`, …), which then fail to read on the user's own runs. `su $(id -un) -c` runs as the host user (the account `docker/setup/entrypoint.sh` provisions) with `HOME` set correctly; `$(id -un)` is evaluated on the host and matches the in-container account.
 
 ## Python invocation
 
@@ -50,7 +54,7 @@ Inside the container, `python` is aliased to `/isaac-sim/python.sh`. Both forms 
 A container is up and importable when:
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "/isaac-sim/python.sh -c 'import isaaclab_arena; print(isaaclab_arena.__file__)'"
 ```
 

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -14,8 +14,6 @@ allowed-tools: Bash(docker exec *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`, **as the host user** (`su $(id -un) -c`, mirroring how `run_docker.sh` attaches) — never as bare-`docker exec` root, which leaves root-owned files in shared caches that break the user's own runs. If the container is not running, use the `dev-container` skill first.
-
 ## Phase 1 — no cameras, no subprocess
 
 The fastest of the three. Useful on its own when iterating on changes that don't touch rendering or subprocess paths.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -14,14 +14,14 @@ allowed-tools: Bash(docker exec *)
 
 The three phases run mutually exclusive sets of tests (selected via different pytest marker filters) and must be invoked separately. For a full pre-PR run, every phase must pass before moving on to the next.
 
-All commands run inside the already-running container via `docker exec`. If the container is not running, use the `dev-container` skill first.
+All commands run inside the already-running container via `docker exec`, **as the host user** (`su $(id -un) -c`, mirroring how `run_docker.sh` attaches) — never as bare-`docker exec` root, which leaves root-owned files in shared caches that break the user's own runs. If the container is not running, use the `dev-container` skill first.
 
 ## Phase 1 — no cameras, no subprocess
 
 The fastest of the three. Useful on its own when iterating on changes that don't touch rendering or subprocess paths.
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'not with_cameras and not with_subprocess' isaaclab_arena/tests"
@@ -30,7 +30,7 @@ docker exec isaaclab_arena-latest bash -c \
 ## Phase 2 — with cameras
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'with_cameras and not with_subprocess' isaaclab_arena/tests"
@@ -39,7 +39,7 @@ docker exec isaaclab_arena-latest bash -c \
 ## Phase 3 — with subprocess
 
 ```bash
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest -sv \
    -m 'with_subprocess' isaaclab_arena/tests"
@@ -49,12 +49,12 @@ docker exec isaaclab_arena-latest bash -c \
 
 ```bash
 # single file
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py"
 
 # single function
-docker exec isaaclab_arena-latest bash -c \
+docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && \
    /isaac-sim/python.sh -m pytest isaaclab_arena/tests/test_asset_registry.py::test_default_assets_registered"
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,15 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
 
+**Run as the host user, not root.** Human contributors enter the container via `./docker/run_docker.sh`, which attaches with `docker exec -it <container> su $(id -un)` — i.e. as their host user (the account `docker/setup/entrypoint.sh` provisions inside the container with the host UID/GID). A bare `docker exec <container> …` runs as **root**; root-run commands write root-owned files into caches the host user shares (`/tmp/Assets`, `~/.config`, …), leaving them unreadable by that user and breaking the user's later interactive runs. Mirror `run_docker.sh` — route every in-container command through the host user:
+
+```bash
+docker exec isaaclab_arena-latest su $(id -un) -c \
+  "cd /workspaces/isaaclab_arena && <command>"
+```
+
+`su $(id -un)` runs as the host user with `HOME=/home/$(id -un)` set correctly; `$(id -un)` is evaluated on the host and matches the in-container account.
+
 Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, isort, pyupgrade, codespell) runs **on the host**.
 
 Use the `dev-container` skill for build, start, attach, and exec inside the container.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,9 +20,7 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 ## Docker environment
 
-Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
-
-**Run as the host user, not root.** Human contributors enter the container via `./docker/run_docker.sh`, which attaches with `docker exec -it <container> su $(id -un)` — i.e. as their host user (the account `docker/setup/entrypoint.sh` provisions inside the container with the host UID/GID). A bare `docker exec <container> …` runs as **root**; root-run commands write root-owned files into caches the host user shares (`/tmp/Assets`, `~/.config`, …), leaving them unreadable by that user and breaking the user's later interactive runs. Mirror `run_docker.sh` — route every in-container command through the host user:
+Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active. Run as the host user, not root.
 
 ```bash
 docker exec isaaclab_arena-latest su $(id -un) -c \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,14 +20,14 @@ pre-commit install    # on the host — registers git pre-commit hooks
 
 ## Docker environment
 
-Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active. Run as the host user, not root.
+Commands that touch Isaac Sim or Arena's package code (tests, training, evaluation, runtime scripts) run inside the `isaaclab_arena-latest` Docker container. The repo root is mounted at `/workspaces/isaaclab_arena`. Inside the container, `python` is aliased to `/isaac-sim/python.sh` — prefer the explicit path in `docker exec` invocations from outside the container, where the alias is not active.
+
+Run as the host user, not root.
 
 ```bash
 docker exec isaaclab_arena-latest su $(id -un) -c \
   "cd /workspaces/isaaclab_arena && <command>"
 ```
-
-`su $(id -un)` runs as the host user with `HOME=/home/$(id -un)` set correctly; `$(id -un)` is evaluated on the host and matches the in-container account.
 
 Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, isort, pyupgrade, codespell) runs **on the host**.
 


### PR DESCRIPTION
## Summary
Agents now run in container as the host user, not root

## Detailed description
- We were running as root which could cause bugs where assets were downloaded as root, and therefore inaccessable by human users.
- We now instruct agents to run as the user.