### PR TITLE
Inject default lighting when EnvGraph has none

### DIFF
--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -17,10 +17,14 @@ from isaaclab_arena.environments.arena_env_graph_types import (
     ArenaEnvGraphObjectReferenceNodeSpec,
     ArenaEnvGraphStateSpec,
 )
-from isaaclab_arena.environments.graph_spec_utils import relation_class_for_spatial_constraint_type
+from isaaclab_arena.environments.graph_spec_utils import relation_class_for_spatial_constraint_type, unique_node_id
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 from isaaclab_arena.scene.scene import Scene
 from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.usd_helpers import has_light, open_stage
+
+# Registered asset name (DomeLight) used as the default light when a scene has none.
+_DEFAULT_LIGHT_ASSET_NAME = "light"
 
 if TYPE_CHECKING:
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -40,14 +44,20 @@ def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec) -> Any:
     #    constraints and task args can reference each node by its graph-local id.
     assets_by_node_id = _instantiate_assets_from_nodes(graph_spec.nodes, AssetRegistry())
 
-    # 2. Wire the initial state's spatial relations / fixed poses into those assets.
+    # 2. Guarantee the scene has a light. A graph (or its background USD) with no light renders
+    #    black, which today only surfaces once the policy runner launches the generated env. When
+    #    nothing provides a light, inject a default DomeLight as a tracked LIGHTING node so the
+    #    augmented graph stays faithful to what actually spawns.
+    _ensure_scene_lighting(graph_spec, assets_by_node_id)
+
+    # 3. Wire the initial state's spatial relations / fixed poses into those assets.
     if initial_state_spec is not None:
         _attach_spatial_constraints_to_assets(initial_state_spec, assets_by_node_id)
 
-    # 3. Partition nodes into the env's embodiment (exactly one) and its scene assets.
+    # 4. Partition nodes into the env's embodiment (exactly one) and its scene assets.
     embodiment, scene_assets = _partition_nodes_into_embodiment_and_scene(graph_spec.nodes, assets_by_node_id)
 
