### PR TITLE
Add EpisodeRecord with task metadata, metrics output, and episode boundaries

### DIFF
--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -3,24 +3,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Gym wrapper that records one mp4 per camera in ``obs['camera_obs']``.
+"""Gym wrapper that records one mp4 per camera per env in ``obs['camera_obs']``.
 
 Mirrors ``gymnasium.wrappers.RecordVideo`` — same ``step_trigger`` /
 ``video_length`` semantics and the same moviepy ``ImageSequenceClip``
 encoder, but frames come from ``obs["camera_obs"][<cam>]`` rather than
-``env.render()``. Output is one mp4 per camera under ``video_folder``,
-named ``<name_prefix>-<cam>-step-<N>.mp4``.
+``env.render()``. Output is one mp4 per (env, camera) under ``video_folder``,
+named ``<name_prefix>-env<N>-<cam>-step-<S>.mp4``.
 
 policy_runner.py wraps the env with this alongside ``RecordVideo`` so
 the kit viewport mp4 (third-person scene view) and the embodiment-
 mounted camera mp4s (what the policy actually sees) are written
 together when ``--video --camera_video`` is set.
 
-Multi-env note: Arena batches camera observations as
-``[N_envs, H, W, C]``. This wrapper records env 0 only (``frame[0]``);
-other envs are silently dropped. ``RecordVideo`` for the kit viewport
-is unaffected — the viewport shows the full scene regardless of
-``num_envs``.
+Memory note: with N envs, L steps, and H×W×C frames, the in-memory
+buffer is N×L×H×W×C bytes. For 10 envs, 500 steps, 512×512×3 frames
+that is ~3.8 GB — consider reducing num_envs or video_length for long runs.
 """
 
 from __future__ import annotations
@@ -54,10 +52,11 @@ def _sanitize_cam_key(key: str) -> str:
 
 
 class CameraObsVideoRecorder(gym.Wrapper):
-    """Record an mp4 per camera in ``obs['camera_obs']``.
+    """Record one mp4 per (env, camera) in ``obs['camera_obs']``.
 
