### PR TITLE
split camera recordings per episode instead of one long video

### DIFF
--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -9,7 +9,7 @@ Frames are flushed to disk each time an environment resets (terminated or
 truncated), so each output file corresponds to exactly one complete episode.
 Partial episodes cut off by ``num_steps`` are discarded on ``close()``.
 
-Output filename: ``<name_prefix>-env<N>-<cam>-episode-<E>.mp4``
+Output filename: ``<name_prefix>-env<N>-<camera_name>-episode-<E>.mp4``
 
 policy_runner.py wraps the env with this alongside ``RecordVideo`` so
 the kit viewport mp4 (third-person scene view) and the embodiment-
@@ -17,9 +17,10 @@ mounted camera mp4s (what the policy actually sees) are written
 together when ``--video --camera_video`` is set.
 
 Memory note: each env buffers raw uint8 frames for its current episode before
-encoding.  Peak RAM is N×L×H×W×C bytes where L is max episode length, not the
-full rollout.  For 10 envs, 500-step episodes, 512×512×3 frames that is ~3.8 GB
-of raw frames — the encoded mp4s are far smaller (H.264 compresses ~100:1).
+encoding.  Buffers are cleared after each episode is written to disk, so peak
+RAM is N×L×H×W×C bytes where L is max episode length, not the full rollout.
+For 10 envs, 500-step episodes, 512×512×3 frames that is ~3.8 GB of raw frames
+— the encoded mp4s are far smaller (H.264 compresses ~100:1).
 """
 
 from __future__ import annotations
@@ -46,9 +47,9 @@ def _to_uint8(frame: torch.Tensor | np.ndarray) -> np.ndarray:
     return frame.astype(np.uint8)
 
 
-def _sanitize_cam_key(key: str) -> str:
-    """Strip path separators so a camera key can't escape video_folder."""
-    return key.replace("/", "_").replace(os.sep, "_")
+def _sanitize_cam_key(camera_name: str) -> str:
+    """Strip path separators so a camera name can't escape video_folder."""
+    return camera_name.replace("/", "_").replace(os.sep, "_")
 
 
 class CameraObsVideoRecorder(gym.Wrapper):
@@ -57,7 +58,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
     Cameras are batched as ``[N_envs, H, W, C]``.  Each env is recorded
     independently; its buffer is flushed when that env resets (terminated
     or truncated), producing one file per completed episode:
