### PR TITLE
Add pandas as a dep to arena

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ RUNTIME_DEPS = [
     "sbi",
     "scipy",
     "matplotlib",
+    # HDF5 -> LeRobot conversion (isaaclab_arena_gr00t.lerobot.convert_hdf5_to_lerobot), imported at module level.
+    # Pinned to 2.2.3 to match the version used in GR00T.
+    "pandas==2.2.3",
 ]
 
 DEV_DEPS = [


### PR DESCRIPTION
## Summary
Adds `pandas` as a dependency to arena.

## Detailed description
- We started getting CI failures due to the dependency missing.
- Dependency comes from the hdf5 to lerobot file conversion.
- We must have been getting this transitively from somewhere before, which is no longer working.
- This addresses the issue by properly depending on pandas.