-    Records env 0 only: cameras are batched as ``[N_envs, H, W, C]`` and the
-    wrapper picks ``frame[0]``. Intended for single-env evaluation rollouts.
+    Cameras are batched as ``[N_envs, H, W, C]``. All envs are recorded;
+    each produces a separate file named
+    ``<name_prefix>-env<N>-<cam>-step-<S>.mp4``.
     """
 
     def __init__(
@@ -80,7 +79,8 @@ class CameraObsVideoRecorder(gym.Wrapper):
         self.step_id = -1
         self.recording = False
         self.recording_start_step = 0
-        self.buffers: dict[str, list[np.ndarray]] = {}
+        # cam_key -> list of per-env frame lists: buffers[cam][env_idx] = [frame, ...]
+        self.buffers: dict[str, list[list[np.ndarray]]] = {}
 
     def step(self, action):
         result = self.env.step(action)
@@ -91,34 +91,48 @@ class CameraObsVideoRecorder(gym.Wrapper):
         if not self.recording and self.step_trigger(self.step_id):
             self.recording = True
             self.recording_start_step = self.step_id
-            self.buffers = {k: [] for k in cam_obs}
+            self.buffers = {}
 
         if self.recording and cam_obs:
-            for k, frame in cam_obs.items():
-                # frame: [N_envs, H, W, C]; record env 0 only.
-                self.buffers.setdefault(k, []).append(_to_uint8(frame[0]))
-            if self.buffers and all(len(v) >= self.video_length for v in self.buffers.values()):
+            for k, frames in cam_obs.items():
+                # frames: [N_envs, H, W, C]
+                n_envs = frames.shape[0]
+                if k not in self.buffers:
+                    self.buffers[k] = [[] for _ in range(n_envs)]
+                for env_idx in range(n_envs):
+                    self.buffers[k][env_idx].append(_to_uint8(frames[env_idx]))
+
+            if self.buffers and all(
+                len(env_frames) >= self.video_length
+                for env_frame_lists in self.buffers.values()
+                for env_frames in env_frame_lists
+            ):
                 self._flush()
 
         return result
 
     def _flush(self) -> None:
-        for cam, frames in self.buffers.items():
-            if not frames:
-                continue
-            path = os.path.join(
-                self.video_folder,
-                f"{self.name_prefix}-{_sanitize_cam_key(cam)}-step-{self.recording_start_step}.mp4",
-            )
-            clip = ImageSequenceClip(list(frames), fps=self.fps)
-            clip.write_videofile(path, logger=None, audio=False)
-            del clip
+        for cam, env_frame_lists in self.buffers.items():
+            for env_idx, frames in enumerate(env_frame_lists):
+                if not frames:
+                    continue
+                path = os.path.join(
+                    self.video_folder,
+                    f"{self.name_prefix}-env{env_idx}-{_sanitize_cam_key(cam)}-step-{self.recording_start_step}.mp4",
+                )
+                clip = ImageSequenceClip(list(frames), fps=self.fps)
+                clip.write_videofile(path, logger=None, audio=False)
+                del clip
         self.recording = False
         self.buffers = {}
 
     def close(self) -> None:
         try:
-            if self.recording and any(len(v) > 0 for v in self.buffers.values()):
+            if self.recording and any(
+                len(env_frames) > 0
+                for env_frame_lists in self.buffers.values()
+                for env_frames in env_frame_lists
+            ):
                 self._flush()
         finally:
             self.env.close()

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -129,9 +129,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
     def close(self) -> None:
         try:
             if self.recording and any(
-                len(env_frames) > 0
-                for env_frame_lists in self.buffers.values()
-                for env_frames in env_frame_lists
+                len(env_frames) > 0 for env_frame_lists in self.buffers.values() for env_frames in env_frame_lists
             ):
                 self._flush()
         finally:

--- a/isaaclab_arena/evaluation/episode_record.py
+++ b/isaaclab_arena/evaluation/episode_record.py
@@ -230,11 +230,7 @@ def _find_video_paths(video_dir: str | None, job_name: str) -> list[str]:
     job_video_dir = os.path.join(video_dir, job_name)
     if not os.path.isdir(job_video_dir):
         return []
-    return sorted(
-        os.path.join(job_video_dir, f)
-        for f in os.listdir(job_video_dir)
-        if f.endswith(".mp4")
-    )
+    return sorted(os.path.join(job_video_dir, f) for f in os.listdir(job_video_dir) if f.endswith(".mp4"))
 
 
 def _get_hdf5_path(env) -> str | None:
@@ -246,8 +242,7 @@ def _get_hdf5_path(env) -> str | None:
         if not hasattr(cfg, "recorders") or cfg.recorders is None:
             return None
         return str(
-            pathlib.Path(cfg.recorders.dataset_export_dir_path)
-            / pathlib.Path(cfg.recorders.dataset_filename + ".hdf5")
+            pathlib.Path(cfg.recorders.dataset_export_dir_path) / pathlib.Path(cfg.recorders.dataset_filename + ".hdf5")
         )
     except Exception:
         return None

--- a/isaaclab_arena/evaluation/episode_record.py
+++ b/isaaclab_arena/evaluation/episode_record.py
@@ -98,8 +98,10 @@ class ModelOutput:
 
     @classmethod
     def from_dict(cls, data: dict) -> "ModelOutput":
+        data = dict(data)  # don't mutate the caller's dict
         phases_raw = data.pop("subtask_phases", [])
-        obj = cls(**data)
+        known = {f.name for f in dataclasses.fields(cls)}
+        obj = cls(**{k: v for k, v in data.items() if k in known})
         obj.subtask_phases = [SubtaskPhase.from_dict(p) for p in phases_raw]
         return obj
 
@@ -173,8 +175,10 @@ class EpisodeRecord:
 
     @classmethod
     def from_dict(cls, data: dict) -> "EpisodeRecord":
+        data = dict(data)
         data.setdefault("schema_version", SCHEMA_VERSION)
-        return cls(**data)
+        known = {f.name for f in dataclasses.fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
     def to_json(self, indent: int = 2) -> str:
         return json.dumps(self.to_dict(), indent=indent)
@@ -206,10 +210,7 @@ class EpisodeTrace:
     created_at: str = dataclasses.field(default_factory=lambda: _utc_now())
 
     def to_dict(self) -> dict:
-        d = dataclasses.asdict(self)
-        d["episode_record"] = self.episode_record.to_dict()
-        d["model_outputs"] = [m.to_dict() for m in self.model_outputs]
-        return d
+        return dataclasses.asdict(self)
 
 
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/evaluation/episode_record.py
+++ b/isaaclab_arena/evaluation/episode_record.py
@@ -13,6 +13,7 @@ ModelOutput, SubtaskPhase, and EpisodeTrace are defined here as stubs so
 code in later phases can import them from a stable location.
 """
 
+import contextlib
 import dataclasses
 import json
 import os
