### PR TITLE
Fix docker entrypoint failure when host user is 'ubuntu'

### DIFF
--- a/docker/setup/entrypoint.sh
+++ b/docker/setup/entrypoint.sh
@@ -12,12 +12,15 @@ set -euo pipefail
 # at the end of the dockerfile
 ldconfig
 
-# Add the group of the user. User/group ID of the host user are set through env variables when calling docker run further down.
+# Remove any existing user with the same name (userdel may also remove its primary group)
+userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
+userdel ubuntu 2>/dev/null || true
+
+# Add the group of the user AFTER userdel, since userdel may have removed the primary group.
+# User/group ID of the host user are set through env variables when calling docker run further down.
 groupadd --force --gid "$DOCKER_RUN_GROUP_ID" "$DOCKER_RUN_GROUP_NAME"
 
 # Re-add the user
-userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
-userdel ubuntu || true
 useradd --no-log-init \
         --uid "$DOCKER_RUN_USER_ID" \
         --gid "$DOCKER_RUN_GROUP_NAME" \

--- a/docker/setup/entrypoint.sh
+++ b/docker/setup/entrypoint.sh
@@ -16,7 +16,6 @@ ldconfig
 userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
 userdel ubuntu 2>/dev/null || true
 
-# Add the group of the user AFTER userdel, since userdel may have removed the primary group.
 # User/group ID of the host user are set through env variables when calling docker run further down.
 groupadd --force --gid "$DOCKER_RUN_GROUP_ID" "$DOCKER_RUN_GROUP_NAME"
 


### PR DESCRIPTION
## Summary
Reorder userdel/groupadd in docker entrypoint

## Detailed description
- The container entrypoint failed when the host user and group are both `ubuntu` (e.g. Brev Desktop VMs), since `userdel ubuntu` removes the primary group that `groupadd --force` had just relied on, leaving `useradd --gid ubuntu` with no group.
- Move both `userdel` calls before `groupadd` so the group is (re)created after any user/group cleanup.
- Forward-port of #415 (authored by @jo-fra, which targets `release/0.1.1`) onto `main`.