### PR TITLE
Isolate maple table background

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -197,9 +197,8 @@ class MapleTableRobolab(LibraryBackground):
 
     name = "maple_table_robolab"
     tags = ["background", "robolab"]
-    usd_path = (
-        f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/scenes/maple_table_background.usda"
-    )
+    usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/scenes/maple_table.usda"
+    spawn_cfg_addon = {"rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True)}
     object_min_z = -0.05
 
     def __init__(self):

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -198,7 +198,6 @@ class MapleTableRobolab(LibraryBackground):
     name = "maple_table_robolab"
     tags = ["background", "robolab"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/scenes/maple_table.usda"
-    spawn_cfg_addon = {"rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True)}
     object_min_z = -0.05
 
     def __init__(self):

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -220,7 +220,10 @@ class DroidSceneCfg:
         prim_path="{ENV_REGEX_NS}/Robot_Stand",
         init_state=AssetBaseCfg.InitialStateCfg(pos=[-0.05, 0.0, 0.0], rot=[0.0, 0.0, 0.0, 1.0]),
         spawn=UsdFileCfg(
-            usd_path="https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/Isaac/Props/Mounts/Stand/stand_instanceable.usd",
+            # usd_path="https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/Isaac/Props/Mounts/Stand/stand_instanceable.usd",
+            usd_path=(
+                f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/robots/franka_stand_grey.usda"
+            ),
             scale=(1.2, 1.2, 1.7),
             activate_contact_sensors=False,
         ),

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -220,7 +220,6 @@ class DroidSceneCfg:
         prim_path="{ENV_REGEX_NS}/Robot_Stand",
         init_state=AssetBaseCfg.InitialStateCfg(pos=[-0.05, 0.0, 0.0], rot=[0.0, 0.0, 0.0, 1.0]),
         spawn=UsdFileCfg(
-            # usd_path="https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/Isaac/Props/Mounts/Stand/stand_instanceable.usd",
             usd_path=(
                 f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/robots/franka_stand_grey.usda"
             ),


### PR DESCRIPTION
## Summary
Before: 
`Arena/assets/object_library/srl_robolab_assets/scenes/maple_table_robolab.usda`
(will be removed from OV once this MR is merged)

After:
maple table background: `Arena/assets/object_library/srl_robolab_assets/scenes/maple_table.usda`
robot stand added in `droid.py:` `Arena/assets/object_library/srl_robolab_assets/robots/franka_stand_grey.usda`

<img width="1338" height="587" alt="Screenshot from 2026-06-11 22-53-15" src="https://github.com/user-attachments/assets/ab16799a-efe3-42e7-88a1-10e80a5cb4a2" />


