### PR TITLE
Support anchor in agentic env gen

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -299,6 +299,7 @@ class EnvironmentGenerationAgent:
             "  Do NOT hallucinate values — the resolver tolerates nulls; it cannot fix invented data.\n"
             "- For binary relations (e.g. on), subject is the placed object and reference is "
             "the surface it is relative to (typically the background name).\n"
+            "- REQUIRED: include an is_anchor (unary) relation for the surface other objects rest on.\n"
             "- Articulated objects (microwave, fridge, cabinet) still need an "
             "'on' relation in initial_state_graph (subject=object, reference=background) "
             "to anchor them.\n"

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -288,24 +288,23 @@ class EnvironmentGenerationAgent:
         return spec, text
 
     def _system_prompt(self) -> str:
-        return (
-            "You are an env-generation parser for robot manipulation tasks.\n"
-            "Convert a natural-language prompt into an EnvironmentIntentSpec.\n\n"
-            "GUIDANCE:\n"
-            "- Follow the per-field ``description`` strings in the schema for what each field expects.\n"
-            "- Use only asset names from EMBODIMENTS / BACKGROUNDS / OBJECTS, relation "
-            "kinds from RELATIONS, and task kinds from TASKS in the user message.\n"
-            "- If the prompt does not specify a value for an optional field, output null.\n"
-            "  Do NOT hallucinate values — the resolver tolerates nulls; it cannot fix invented data.\n"
-            "- For binary relations (e.g. on), subject is the placed object and reference is "
-            "the surface it is relative to (typically the background name).\n"
-            "- REQUIRED: include an is_anchor (unary) relation for the surface other objects rest on.\n"
-            "- Articulated objects (microwave, fridge, cabinet) still need an "
-            "'on' relation in initial_state_graph (subject=object, reference=background) "
-            "to anchor them.\n"
-            "- Distractor items around the appliance need the same 'on' pattern in "
-            "initial_state_graph.\n"
-            "- Do not invent relation or task kinds absent from RELATIONS / TASKS.\n"
-            "- Each task entry needs kind, params (all required keys from TASKS), and description.\n"
-            "- params values are Item.query strings or the background name, not registry asset names.\n"
-        )
+        return """\
+You are an env-generation parser for robot manipulation tasks.
+Convert a natural-language prompt into an EnvironmentIntentSpec.
+
+GUIDANCE:
+- Follow the per-field ``description`` strings in the schema for what each field expects.
+- Use only asset names from EMBODIMENTS / BACKGROUNDS / OBJECTS, relation kinds from \
+RELATIONS, and task kinds from TASKS in the user message.
+- If the prompt does not specify a value for an optional field, output null.
+  Do NOT hallucinate values — the resolver tolerates nulls; it cannot fix invented data.
+- For binary relations (e.g. on), subject is the placed object and reference is \
+the surface it is relative to (typically the background name).
+- REQUIRED: include an is_anchor (unary) relation for the surface other objects rest on.
+- Articulated objects (microwave, fridge, cabinet) still need an 'on' relation in \
+initial_state_graph (subject=object, reference=background) to anchor them.
+- Distractor items around the appliance need the same 'on' pattern in initial_state_graph.
+- Do not invent relation or task kinds absent from RELATIONS / TASKS.
+- Each task entry needs kind, params (all required keys from TASKS), and description.
+- params values are Item.query strings or the background name, not registry asset names.
+"""

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -20,6 +20,7 @@ from isaaclab_arena.environments.arena_env_graph_types import (
 from isaaclab_arena.environments.graph_spec_utils import relation_class_for_spatial_constraint_type
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 from isaaclab_arena.scene.scene import Scene
+from isaaclab_arena.utils.pose import Pose
 
 if TYPE_CHECKING:
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -125,6 +126,11 @@ def _attach_spatial_constraints_to_assets(
         # is passed as the Relation constructor's first arg — matches how add_relation is wired.
         if relation_class.is_unary():
             subject_asset.add_relation(relation_class(**spatial_constraint.params))
+            # An is_anchor asset must have a fixed initial pose for the placement solver.
+            # If the asset class does not declare one, default to the world origin so
+            # LLM-generated specs (which never set an explicit pose) work out of the box.
+            if spatial_constraint.kind == "is_anchor" and subject_asset.get_initial_pose() is None:
+                subject_asset.set_initial_pose(Pose.identity())
         else:
             reference_asset = assets_by_node_id[spatial_constraint.reference]
             subject_asset.add_relation(relation_class(reference_asset, **spatial_constraint.params))


### PR DESCRIPTION
## Summary
EnvGenAgent adds the is_anchor relation.

## Detailed description
- What was the reason for the change?
  is_anchor is currently missing from agent generated spec.
- What has been changed?
  -- agent prompt is updated to include request for is_anchor in system prompt.
  -- reformat system prompt for better readibility.
  -- pose is required for anchor object. set pose during conversion to arena env if missing.
- What is the impact of this change?
  -- Agent generated env spec should now work with relation solver.
