### PR TITLE
Asset matcher excludes procedural

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/asset_matcher.py
+++ b/isaaclab_arena/agentic_environment_generation/asset_matcher.py
@@ -38,6 +38,19 @@ ASSET_ERROR_STAGES: frozenset[str] = frozenset({
 })
 """Trace stage identifiers that indicate an asset-query failure."""
 
+_EXCLUDED_MATCH_TAGS: frozenset[str] = frozenset({"procedural"})
+"""Registry tags that disqualify an asset from LLM intent resolution."""
+
+
+def _matching_candidates(registry: AssetRegistry, tags: list[str]) -> list[str]:
+    """Return sorted asset names matching ``tags``, omitting excluded tags."""
+    names = registry.get_assets_with_all_tags(tags)
+    return sorted(
+        name
+        for name in names
+        if not _EXCLUDED_MATCH_TAGS.intersection(getattr(registry.get_asset_by_name(name), "tags", []))
+    )
+
 
 def match_asset(
     registry: AssetRegistry,
@@ -55,6 +68,9 @@ def match_asset(
     2. **Fuzzy match** (substring, then difflib) in the pool narrowed by
        ``required_tags + preferred_tags`` when ``preferred_tags`` is non-empty.
     3. **Fuzzy match** in the ``required_tags`` pool only (relaxed fallback).
+
+    Assets tagged ``procedural`` are never considered (Newton cuboid spawners, not
+    catalogued USD scenes/objects for LLM-generated layouts).
 
     Args:
         registry: Registry to look up asset names in.
@@ -74,7 +90,7 @@ def match_asset(
         The resolved asset key, or ``None`` when no match is found.
     """
     required_tags = required_tags or []
-    candidates = sorted(registry.get_assets_with_all_tags(required_tags))
+    candidates = _matching_candidates(registry, required_tags)
     # 1. Exact name match in a pool of assets with only the required tags.
     if query in candidates:
         trace.append(IntentResolutionTraceEvent(f"{trace_prefix}.exact", query, query))
@@ -82,7 +98,7 @@ def match_asset(
 
     # 2. Fuzzy matching in a pool narrowed by required + preferred tags.
     if preferred_tags:
-        preferred_candidates = sorted(registry.get_assets_with_all_tags(required_tags + preferred_tags))
+        preferred_candidates = _matching_candidates(registry, required_tags + preferred_tags)
         chosen = _fuzzy_match(
             preferred_candidates,
             query,

--- a/isaaclab_arena/tests/test_asset_matcher.py
+++ b/isaaclab_arena/tests/test_asset_matcher.py
@@ -141,3 +141,23 @@ def test_item_required_tag_pool_empty():
     chosen = match_asset(make_registry(assets), "bowl", "item", trace, ["object"], ["bowl"])
     assert chosen is None
     assert any(e.stage == "item.required_tags.empty_pool" for e in trace)
+
+
+def test_procedural_assets_excluded_from_matching():
+    assets = [
+        FakeAsset(name="maple_table", tags=["background"]),
+        FakeAsset(name="procedural_table", tags=["background", "procedural"]),
+        FakeAsset(name="procedural_cube", tags=["object", "procedural"]),
+        FakeAsset(name="cracker_box", tags=["object", "graspable"]),
+    ]
+    trace: list[IntentResolutionTraceEvent] = []
+    chosen = match_asset(make_registry(assets), "table", "background", trace, ["background"])
+    assert chosen == "maple_table"
+
+    trace = []
+    chosen = match_asset(make_registry(assets), "procedural_table", "background", trace, ["background"])
+    assert chosen != "procedural_table"
+
+    trace = []
+    chosen = match_asset(make_registry(assets), "cube", "item", trace, ["object"])
+    assert chosen is None


### PR DESCRIPTION
## Summary


## Detailed description
- What was the reason for the change?
Procedural cube crashes the light checker during arena env build from spec

- What has been changed?
Exclude assets with procedural tag from asset matcher, so they will not be included in compiled env spec

- What is the impact of this change?
Fix potential crashes in the e2e agentic env gen script
