### PR TITLE
Rename UnresolvedArenaEnvGraphSpec to ArenaEnvInitialGraphSpec

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -12,7 +12,7 @@ from isaaclab_arena.agentic_environment_generation.asset_matcher import (
 )
 from isaaclab_arena.agentic_environment_generation.environment_intent_spec import EnvironmentIntentSpec, Item
 from isaaclab_arena.assets.registries import AssetRegistry
-from isaaclab_arena.environments.arena_env_graph_spec import UnresolvedArenaEnvGraphSpec
+from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvInitialGraphSpec
 from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphNodeSpec,
     ArenaEnvGraphNodeType,
@@ -26,7 +26,7 @@ _INITIAL_STATE_SPEC_ID = "state_initial"
 
 
 class IntentCompiler:
-    """Compiles an agent intent spec into a validated :class:`UnresolvedArenaEnvGraphSpec`."""
+    """Compiles an agent intent spec into a validated :class:`ArenaEnvInitialGraphSpec`."""
 
     _ERROR_TRACE_STAGES: frozenset[str] = frozenset({
         "relation.initial.unknown_subject",
@@ -53,8 +53,8 @@ class IntentCompiler:
         """``True`` if the last :meth:`compile` call produced any error-stage trace events."""
         return bool(self.resolution_errors)
 
-    def compile(self, spec: EnvironmentIntentSpec, env_name: str | None = None) -> UnresolvedArenaEnvGraphSpec:
-        """Compile an :class:`EnvironmentIntentSpec` into an :class:`UnresolvedArenaEnvGraphSpec`.
+    def compile(self, spec: EnvironmentIntentSpec, env_name: str | None = None) -> ArenaEnvInitialGraphSpec:
+        """Compile an :class:`EnvironmentIntentSpec` into an :class:`ArenaEnvInitialGraphSpec`.
 
         Args:
             spec: Agent-produced intent spec describing the scene, initial relations,
@@ -63,8 +63,8 @@ class IntentCompiler:
                 the name is derived as ``llm_gen_{background}_{first_task_kind}``.
 
         Returns:
-            An :class:`UnresolvedArenaEnvGraphSpec` ready for YAML round-tripping or
-            further resolution via :meth:`~UnresolvedArenaEnvGraphSpec.resolve`.
+            An :class:`ArenaEnvInitialGraphSpec` ready for YAML round-tripping or
+            further linking via :meth:`~ArenaEnvInitialGraphSpec.link`.
         """
         self.trace = []
 
@@ -90,7 +90,7 @@ class IntentCompiler:
         initial_state_spec = self._build_initial_state_spec(spec.initial_state_graph, known_ids)
         self._trace_tasks(spec.tasks, known_ids)
 
-        return UnresolvedArenaEnvGraphSpec(
+        return ArenaEnvInitialGraphSpec(
             env_name=env_name or self._derive_env_name(spec),
             nodes=nodes,
             tasks=spec.tasks,

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -151,8 +151,8 @@ class ArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
         return build_arena_env_from_graph_spec(self)
 
 
-class UnresolvedArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
-    """Partially-specified environment graph produced by the LLM intent pipeline."""
+class ArenaEnvInitialGraphSpec(ArenaEnvGraphSpecBase):
+    """Initial-state environment graph produced by the agent intent pipeline."""
 
     tasks: list[TaskSpec] = Field(default_factory=list)
     initial_state_spec: ArenaEnvGraphStateSpec
@@ -165,8 +165,8 @@ class UnresolvedArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
         assert_spatial_constraint_shapes([self.initial_state_spec])
         return self
 
-    def resolve(self) -> ArenaEnvGraphSpec:
-        """Derive a fully-wired :class:`ArenaEnvGraphSpec` from this unresolved graph.
+    def link(self) -> ArenaEnvGraphSpec:
+        """Link this initial graph into a fully-wired :class:`ArenaEnvGraphSpec`.
 
         Uses :attr:`initial_state_spec` as ``state_spec_0``, then chains each task's declared
         ``success_state_transition`` to produce a delta state.  The topology is implicit in the
@@ -203,7 +203,7 @@ class UnresolvedArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
 
 
 # ---------------------------------------------------------------------------
-# Resolution helpers (used by UnresolvedArenaEnvGraphSpec.resolve)
+# Link helpers (used by ArenaEnvInitialGraphSpec.link)
 # ---------------------------------------------------------------------------
 
 

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -13,7 +13,7 @@ from isaaclab_arena.assets.registries import TaskRegistry
 from isaaclab_arena.environments.arena_env_graph_spec import (
     ArenaEnvGraphSpec,
     ArenaEnvGraphStateSpec,
-    UnresolvedArenaEnvGraphSpec,
+    ArenaEnvInitialGraphSpec,
 )
 from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphNodeType,
@@ -301,39 +301,39 @@ def test_arena_env_graph_spec_rejects_invalid_data():
         assert error_match in str(exc_info.value), label
 
 
-# --- ArenaEnvGraphSpec.resolve_constraints: chaining a partially-wired graph into a full one ---
+# --- ArenaEnvInitialGraphSpec.link: chaining a partially-wired graph into a full one ---
 
 
-def test_resolve_constraints_reproduces_groundtruth_full_graph():
-    """Resolving the partial init graph yields the hand-authored full graph (structurally)."""
-    resolved = UnresolvedArenaEnvGraphSpec.from_yaml(_INIT_GRAPH).resolve()
+def test_link_reproduces_groundtruth_full_graph():
+    """Linking the partial init graph yields the hand-authored full graph (structurally)."""
+    linked = ArenaEnvInitialGraphSpec.from_yaml(_INIT_GRAPH).link()
     groundtruth = ArenaEnvGraphSpec.from_yaml(_FULL_GRAPH)
 
     # N tasks yield N+1 state specs, chained 0..N.
-    assert set(resolved.state_specs_by_id) == set(groundtruth.state_specs_by_id)
-    assert len(resolved.state_specs) == len(resolved.tasks) + 1
+    assert set(linked.state_specs_by_id) == set(groundtruth.state_specs_by_id)
+    assert len(linked.state_specs) == len(linked.tasks) + 1
 
     # Each state's spatial constraints match content-wise (IDs are auto-generated and may differ
     # from hand-authored ones, so compare as sets of (kind, subject, reference, params) tuples).
     for state_id, groundtruth_state in groundtruth.state_specs_by_id.items():
-        got = resolved.state_specs_by_id[state_id]
+        got = linked.state_specs_by_id[state_id]
         assert _spatial_contents(got) == _spatial_contents(groundtruth_state), f"spatial mismatch in {state_id}"
         assert got.is_delta == groundtruth_state.is_delta, f"is_delta mismatch in {state_id}"
 
     # The initial state is a full snapshot; every derived state is a delta off its predecessor.
-    assert resolved.state_specs_by_id["state_spec_0"].is_delta is False
-    assert all(resolved.state_specs_by_id[f"state_spec_{i}"].is_delta for i in range(1, len(resolved.tasks) + 1))
+    assert linked.state_specs_by_id["state_spec_0"].is_delta is False
+    assert all(linked.state_specs_by_id[f"state_spec_{i}"].is_delta for i in range(1, len(linked.tasks) + 1))
 
     # Tasks are wired correctly (compared in order; auto-generated IDs differ from hand-authored ones).
-    assert len(resolved.tasks) == len(groundtruth.tasks)
-    for got_task, groundtruth_task in zip(resolved.tasks, groundtruth.tasks):
+    assert len(linked.tasks) == len(groundtruth.tasks)
+    for got_task, groundtruth_task in zip(linked.tasks, groundtruth.tasks):
         assert got_task.kind == groundtruth_task.kind
         assert got_task.initial_state_spec_id == groundtruth_task.initial_state_spec_id
         assert got_task.success_state_spec_id == groundtruth_task.success_state_spec_id
         assert got_task.params == groundtruth_task.params
 
 
-def test_unresolved_graph_is_not_directly_loadable():
+def test_initial_graph_is_not_directly_loadable():
     """The init graph leaves tasks unwired, so the strict ArenaEnvGraphSpec loader rejects it."""
     with pytest.raises(ValidationError):
         ArenaEnvGraphSpec.from_yaml(_INIT_GRAPH)
@@ -341,24 +341,24 @@ def test_unresolved_graph_is_not_directly_loadable():
 
 def test_chain_wires_each_success_state_as_next_initial_state():
     """task[i].success_state_spec_id == task[i+1].initial_state_spec_id (a single chain)."""
-    resolved = UnresolvedArenaEnvGraphSpec.from_yaml(_INIT_GRAPH).resolve()
-    ordered = resolved.tasks  # preserved in execution order by resolve()
+    linked = ArenaEnvInitialGraphSpec.from_yaml(_INIT_GRAPH).link()
+    ordered = linked.tasks  # preserved in execution order by link()
     for earlier, later in zip(ordered, ordered[1:]):
         assert earlier.success_state_spec_id == later.initial_state_spec_id
 
 
 def test_task_without_a_transition_is_rejected():
     """A task whose class declares no success_state_transition fails loudly rather than silently skipping."""
-    spec = UnresolvedArenaEnvGraphSpec.from_yaml(_INIT_GRAPH)
+    spec = ArenaEnvInitialGraphSpec.from_yaml(_INIT_GRAPH)
     spec.tasks[0].kind = "NoTask"  # registered, but declares no transition
     with pytest.raises(NotImplementedError, match="success_state_transition not implemented"):
-        spec.resolve()
+        spec.link()
 
 
 def _spatial_contents(state: ArenaEnvGraphStateSpec) -> set[tuple]:
     """Project a state's spatial constraints to a set of (kind, subject, reference, params) tuples.
 
-    ID-independent, so auto-generated constraint IDs from resolve() compare correctly against
+    ID-independent, so auto-generated constraint IDs from link() compare correctly against
     hand-authored IDs in the groundtruth YAML.
     """
     return {(c.kind, c.subject, c.reference, tuple(sorted(c.params.items()))) for c in state.spatial_constraints}

--- a/isaaclab_arena/tests/test_data/pick_and_place_maple_table_init_env_graph.yaml
+++ b/isaaclab_arena/tests/test_data/pick_and_place_maple_table_init_env_graph.yaml
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Unresolved env graph for UnresolvedArenaEnvGraphSpec: tasks carry only kind/params; the initial
-# state is an explicit ArenaEnvGraphStateSpec.  Call UnresolvedArenaEnvGraphSpec.resolve() to
+# Initial env graph for ArenaEnvInitialGraphSpec: tasks carry only kind/params; the initial
+# state is an explicit ArenaEnvGraphStateSpec.  Call ArenaEnvInitialGraphSpec.link() to
 # produce the fully-wired ArenaEnvGraphSpec.
 
 env_name: pick_and_place_maple_table_init

--- a/isaaclab_arena_examples/agentic_environment_generation/try_environment_intent_schema.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/try_environment_intent_schema.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run the agent on a prompt and dump the compiled UnresolvedArenaEnvGraphSpec.
+"""Run the agent on a prompt and dump the compiled ArenaEnvInitialGraphSpec.
 
 Examples:
     # Print the Pydantic EnvironmentIntentSpec JSON schema (no agent call):
@@ -33,7 +33,7 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
 )
 from isaaclab_arena.agentic_environment_generation.environment_intent_spec import EnvironmentIntentSpec
 from isaaclab_arena.agentic_environment_generation.intent_compiler import IntentCompiler
-from isaaclab_arena.environments.arena_env_graph_spec import UnresolvedArenaEnvGraphSpec
+from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvInitialGraphSpec
 
 _LLM_GENERATED_DIR = Path("isaaclab_arena_environments/llm_generated")
 
@@ -59,9 +59,9 @@ def _format_trace_event(event: IntentResolutionTraceEvent) -> str:
     return f"  {event.stage:34s} {event.query!s:24s} -> {chosen}{extra}"
 
 
-def print_unresolved_graph(spec: UnresolvedArenaEnvGraphSpec) -> None:
+def print_initial_graph(spec: ArenaEnvInitialGraphSpec) -> None:
     """Print the compiled graph in a human-readable tabular layout."""
-    print(f"\n=== UnresolvedArenaEnvGraphSpec (env_name={spec.env_name!r}) ===")
+    print(f"\n=== ArenaEnvInitialGraphSpec (env_name={spec.env_name!r}) ===")
 
     print("\nnodes:")
     for node in spec.nodes:
@@ -145,13 +145,13 @@ def main() -> None:
 
     compiler = IntentCompiler()
     env_graph_spec = compiler.compile(spec)
-    print_unresolved_graph(env_graph_spec)
+    print_initial_graph(env_graph_spec)
     print_resolution_trace(compiler)
 
     out_path = _LLM_GENERATED_DIR / f"{_safe_filename_stem(env_graph_spec.env_name)}_proposal.yaml"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     env_graph_spec.write_yaml(out_path)
-    print(f"\n=== wrote UnresolvedArenaEnvGraphSpec YAML to {out_path} ===")
+    print(f"\n=== wrote ArenaEnvInitialGraphSpec YAML to {out_path} ===")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
UnresolvedArenaEnvGraphSpec naming improvements

## Detailed description
- What was the reason for the change?
The current naming is not informative.
- What has been changed?
-- UnresolvedArenaEnvGraphSpec renamed to ArenaEnvInitialGraphSpec. It captures only the initial state, vs ArenaEnvGraphSpec capturing all subtask success states additionally.
-- Use link() instead of resolve(). This adds subtask success states and linkage between tasks and states.
- What is the impact of this change?
 Pure naming change