-    ``<name_prefix>-env<N>-<cam>-episode-<E>.mp4``.
+    ``<name_prefix>-env<N>-<camera_name>-episode-<E>.mp4``.
     """
 
     def __init__(
@@ -73,7 +74,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
         self.name_prefix = name_prefix
         self.fps = fps if fps is not None else int(env.metadata.get("render_fps", 30))
 
-        # cam_key -> list of per-env frame lists: buffers[cam][env_idx] = [frame, ...]
+        # camera_name -> list of per-env frame lists: buffers[camera_name][env_idx] = [frame, ...]
         self.buffers: dict[str, list[list[np.ndarray]]] = {}
         # How many episodes have been flushed for each env.
         self.episode_counts: list[int] = []
@@ -85,8 +86,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
         cam_obs = obs.get(CAMERA_OBS_GROUP_KEY, {}) if isinstance(obs, dict) else {}
 
         if cam_obs:
-            frames_sample = next(iter(cam_obs.values()))
-            n_envs = frames_sample.shape[0]
+            n_envs = next(iter(cam_obs.values())).shape[0]
 
             if self._n_envs is None:
                 self._n_envs = n_envs
@@ -95,19 +95,17 @@ class CameraObsVideoRecorder(gym.Wrapper):
             # Determine done envs before appending frames. Isaac Lab auto-resets on
             # termination, so the obs returned for a done env is the post-reset first
             # frame of the new episode — discard it so it doesn't contaminate the
-            # current episode or create a phantom one-frame episode on close().
-            if isinstance(terminated, torch.Tensor):
-                done_envs = (terminated | truncated).nonzero().flatten().tolist()
-            else:
-                done_envs = [0] if (terminated or truncated) else []
+            # current episode. This means each recorded episode is missing its first
+            # frame, which is acceptable given episodes are typically hundreds of steps.
+            done_envs = (terminated | truncated).nonzero().flatten().tolist()
             done_set = set(done_envs)
 
-            for k, frames in cam_obs.items():
-                if k not in self.buffers:
-                    self.buffers[k] = [[] for _ in range(n_envs)]
+            for camera_name, frames in cam_obs.items():
+                if camera_name not in self.buffers:
+                    self.buffers[camera_name] = [[] for _ in range(n_envs)]
                 for env_idx in range(n_envs):
                     if env_idx not in done_set:
-                        self.buffers[k][env_idx].append(_to_uint8(frames[env_idx]))
+                        self.buffers[camera_name][env_idx].append(_to_uint8(frames[env_idx]))
 
             if done_envs:
                 self._flush_envs(done_envs)
@@ -118,13 +116,13 @@ class CameraObsVideoRecorder(gym.Wrapper):
         for env_idx in env_ids:
             episode_num = self.episode_counts[env_idx]
             wrote_any = False
-            for cam, env_frame_lists in self.buffers.items():
+            for camera_name, env_frame_lists in self.buffers.items():
                 frames = env_frame_lists[env_idx]
                 if not frames:
                     continue
                 path = os.path.join(
                     self.video_folder,
-                    f"{self.name_prefix}-env{env_idx}-{_sanitize_cam_key(cam)}-episode-{episode_num}.mp4",
+                    f"{self.name_prefix}-env{env_idx}-{_sanitize_cam_key(camera_name)}-episode-{episode_num}.mp4",
                 )
                 clip = ImageSequenceClip(list(frames), fps=self.fps)
                 clip.write_videofile(path, logger=None, audio=False)

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -6,8 +6,8 @@
 """Gym wrapper that records one mp4 per (env, camera, episode) in ``obs['camera_obs']``.
 
 Frames are flushed to disk each time an environment resets (terminated or
-truncated), so each output file corresponds to exactly one episode.  A final
-flush on ``close()`` captures any trailing incomplete episode.
+truncated), so each output file corresponds to exactly one complete episode.
+Partial episodes cut off by ``num_steps`` are discarded on ``close()``.
 
 Output filename: ``<name_prefix>-env<N>-<cam>-episode-<E>.mp4``
 
@@ -135,12 +135,5 @@ class CameraObsVideoRecorder(gym.Wrapper):
                 self.episode_counts[env_idx] += 1
 
     def close(self) -> None:
-        try:
-            if self._n_envs is not None and self.buffers:
-                envs_with_frames = [
-                    i for i in range(self._n_envs) if any(len(self.buffers[cam][i]) > 0 for cam in self.buffers)
-                ]
-                if envs_with_frames:
-                    self._flush_envs(envs_with_frames)
-        finally:
-            self.env.close()
+        # Partial episodes (cut off by num_steps rather than a real reset) are discarded.
+        self.env.close()

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -117,6 +117,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
     def _flush_envs(self, env_ids: list[int]) -> None:
         for env_idx in env_ids:
             episode_num = self.episode_counts[env_idx]
+            wrote_any = False
             for cam, env_frame_lists in self.buffers.items():
                 frames = env_frame_lists[env_idx]
                 if not frames:
@@ -129,7 +130,9 @@ class CameraObsVideoRecorder(gym.Wrapper):
                 clip.write_videofile(path, logger=None, audio=False)
                 del clip
                 env_frame_lists[env_idx] = []