-    # 4. Resolve task specs against the same assets_by_node_id so task args bind to the
+    # 5. Resolve task specs against the same assets_by_node_id so task args bind to the
     #    actual asset instances created in step 1 (not duplicates).
     return IsaacLabArenaEnvironment(
         name=graph_spec.env_name,
@@ -63,27 +73,62 @@ def _partition_nodes_into_embodiment_and_scene(
     """Split materialized nodes into the optional embodiment asset and the list of scene assets.
 
     Asserts at most one EMBODIMENT node; zero is allowed and returns ``None`` here — the env
-    builder substitutes a ``NoEmbodiment`` for scene-only specs. BACKGROUND / OBJECT /
-    OBJECT_REFERENCE nodes become scene assets; any other node type raises. Lighting is not handled yet.
+    builder substitutes a ``NoEmbodiment`` for scene-only specs. Every non-embodiment node is a
+    scene asset; ``Scene.add_asset`` validates each instance is an ``Asset``/``RigidObjectSet`` and
+    raises otherwise (embodiments are ``Asset`` too, so node type — not isinstance — separates them).
     """
     embodiment = None
     scene_assets: list[Asset] = []
-    # TODO(xinjieyao, 2026-05-26): include lighting later
     for node_spec in node_specs:
         if node_spec.type == ArenaEnvGraphNodeType.EMBODIMENT:
             assert embodiment is None, "Only one embodiment node can be converted to an IsaacLabArenaEnvironment"
             embodiment = assets_by_node_id[node_spec.id]
-        elif node_spec.type in (
-            ArenaEnvGraphNodeType.BACKGROUND,
-            ArenaEnvGraphNodeType.OBJECT,
-            ArenaEnvGraphNodeType.OBJECT_REFERENCE,
-        ):
-            scene_assets.append(assets_by_node_id[node_spec.id])
         else:
-            raise ValueError(f"Unsupported node type: {node_spec.type}")
+            scene_assets.append(assets_by_node_id[node_spec.id])
     # No embodiment node -> embodiment stays None; the env builder resolves that to a
     # NoEmbodiment (`self.arena_env.embodiment or NoEmbodiment()`), so scene-only specs are valid.
     return embodiment, scene_assets
+
+
+def _ensure_scene_lighting(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: dict[str, Any]) -> None:
+    """Inject a default light when the scene would otherwise render black.
+
+    Mutates ``graph_spec.nodes`` and ``assets_by_node_id`` in place: appends a ``LIGHTING`` node
+    backed by the registered ``DomeLight`` when no explicit light is declared and no base scene USD
+    already ships one. Tracking it as a real node keeps the augmented graph faithful to what spawns.
+    No-op when a light is already present, so a scene that defines or bakes in its own light is left
+    untouched (avoids double-lighting).
+    """
+    if _scene_already_has_light(graph_spec, assets_by_node_id):
+        return
+
+    node_id = unique_node_id({node.id for node in graph_spec.nodes}, "auto_dome_light")
+    light_node = ArenaEnvGraphNodeSpec(id=node_id, name=_DEFAULT_LIGHT_ASSET_NAME, type=ArenaEnvGraphNodeType.LIGHTING)
+    graph_spec.nodes.append(light_node)
+    assets_by_node_id[node_id] = AssetRegistry().get_asset_by_name(_DEFAULT_LIGHT_ASSET_NAME)()
+    print(f"INFO: no light found in scene or background USD(s); injected default light node '{node_id}'.")
+
+
+def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: dict[str, Any]) -> bool:
+    """Return whether the scene is already lit, either explicitly or via a baked-in USD light."""
+    # Explicit: a LIGHTING node, or any materialized asset tagged as a light (e.g. DomeLight).
+    if any(node.type == ArenaEnvGraphNodeType.LIGHTING for node in graph_spec.nodes):
+        return True
+    if any("light" in (getattr(asset, "tags", None) or []) for asset in assets_by_node_id.values()):
+        return True
+    # Implicit: any base scene asset whose USD already contains a light.
+    for node in graph_spec.nodes:
+        if node.type == ArenaEnvGraphNodeType.EMBODIMENT:
+            continue
+        asset = assets_by_node_id[node.id]
+        # Only USD-backed base assets can carry a baked-in light; assets with an explicit
+        # spawner_cfg (DomeLight, GroundPlane, primitives) declare their own prim instead.
+        usd_path = getattr(asset, "usd_path", None)
+        if usd_path is not None and getattr(asset, "spawner_cfg", None) is None:
+            with open_stage(usd_path) as stage:
+                if has_light(stage):
+                    return True
+    return False
 
 
 def _instantiate_assets_from_nodes(node_specs: list[ArenaEnvGraphNodeSpec], asset_registry: Any) -> dict[str, Any]:

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -118,7 +118,7 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
         return True
     # Implicit: any base scene asset whose USD already contains a light.
     for node in graph_spec.nodes:
-        if node.type == ArenaEnvGraphNodeType.EMBODIMENT or node.type == ArenaEnvGraphNodeType.OBJECTREFERENCE:
+        if node.type == ArenaEnvGraphNodeType.EMBODIMENT or node.type == ArenaEnvGraphNodeType.OBJECT_REFERENCE:
             continue
         asset = assets_by_node_id[node.id]
         # Only USD-backed base assets can carry a baked-in light; assets with an explicit

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -118,7 +118,7 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
         return True
     # Implicit: any base scene asset whose USD already contains a light.
     for node in graph_spec.nodes:
-        if node.type == ArenaEnvGraphNodeType.EMBODIMENT:
+        if node.type == ArenaEnvGraphNodeType.EMBODIMENT or node.type == ArenaEnvGraphNodeType.OBJECTREFERENCE:
             continue
         asset = assets_by_node_id[node.id]
         # Only USD-backed base assets can carry a baked-in light; assets with an explicit

--- a/isaaclab_arena/environments/graph_spec_utils.py
+++ b/isaaclab_arena/environments/graph_spec_utils.py
@@ -28,6 +28,16 @@ def coerce_number_sequence(value: Any, length: int, field_name: str) -> tuple[fl
     return tuple(float(item) for item in value)
 
 
+def unique_node_id(existing_ids: set[str], base: str) -> str:
+    """Return the first non-colliding id from ``base``, ``base_1``, ``base_2``, ... given ``existing_ids``."""
+    if base not in existing_ids:
+        return base
+    suffix = 1
+    while f"{base}_{suffix}" in existing_ids:
+        suffix += 1
+    return f"{base}_{suffix}"
+
+
 def assert_unique_ids(nodes: list[Any], tasks: list[Any], state_specs: list[Any]) -> None:
     """Ensure every graph id is unique, including spatial constraint ids inside states."""
     id_locations: dict[str, list[str]] = {}

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -103,3 +103,46 @@ def test_get_arena_builder_from_cli_builds_env_from_graph_yaml():
 
     result = run_simulation_app_function(_test_get_arena_builder_from_cli_builds_env_from_graph_yaml)
     assert result
+
+
+def _test_default_light_is_injected_when_scene_has_none(simulation_app):
+    from isaaclab_arena.assets.object_library import DomeLight
+    from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphNodeSpec, ArenaEnvGraphNodeType
+
+    # A single YCB object with no light node and no light baked into its USD: the converter
+    # must inject a default light so the env does not render black.
+    spec = ArenaEnvGraphSpec(
+        env_name="lighting_injection_test",
+        nodes=[ArenaEnvGraphNodeSpec(id="mug", name="mug_ycb_robolab", type=ArenaEnvGraphNodeType.OBJECT)],
+    )
+    arena_env = spec.to_arena_env()
+
+    # The injected light is tracked as a real LIGHTING node (so the augmented graph stays faithful)
+    # and materializes as a DomeLight scene asset.
+    light_nodes = [node for node in spec.nodes if node.type == ArenaEnvGraphNodeType.LIGHTING]
+    assert len(light_nodes) == 1, f"expected one injected light node, got {light_nodes}"
+    assert any(isinstance(asset, DomeLight) for asset in arena_env.scene.assets.values())
+
+    # An explicit light suppresses injection — no double-lighting.
+    explicit = ArenaEnvGraphSpec(
+        env_name="lighting_explicit_test",
+        nodes=[
+            ArenaEnvGraphNodeSpec(id="mug", name="mug_ycb_robolab", type=ArenaEnvGraphNodeType.OBJECT),
+            ArenaEnvGraphNodeSpec(id="my_light", name="light", type=ArenaEnvGraphNodeType.LIGHTING),
+        ],
+    )
+    num_nodes_before = len(explicit.nodes)
+    explicit_env = explicit.to_arena_env()
+    assert len(explicit.nodes) == num_nodes_before, "must not inject a light when one is already declared"
+    assert sum(isinstance(asset, DomeLight) for asset in explicit_env.scene.assets.values()) == 1
+
+    return True
+
+
+def test_default_light_is_injected_when_scene_has_none():
+    pytest.importorskip("isaaclab.app")
+
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    result = run_simulation_app_function(_test_default_light_is_injected_when_scene_has_none)
+    assert result


### PR DESCRIPTION
## Summary
Inject default light at Arena Env built time from EnvGraph yaml

## Detailed description
- Why: Some graph-built/generated envs has no light  either in the spec or baked into the USD, so it renders black when spawning in SimApp. 
- What: During Env built time, ensure light is added as a node.
- Light will be included in any generated/graph-built Envs.

<img width="1456" height="546" alt="Screenshot from 2026-06-11 17-27-06" src="https://github.com/user-attachments/assets/5606e8d5-5ed9-4009-9a37-5a68b2a12122" />

