### PR TITLE
Unify Env src thru example env name or graph spec yaml

### DIFF
--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -135,9 +135,9 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
 
 def _instantiate_assets_from_nodes(
     node_specs: list[ArenaEnvGraphNodeSpec], asset_registry: Any, enable_cameras: bool = False
-) -> dict[str, Any]:
+) -> dict[str, type[Asset]]:
     """Return ``{node.id: live_asset}`` after a single pass over ``node_specs``."""
-    assets_by_node_id: dict[str, Any] = {}
+    assets_by_node_id: dict[str, type[Asset]] = {}
     for node_spec in node_specs:
         # OBJECT_REFERENCE wraps a USD prim inside an already-instantiated parent asset
         # (e.g. a table inside a kitchen background). Validation guarantees the parent
@@ -164,7 +164,7 @@ def _instantiate_assets_from_nodes(
 
 
 def _attach_spatial_constraints_to_assets(
-    state_spec: ArenaEnvGraphStateSpec, assets_by_node_id: dict[str, Any]
+    state_spec: ArenaEnvGraphStateSpec, assets_by_node_id: dict[str, type[Asset]]
 ) -> None:
     """Attach one Relation per spatial constraint to the asset(s) it targets, in place."""
     for spatial_constraint in state_spec.spatial_constraints:

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -30,10 +30,12 @@ if TYPE_CHECKING:
     from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 
 
-def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec) -> Any:
+def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec, enable_cameras: bool = False) -> Any:
     """Build an IsaacLabArenaEnvironment from a validated ``ArenaEnvGraphSpec``.
 
-    Precondition: ``graph_spec`` is already validated (node refs exist, ids unique, etc.).
+    Args:
+        graph_spec: A validated graph spec (node refs exist, ids unique, etc.).
+        enable_cameras: Forwarded to the embodiment node so its cameras are added.
     """
     # TODO(xinjieyao, 2026-05-26): aggregate every state_spec into a single combined initial state instead of
     # picking one. For now we just take the first state_spec, which is the initial state
@@ -42,7 +44,7 @@ def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec) -> Any:
 
     # 1. Materialize every graph node into a live asset, keyed by node id so spatial
     #    constraints and task args can reference each node by its graph-local id.
-    assets_by_node_id = _instantiate_assets_from_nodes(graph_spec.nodes, AssetRegistry())
+    assets_by_node_id = _instantiate_assets_from_nodes(graph_spec.nodes, AssetRegistry(), enable_cameras=enable_cameras)
 
     # 2. Guarantee the scene has a light. A graph (or its background USD) with no light renders
     #    black, which today only surfaces once the policy runner launches the generated env. When
@@ -131,12 +133,10 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
     return False
 
 
-def _instantiate_assets_from_nodes(node_specs: list[ArenaEnvGraphNodeSpec], asset_registry: Any) -> dict[str, Any]:
-    """Return ``{node.id: live_asset}`` after a single pass over ``node_specs``.
-
-    Each ``node_spec.params`` is forwarded verbatim to the asset constructor. Assumes parent
-    nodes precede their OBJECT_REFERENCE children — guaranteed by graph-spec reference validation.
-    """
+def _instantiate_assets_from_nodes(
+    node_specs: list[ArenaEnvGraphNodeSpec], asset_registry: Any, enable_cameras: bool = False
+) -> dict[str, Any]:
+    """Return ``{node.id: live_asset}`` after a single pass over ``node_specs``."""
     assets_by_node_id: dict[str, Any] = {}
     for node_spec in node_specs:
         # OBJECT_REFERENCE wraps a USD prim inside an already-instantiated parent asset
