### PR TITLE
Unify Object Placement

### DIFF
--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -101,10 +101,9 @@ def solve_and_place_objects(
 ) -> None:
     """Coordinated reset event that draws layouts from the pool and writes poses.
 
-    Registered as a single EventTermCfg(mode="reset"). Env-indexed pools
-    consume one layout for each requested absolute env id. Reusable pools
-    consume only the number of resetting envs because those layouts are
-    interchangeable.
+    Registered as a single EventTermCfg(mode="reset"). Layouts are env-indexed:
+    one layout is consumed for each requested absolute env id, so partial resets
+    only advance the pools of the resetting envs.
 
     Args:
         env: The Isaac Lab environment.
@@ -116,16 +115,12 @@ def solve_and_place_objects(
         return
 
     reset_env_ids = env_ids.tolist()
-    if placement_pool.requires_env_indexed_layouts:
-        num_scene_envs = env.scene.env_origins.shape[0]
-        if placement_pool.num_envs != num_scene_envs:
-            raise ValueError(
-                f"Placement pool has {placement_pool.num_envs} envs, but scene has {num_scene_envs} env origins."
-            )
-        results_by_env = placement_pool.sample_for_envs(reset_env_ids)
-    else:
-        reset_results = placement_pool.sample_without_replacement(len(reset_env_ids))
-        results_by_env = dict(zip(reset_env_ids, reset_results))
+    num_scene_envs = env.scene.env_origins.shape[0]
+    if placement_pool.num_envs != num_scene_envs:
+        raise ValueError(
+            f"Placement pool has {placement_pool.num_envs} envs, but scene has {num_scene_envs} env origins."
+        )
+    results_by_env = placement_pool.sample_for_envs(reset_env_ids)
 
     anchor_objects_set = set(get_anchor_objects(objects))
     base_rotations = get_base_rotation_per_object(objects)

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -116,10 +116,9 @@ def solve_and_place_objects(
 
     reset_env_ids = env_ids.tolist()
     num_scene_envs = env.scene.env_origins.shape[0]
-    if placement_pool.num_envs != num_scene_envs:
-        raise ValueError(
-            f"Placement pool has {placement_pool.num_envs} envs, but scene has {num_scene_envs} env origins."
-        )
+    assert (
+        placement_pool.num_envs == num_scene_envs
+    ), f"Placement pool has {placement_pool.num_envs} envs, but scene has {num_scene_envs} env origins."
     results_by_env = placement_pool.sample_for_envs(reset_env_ids)
 
     anchor_objects_set = set(get_anchor_objects(objects))

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -50,32 +50,20 @@ class EnvLayoutPool:
 class PooledObjectPlacer:
     """Object placer that maintains solved placement layouts.
 
-    Storage is organized as one queue per environment. Env-specific layouts
-    are solved for fixed env geometry. sample_without_replacement consumes
-    complete env rounds; sample_for_envs consumes only the requested absolute
-    env ids. Reusable layouts are interchangeable and can be consumed one at a
-    time from the pooled queues.
+    Storage is organized as one queue per environment: every layout is solved
+    against its env's geometry and bound to that absolute env id.
 
     Strictly valid layouts are preferred. On the final retry batch, best-loss
     solver results may be kept as a fallback.
 
     The pool is refilled automatically when an env's queue runs out.
 
-    * sample_without_replacement(count) consumes count layouts. For
-      env-specific layouts, count must be a multiple of num_envs and
-      may cover multiple complete env rounds.
-    * sample_for_envs(env_ids) consumes one layout for each requested
-      absolute env id (used for partial resets).
-    * sample_with_replacement(count) is non-consuming. Env-specific layouts
-      are sampled from matching env slots; reusable layouts stay marginally
-      uniform over all stored layouts.
-
     Args:
         objects: All objects (including anchors) participating in relation solving.
         placer_params: Parameters forwarded to ObjectPlacer for the batched solve.
         pool_size: Number of layouts to solve per batch.