@@ -287,17 +288,13 @@ def build_episode_record(
     language_instruction = job.language_instruction or getattr(env.unwrapped.cfg, "task_description", None)
 
     step_dt: float | None = None
-    try:
+    with contextlib.suppress(Exception):
         step_dt = float(env.unwrapped.step_dt)
-    except Exception:
-        pass
 
     episode_length_steps: int | None = job.num_steps
     if episode_length_steps is None:
-        try:
+        with contextlib.suppress(Exception):
             episode_length_steps = int(env.unwrapped.max_episode_length)
-        except Exception:
-            pass
 
     return EpisodeRecord(
         episode_id=job.name,

--- a/isaaclab_arena/evaluation/episode_record.py
+++ b/isaaclab_arena/evaluation/episode_record.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Episode record schema for the Agentic Autograder (Phase 1).
+
+Phase 1 writes one EpisodeRecord per eval job. Future phases will produce
+per-episode records once individual episode tracking is wired into the
+rollout loop.
+
+ModelOutput, SubtaskPhase, and EpisodeTrace are defined here as stubs so
+code in later phases can import them from a stable location.
+"""
+
+import dataclasses
+import json
+import os
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+SCHEMA_VERSION = "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class FailureCategory(str, Enum):
+    """Root-cause taxonomy for episode failures."""
+
+    GRASP_MISS = "grasp_miss"
+    GRASP_SLIP = "grasp_slip"
+    WRONG_OBJECT = "wrong_object"
+    WRONG_DESTINATION = "wrong_destination"
+    COLLISION = "collision"
+    TIMEOUT = "timeout"
+    APPROACH_FAILURE = "approach_failure"
+    STAGNATION = "stagnation"
+    RECOVERY_FAILED = "recovery_failed"
+    UNKNOWN = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Sub-dataclasses (stubs populated by Phase 3+ components)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class SubtaskPhase:
+    """A single phase within a task episode."""
+
+    name: str
+    start_timestep: float
+    end_timestep: float
+    completed: bool
+    confidence: float = 1.0
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SubtaskPhase":
+        return cls(**data)
+
+
+@dataclasses.dataclass
+class ModelOutput:
+    """Output from one VLM analysis component on one episode.
+
+    All fields are optional so Phase 1 records can coexist with fully
+    populated Phase 3+ records.
+    """
+
+    model_id: str
+    model_version: str = ""
+    prompt_version: str = ""
+    progress_score: float | None = None
+    progress_label: int | None = None
+    progress_per_frame: list[float] | None = None
+    success_judgment: bool | None = None
+    failure_detected: bool | None = None
+    failure_timestep: float | None = None
+    failure_description: str | None = None
+    failure_category: str | None = None
+    subtask_phases: list[SubtaskPhase] = dataclasses.field(default_factory=list)
+    key_frame_timestamps: list[float] = dataclasses.field(default_factory=list)
+    confidence: float | None = None
+    uncertainty_notes: str | None = None
+    raw_output: dict = dataclasses.field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["subtask_phases"] = [p.to_dict() for p in self.subtask_phases]
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ModelOutput":
+        phases_raw = data.pop("subtask_phases", [])
+        obj = cls(**data)
+        obj.subtask_phases = [SubtaskPhase.from_dict(p) for p in phases_raw]
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# EpisodeRecord
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class EpisodeRecord:
+    """Structured record for one eval job run.
+
+    In Phase 1 this is one record per job. Future phases will split this
+    into one record per individual episode (episode_id will then be
+    {job_name}_{seed}_{env_idx}).
+    """
+
+    # Identity
+    episode_id: str
+    job_name: str
+    policy_type: str
+    policy_config: dict
+    arena_env_args: list[str]
+    num_envs: int
+
+    # Simulation length
+    num_steps: int | None
+    num_episodes: int | None
+
+    # Task
+    language_instruction: str | None
+
+    # Artifacts
+    video_paths: list[str]
+    hdf5_path: str | None
+
+    # Outcome
+    status: str
+    success: bool | None
+    scalar_metrics: dict[str, Any]
+
+    # Timing
+    wall_time_seconds: float | None
+
+    # Metadata
+    created_at: str
+    schema_version: str = SCHEMA_VERSION
+
+    # Extended task identity (None for records written before these fields were added)
+    task_name: str | None = None
+    embodiment: str | None = None
+    env_params: dict | None = None
+    seed: int | None = None
+    sensitivity_sweep_params: dict | None = None
+
+    # Extended timing
+    episode_length_steps: int | None = None
+    step_dt: float | None = None
+
+    # Per-episode boundaries within the job video (one entry per completed episode).
+    # Each dict: {env_idx: int, start_step: int, end_step: int} (0-indexed, inclusive).
+    # Frame index in CameraObsVideoRecorder output equals step index, so these can be
+    # used to slice the job video into per-episode clips.
+    episode_boundaries: list[dict] = dataclasses.field(default_factory=list)
+
+    # ---------------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "EpisodeRecord":
+        data.setdefault("schema_version", SCHEMA_VERSION)
+        return cls(**data)
+
+    def to_json(self, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_json(cls, text: str) -> "EpisodeRecord":
+        return cls.from_dict(json.loads(text))
+
+
+# ---------------------------------------------------------------------------
+# EpisodeTrace (stub for Phase 3+)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class EpisodeTrace:
+    """Merged per-episode record combining EpisodeRecord with VLM model outputs.
+
+    Populated by the Autograder dispatcher in Phase 3+.
+    """
+
+    episode_record: EpisodeRecord
+    model_outputs: list[ModelOutput] = dataclasses.field(default_factory=list)
+    consensus_progress: float | None = None
+    consensus_success: bool | None = None
+    consensus_failure_category: str | None = None
+    disagreements: list[dict] = dataclasses.field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+    created_at: str = dataclasses.field(default_factory=lambda: _utc_now())
+
+    def to_dict(self) -> dict:
+        d = dataclasses.asdict(self)
+        d["episode_record"] = self.episode_record.to_dict()
+        d["model_outputs"] = [m.to_dict() for m in self.model_outputs]
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _find_video_paths(video_dir: str | None, job_name: str) -> list[str]:
+    """Return paths to MP4 files written for this job, sorted."""
+    if not video_dir:
+        return []
+    job_video_dir = os.path.join(video_dir, job_name)
+    if not os.path.isdir(job_video_dir):
+        return []
+    return sorted(
+        os.path.join(job_video_dir, f)
+        for f in os.listdir(job_video_dir)
+        if f.endswith(".mp4")
+    )
+
+
+def _get_hdf5_path(env) -> str | None:
+    """Extract HDF5 dataset path from the environment config if available."""
+    try:
+        import pathlib
+
+        cfg = env.unwrapped.cfg
+        if not hasattr(cfg, "recorders") or cfg.recorders is None:
+            return None
+        return str(
+            pathlib.Path(cfg.recorders.dataset_export_dir_path)
+            / pathlib.Path(cfg.recorders.dataset_filename + ".hdf5")
+        )
+    except Exception:
+        return None
+
+
+def build_episode_record(
+    job,
+    env,
+    metrics: dict[str, Any] | None,
+    status: str,
+    video_dir: str | None = None,
+    seed: int | None = None,
+    episode_boundaries: list[dict] | None = None,
+) -> EpisodeRecord:
+    """Build an EpisodeRecord from a completed eval job.
+
+    Args:
+        job: Completed Job instance.
+        env: The gymnasium environment (may be wrapped with RecordVideo).
+        metrics: Scalar metrics returned by rollout_policy(), or None.
+        status: Job status string ("completed" or "failed").
+        video_dir: Root video directory (args_cli.video_dir) if recording was enabled.
+        seed: RNG seed used for this job, if set.
+
+    Returns:
+        Populated EpisodeRecord.
+    """
+    scalar_metrics = dict(metrics) if metrics else {}
+
+    success: bool | None = None
+    if "success_rate" in scalar_metrics:
+        success = float(scalar_metrics["success_rate"]) > 0.0
+
+    wall_time: float | None = None
+    if job.start_time is not None and job.end_time is not None:
+        wall_time = round(job.end_time - job.start_time, 3)
+
+    language_instruction = job.language_instruction or getattr(env.unwrapped.cfg, "task_description", None)
+
+    step_dt: float | None = None
+    try:
+        step_dt = float(env.unwrapped.step_dt)
+    except Exception:
+        pass
+
+    episode_length_steps: int | None = job.num_steps
+    if episode_length_steps is None:
+        try:
+            episode_length_steps = int(env.unwrapped.max_episode_length)
+        except Exception:
+            pass
+
+    return EpisodeRecord(
+        episode_id=job.name,
+        job_name=job.name,
+        policy_type=job.policy_type,
+        policy_config=dict(job.policy_config_dict),
+        arena_env_args=list(job.arena_env_args),
+        num_envs=job.num_envs,
+        num_steps=job.num_steps,
+        num_episodes=job.num_episodes,
+        language_instruction=language_instruction,
+        video_paths=_find_video_paths(video_dir, job.name),
+        hdf5_path=_get_hdf5_path(env),
+        status=status,
+        success=success,
+        scalar_metrics=scalar_metrics,
+        wall_time_seconds=wall_time,
+        created_at=_utc_now(),
+        task_name=job.task_name,
+        embodiment=job.embodiment,
+        env_params=dict(job.env_params) if job.env_params else None,
+        seed=seed,
+        episode_length_steps=episode_length_steps,
+        step_dt=step_dt,
+        episode_boundaries=episode_boundaries if episode_boundaries is not None else [],
+    )
+
+
+def write_episode_record(record: EpisodeRecord, output_dir: str) -> str:
+    """Write an EpisodeRecord to a JSON file.
+
+    Args:
+        record: The episode record to write.
+        output_dir: Directory to write into.
+
+    Returns:
+        Absolute path of the written file.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, f"{record.episode_id}.json")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(record.to_json())
+    return path

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import torch
+from datetime import datetime
 import traceback
 from gymnasium.wrappers import RecordVideo
 from pathlib import Path
@@ -209,6 +210,8 @@ def main():
         job_manager.print_jobs_info()
 
         if args_cli.video or args_cli.camera_video:
+            run_ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+            args_cli.video_dir = os.path.join(args_cli.video_dir, run_ts)
             os.makedirs(args_cli.video_dir, exist_ok=True)
             print(f"[INFO] Video recording enabled. Videos will be saved to: {args_cli.video_dir}")
 

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -12,9 +12,10 @@ import os
 import subprocess
 import sys
 import tempfile
-import torch
-from datetime import datetime
 import traceback
+from datetime import datetime
+
+import torch
 from gymnasium.wrappers import RecordVideo
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -205,15 +206,21 @@ def main():
 
     with SimulationAppContext(args_cli):
         job_manager = JobManager(eval_jobs_config["jobs"])
-        metrics_logger = MetricsLogger()
+        metrics_logger = MetricsLogger(metrics_file=args_cli.metrics_file or "metrics.json")
 
         job_manager.print_jobs_info()
 
-        if args_cli.video or args_cli.camera_video:
+        if args_cli.video or args_cli.camera_video or args_cli.episode_record_dir or args_cli.metrics_file:
             run_ts = datetime.now().strftime("%Y%m%dT%H%M%S")
-            args_cli.video_dir = os.path.join(args_cli.video_dir, run_ts)
-            os.makedirs(args_cli.video_dir, exist_ok=True)
-            print(f"[INFO] Video recording enabled. Videos will be saved to: {args_cli.video_dir}")
+            if args_cli.video or args_cli.camera_video:
+                args_cli.video_dir = os.path.join(args_cli.video_dir, run_ts)
+                os.makedirs(args_cli.video_dir, exist_ok=True)
+                print(f"[INFO] Video recording enabled. Videos will be saved to: {args_cli.video_dir}")
+            if args_cli.episode_record_dir is not None:
+                args_cli.episode_record_dir = os.path.join(args_cli.episode_record_dir, run_ts)
+            if args_cli.metrics_file is not None:
+                base, ext = os.path.splitext(args_cli.metrics_file)
+                args_cli.metrics_file = f"{base}_{run_ts}{ext}"
 
         for job in job_manager:
             if job is not None:
@@ -317,9 +324,8 @@ def main():
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()
         if args_cli.metrics_file is not None:
-            metrics_logger.metrics_file = args_cli.metrics_file
             metrics_logger.save_metrics_to_file()
-            print(f"[INFO] Metrics saved to: {args_cli.metrics_file}")
+            print(f"[INFO] Metrics saved to: {metrics_logger.metrics_file}")
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -19,6 +19,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.evaluation.camera_video import CameraObsVideoRecorder
+from isaaclab_arena.evaluation.episode_record import build_episode_record, write_episode_record
 from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
 from isaaclab_arena.evaluation.job_manager import Job, JobManager, Status
 from isaaclab_arena.evaluation.policy_runner import get_policy_cls, rollout_policy
@@ -206,7 +208,7 @@ def main():
 
         job_manager.print_jobs_info()
 
-        if args_cli.video:
+        if args_cli.video or args_cli.camera_video:
             os.makedirs(args_cli.video_dir, exist_ok=True)
             print(f"[INFO] Video recording enabled. Videos will be saved to: {args_cli.video_dir}")
 
@@ -228,21 +230,33 @@ def main():
                         else:
                             job.num_steps = args_cli.num_steps
 
-                    if args_cli.video:
+                    if args_cli.video or args_cli.camera_video:
                         if job.num_steps is not None:
                             video_length = job.num_steps
                         else:
                             video_length = job.num_episodes * env.unwrapped.max_episode_length
+                        job_video_dir = os.path.join(args_cli.video_dir, job.name)
+
+                    if args_cli.video:
                         video_kwargs = {
-                            "video_folder": os.path.join(args_cli.video_dir, job.name),
+                            "video_folder": job_video_dir,
                             "step_trigger": lambda step: step == 0,
                             "video_length": video_length,
                             "disable_logger": True,
                         }
-                        print(f"[INFO] Recording video for job '{job.name}' -> {video_kwargs['video_folder']}")
+                        print(f"[INFO] Recording viewport video for job '{job.name}' -> {job_video_dir}")
                         env = RecordVideo(env, **video_kwargs)
 
-                    metrics = rollout_policy(
+                    if args_cli.camera_video:
+                        print(f"[INFO] Recording camera video for job '{job.name}' -> {job_video_dir}")
+                        env = CameraObsVideoRecorder(
+                            env,
+                            video_folder=job_video_dir,
+                            step_trigger=lambda step: step == 0,
+                            video_length=video_length,
+                        )
+
+                    metrics, episode_boundaries = rollout_policy(
                         env,
                         policy,
                         num_steps=job.num_steps,
@@ -252,6 +266,19 @@ def main():
 
                     job_manager.complete_job(job, metrics=metrics, status=Status.COMPLETED)
 
+                    if args_cli.episode_record_dir is not None:
+                        record = build_episode_record(
+                            job,
+                            env,
+                            metrics,
+                            status="completed",
+                            video_dir=args_cli.video_dir if (args_cli.video or args_cli.camera_video) else None,
+                            seed=args_cli.seed if hasattr(args_cli, "seed") else None,
+                            episode_boundaries=episode_boundaries,
+                        )
+                        path = write_episode_record(record, args_cli.episode_record_dir)
+                        print(f"[INFO] Episode record written: {path}")
+
                     # users may not specify metrics for a task, although it's not recommended
                     if metrics is not None:
                         metrics_logger.append_job_metrics(job.name, metrics)
@@ -260,6 +287,19 @@ def main():
                     job_manager.complete_job(job, metrics={}, status=Status.FAILED)
                     print(f"Job {job.name} failed with error: {e}")
                     print(f"Traceback: {traceback.format_exc()}")
+                    if args_cli.episode_record_dir is not None and env is not None:
+                        try:
+                            record = build_episode_record(
+                                job,
+                                env,
+                                metrics=None,
+                                status="failed",
+                                video_dir=args_cli.video_dir if (args_cli.video or args_cli.camera_video) else None,
+                                seed=args_cli.seed if hasattr(args_cli, "seed") else None,
+                            )
+                            write_episode_record(record, args_cli.episode_record_dir)
+                        except Exception:
+                            pass
                     if not args_cli.continue_on_error:
                         raise
 
@@ -273,6 +313,10 @@ def main():
 
         job_manager.print_jobs_info()
         metrics_logger.print_metrics()
+        if args_cli.metrics_file is not None:
+            metrics_logger.metrics_file = args_cli.metrics_file
+            metrics_logger.save_metrics_to_file()
+            print(f"[INFO] Metrics saved to: {args_cli.metrics_file}")
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -12,10 +12,9 @@ import os
 import subprocess
 import sys
 import tempfile
+import torch
 import traceback
 from datetime import datetime
-
-import torch
 from gymnasium.wrappers import RecordVideo
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -16,6 +16,12 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--video", action="store_true", default=False, help="Record videos for each eval job.")
     parser.add_argument(
+        "--camera_video",
+        action="store_true",
+        default=False,
+        help="Record per-camera videos from obs['camera_obs'] for each eval job. Works in headless mode.",
+    )
+    parser.add_argument(
         "--video_dir",
         type=str,
         default="/eval/videos",
@@ -26,6 +32,18 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         default=False,
         help="Continue evaluation with remaining jobs when a job fails instead of stopping immediately.",
+    )
+    parser.add_argument(
+        "--episode_record_dir",
+        type=str,
+        default=None,
+        help="Directory to write one EpisodeRecord JSON per job. If not set, no records are written.",
+    )
+    parser.add_argument(
+        "--metrics_file",
+        type=str,
+        default=None,
+        help="Path to save metrics as JSON. If not set, metrics are only printed to stdout.",
     )
     parser.add_argument(
         "--chunk_size",

--- a/isaaclab_arena/evaluation/job_manager.py
+++ b/isaaclab_arena/evaluation/job_manager.py
@@ -28,6 +28,9 @@ class Job:
         policy_config_dict: dict = None,
         status: Status = None,
         language_instruction: str = None,
+        task_name: str = None,
+        embodiment: str = None,
+        env_params: dict = None,
     ):
         """Initialize a Job instance.
 
@@ -42,6 +45,9 @@ class Job:
             status: Job status (defaults to PENDING)
             language_instruction: Optional language instruction override for the policy. When set,
                 takes precedence over the task's own description.
+            task_name: Environment/task name (e.g. "put_item_in_fridge_and_close_door").
+            embodiment: Robot embodiment name (e.g. "gr1_joint").
+            env_params: Raw arena_env_args dict from the job config, preserved for EpisodeRecord.
         """
         self.name = name
         self.arena_env_args = arena_env_args
@@ -55,6 +61,9 @@ class Job:
         self.policy_type = policy_type
         self.policy_config_dict = policy_config_dict if policy_config_dict is not None else {}
         self.language_instruction = language_instruction
+        self.task_name = task_name
+        self.embodiment = embodiment
+        self.env_params = env_params if env_params is not None else {}
         self.status = status if status is not None else Status.PENDING
         self.start_time = None
         self.end_time = None
@@ -98,6 +107,9 @@ class Job:
         else:
             status = Status.PENDING
         num_envs = data["arena_env_args"].get("num_envs", 1)
+        task_name = data["arena_env_args"].get("environment")
+        embodiment = data["arena_env_args"].get("embodiment")
+        env_params = dict(data["arena_env_args"])
 
         return cls(
             name=data["name"],
@@ -109,6 +121,9 @@ class Job:
             policy_config_dict=data["policy_config_dict"],
             status=status,
             language_instruction=data.get("language_instruction"),
+            task_name=task_name,
+            embodiment=embodiment,
+            env_params=env_params,
         )
 
     @classmethod

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -143,6 +143,18 @@ def rollout_policy(
 
         pbar.close()
 
+        # Append boundaries for episodes still in progress when the rollout ended.
+        # num_steps mode: last executed step = num_steps_completed - 1 (increment fired before break)
+        # num_episodes mode: last executed step = num_steps_completed (break fired before increment)
+        last_step = (num_steps_completed - 1) if num_steps is not None else num_steps_completed
+        n_envs = terminated.shape[0]
+        for env_idx in range(n_envs):
+            start = episode_starts.get(env_idx, 0)
+            if start <= last_step:
+                episode_boundaries.append(
+                    {"env_idx": env_idx, "start_step": start, "end_step": last_step}
+                )
+
     except Exception as e:
         if pbar is not None:
             pbar.close()

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -112,11 +112,13 @@ def rollout_policy(
                     policy.reset(env_ids=env_ids)
 
                     for env_idx in env_ids.tolist():
-                        episode_boundaries.append({
-                            "env_idx": env_idx,
-                            "start_step": episode_starts.get(env_idx, 0),
-                            "end_step": num_steps_completed,
-                        })
+                        episode_boundaries.append(
+                            {
+                                "env_idx": env_idx,
+                                "start_step": episode_starts.get(env_idx, 0),
+                                "end_step": num_steps_completed,
+                            }
+                        )
                         episode_starts[env_idx] = num_steps_completed + 1
 
                     # Break if number of episodes is reached

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -112,13 +112,11 @@ def rollout_policy(
                     policy.reset(env_ids=env_ids)
 
                     for env_idx in env_ids.tolist():
-                        episode_boundaries.append(
-                            {
-                                "env_idx": env_idx,
-                                "start_step": episode_starts.get(env_idx, 0),
-                                "end_step": num_steps_completed,
-                            }
-                        )
+                        episode_boundaries.append({
+                            "env_idx": env_idx,
+                            "start_step": episode_starts.get(env_idx, 0),
+                            "end_step": num_steps_completed,
+                        })
                         episode_starts[env_idx] = num_steps_completed + 1
 
                     # Break if number of episodes is reached

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -112,13 +112,11 @@ def rollout_policy(
                     policy.reset(env_ids=env_ids)
 
                     for env_idx in env_ids.tolist():
-                        episode_boundaries.append(
-                            {
-                                "env_idx": env_idx,
-                                "start_step": episode_starts.get(env_idx, 0),
-                                "end_step": num_steps_completed,
-                            }
-                        )
+                        episode_boundaries.append({
+                            "env_idx": env_idx,
+                            "start_step": episode_starts.get(env_idx, 0),
+                            "end_step": num_steps_completed,
+                        })
                         episode_starts[env_idx] = num_steps_completed + 1
 
                     # Break if number of episodes is reached
@@ -147,13 +145,11 @@ def rollout_policy(
         # num_steps mode: last executed step = num_steps_completed - 1 (increment fired before break)
         # num_episodes mode: last executed step = num_steps_completed (break fired before increment)
         last_step = (num_steps_completed - 1) if num_steps is not None else num_steps_completed
-        n_envs = terminated.shape[0]
+        n_envs = env.unwrapped.num_envs
         for env_idx in range(n_envs):
             start = episode_starts.get(env_idx, 0)
             if start <= last_step:
-                episode_boundaries.append(
-                    {"env_idx": env_idx, "start_step": start, "end_step": last_step}
-                )
+                episode_boundaries.append({"env_idx": env_idx, "start_step": start, "end_step": last_step})
 
     except Exception as e:
         if pbar is not None:

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -63,7 +63,17 @@ def rollout_policy(
     num_steps: int | None,
     num_episodes: int | None,
     language_instruction: str | None = None,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any] | None, list[dict]]:
+    """Run a policy rollout and return (metrics, episode_boundaries).
+
+    episode_boundaries is a list of dicts with keys:
+      env_idx    — which parallel env completed
+      start_step — first step of that episode (0-indexed, inclusive)
+      end_step   — last step of that episode (0-indexed, inclusive)
+
+    Frame index in CameraObsVideoRecorder output equals step index, so
+    these boundaries can be used to slice the recorded video into per-episode clips.
+    """
     assert num_steps is not None or num_episodes is not None, "Either num_steps or num_episodes must be provided"
     assert num_steps is None or num_episodes is None, "Only one of num_steps or num_episodes must be provided"
 
@@ -84,6 +94,8 @@ def rollout_policy(
 
         num_episodes_completed = 0
         num_steps_completed = 0
+        episode_starts: dict[int, int] = {}  # env_idx -> step at which current episode started
+        episode_boundaries: list[dict] = []
 
         while True:
             with torch.inference_mode():
@@ -98,6 +110,17 @@ def rollout_policy(
                     )
                     env_ids = (terminated | truncated).nonzero().flatten()
                     policy.reset(env_ids=env_ids)
+
+                    for env_idx in env_ids.tolist():
+                        episode_boundaries.append(
+                            {
+                                "env_idx": env_idx,
+                                "start_step": episode_starts.get(env_idx, 0),
+                                "end_step": num_steps_completed,
+                            }
+                        )
+                        episode_starts[env_idx] = num_steps_completed + 1
+
                     # Break if number of episodes is reached
                     completed_episodes = env_ids.shape[0]
                     num_episodes_completed += completed_episodes
@@ -130,8 +153,8 @@ def rollout_policy(
         # Only compute metrics if env has non-None metrics.
         # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
         if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-            return env.unwrapped.compute_metrics()
-        return None
+            return env.unwrapped.compute_metrics(), episode_boundaries
+        return None, episode_boundaries
 
 
 def main():
@@ -243,7 +266,7 @@ def main():
 
         steps_str = f"{num_steps} steps" if num_steps is not None else f"{num_episodes} episodes"
         print(f"[Rank {local_rank}/{world_size}] Starting rollout ({steps_str})")
-        metrics = rollout_policy(env, policy, num_steps, num_episodes, args_cli.language_instruction)
+        metrics, _ = rollout_policy(env, policy, num_steps, num_episodes, args_cli.language_instruction)
 
         if metrics is not None:
             print(f"[Rank {local_rank}/{world_size}] Metrics: {metrics_to_plain_python_types(metrics)}")


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                           
Add EpisodeRecord schema and wire up metrics, video, and boundary output in eval_runner
                                                                                                                                                                                                                                                      
## Detailed description
- Add `episode_record.py` with `EpisodeRecord`, `EpisodeTrace`, `ModelOutput`, `SubtaskPhase`, and `FailureCategory` dataclasses (Phase 1 of the Agentic Autograder schema); `build_episode_record()` and `write_episode_record()` populate and      
persist one JSON per eval job                                                                                                                                                                                                                        
- `EpisodeRecord` captures task metadata (`task_name`, `embodiment`, `env_params`, `seed`, `step_dt`, `episode_length_steps`) and per-episode boundaries `{env_idx, start_step, end_step}` for post-hoc video slicing; `Job` now preserves these
fields from `arena_env_args` before it is converted to a CLI list                                                                                                                                                                                    
- `rollout_policy()` tracks episode boundaries during the rollout loop; frame index in `CameraObsVideoRecorder` output equals step index so boundaries can be used to slice per-env videos into individual episode clips
- `eval_runner` gains `--episode_record_dir`, `--metrics_file`, and `--camera_video` flags; `save_metrics_to_file()` and camera video recording existed but were never called                                                                        
- `CameraObsVideoRecorder` now records all parallel envs (one file per env per camera) instead of env 0 only; each run gets a timestamped subdirectory under `--video_dir` to avoid stale files accumulating across runs