-            self.episode_counts[env_idx] += 1
+                wrote_any = True
+            if wrote_any:
+                self.episode_counts[env_idx] += 1
 
     def close(self) -> None:
         try:

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -3,24 +3,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Gym wrapper that records one mp4 per camera in ``obs['camera_obs']``.
+"""Gym wrapper that records one mp4 per (env, camera, episode) in ``obs['camera_obs']``.
 
-Mirrors ``gymnasium.wrappers.RecordVideo`` — same ``step_trigger`` /
-``video_length`` semantics and the same moviepy ``ImageSequenceClip``
-encoder, but frames come from ``obs["camera_obs"][<cam>]`` rather than
-``env.render()``. Output is one mp4 per camera under ``video_folder``,
-named ``<name_prefix>-<cam>-step-<N>.mp4``.
+Frames are flushed to disk each time an environment resets (terminated or
+truncated), so each output file corresponds to exactly one episode.  A final
+flush on ``close()`` captures any trailing incomplete episode.
+
+Output filename: ``<name_prefix>-env<N>-<cam>-episode-<E>.mp4``
 
 policy_runner.py wraps the env with this alongside ``RecordVideo`` so
 the kit viewport mp4 (third-person scene view) and the embodiment-
 mounted camera mp4s (what the policy actually sees) are written
 together when ``--video --camera_video`` is set.
 
-Multi-env note: Arena batches camera observations as
-``[N_envs, H, W, C]``. This wrapper records env 0 only (``frame[0]``);
-other envs are silently dropped. ``RecordVideo`` for the kit viewport
-is unaffected — the viewport shows the full scene regardless of
-``num_envs``.
+Memory note: each env buffers raw uint8 frames for its current episode before
+encoding.  Peak RAM is N×L×H×W×C bytes where L is max episode length, not the
+full rollout.  For 10 envs, 500-step episodes, 512×512×3 frames that is ~3.8 GB
+of raw frames — the encoded mp4s are far smaller (H.264 compresses ~100:1).
 """
 
 from __future__ import annotations
@@ -29,8 +28,6 @@ import gymnasium as gym
 import numpy as np
 import os
 import torch
-from collections.abc import Callable
-
 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 
 CAMERA_OBS_GROUP_KEY = "camera_obs"
@@ -54,71 +51,93 @@ def _sanitize_cam_key(key: str) -> str:
 
 
 class CameraObsVideoRecorder(gym.Wrapper):
-    """Record an mp4 per camera in ``obs['camera_obs']``.
+    """Record one mp4 per (env, camera, episode) in ``obs['camera_obs']``.
 
