### PR TITLE
Cherry-Pick Fix docker entrypoint failure when host user is 'ubuntu'

### DIFF
--- a/docker/setup/entrypoint.sh
+++ b/docker/setup/entrypoint.sh
@@ -12,12 +12,14 @@ set -euo pipefail
 # at the end of the dockerfile
 ldconfig
 
-# Add the group of the user. User/group ID of the host user are set through env variables when calling docker run further down.
+# Remove any existing user with the same name (userdel may also remove its primary group)
+userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
+userdel ubuntu 2>/dev/null || true
+
+# User/group ID of the host user are set through env variables when calling docker run further down.
 groupadd --force --gid "$DOCKER_RUN_GROUP_ID" "$DOCKER_RUN_GROUP_NAME"
 
 # Re-add the user
-userdel "$DOCKER_RUN_USER_NAME" 2>/dev/null || true
-userdel ubuntu || true
 useradd --no-log-init \
         --uid "$DOCKER_RUN_USER_ID" \
         --gid "$DOCKER_RUN_GROUP_NAME" \


### PR DESCRIPTION
Cherry-pick of #763 onto release/0.2.1.

- Reorder `userdel`/`groupadd` in the docker entrypoint so the group survives user cleanup.
- Fixes container entrypoint failure when the host user and group are both `ubuntu` (e.g. Brev Desktop VMs).
- Clean cherry-pick of a66739257 ; originally a forward-port of #415 by @jo-fra.