### PR TITLE
[CP #764] [static apple pick and place] Update the task description in env file

### DIFF
--- a/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_static_pick_and_place_environment.py
@@ -254,15 +254,7 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
             )
         )
 
-        if args_cli.task_description is not None:
-            task_description = args_cli.task_description
-        else:
-            object_label = args_cli.object.replace("_", " ")
-            destination_label = args_cli.destination.replace("_", " ")
-            task_description = (
-                f"Pick up the {object_label} from the shelf and place it onto the "
-                f"{destination_label} on the same shelf next to it."
-            )
+        task_description = args_cli.task_description
 
         def env_cfg_callback(env_cfg):
             from isaaclab.managers import EventTermCfg
@@ -316,11 +308,8 @@ class GalileoG1StaticPickAndPlaceEnvironment(ExampleEnvironmentBase):
         parser.add_argument(
             "--task_description",
             type=str,
-            default=None,
-            help=(
-                "Override the natural-language task description. Defaults to a template "
-                "derived from --object and --destination."
-            ),
+            default="move the apple to the plate",
+            help="Natural-language task description for language-conditioned policies.",
         )
         # The static task is upper-body-only by design, so we lock the 3 waist
         # joints by default. Pass ``--no-lock_waist`` to fall back to the default


### PR DESCRIPTION
CP: [#764 ](https://github.com/isaac-sim/IsaacLab-Arena/pull/764)

## Summary
Fix static apple env task description default

## Detailed description
- **Reason:** The env auto-generated `task_description` from asset registry names (e.g. `apple_01_objaverse_robolab`), which did not match the instruction used in GR00T training and eval (`"move the apple to the plate"`). During closed-loop eval, `policy_runner` falls back to `env.cfg.task_description` when `--language_instruction` is not set, so the policy could receive the wrong language input.
- **Changed:** Set `--task_description` default to `"move the apple to the plate"` in `galileo_g1_static_pick_and_place_environment.py` and removed the asset-name template logic.
- **Impact:** Default env runs and eval now use the same language instruction as `g1_static_apple_config.yaml` and `g1_static_apple_gr00t_closedloop_config.yaml`, with no behavior change to simulation physics or success criteria. Users can still override via `--task_description`.