-        num_envs: Total number of simulation environments.  Required when
-            layouts use env-specific object variants and defaults to 1 otherwise.
+        num_envs: Total number of simulation environments. Required for
+            heterogeneous scenes; defaults to 1.
     """
 
     def __init__(
@@ -86,10 +74,9 @@ class PooledObjectPlacer:
         num_envs: int | None = None,
     ) -> None:
         assert pool_size >= 1, f"pool_size must be >= 1, got {pool_size}"
-        self._uses_env_specific_bboxes = has_heterogeneous_objects(objects)
         assert not (
-            self._uses_env_specific_bboxes and num_envs is None
-        ), "num_envs is required when layouts use env-specific object variants."
+            has_heterogeneous_objects(objects) and num_envs is None
+        ), "num_envs is required for heterogeneous scenes."
         self._num_envs = num_envs if num_envs is not None else 1
         assert self._num_envs >= 1, f"num_envs must be >= 1, got {self._num_envs}"
 
@@ -139,11 +126,9 @@ class PooledObjectPlacer:
         self._next_seed_offset += num_candidates
 
     def _solve_and_store(self, num_layouts: int) -> None:
-        """Solve layouts in batches until every env has target_per_env unread layouts.
+        """Solve and store layouts until every env has target_per_env unread layouts.
 
-        Each batch contributes one or more layout rounds per env. The outer
-        loop is bounded by max_placement_attempts to avoid an
-        unbounded refill in pathological configurations.
+        Bounded by max_placement_attempts; raises if the target cannot be met.
         """
         self._discard_consumed_layouts()
         target_per_env = max(1, (num_layouts + self._num_envs - 1) // self._num_envs)
@@ -156,17 +141,13 @@ class PooledObjectPlacer:
 
             batch_size = max_missing * self._num_envs
             allow_fallback = batch_idx == max_solve_batches - 1
-            if self._uses_env_specific_bboxes:
-                ranked_results_per_env, layouts_per_env = self._solve_env_ranked_layouts(batch_size)
-                self._store_env_matched_results(
-                    ranked_results_per_env,
-                    layouts_per_env,
-                    allow_fallback=allow_fallback,
-                    target_per_env=target_per_env,
-                )
-            else:
-                layouts = self._solve_reusable_layouts(batch_size, allow_fallback=allow_fallback)
-                self._store_reusable_results(layouts)
+            ranked_results_per_env, layouts_per_env = self._solve_env_ranked_layouts(batch_size)
+            self._store_env_matched_results(
+                ranked_results_per_env,
+                layouts_per_env,
+                allow_fallback=allow_fallback,
+                target_per_env=target_per_env,
+            )
 
             if min(self._available_per_env()) >= target_per_env:
                 return
@@ -175,52 +156,6 @@ class PooledObjectPlacer:
             f"Placement pool could not fill {target_per_env} layouts per env after "
             f"{max_solve_batches} solve batches. Available per env: {self._available_per_env()}."
         )
-
-    def _solve_reusable_layouts(self, num_layouts: int, allow_fallback: bool = False) -> list[PlacementResult]:
-        """Solve layouts that can be used by any env pool.
-
-        Invalid candidates are discarded when at least one valid layout exists.
-        If no candidate passes strict validation on the final retry batch, fall
-        back to best-loss results so environments with imperfect validation can
-        still run.
-        """
-        self._prepare_seeded_solve(num_layouts * self._placer.params.max_placement_attempts)
-        with torch.inference_mode(False):
-            all_layouts = self._placer.place(self._objects, num_envs=num_layouts)
-        valid_layouts = [layout for layout in all_layouts if layout.success]
-
-        if len(valid_layouts) < num_layouts:
-            print(
-                f"Pooled object placer: solved {num_layouts} layouts,"
-                f" {len(valid_layouts)} valid, {num_layouts - len(valid_layouts)} failed validation"
-            )
-
-        if valid_layouts:
-            return valid_layouts
-
-        if not allow_fallback:
-            return []
-
-        self._had_fallbacks = True
-        print("Warning: No candidates passed strict validation. Accepting best-loss layouts as fallback.")
-        return all_layouts
-
-    def _store_reusable_results(self, layouts: list[PlacementResult]) -> None:
-        """Distribute reusable layouts across env pools using greedy shortest-first.
-
-        Layouts produced by _solve_reusable_layouts are interchangeable
-        across envs, so we place each one into whichever pool currently has
-        the fewest unread layouts. This keeps reusable capacity balanced
-        across env pools.
-        """
-        if not layouts:
-            return
-
-        available = self._available_per_env()
-        for layout in layouts:
-            cur_env = min(range(self._num_envs), key=available.__getitem__)
-            self._env_pools[cur_env].append(layout)
-            available[cur_env] += 1
 
     def _solve_env_ranked_layouts(self, num_layouts: int) -> tuple[list[list[PlacementResult]], int]:
         """Solve ranked layouts tied to each env's actual object geometry.
@@ -251,13 +186,10 @@ class PooledObjectPlacer:
         target_per_env: int,
         allow_fallback: bool = False,
     ) -> None:
-        """Store env-matched results into their corresponding pools.
+        """Store each env's results into its pool, up to target_per_env unread layouts.
 
-        Each env is filled only up to target_per_env unread layouts, so envs
-        that already met the target are not overfilled. Successful layouts are
-        preferred; if allow_fallback is set and an env has no valid layouts,
-        fall back to its best-loss results so environments with imperfect
-        validation can still run.
+        Valid layouts are preferred; when allow_fallback is set, an env with no
+        valid layout keeps its best-loss results instead of staying empty.
         """
         total_valid = 0
         fallback_envs = []