-    Records env 0 only: cameras are batched as ``[N_envs, H, W, C]`` and the
-    wrapper picks ``frame[0]``. Intended for single-env evaluation rollouts.
+    Cameras are batched as ``[N_envs, H, W, C]``.  Each env is recorded
+    independently; its buffer is flushed when that env resets (terminated
+    or truncated), producing one file per completed episode:
+    ``<name_prefix>-env<N>-<cam>-episode-<E>.mp4``.
     """
 
     def __init__(
         self,
         env: gym.Env,
         video_folder: str,
-        step_trigger: Callable[[int], bool],
-        video_length: int,
         name_prefix: str = "robot-cam",
         fps: int | None = None,
     ):
         super().__init__(env)
         os.makedirs(video_folder, exist_ok=True)
         self.video_folder = video_folder
-        self.step_trigger = step_trigger
-        self.video_length = video_length
         self.name_prefix = name_prefix
         self.fps = fps if fps is not None else int(env.metadata.get("render_fps", 30))
 
-        self.step_id = -1
-        self.recording = False
-        self.recording_start_step = 0
-        self.buffers: dict[str, list[np.ndarray]] = {}
+        # cam_key -> list of per-env frame lists: buffers[cam][env_idx] = [frame, ...]
+        self.buffers: dict[str, list[list[np.ndarray]]] = {}
+        # How many episodes have been flushed for each env.
+        self.episode_counts: list[int] = []
+        self._n_envs: int | None = None
 
     def step(self, action):
         result = self.env.step(action)
-        self.step_id += 1
-        obs = result[0]
+        obs, _, terminated, truncated, _ = result
         cam_obs = obs.get(CAMERA_OBS_GROUP_KEY, {}) if isinstance(obs, dict) else {}
 
-        if not self.recording and self.step_trigger(self.step_id):
-            self.recording = True
-            self.recording_start_step = self.step_id
-            self.buffers = {k: [] for k in cam_obs}
+        if cam_obs:
+            frames_sample = next(iter(cam_obs.values()))
+            n_envs = frames_sample.shape[0]
 
-        if self.recording and cam_obs:
-            for k, frame in cam_obs.items():
-                # frame: [N_envs, H, W, C]; record env 0 only.
-                self.buffers.setdefault(k, []).append(_to_uint8(frame[0]))
-            if self.buffers and all(len(v) >= self.video_length for v in self.buffers.values()):
-                self._flush()
+            if self._n_envs is None:
+                self._n_envs = n_envs
+                self.episode_counts = [0] * n_envs
+
+            # Determine done envs before appending frames. Isaac Lab auto-resets on
+            # termination, so the obs returned for a done env is the post-reset first
+            # frame of the new episode — discard it so it doesn't contaminate the
+            # current episode or create a phantom one-frame episode on close().
+            if isinstance(terminated, torch.Tensor):
+                done_envs = (terminated | truncated).nonzero().flatten().tolist()
+            else:
+                done_envs = [0] if (terminated or truncated) else []
+            done_set = set(done_envs)
+
+            for k, frames in cam_obs.items():
+                if k not in self.buffers:
+                    self.buffers[k] = [[] for _ in range(n_envs)]
+                for env_idx in range(n_envs):
+                    if env_idx not in done_set:
+                        self.buffers[k][env_idx].append(_to_uint8(frames[env_idx]))
+
+            if done_envs:
+                self._flush_envs(done_envs)
 
         return result
 
-    def _flush(self) -> None:
-        for cam, frames in self.buffers.items():
-            if not frames:
-                continue
-            path = os.path.join(
-                self.video_folder,
-                f"{self.name_prefix}-{_sanitize_cam_key(cam)}-step-{self.recording_start_step}.mp4",
-            )
-            clip = ImageSequenceClip(list(frames), fps=self.fps)
-            clip.write_videofile(path, logger=None, audio=False)
-            del clip
-        self.recording = False
-        self.buffers = {}
+    def _flush_envs(self, env_ids: list[int]) -> None:
+        for env_idx in env_ids:
+            episode_num = self.episode_counts[env_idx]
+            for cam, env_frame_lists in self.buffers.items():
+                frames = env_frame_lists[env_idx]
+                if not frames:
+                    continue
+                path = os.path.join(
+                    self.video_folder,
+                    f"{self.name_prefix}-env{env_idx}-{_sanitize_cam_key(cam)}-episode-{episode_num}.mp4",
+                )
+                clip = ImageSequenceClip(list(frames), fps=self.fps)
+                clip.write_videofile(path, logger=None, audio=False)
+                del clip
+                env_frame_lists[env_idx] = []
+            self.episode_counts[env_idx] += 1
 
     def close(self) -> None:
         try:
-            if self.recording and any(len(v) > 0 for v in self.buffers.values()):
-                self._flush()
+            if self._n_envs is not None and self.buffers:
+                envs_with_frames = [
+                    i for i in range(self._n_envs)
+                    if any(len(self.buffers[cam][i]) > 0 for cam in self.buffers)
+                ]
+                if envs_with_frames:
+                    self._flush_envs(envs_with_frames)
         finally:
             self.env.close()

--- a/isaaclab_arena/evaluation/camera_video.py
+++ b/isaaclab_arena/evaluation/camera_video.py
@@ -28,6 +28,7 @@ import gymnasium as gym
 import numpy as np
 import os
 import torch
+
 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 
 CAMERA_OBS_GROUP_KEY = "camera_obs"
@@ -134,8 +135,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
         try:
             if self._n_envs is not None and self.buffers:
                 envs_with_frames = [
-                    i for i in range(self._n_envs)
-                    if any(len(self.buffers[cam][i]) > 0 for cam in self.buffers)
+                    i for i in range(self._n_envs) if any(len(self.buffers[cam][i]) > 0 for cam in self.buffers)
                 ]
                 if envs_with_frames:
                     self._flush_envs(envs_with_frames)

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -305,7 +305,11 @@ def main():
                     if args_cli.camera_video:
                         job_video_dir = os.path.join(args_cli.video_dir, job.name)
                         print(f"[INFO] Recording per-episode camera videos for job '{job.name}' -> {job_video_dir}")
-                        env = CameraObsVideoRecorder(env, video_folder=job_video_dir)
+                        env = CameraObsVideoRecorder(
+                            env,
+                            video_folder=job_video_dir,
+                            name_prefix=f"robot-cam-rebuild{rebuild_idx}",
+                        )
 
                     metrics = rollout_policy(
                         env,

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.evaluation.camera_video import CameraObsVideoRecorder
 from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
 from isaaclab_arena.evaluation.job_manager import Job, JobManager, Status
 from isaaclab_arena.evaluation.policy_runner import get_policy_cls, rollout_policy
@@ -242,6 +243,8 @@ def main():
         return
 
     # Check if any job requires cameras and enable them if needed before starting simulation
+    if args_cli.camera_video:
+        args_cli.enable_cameras = True
     enable_cameras_if_required(eval_jobs_config, args_cli)
 
     with SimulationAppContext(args_cli):
@@ -298,6 +301,11 @@ def main():
                         }
                         print(f"[INFO] Recording video for job '{job.name}' -> {video_kwargs['video_folder']}")
                         env = RecordVideo(env, **video_kwargs)
+
+                    if args_cli.camera_video:
+                        job_video_dir = os.path.join(args_cli.video_dir, job.name)
+                        print(f"[INFO] Recording per-episode camera videos for job '{job.name}' -> {job_video_dir}")
+                        env = CameraObsVideoRecorder(env, video_folder=job_video_dir)
 
                     metrics = rollout_policy(
                         env,

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -16,6 +16,12 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--video", action="store_true", default=False, help="Record videos for each eval job.")
     parser.add_argument(
+        "--camera_video",
+        action="store_true",
+        default=False,
+        help="Record one mp4 per (env, camera, episode) from obs['camera_obs'] for each eval job.",
+    )
+    parser.add_argument(
         "--video_dir",
         type=str,
         default="/eval/videos",

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -251,10 +251,7 @@ def main():
                 env,
                 video_folder=args_cli.video_dir,
             )
-            print(
-                f"[Rank {local_rank}/{world_size}] Recording per-episode per-camera videos to:"
-                f" {args_cli.video_dir}"
-            )
+            print(f"[Rank {local_rank}/{world_size}] Recording per-episode per-camera videos to: {args_cli.video_dir}")
 
         steps_str = f"{num_steps} steps" if num_steps is not None else f"{num_episodes} episodes"
         print(f"[Rank {local_rank}/{world_size}] Starting rollout ({steps_str})")

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -154,7 +154,7 @@ def main():
         print(f"[Rank {local_rank}/{world_size}] One Isaac Lab instance per process on cuda:{local_rank}")
 
     # --camera_video requires cameras to be enabled at sim startup, before SimulationAppContext.
-    if "--camera_video" in unknown:
+    if "--camera_video" in unknown or "--camera-video" in unknown:
         args_cli.enable_cameras = True
 
     with SimulationAppContext(args_cli):

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -153,6 +153,10 @@ def main():
         args_cli.device = f"cuda:{local_rank}"
         print(f"[Rank {local_rank}/{world_size}] One Isaac Lab instance per process on cuda:{local_rank}")
 
+    # --camera_video requires cameras to be enabled at sim startup, before SimulationAppContext.
+    if "--camera_video" in unknown:
+        args_cli.enable_cameras = True
+
     with SimulationAppContext(args_cli):
 
         # Get the policy-type flag before proceeding to other arguments
@@ -175,6 +179,9 @@ def main():
         if is_distributed(args_cli):
             args_cli.distributed = True
             args_cli.device = f"cuda:{local_rank}"
+        # Re-apply enable_cameras: the full parse resets it to default False.
+        if args_cli.camera_video:
+            args_cli.enable_cameras = True
 
         # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
         arena_builder = get_arena_builder_from_cli(args_cli, hydra_overrides=hydra_overrides)
@@ -238,16 +245,14 @@ def main():
             )
 
         if args_cli.camera_video:
-            # Record one mp4 per camera in obs["camera_obs"] (what the policy sees),
-            # using the same encoder as RecordVideo.
+            # Record one mp4 per (env, camera, episode) in obs["camera_obs"].
+            # Flushed at each episode reset rather than after a fixed number of steps.
             env = CameraObsVideoRecorder(
                 env,
                 video_folder=args_cli.video_dir,
-                step_trigger=lambda step: step == 0,
-                video_length=video_length,
             )
             print(
-                f"[Rank {local_rank}/{world_size}] Recording {video_length}-step per-camera videos to:"
+                f"[Rank {local_rank}/{world_size}] Recording per-episode per-camera videos to:"
                 f" {args_cli.video_dir}"
             )
 

--- a/isaaclab_arena/tests/test_camera_video.py
+++ b/isaaclab_arena/tests/test_camera_video.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for CameraObsVideoRecorder.
+
+No Isaac Sim or GPU required. The moviepy encoder is mocked so tests run
+fast and on CPU-only machines.
+"""
+
+import gymnasium as gym
+import os
+import shutil
+import torch
+from unittest.mock import patch
+
+import pytest
+
+from isaaclab_arena.evaluation.camera_video import CAMERA_OBS_GROUP_KEY, CameraObsVideoRecorder
+
+# ---------------------------------------------------------------------------
+# Minimal gym.Env stub — satisfies gymnasium.Wrapper's isinstance check
+# ---------------------------------------------------------------------------
+
+H, W, C = 4, 4, 3
+CAMERAS = ["front", "wrist"]
+
+
+class _StubEnv(gym.Env):
+    metadata = {"render_fps": 30}
+    observation_space = gym.spaces.Dict({})
+    action_space = gym.spaces.Discrete(1)
+
+    def __init__(self):
+        super().__init__()
+        self._step_return = ({}, None, torch.zeros(1, dtype=torch.bool), torch.zeros(1, dtype=torch.bool), None)
+
+    def reset(self, **kwargs):
+        return {}, {}
+
+    def step(self, action):
+        return self._step_return
+
+    def render(self):
+        pass
+
+
+def _make_env() -> _StubEnv:
+    return _StubEnv()
+
+
+def _configure_step(env: _StubEnv, done_envs: list[int] | None = None, n_envs: int = 2):
+    """Set the next step return value with given terminations."""
+    terminated = torch.zeros(n_envs, dtype=torch.bool)
+    for idx in done_envs or []:
+        terminated[idx] = True
+    truncated = torch.zeros(n_envs, dtype=torch.bool)
+    cam_obs = {cam: torch.zeros(n_envs, H, W, C, dtype=torch.uint8) for cam in CAMERAS}
+    obs = {CAMERA_OBS_GROUP_KEY: cam_obs}
+    env._step_return = (obs, None, terminated, truncated, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_video_files_written_on_termination(tmp_path):
+    """A file per camera is written when an env terminates."""
+    env = _make_env()
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip") as mock_clip_cls:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)  # accumulate one frame
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)  # env 0 terminates → flush
+
+        written_paths = [c.args[0] for c in mock_clip_cls.return_value.write_videofile.call_args_list]
+        assert len(written_paths) == len(CAMERAS)
+        for cam in CAMERAS:
+            assert os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-0.mp4") in written_paths
+
+
+def test_episode_counter_increments_per_env(tmp_path):
+    """Each env tracks its own episode count independently."""
+    env = _make_env()
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip"):
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)  # env 0: episode 0 done
+
+        _configure_step(env)
+        recorder.step(None)
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)  # env 0: episode 1 done
+
+        _configure_step(env, done_envs=[1])
+        recorder.step(None)  # env 1: episode 0 done
+
+        assert recorder.episode_counts[0] == 2
+        assert recorder.episode_counts[1] == 1
+
+
+def test_multiple_episodes_produce_sequential_filenames(tmp_path):
+    """Consecutive episodes for an env are named episode-0, episode-1, ..."""
+    env = _make_env()
+    written_paths = []
+
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip") as mock_clip_cls:
+        mock_clip_cls.return_value.write_videofile.side_effect = lambda path, **_: written_paths.append(path)
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        for _ in range(3):
+            _configure_step(env, n_envs=1)
+            recorder.step(None)
+            _configure_step(env, done_envs=[0], n_envs=1)
+            recorder.step(None)
+
+    for episode in range(3):
+        for cam in CAMERAS:
+            assert os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-{episode}.mp4") in written_paths
+
+
+def test_partial_episode_dropped_on_close(tmp_path):
+    """Frames accumulated without termination are silently discarded on close()."""
+    env = _make_env()
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip") as mock_clip_cls:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)  # accumulate frames, no termination
+
+        recorder.close()
+
+        mock_clip_cls.return_value.write_videofile.assert_not_called()
+
+
+def test_episode_counter_not_incremented_for_empty_buffer(tmp_path):
+    """Episode count stays at 0 if the env terminates before any frame is appended."""
+    env = _make_env()
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip"):
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        # Terminate on the very first step — no prior frames were recorded.
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)
+
+        assert recorder.episode_counts[0] == 0
+
+
+def test_post_reset_frame_not_appended(tmp_path):
+    """The obs on a terminal step (post-reset) is not buffered for the next episode."""
+    env = _make_env()
+    with patch("isaaclab_arena.evaluation.camera_video.ImageSequenceClip"):
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)  # 1 frame buffered for both envs
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)  # env 0 terminates; post-reset frame discarded
+
+        # env 0's buffer is empty (flushed and post-reset frame discarded)
+        for cam in CAMERAS:
+            assert recorder.buffers[cam][0] == []
+
+        # env 1 accumulated 2 frames (neither step was terminal for it)
+        for cam in CAMERAS:
+            assert len(recorder.buffers[cam][1]) == 2
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not available")
+def test_real_video_file_written_on_termination(tmp_path):
+    """An actual mp4 file appears on disk when an env terminates (requires ffmpeg)."""
+    env = _make_env()
+    recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+    _configure_step(env)
+    recorder.step(None)
+
+    _configure_step(env, done_envs=[0])
+    recorder.step(None)
+
+    for cam in CAMERAS:
+        path = os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-0.mp4")
+        assert os.path.isfile(path), f"Expected video file not found: {path}"
+        assert os.path.getsize(path) > 0

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ RUNTIME_DEPS = [
     "sbi",
     "scipy",
     "matplotlib",
+    # HDF5 -> LeRobot conversion (isaaclab_arena_gr00t.lerobot.convert_hdf5_to_lerobot), imported at module level.
+    # Pinned to 2.2.3 to match the version used in GR00T.
+    "pandas==2.2.3",
 ]
 
 DEV_DEPS = [


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
Split camera recordings per episode
                                                                                                                                                                                                                                                            
## Detailed description                                         
- `CameraObsVideoRecorder` recorded one long video per `(env, camera)` spanning all episodes, requiring `episode_boundaries` metadata to slice it afterward. It also only recorded env 0, silently dropping all other envs.                                 
- Replaced with per-episode flushing: each env's buffer is flushed independently on reset, producing one mp4 per `(env, camera, episode)` named `<prefix>-env<N>-<camera_name>-episode-<E>.mp4`                                                             
- Removed `step_trigger` and `video_length` from the interface                                                                                                                                                                                              
- Partial episodes cut off by `--num_steps` are discarded on close; only episodes that end with a real reset produce output files                                                                                                                                                                                                                                                             
- Added `--camera_video` to `eval_runner`
- Fixed `policy_runner` to set `enable_cameras=True` both before `SimulationAppContext` and after the full arg parse, covering both `--camera_video` and `--camera-video` aliases                                                                           
- Added 7 unit tests covering flush-on-termination, per-env episode counters, sequential filenames, partial episode drop, empty buffer handling, and post-reset frame discard - no Isaac Sim or GPU required; real file-writing test skipped without ffmpeg 
