### PR TITLE
Unify env random seeding using ManagerBasedRLEnv seed

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -316,7 +316,7 @@ class ArenaEnvBuilder:
             env_cfg = self.arena_env.env_cfg_callback(env_cfg)
 
         # Set seed for Isaac Lab env.
-        env_cfg.seed = getattr(self.args, "seed", None)
+        env_cfg.seed = self.args.seed
 
         # Apply the --presets CLI flag (e.g. --presets newton).
         # This runs after the callback so the user's CLI choice is the final authority.

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -310,13 +310,13 @@ class ArenaEnvBuilder:
                 viewer=viewer_cfg,
             )
 
-        # Set seed for Isaac Lab env.
-        env_cfg.seed = getattr(self.args, "seed", None)
-
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.
         if self.arena_env.env_cfg_callback is not None:
             env_cfg = self.arena_env.env_cfg_callback(env_cfg)
+
+        # Set seed for Isaac Lab env.
+        env_cfg.seed = getattr(self.args, "seed", None)
 
         # Apply the --presets CLI flag (e.g. --presets newton).
         # This runs after the callback so the user's CLI choice is the final authority.

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -310,6 +310,9 @@ class ArenaEnvBuilder:
                 viewer=viewer_cfg,
             )
 
+        # Set seed for Isaac Lab env.
+        env_cfg.seed = getattr(self.args, "seed", None)
+
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.
         if self.arena_env.env_cfg_callback is not None:

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -20,7 +20,6 @@ from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
-from isaaclab_arena.utils.random import set_seed
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
 
 if TYPE_CHECKING:
@@ -179,6 +178,10 @@ def main():
         if is_distributed(args_cli):
             args_cli.distributed = True
             args_cli.device = f"cuda:{local_rank}"
+            # Per-rank seed when distributed so each process has a different seed
+            if args_cli.seed is not None:
+                args_cli.seed += local_rank
+
         # Re-apply enable_cameras: the full parse resets it to default False.
         if args_cli.camera_video:
             args_cli.enable_cameras = True
@@ -192,13 +195,6 @@ def main():
 
         render_mode = "rgb_array" if args_cli.video else None
         env, cfg = arena_builder.make_registered_and_return_cfg(render_mode=render_mode)
-
-        # Per-rank seed when distributed so each process has a different seed
-        seed = args_cli.seed
-        if seed is not None and is_distributed(args_cli):
-            seed = seed + local_rank
-        if seed is not None:
-            set_seed(seed, env)
 
         # Create the policy from the arguments
         policy = policy_cls.from_args(args_cli)

--- a/isaaclab_arena/utils/random.py
+++ b/isaaclab_arena/utils/random.py
@@ -3,21 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import gymnasium as gym
 import math
-import numpy as np
 import random
 import torch
-
-
-def set_seed(seed: int, env: gym.Env = None):
-    """Set the seed for the random number generators."""
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-    np.random.seed(seed)
-    random.seed(seed)
-    if env is not None:
-        env.unwrapped.seed(seed)
 
 
 def get_random_rotation(generator: torch.Generator | None = None) -> float:


### PR DESCRIPTION
## Summary

Arena was previously setting the seed using a custom `set_seed` function in Arena. The seeding was inconsistent and not always being set (for example it was not used for batched eval). This gave non-deterministic results.

This PR removes the inconsistent env seeding and uses Isaac Lab's built in env random seeding mechanism. Any time a user provides a seed via CLI, it is passed to the arena environment builder which sets it in the env_cfg. Isaac Lab then handles setting all global seeds. 

Note:  Isaac Lab's seed mechanism sets all of the seeds that Arena was setting plus additional seeds for replicator and warp. It is more comprehensive than what Arena had. 