@@ -278,9 +210,9 @@ class PooledObjectPlacer:
                 self._had_fallbacks = True
 
         total_solved = sum(min(len(env_results), layouts_per_env) for env_results in ranked_results_per_env)
-        if total_valid < total_solved:
+        if total_valid < total_solved or fallback_envs:
             msg = (
-                f"Placement pool (env-specific bbox layouts) solved {total_solved} candidates,"
+                f"Placement pool solved {total_solved} candidates,"
                 f" {total_valid} valid, {total_solved - total_valid} failed validation"
             )
             if fallback_envs:
@@ -292,26 +224,15 @@ class PooledObjectPlacer:
     # ------------------------------------------------------------------
 
     def sample_without_replacement(self, count: int) -> list[PlacementResult]:
-        """Return the next count layouts.
+        """Return the next count layouts as complete env rounds.
 
-        Env-specific layouts are returned as complete rounds of
-        [env_0, env_1, ..., env_{num_envs-1}] so each result still maps
-        to the absolute environment it was solved for. Reusable layouts consume
-        exactly count interchangeable entries.
+        Layouts are returned as complete rounds of
+        [env_0, env_1, ..., env_{num_envs-1}] so each result maps to the
+        absolute environment it was solved for.
 
         Args:
-            count: Number of layouts to return.
-
-        Raises:
-            ValueError: If env-specific layouts are requested without a complete env round.
-            RuntimeError: If the pool cannot provide count layouts after refilling.
+            count: Number of layouts to return. Must be a multiple of num_envs.
         """
-        if self._uses_env_specific_bboxes:
-            return self._sample_env_indexed_without_replacement(count)
-        return self._sample_reusable_without_replacement(count)
-
-    def _sample_env_indexed_without_replacement(self, count: int) -> list[PlacementResult]:
-        """Consume complete env rounds for layouts tied to absolute env ids."""
         if count % self._num_envs != 0:
             raise ValueError(f"count must be a multiple of num_envs ({self._num_envs}), got {count}")
 
@@ -333,10 +254,6 @@ class PooledObjectPlacer:
 
     def sample_for_envs(self, env_ids: list[int]) -> dict[int, PlacementResult]:
         """Consume one layout for each requested absolute env id."""
-        if not self._uses_env_specific_bboxes:
-            layouts = self._sample_reusable_without_replacement(len(env_ids))
-            return dict(zip(env_ids, layouts))
-
         if any(env_id < 0 or env_id >= self._num_envs for env_id in env_ids):
             raise ValueError(f"env_ids must be in [0, {self._num_envs}); got {env_ids}")
 
@@ -354,36 +271,6 @@ class PooledObjectPlacer:
             results[env_id] = pool.next()
         return results
 
-    def _sample_reusable_without_replacement(self, count: int) -> list[PlacementResult]:
-        """Consume exactly count interchangeable layouts."""
-        if self._total_available() < count:
-            self._solve_and_store(max(self._pool_size, count))
-
-        available = self._available_per_env()
-        if sum(available) < count:
-            raise RuntimeError(
-                f"Placement pool has {sum(available)} reusable layouts but {count} were requested. "
-                "The solver is not producing enough valid placements."
-            )
-
-        results: list[PlacementResult] = []
-        for _ in range(count):
-            cur_env = max(range(self._num_envs), key=available.__getitem__)
-            pool = self._env_pools[cur_env]
-            if pool.available <= 0:
-                raise RuntimeError(
-                    f"Placement pool: env {cur_env} has no more valid layouts. "
-                    "The solver is not producing enough valid placements."
-                )
-            results.append(pool.next())
-            available[cur_env] -= 1
-        return results
-
-    @property
-    def requires_env_indexed_layouts(self) -> bool:
-        """Whether sampled layouts must be matched back to absolute env ids."""
-        return self._uses_env_specific_bboxes
-
     @property
     def num_envs(self) -> int:
         """Number of environment pools managed by this placer."""
@@ -397,42 +284,21 @@ class PooledObjectPlacer:
     def sample_with_replacement(self, count: int) -> list[PlacementResult]:
         """Pick count layouts at random with replacement (non-consuming).
 