@@ -155,7 +155,11 @@ def _instantiate_assets_from_nodes(node_specs: list[ArenaEnvGraphNodeSpec], asse
             # Standard nodes (object / background / embodiment): look up the registered class
             # by name and instantiate with the spec's verbatim kwargs.
             asset_class = asset_registry.get_asset_by_name(node_spec.name)
-            assets_by_node_id[node_spec.id] = asset_class(**node_spec.params)
+            params = dict(node_spec.params)
+            # Embodiment cameras are enabled thru the flag passed to the env builder.
+            if node_spec.type == ArenaEnvGraphNodeType.EMBODIMENT:
+                params.setdefault("enable_cameras", enable_cameras)
+            assets_by_node_id[node_spec.id] = asset_class(**params)
     return assets_by_node_id
 
 

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -157,8 +157,8 @@ def _instantiate_assets_from_nodes(
             asset_class = asset_registry.get_asset_by_name(node_spec.name)
             params = dict(node_spec.params)
             # Embodiment cameras are enabled thru the flag passed to the env builder.
-            if node_spec.type == ArenaEnvGraphNodeType.EMBODIMENT:
-                params.setdefault("enable_cameras", enable_cameras)
+            if node_spec.type == ArenaEnvGraphNodeType.EMBODIMENT and enable_cameras:
+                params.setdefault("enable_cameras", True)
             assets_by_node_id[node_spec.id] = asset_class(**params)
     return assets_by_node_id
 

--- a/isaaclab_arena/environments/arena_env_graph_spec.py
+++ b/isaaclab_arena/environments/arena_env_graph_spec.py
@@ -135,10 +135,13 @@ class ArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
     def state_specs_by_id(self) -> dict[str, ArenaEnvGraphStateSpec]:
         return {state_spec.id: state_spec for state_spec in self.state_specs}
 
-    def to_arena_env(self) -> IsaacLabArenaEnvironment:
+    def to_arena_env(self, enable_cameras: bool = False) -> IsaacLabArenaEnvironment:
         """Convert this graph spec into an `IsaacLabArenaEnvironment`.
 
         The first ``state_spec`` is used as the scene's initial state.
+
+        Args:
+            enable_cameras: Forwarded to the embodiment so its cameras are spawned.
         """
         # Lazy import: build_arena_env_from_graph_spec pulls in Scene -> phyx_utils ->
         # pxr.PhysxSchema, which requires SimulationApp. Keeping the import here lets
@@ -148,7 +151,7 @@ class ArenaEnvGraphSpec(ArenaEnvGraphSpecBase):
         # this wrapper stays single-arg — no caller-side selection is needed.
         from isaaclab_arena.environments.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
 
-        return build_arena_env_from_graph_spec(self)
+        return build_arena_env_from_graph_spec(self, enable_cameras=enable_cameras)
 
 
 class ArenaEnvInitialGraphSpec(ArenaEnvGraphSpecBase):

--- a/isaaclab_arena/evaluation/job_manager.py
+++ b/isaaclab_arena/evaluation/job_manager.py
@@ -158,7 +158,9 @@ class Job:
     def convert_args_dict_to_cli_args_list(cls, args_dict: dict) -> list[str]:
         """Convert a dictionary of arguments to a list of arguments that can be passed to the CLI parser.
 
-        Enforces ordering: num_envs, enable_cameras, environment, then object/embodiment/etc.
+        The ``environment`` value is the env source: a path ending in yaml is a graph spec YAML.
+        Else it is an example-environment name.
+        Enforces ordering: num_envs, enable_cameras, the env source, then object/embodiment/etc.
 
         Args:
             args_dict: Dictionary of arguments
@@ -186,8 +188,12 @@ class Job:
                 elif not isinstance(value, bool) and value is not None:
                     args_list += [f"--{key}", str(value)]
 
-        # Environment argument comes second (without -- prefix) - already validated above
-        args_list += [str(args_dict["environment"])]
+        # The env source comes next. Graph spec yaml is detected by its extension.
+        environment = str(args_dict["environment"])
+        if environment.endswith((".yaml", ".yml")):
+            args_list += ["--env_graph_spec_yaml", environment]
+        else:
+            args_list += [environment]
 
         # Process all other arguments (object, embodiment, etc.)
         for key, value in args_dict.items():

--- a/isaaclab_arena/evaluation/job_manager.py
+++ b/isaaclab_arena/evaluation/job_manager.py
@@ -158,8 +158,6 @@ class Job:
     def convert_args_dict_to_cli_args_list(cls, args_dict: dict) -> list[str]:
         """Convert a dictionary of arguments to a list of arguments that can be passed to the CLI parser.
 
-        The ``environment`` value is the env source: a path ending in yaml is a graph spec YAML.
-        Else it is an example-environment name.
         Enforces ordering: num_envs, enable_cameras, the env source, then object/embodiment/etc.
 
         Args:
@@ -188,7 +186,8 @@ class Job:
                 elif not isinstance(value, bool) and value is not None:
                     args_list += [f"--{key}", str(value)]
 
-        # The env source comes next. Graph spec yaml is detected by its extension.
+        # The env source comes next.
+        # It could be either an example-environment name or a graph spec yaml detected via extension.
         environment = str(args_dict["environment"])
         if environment.endswith((".yaml", ".yml")):
             args_list += ["--env_graph_spec_yaml", environment]

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -62,7 +62,7 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     # optional) and the runner builds the env from the graph spec instead of the registry.
     sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path]
     args = get_isaaclab_arena_environments_cli_parser().parse_args()
-    assert args.example_environment is None
+
     builder = get_arena_builder_from_cli(args)
     assert builder.arena_env.name == "pick_and_place_maple_table_default"
 

--- a/isaaclab_arena/tests/test_eval_runner.py
+++ b/isaaclab_arena/tests/test_eval_runner.py
@@ -209,6 +209,38 @@ def test_eval_runner_enable_cameras(tmp_path):
     run_eval_runner(temp_config_path)
 
 
+@pytest.mark.with_subprocess
+def test_eval_runner_graph_spec_with_variation(tmp_path):
+    """Eval a graph-spec env (built from YAML) with --enable_cameras and a camera variation.
+
+    Mirrors the example-environment camera-variation job but sources the env from a graph spec
+    YAML, exercising that the eval runner builds graph-spec envs and that --enable_cameras reaches
+    the embodiment so the wrist camera (and its variation) resolve.
+    """
+    graph_spec_yaml = f"{TestConstants.test_data_dir}/pick_and_place_maple_table_env_graph.yaml"
+    assert os.path.exists(graph_spec_yaml), f"Graph spec YAML not found: {graph_spec_yaml}"
+    jobs = [
+        {
+            "name": "maple_table_graph_spec_camera_variation",
+            "arena_env_args": {
+                "enable_cameras": True,
+                "environment": graph_spec_yaml,
+            },
+            "num_steps": NUM_STEPS,
+            "policy_type": "zero_action",
+            "policy_args": {},
+            "variations": {
+                "light": {"hdr_image": {"enabled": True}},
+                "droid_abs_joint_pos": {"camera_extrinsics_wrist_camera": {"enabled": True}},
+            },
+        },
+    ]
+
+    temp_config_path = str(tmp_path / "test_eval_runner_graph_spec_with_variation.json")
+    write_jobs_config_to_file(jobs, temp_config_path)
+    run_eval_runner(temp_config_path)
+
+
 def _test_eval_config_variation_lands_in_events_cfg(simulation_app):
     """Enable a wrist camera extrinsics variation and check that it shows up as an event term in the cfg."""
     from isaaclab_arena.evaluation.eval_runner import load_env

--- a/isaaclab_arena/tests/test_job_manager.py
+++ b/isaaclab_arena/tests/test_job_manager.py
@@ -46,6 +46,16 @@ def test_job_convert_args_dict_to_cli_args_list():
     assert "--enable_cameras" not in args_list  # False booleans are skipped
 
 
+def test_job_convert_args_dict_with_graph_spec_environment():
+    """A .yaml environment is emitted as --env_graph_spec_yaml; a plain name stays positional."""
+    graph_args = Job.convert_args_dict_to_cli_args_list({"environment": "/path/to/graph.yaml"})
+    assert graph_args[graph_args.index("--env_graph_spec_yaml") + 1] == "/path/to/graph.yaml"
+
+    name_args = Job.convert_args_dict_to_cli_args_list({"environment": "kitchen_pick_and_place"})
+    assert "kitchen_pick_and_place" in name_args
+    assert "--env_graph_spec_yaml" not in name_args
+
+
 def test_job_convert_variations_dict_to_hydra_overrides():
     """Test flattening a nested variations dict into Hydra override strings."""
     variations = {

--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -45,7 +45,13 @@ def run_policy_runner(
         args.append("--headless")
     if enable_cameras:
         args.append("--enable_cameras")
-    args.append(example_environment)
+    # The env source: a graph spec YAML path (detected by extension) is passed via
+    # --env_graph_spec_yaml; otherwise it is a registered example-environment name (positional).
+    if example_environment.endswith((".yaml", ".yml")):
+        args.append("--env_graph_spec_yaml")
+        args.append(example_environment)
+    else:
+        args.append(example_environment)
     if embodiment is not None:
         args.append("--embodiment")
         args.append(embodiment)

--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -46,7 +46,9 @@ def run_policy_runner(
     if enable_cameras:
         args.append("--enable_cameras")
     # automatically detect if the env source is a graph spec yaml or an example-environment name
-    # and pass the appropriate argument
+    # and pass the appropriate argument.
+    # NOTE: --env_graph_spec_yaml takes the next arg as its value, so example_environment must be
+    # appended directly after it. Do not insert any other arg between these two lines.
     if example_environment.endswith((".yaml", ".yml")):
         args.append("--env_graph_spec_yaml")
     args.append(example_environment)

--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -45,13 +45,11 @@ def run_policy_runner(
         args.append("--headless")
     if enable_cameras:
         args.append("--enable_cameras")
-    # The env source: a graph spec YAML path (detected by extension) is passed via
-    # --env_graph_spec_yaml; otherwise it is a registered example-environment name (positional).
+    # automatically detect if the env source is a graph spec yaml or an example-environment name
+    # and pass the appropriate argument
     if example_environment.endswith((".yaml", ".yml")):
         args.append("--env_graph_spec_yaml")
-        args.append(example_environment)
-    else:
-        args.append(example_environment)
+    args.append(example_environment)
     if embodiment is not None:
         args.append("--embodiment")
         args.append(embodiment)

--- a/isaaclab_arena/tests/test_variations_in_policy_runner.py
+++ b/isaaclab_arena/tests/test_variations_in_policy_runner.py
@@ -11,6 +11,7 @@ import subprocess
 import pytest
 
 from isaaclab_arena.tests.test_policy_runner import NUM_STEPS, run_policy_runner
+from isaaclab_arena.tests.utils.constants import TestConstants
 
 
 @pytest.mark.with_subprocess
@@ -20,6 +21,25 @@ def test_zero_action_policy_with_hydra_variation_overrides():
         policy_type="zero_action",
         example_environment="pick_and_place_maple_table",
         embodiment="droid_abs_joint_pos",
+        num_steps=NUM_STEPS,
+        enable_cameras=True,
+        hydra_overrides=[
+            "light.hdr_image.enabled=true",
+            "droid_abs_joint_pos.camera_extrinsics_wrist_camera.enabled=true",
+        ],
+    )
+
+
+@pytest.mark.with_subprocess
+def test_zero_action_policy_graph_spec_with_variation():
+    """Boot a graph-spec env with --enable_cameras and a camera-extrinsics variation enabled.
+
+    Exercises that --enable_cameras propagates into the graph-spec embodiment so its wrist
+    camera is spawned, letting the camera-extrinsics variation resolve its target scene entity.
+    """
+    run_policy_runner(
+        policy_type="zero_action",
+        example_environment=f"{TestConstants.test_data_dir}/pick_and_place_maple_table_env_graph.yaml",
         num_steps=NUM_STEPS,
         enable_cameras=True,
         hydra_overrides=[

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -142,7 +142,7 @@ def _arena_env_from_graph_spec(env_graph_spec_yaml: str, args_cli: argparse.Name
     spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
     spec.apply_cli_override_args(args_cli)
     # cameras are enabled in embodiment, need to pass along to the env
-    return spec.to_arena_env(enable_cameras=getattr(args_cli, "enable_cameras", False))
+    return spec.to_arena_env(enable_cameras=args_cli.enable_cameras)
 
 
 def _arena_env_from_example_name(example_environment: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -17,6 +17,7 @@ from isaaclab_arena_environments.example_environment_base import ExampleEnvironm
 
 if TYPE_CHECKING:
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 
 
 def ensure_environments_registered():
@@ -78,11 +79,11 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
     # here, before parsing, so they appear in --help and parse like any other flag.
     env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
     if env_graph_spec_yaml is not None:
+        # The env comes from the graph spec, so don't register the example-environment subparsers.
         cli_override_specs_from_yaml = ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml)
         add_cli_override_args(args_parser, cli_override_specs_from_yaml)
+        return args_parser
 
-    # The subcommand is optional: the env may instead come from a graph spec YAML
-    # (--env_graph_spec_yaml).
     subparsers = args_parser.add_subparsers(
         dest="example_environment", required=False, help="Example environment to run"
     )
@@ -127,15 +128,29 @@ def get_arena_builder_from_cli(
         f" (got example_environment={example_environment!r}, env_graph_spec_yaml={env_graph_spec_yaml!r})"
     )
 
-    if env_graph_spec_yaml is not None:
-        spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
-        spec.apply_cli_override_args(args_cli)
-        return ArenaEnvBuilder(spec.to_arena_env(), args_cli, hydra_overrides=hydra_overrides)
+    # Either env graph spec yaml OR example env name
+    arena_env = (
+        _arena_env_from_graph_spec(env_graph_spec_yaml, args_cli)
+        if env_graph_spec_yaml is not None
+        else _arena_env_from_example_name(example_environment, args_cli)
+    )
+    return ArenaEnvBuilder(arena_env, args_cli, hydra_overrides=hydra_overrides)
 
+
+def _arena_env_from_graph_spec(env_graph_spec_yaml: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
+    """Build the arena env from a graph spec YAML, applying any CLI node overrides."""
+    spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
+    spec.apply_cli_override_args(args_cli)
+    # cameras are enabled in embodiment, need to pass along to the env
+    return spec.to_arena_env(enable_cameras=getattr(args_cli, "enable_cameras", False))
+
+
+def _arena_env_from_example_name(example_environment: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
+    """Build the arena env from a registered example-environment name (subcommand)."""
     ensure_environments_registered()
     env_registry = EnvironmentRegistry()
     assert env_registry.is_registered(
         example_environment
     ), f"Example environment type {example_environment} not supported"
     example_env = env_registry.get_component_by_name(example_environment)()
-    return ArenaEnvBuilder(example_env.get_env(args_cli), args_cli, hydra_overrides=hydra_overrides)
+    return example_env.get_env(args_cli)

--- a/isaaclab_arena_environments/eval_jobs_configs/droid_pnp_graph_spec_variations_config.json
+++ b/isaaclab_arena_environments/eval_jobs_configs/droid_pnp_graph_spec_variations_config.json
@@ -1,0 +1,24 @@
+{
+    "jobs": [
+        {
+            "name": "variations_demo_env_graph_spec",
+            "arena_env_args": {
+                "enable_cameras": true,
+                "environment": "isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml"
+            },
+            "num_steps": 10,
+            "num_rebuilds": 5,
+            "policy_type": "zero_action",
+            "policy_config_dict": {},
+            "variations": {
+                "light": {
+                    "hdr_image": { "enabled": true },
+                    "intensity": { "enabled": true }
+                },
+                "droid_abs_joint_pos": {
+                    "camera_extrinsics_wrist_camera": { "enabled": true }
+                }
+            }
+        }
+    ]
+}

--- a/isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json
+++ b/isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json
@@ -11,7 +11,7 @@
                 "hdr": "home_office_robolab"
             },
             "num_steps": 10,
-            "num_rebuilds": 5,
+            "num_rebuilds": 1,
             "policy_type": "zero_action",
             "policy_config_dict": {},
             "variations": {


### PR DESCRIPTION
## Summary
Variations applied thru CLI are supported Env built from example env name or env graph spec yaml

## Detailed description
- Why: Graph-spec envs couldn't be used interchangeably with registered environment names. Variations cannot be applied.
- What: 
1. Skip the example-environment subparsers when `--env_graph_spec_yaml` is given so Hydra overrides pass through.
2. Enable camera flag is passed thru to reach graph-spec embodiment
3. Eval runner takes 'environment' field from either yaml or env name

- Impact: Variation can be applied to agent composited envs

## Results
- Same prompt -> Same env yaml, run policy_runner with same cmds as below (I forgot to set as a deterministic placer)
```
python isaaclab_arena/evaluation/policy_runner.py \
    --viz kit     \
    --policy_type zero_action   \
    --num_steps 50   \
    --enable_cameras  |
    --env_graph_spec_yaml                                                                                                                                                                                          isaaclab_arena_environments/agent_generated/llm_gen_table_PickAndPlaceTask_linked.yaml     \
    light.hdr_image.enabled=true   \
    franka_ik.camera_extrinsics_wrist_cam.enabled=true
```

<img width="963" height="557" alt="Screenshot from 2026-06-22 05-18-58" src="https://github.com/user-attachments/assets/db5835f3-25c0-4f13-af09-1bd8c505aee2" />
<img width="963" height="557" alt="Screenshot from 2026-06-22 05-17-13" src="https://github.com/user-attachments/assets/de5968e6-2338-45ac-9fba-49f307f2a472" />
<img width="963" height="557" alt="Screenshot from 2026-06-22 05-15-11" src="https://github.com/user-attachments/assets/3c117a18-9beb-4952-876f-aefe5143c604" />

- Eval runner
```
python isaaclab_arena/evaluation/eval_runner.py \
      --headless \
      --enable_cameras \
      --eval_jobs_config isaaclab_arena_environments/eval_jobs_configs/droid_pnp_graph_spec_variations_config.json 
```
```
+--------------------------------+-----------+-------------+----------+-----------+--------------+--------------+
|            Job Name            |   Status  | Policy Type | Num Envs | Num Steps | Num Episodes | Num Rebuilds |
+--------------------------------+-----------+-------------+----------+-----------+--------------+--------------+
| variations_demo_env_graph_spec | completed | zero_action |    1     |     10    |     None     |      5       |
+--------------------------------+-----------+-------------+----------+-----------+--------------+--------------+
```

## TODO
doc explaining how env graph works