### PR TITLE
Drop reload_arena_modules from eval job loop

### DIFF
--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -24,7 +24,6 @@ from isaaclab_arena.evaluation.job_manager import Job, JobManager, Status
 from isaaclab_arena.evaluation.policy_runner import get_policy_cls, rollout_policy
 from isaaclab_arena.metrics.metrics_logger import MetricsLogger
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext, teardown_simulation_app
-from isaaclab_arena.utils.reload_modules import reload_arena_modules
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
 
 if TYPE_CHECKING:
@@ -32,8 +31,6 @@ if TYPE_CHECKING:
 
 
 def load_env(arena_env_args: list[str], job_name: str, render_mode: str | None = None):
-
-    reload_arena_modules()
 
     args_parser = get_isaaclab_arena_environments_cli_parser()
 


### PR DESCRIPTION
## Summary
Remove per-job module reload from eval_runner.

## Detailed description
- **What `reload_arena_modules()` is for:** It deletes the cached bytecode and
  re-imports every `isaaclab_arena*` module, so a running Python process picks up
  source edits without a restart. The intended use case is the interactive dev
  notebooks (`example_env_notebook.py`, `compile_env_notebook.py`).

- **Why it is not needed here:** `eval_runner` runs a fixed list of jobs from a
  config and never edits source between them. Reloading every module on each job
  recompiles unchanged code for no benefit, and each reload re-runs the module
  bodies, re-creating the gym registries and env-config dataclasses. Those pile up
  in the process and are never reclaimed (~5 MB plus config/tensor churn per job).

- **Impact:** No behavior change for eval, since source is not edited mid-run.