-        For env-specific layouts, slot i picks from env i % num_envs's pool
-        so each result matches its absolute env. For reusable layouts, each
-        slot stays marginally uniform over the full pool; the per-env RNGs only
-        fix which stream a slot draws from, for parity with the env-specific branch.
+        Slot i picks from env i % num_envs's pool so each result matches its
+        absolute env, using that env's RNG for a reproducible draw.
         """
-        # Non-consuming: reads pool.layouts directly, ignoring the consumption cursor.
-        if self._uses_env_specific_bboxes:
-            results: list[PlacementResult] = []
-            for i in range(count):
-                cur_env = i % self._num_envs
-                pool = self._env_pools[cur_env].layouts
-                assert pool, f"Env {cur_env} has no valid layouts to sample from."
-                results.append(self._env_rngs[cur_env].choice(pool))
-            return results
-        # Serialize all layouts into one flat pool.
-        all_layouts: list[PlacementResult] = []
-        for pool in self._env_pools:
-            for layout in pool.layouts:
-                all_layouts.append(layout)
-        assert all_layouts, "No valid layouts to sample from across any env pool."
-
-        # Draw each slot from its env's RNG over the serialized pool.
+        # Reads pool.layouts directly, ignoring the consumption cursor.
         results: list[PlacementResult] = []
-        for layout_idx in range(count):
-            rng = self._env_rngs[layout_idx % self._num_envs]
-            results.append(rng.choice(all_layouts))
+        for i in range(count):
+            cur_env = i % self._num_envs
+            pool = self._env_pools[cur_env].layouts
+            assert pool, f"Env {cur_env} has no valid layouts to sample from."
+            results.append(self._env_rngs[cur_env].choice(pool))
         return results
 
     @property
     def remaining(self) -> int:
-        """Number of complete env rounds available to :meth:`sample_without_replacement`.
-
-        Returns the minimum unread count across env pools. A single round
-        consumes one layout from every env, so the minimum is what limits
-        without-replacement capacity.
-        """
+        """Number of complete env rounds available, i.e. the minimum unread count across env pools."""
         return min(self._available_per_env())
 
     @property

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -62,10 +62,7 @@ class PooledObjectPlacer:
         objects: All objects (including anchors) participating in relation solving.
         placer_params: Parameters forwarded to ObjectPlacer for the batched solve.
         pool_size: Number of layouts to solve per batch.
-        num_envs: Total number of simulation environments. Defaults to 1; set it to the
-            scene's env count for multi-env placement (otherwise solve_and_place_objects
-            rejects the env-count mismatch). Required for heterogeneous scenes, where it
-            also fixes each env's variant geometry.
+        num_envs: Number of simulation environments.
     """
 
     def __init__(
@@ -128,16 +125,16 @@ class PooledObjectPlacer:
         self._next_seed_offset += num_candidates
 
     def _solve_and_store(self, num_layouts: int) -> None:
-        """Solve and store layouts until every env has target_per_env unread layouts.
+        """Solve and store layouts until every env has target_num_layouts_per_env unread layouts.
 
         Bounded by max_placement_attempts; raises if the target cannot be met.
         """
         self._discard_consumed_layouts()
-        target_per_env = max(1, (num_layouts + self._num_envs - 1) // self._num_envs)
+        target_num_layouts_per_env = max(1, (num_layouts + self._num_envs - 1) // self._num_envs)
         max_solve_batches = max(1, self._placer.params.max_placement_attempts)
 
         for batch_idx in range(max_solve_batches):
-            max_missing = target_per_env - min(self._available_per_env())
+            max_missing = target_num_layouts_per_env - min(self._available_per_env())
             if max_missing <= 0:
                 return
 
@@ -148,14 +145,14 @@ class PooledObjectPlacer:
                 ranked_results_per_env,
                 layouts_per_env,
                 allow_fallback=allow_fallback,
-                target_per_env=target_per_env,
+                target_num_layouts_per_env=target_num_layouts_per_env,
             )
 
-            if min(self._available_per_env()) >= target_per_env:
+            if min(self._available_per_env()) >= target_num_layouts_per_env:
                 return
 
         raise RuntimeError(
-            f"Placement pool could not fill {target_per_env} layouts per env after "
+            f"Placement pool could not fill {target_num_layouts_per_env} layouts per env after "
             f"{max_solve_batches} solve batches. Available per env: {self._available_per_env()}."
         )
 
@@ -185,20 +182,22 @@ class PooledObjectPlacer:
         self,
         ranked_results_per_env: list[list[PlacementResult]],
         layouts_per_env: int,
-        target_per_env: int,
+        target_num_layouts_per_env: int,
         allow_fallback: bool = False,
     ) -> None:
-        """Store each env's results into its pool, up to target_per_env unread layouts.
+        """Store each env's results into its pool, up to target_num_layouts_per_env unread layouts.
 
         Valid layouts are preferred; when allow_fallback is set, an env with no
         valid layout keeps its best-loss results instead of staying empty.
+        An env that has at least one valid layout never falls back to best-loss,
+        even if it has fewer valid layouts than target_num_layouts_per_env.
         """
         total_valid = 0
         fallback_envs = []
         for cur_env in range(self._num_envs):
             env_results = ranked_results_per_env[cur_env][:layouts_per_env]
             valid_results = [r for r in env_results if r.success]
-            missing = target_per_env - self._env_pools[cur_env].available
+            missing = target_num_layouts_per_env - self._env_pools[cur_env].available
             if valid_results:
                 if missing > 0:
                     enqueued = valid_results[:missing]

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -62,8 +62,10 @@ class PooledObjectPlacer:
         objects: All objects (including anchors) participating in relation solving.
         placer_params: Parameters forwarded to ObjectPlacer for the batched solve.
         pool_size: Number of layouts to solve per batch.
-        num_envs: Total number of simulation environments. Required for
-            heterogeneous scenes; defaults to 1.
+        num_envs: Total number of simulation environments. Defaults to 1; set it to the
+            scene's env count for multi-env placement (otherwise solve_and_place_objects
+            rejects the env-count mismatch). Required for heterogeneous scenes, where it
+            also fixes each env's variant geometry.
     """
 
     def __init__(
@@ -205,9 +207,11 @@ class PooledObjectPlacer:
                 else:
                     total_valid += len(valid_results)
             elif allow_fallback and missing > 0:
-                self._env_pools[cur_env].extend(env_results[:missing])
-                fallback_envs.append(cur_env)
-                self._had_fallbacks = True
+                fallback = env_results[:missing]
+                if fallback:
+                    self._env_pools[cur_env].extend(fallback)
+                    fallback_envs.append(cur_env)
+                    self._had_fallbacks = True
 
         total_solved = sum(min(len(env_results), layouts_per_env) for env_results in ranked_results_per_env)
         if total_valid < total_solved or fallback_envs:

--- a/isaaclab_arena/tests/test_heterogeneous_placement.py
+++ b/isaaclab_arena/tests/test_heterogeneous_placement.py
@@ -582,7 +582,9 @@ def test_pooled_placer_env_specific_fallbacks_are_reported(capsys):
         for cur_env in range(2)
     ]
 
-    pool._store_env_matched_results(fallback_results, layouts_per_env=1, target_per_env=1, allow_fallback=True)
+    pool._store_env_matched_results(
+        fallback_results, layouts_per_env=1, target_num_layouts_per_env=1, allow_fallback=True
+    )
     captured = capsys.readouterr()
 
     assert pool.had_fallbacks
@@ -611,7 +613,7 @@ def test_pooled_placer_env_specific_fallbacks_wait_for_final_retry(capsys):
         for cur_env in range(2)
     ]
 
-    pool._store_env_matched_results(fallback_results, layouts_per_env=1, target_per_env=1)
+    pool._store_env_matched_results(fallback_results, layouts_per_env=1, target_num_layouts_per_env=1)
     captured = capsys.readouterr()
 
     assert not pool.had_fallbacks
@@ -652,7 +654,7 @@ def test_pooled_placer_env_specific_fallback_only_fills_short_env(capsys):
         fallback_results,
         layouts_per_env=1,
         allow_fallback=True,
-        target_per_env=1,
+        target_num_layouts_per_env=1,
     )
     captured = capsys.readouterr()
 
@@ -692,7 +694,7 @@ def test_pooled_placer_env_specific_valid_results_only_fill_short_envs():
         for cur_env in range(2)
     ]
 
-    pool._store_env_matched_results(ranked_results, layouts_per_env=2, target_per_env=1)
+    pool._store_env_matched_results(ranked_results, layouts_per_env=2, target_num_layouts_per_env=1)
 
     assert [env_pool.available for env_pool in pool._env_pools] == [1, 1]
     assert pool._env_pools[0].layouts == [existing_layout]
@@ -723,7 +725,7 @@ def test_pooled_placer_env_specific_partial_valid_results_kept_for_available_env
 
     # No fallback: env 1 has no valid candidate this batch, so it stays empty
     # while env 0's valid layout is still kept (partial fill is preserved).
-    pool._store_env_matched_results(ranked_results, layouts_per_env=1, target_per_env=1)
+    pool._store_env_matched_results(ranked_results, layouts_per_env=1, target_num_layouts_per_env=1)
 
     assert [env_pool.available for env_pool in pool._env_pools] == [1, 0]
     assert pool._env_pools[0].layouts == [valid_for_env0]

--- a/isaaclab_arena/tests/test_heterogeneous_placement.py
+++ b/isaaclab_arena/tests/test_heterogeneous_placement.py
@@ -453,17 +453,6 @@ def test_pooled_placer_env_specific_layouts_sample_from_fixed_env_order():
         assert hetero in draw.positions
 
 
-def test_pooled_placer_heterogeneous_sample_without_replacement():
-    """sample_without_replacement should return one layout per requested sample."""
-    desk, hetero, placer_params = _make_hetero_pool_objects()
-    pool = PooledObjectPlacer(objects=[desk, hetero], placer_params=placer_params, pool_size=20, num_envs=4)
-
-    draws = pool.sample_without_replacement(4)
-    assert len(draws) == 4
-    for d in draws:
-        assert hetero in d.positions
-
-
 def test_pooled_placer_heterogeneous_sample_without_replacement_requires_complete_rounds():
     """sample_without_replacement should consume complete env rounds."""
     desk, hetero, placer_params = _make_hetero_pool_objects()
@@ -710,8 +699,39 @@ def test_pooled_placer_env_specific_valid_results_only_fill_short_envs():
     assert pool._env_pools[1].layouts == [ranked_results[1][0]]
 
 
-def test_pooled_placer_reusable_layouts_report_complete_env_rounds():
-    """Reusable layouts should still expose equal without-replacement capacity per env."""
+def test_pooled_placer_env_specific_partial_valid_results_kept_for_available_envs():
+    """When only some envs have a valid layout this batch, those are stored and the rest stay empty."""
+    desk, hetero, placer_params = _make_hetero_pool_objects()
+    pool = PooledObjectPlacer(objects=[desk, hetero], placer_params=placer_params, pool_size=2, num_envs=2)
+    for env_pool in pool._env_pools:
+        env_pool.layouts = []
+        env_pool.cursor = 0
+
+    valid_for_env0 = PlacementResult(
+        validation_results=_checklist(True),
+        positions={hetero: (0.0, 0.0, 0.0)},
+        final_loss=0.0,
+        attempts=1,
+    )
+    invalid_for_env1 = PlacementResult(
+        validation_results=_checklist(False),
+        positions={hetero: (1.0, 0.0, 0.0)},
+        final_loss=1.0,
+        attempts=1,
+    )
+    ranked_results = [[valid_for_env0], [invalid_for_env1]]
+
+    # No fallback: env 1 has no valid candidate this batch, so it stays empty
+    # while env 0's valid layout is still kept (partial fill is preserved).
+    pool._store_env_matched_results(ranked_results, layouts_per_env=1, target_per_env=1)
+
+    assert [env_pool.available for env_pool in pool._env_pools] == [1, 0]
+    assert pool._env_pools[0].layouts == [valid_for_env0]
+    assert pool._env_pools[1].layouts == []
+
+
+def test_pooled_placer_homogeneous_reports_complete_env_rounds():
+    """Homogeneous objects use per-env pools too and expose equal capacity per env."""
     desk = _make_desk()
     box = DummyObject(
         name="box",
@@ -723,39 +743,13 @@ def test_pooled_placer_reusable_layouts_report_complete_env_rounds():
     placer_params = ObjectPlacerParams(solver_params=solver_params, placement_seed=None)
 
     pool = PooledObjectPlacer(objects=[desk, box], placer_params=placer_params, pool_size=10, num_envs=4)
+    # Homogeneous objects route through per-env pools: every env gets equal capacity.
+    assert [env_pool.available for env_pool in pool._env_pools] == [3, 3, 3, 3]
     assert pool.remaining == 3
     draws = pool.sample_without_replacement(4)
     assert len(draws) == 4
+    assert [env_pool.available for env_pool in pool._env_pools] == [2, 2, 2, 2]
     assert pool.remaining == 2
-
-
-def test_pooled_placer_reusable_layouts_keep_partial_valid_results():
-    """Reusable layouts should not be dropped when fewer than num_envs are valid."""
-    desk = _make_desk()
-    box = DummyObject(
-        name="box",
-        bounding_box=AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(0.2, 0.2, 0.2)),
-    )
-    box.add_relation(On(desk, clearance_m=0.01))
-
-    solver_params = RelationSolverParams(max_iters=200, convergence_threshold=1e-3, verbose=False)
-    placer_params = ObjectPlacerParams(solver_params=solver_params, placement_seed=None)
-
-    pool = PooledObjectPlacer(objects=[desk, box], placer_params=placer_params, pool_size=4, num_envs=4)
-    for env_pool in pool._env_pools:
-        env_pool.layouts = []
-        env_pool.cursor = 0
-
-    layouts = [
-        PlacementResult(
-            validation_results=_checklist(True), positions={box: (float(i), 0.0, 0.0)}, final_loss=0.0, attempts=1
-        )
-        for i in range(3)
-    ]
-    pool._store_reusable_results(layouts)
-
-    assert sum(len(env_pool.layouts) for env_pool in pool._env_pools) == 3
-    assert pool.remaining == 0
 
 
 def test_pooled_placer_mixed_heterogeneous_and_homogeneous_objects():
@@ -937,7 +931,6 @@ def test_real_rigid_object_set_through_pooled_placer():
 
     pool = PooledObjectPlacer(objects=[desk, obj_set], placer_params=placer_params, pool_size=20, num_envs=num_envs)
 
-    assert pool.requires_env_indexed_layouts
     assert pool.remaining > 0
 
     draws = pool.sample_without_replacement(num_envs)

--- a/isaaclab_arena/tests/test_placement_events.py
+++ b/isaaclab_arena/tests/test_placement_events.py
@@ -409,7 +409,7 @@ def test_solve_and_place_objects_asserts_env_indexed_pool_size_matches_scene():
     class MismatchedEnvIndexedPool:
         num_envs = 1
 
-    with pytest.raises(ValueError, match="scene has 2 env origins"):
+    with pytest.raises(AssertionError, match="scene has 2 env origins"):
         solve_and_place_objects(env, torch.tensor([0]), objects, MismatchedEnvIndexedPool())
 
 

--- a/isaaclab_arena/tests/test_placement_events.py
+++ b/isaaclab_arena/tests/test_placement_events.py
@@ -293,8 +293,8 @@ def test_solve_and_place_objects_handles_multiple_env_ids():
         )
 
 
-def test_solve_and_place_objects_partial_reset_reusable_pool_consumes_only_reset_envs():
-    """Reusable layouts should not consume a full env round for a partial reset."""
+def test_solve_and_place_objects_partial_reset_homogeneous_pool_consumes_only_reset_envs():
+    """A partial reset should consume only the resetting env pools, not a full env round."""
 
     from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
     from isaaclab_arena.relations.placement_events import solve_and_place_objects
@@ -329,18 +329,18 @@ def test_solve_and_place_objects_writes_invalid_fallback_layout(capsys):
     env = _make_mock_env(num_envs=1)
 
     class InvalidPool:
-        requires_env_indexed_layouts = False
+        num_envs = 1
 
-        def sample_without_replacement(self, count: int) -> list[PlacementResult]:
-            assert count == 1
-            return [
-                PlacementResult(
+        def sample_for_envs(self, env_ids: list[int]) -> dict[int, PlacementResult]:
+            assert env_ids == [0]
+            return {
+                0: PlacementResult(
                     validation_results=_checklist(False),
                     positions={box1: (0.0, 0.0, 0.0), box2: (0.0, 0.0, 0.0)},
                     final_loss=float("nan"),
                     attempts=1,
                 )
-            ]
+            }
 
     solve_and_place_objects(env, torch.tensor([0]), objects, InvalidPool())
     captured = capsys.readouterr()
@@ -362,7 +362,6 @@ def test_solve_and_place_objects_partial_reset_env_indexed_uses_absolute_env_res
     env = _make_mock_env(num_envs=4)
 
     class EnvIndexedPool:
-        requires_env_indexed_layouts = True
         num_envs = 4
         requested_env_ids = None
 
@@ -408,7 +407,6 @@ def test_solve_and_place_objects_asserts_env_indexed_pool_size_matches_scene():
     env = _make_mock_env(num_envs=2)
 
     class MismatchedEnvIndexedPool:
-        requires_env_indexed_layouts = True
         num_envs = 1
 
     with pytest.raises(ValueError, match="scene has 2 env origins"):
@@ -533,7 +531,6 @@ def test_env_indexed_pool_seeds_init_state_before_reset_without_event():
             raise AssertionError("resolve_on_reset init seeding must not register per-object reset events")
 
     class EnvIndexedPool:
-        requires_env_indexed_layouts = True
         num_envs = 3
         sample_count = None
 
@@ -591,7 +588,6 @@ def test_env_indexed_static_poses_apply_per_env_positions():
     num_envs = 3
 
     class PerEnvPool:
-        requires_env_indexed_layouts = True
         num_envs = 3
 
         def sample_with_replacement(self, count: int):
@@ -657,5 +653,5 @@ def test_pooled_placer_falls_back_when_no_valid_layouts(capsys):
 
     assert pool.remaining == 5
     assert pool.had_fallbacks
-    assert "Accepting best-loss layouts as fallback" in captured.out
+    assert "Falling back to best-loss layouts" in captured.out
     assert not pool.sample_without_replacement(1)[0].success

--- a/isaaclab_arena/tests/test_relation_solver_interface.py
+++ b/isaaclab_arena/tests/test_relation_solver_interface.py
@@ -32,8 +32,6 @@ def _make_box(name: str = "box"):
 
 
 class _FakePlacementPool:
-    requires_env_indexed_layouts = False
-
     def __init__(self, layouts) -> None:
         self._layouts = layouts
 


### PR DESCRIPTION
## Summary
Unify homogeneous & heterogeneous object placement

## Detailed description
- Reason: previously homogeneous and heterogeneous objects took different placement paths in `PooledObjectPlacer` (shared interchangeable pool vs per-env pools), so behavior depended on object type.
- Change: unified on the per-env behavior for both homogeneous and heterogeneous  mode. Removed the shared pool of layouts and the `requires_env_indexed_layouts` flag
