### PR TITLE
Support duplicate asset instances in agentic env gen

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -327,5 +327,10 @@ initial_state_graph (subject=object, reference=background) to anchor them.
 - Distractor items around the appliance need the same 'on' pattern in initial_state_graph.
 - Do not invent relation or task kinds absent from RELATIONS / TASKS.
 - Each task entry needs kind, params (all required keys from TASKS), and description.
-- params values are Item.query strings or the background name, not registry asset names.
+- params values are node ids or the background name, not registry asset names.
+- NODE IDS: an item's id is its instance_name if set, else its query. For multiple
+  items of the same kind, give each a unique instance_name and use those exact ids everywhere.
+- Every relation subject/reference and object task param must name one node id — never
+  a bare query that maps to several instances. Each must name exactly one;
+  if the prompt doesn't say which, pick any.
 """

--- a/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
@@ -40,7 +40,13 @@ class Item(BaseModel):
     )
     instance_name: str | None = Field(
         default=None,
-        description="Optional explicit instance label for the item; leave null if the prompt does not name one.",
+        description=(
+            "Explicit, unique instance label for this item. REQUIRED whenever the "
+            "scene has more than one item sharing the same query (e.g. 5 bananas → "
+            "'banana_1' … 'banana_5'); leave null only for a singleton item. When "
+            "set, this label — NOT the query — is the node id that every relation "
+            "subject/reference and task param must use to refer to this item."
+        ),
     )
 
 

--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -275,33 +275,42 @@ class IntentCompiler:
     def _resolve_task_params_to_node_ids(
         self, tasks: list[TaskSpec], known_ids: set[str], query_to_instances: dict[str, list[str]]
     ) -> list[TaskSpec]:
-        """Resolve object-valued task params in place to concrete node ids.
+        """Resolve object-valued task params to concrete node ids, returning new specs.
 
         Each string param is resolved to the node id it references, picking one
         instance at random when the query is shared by several. A param that
         resolves to no node is left unchanged and flagged with a ``task.unknown_param``
         error trace (so :attr:`has_resolution_errors` reports it).
 
+        The input ``tasks`` (and the ``EnvironmentIntentSpec`` they belong to) are left
+        unmodified: each task is copied with a fresh ``params`` dict, so a second
+        ``compile`` of the same spec re-samples from scratch instead of finding already
+        resolved ids in ``known_ids`` and silently diverging.
+
         Args:
             tasks: Agent-emitted task specs.
             known_ids: The set of resolved graph node ids.
             query_to_instances: Map from item query to the node ids it produced.
         """
+        resolved_tasks: list[TaskSpec] = []
         for task in tasks:
             self.trace.append(
                 IntentResolutionTraceEvent("task.resolve", task.kind, task.kind, note=f"params={task.params}")
             )
-            for param_name, param_value in task.params.items():
-                if not isinstance(param_value, str):
-                    continue
-                chosen = self._resolve_reference_to_node_id(
-                    param_value,
-                    known_ids,
-                    query_to_instances,
-                    resolved_stage="task.resolved_param",
-                    unknown_stage="task.unknown_param",
-                    note=f"param={param_name}, task kind={task.kind}",
-                )
-                if chosen is not None:
-                    task.params[param_name] = chosen
-        return tasks
+            resolved_params = dict(task.params)
+            for param_name, param_value in resolved_params.items():
+                # ASSUMPTION: every string-valued task param is a node reference.
+                # Downstream conversion will check against the task class signature.
+                if isinstance(param_value, str):
+                    chosen = self._resolve_reference_to_node_id(
+                        param_value,
+                        known_ids,
+                        query_to_instances,
+                        resolved_stage="task.resolved_param",
+                        unknown_stage="task.unknown_param",
+                        note=f"param={param_name}, task kind={task.kind}",
+                    )
+                    if chosen is not None:
+                        resolved_params[param_name] = chosen
+            resolved_tasks.append(task.model_copy(update={"params": resolved_params}))
+        return resolved_tasks

--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -76,13 +76,20 @@ class IntentCompiler:
         nodes: list[ArenaEnvGraphNodeSpec] = []
 
         background_node = self._resolve_asset_node(
-            spec.background, "background", ArenaEnvGraphNodeType.BACKGROUND, ["background"]
+            query=spec.background,
+            trace_prefix="background",
+            node_type=ArenaEnvGraphNodeType.BACKGROUND,
+            required_tags=["background"],
         )
         if background_node is not None:
             nodes.append(background_node)
 
         embodiment_node = self._resolve_asset_node(
-            spec.embodiment, "embodiment", ArenaEnvGraphNodeType.EMBODIMENT, ["embodiment"], ["ik"]
+            query=spec.embodiment,
+            trace_prefix="embodiment",
+            node_type=ArenaEnvGraphNodeType.EMBODIMENT,
+            required_tags=["embodiment"],
+            preferred_tags=["ik"],
         )
         if embodiment_node is not None:
             nodes.append(embodiment_node)
@@ -93,11 +100,11 @@ class IntentCompiler:
         query_to_instances: dict[str, list[str]] = {}
         for item in spec.items:
             item_node = self._resolve_asset_node(
-                item.query,
-                "item",
-                ArenaEnvGraphNodeType.OBJECT,
-                ["object"],
-                item.category_tags,
+                query=item.query,
+                trace_prefix="item",
+                node_type=ArenaEnvGraphNodeType.OBJECT,
+                required_tags=["object"],
+                preferred_tags=item.category_tags,
                 instance_name=item.instance_name,
             )
             if item_node is not None:
@@ -151,7 +158,6 @@ class IntentCompiler:
         node_type: ArenaEnvGraphNodeType,
         required_tags: list[str],
         preferred_tags: list[str] | None = None,
-        *,
         instance_name: str | None = None,
     ) -> ArenaEnvGraphNodeSpec | None:
         """Match ``query`` to a registered asset and build the corresponding graph node, or None.
@@ -226,7 +232,6 @@ class IntentCompiler:
         ref: str,
         known_ids: set[str],
         query_to_instances: dict[str, list[str]],
-        *,
         resolved_stage: str,
         unknown_stage: str,
         note: str,

--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -5,13 +5,15 @@
 
 from __future__ import annotations
 
+import random
+
 from isaaclab_arena.agentic_environment_generation.asset_matcher import (
     ASSET_ERROR_STAGES,
     IntentResolutionTraceEvent,
     match_asset,
 )
 from isaaclab_arena.agentic_environment_generation.default_params import INITIAL_STATE_SPEC_ID
-from isaaclab_arena.agentic_environment_generation.environment_intent_spec import EnvironmentIntentSpec, Item
+from isaaclab_arena.agentic_environment_generation.environment_intent_spec import EnvironmentIntentSpec
 from isaaclab_arena.assets.registries import AssetRegistry
 from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvInitialGraphSpec
 from isaaclab_arena.environments.arena_env_graph_types import (
@@ -73,32 +75,60 @@ class IntentCompiler:
 
         nodes: list[ArenaEnvGraphNodeSpec] = []
 
-        background_node = self._resolve_background_node(spec.background)
+        background_node = self._resolve_asset_node(
+            spec.background, "background", ArenaEnvGraphNodeType.BACKGROUND, ["background"]
+        )
         if background_node is not None:
             nodes.append(background_node)
 
-        embodiment_node = self._resolve_embodiment_node(spec.embodiment)
+        embodiment_node = self._resolve_asset_node(
+            spec.embodiment, "embodiment", ArenaEnvGraphNodeType.EMBODIMENT, ["embodiment"], ["ik"]
+        )
         if embodiment_node is not None:
             nodes.append(embodiment_node)
 
-        # TODO(qianl): handle duplicate node IDs when two items share the same query and
-        # neither has an instance_name.
+        # Map each item query to the node ids it produced, so a bare query reference
+        # (e.g. 'banana' when the scene holds banana_1..banana_5) can be resolved
+        # to one concrete instance.
+        query_to_instances: dict[str, list[str]] = {}
         for item in spec.items:
-            item_node = self._resolve_item_node(item)
+            item_node = self._resolve_asset_node(
+                item.query,
+                "item",
+                ArenaEnvGraphNodeType.OBJECT,
+                ["object"],
+                item.category_tags,
+                instance_name=item.instance_name,
+            )
             if item_node is not None:
                 nodes.append(item_node)
+                query_to_instances.setdefault(item.query, []).append(item_node.id)
 
         known_ids = {node.id for node in nodes}
 
-        initial_state_spec = self._build_initial_state_spec(spec.initial_state_graph, known_ids)
-        self._trace_tasks(spec.tasks, known_ids)
+        initial_state_spec = self._build_initial_state_spec(spec.initial_state_graph, known_ids, query_to_instances)
+        resolved_tasks = self._resolve_task_params_to_node_ids(spec.tasks, known_ids, query_to_instances)
 
         return ArenaEnvInitialGraphSpec(
             env_name=env_name or self._derive_env_name(spec),
             nodes=nodes,
-            tasks=spec.tasks,
+            tasks=resolved_tasks,
             initial_state_spec=initial_state_spec,
         )
+
+    @staticmethod
+    def _sample_one_instance_for_query(query: str, query_to_instances: dict[str, list[str]]) -> str | None:
+        """Return one instance id the ``query`` expands to (chosen at random), or ``None``.
+
+        When the scene holds duplicates, exactly one instance is sampled so a single query resolves
+        unambiguously. Returns ``None`` when the query resolves to no instances.
+
+        Args:
+            query: The agent-emitted item query (e.g. 'banana') shared by one or more instances.
+            query_to_instances: Map from item query (e.g. 'banana') to the node ids it produced (e.g. 'banana_1'..'banana_5').
+        """
+        instances = query_to_instances.get(query)
+        return random.choice(instances) if instances else None
 
     @staticmethod
     def _derive_env_name(spec: EnvironmentIntentSpec) -> str:
@@ -114,42 +144,41 @@ class IntentCompiler:
         """
         return instance_name or query
 
-    def _resolve_background_node(self, query: str) -> ArenaEnvGraphNodeSpec | None:
-        asset_name = match_asset(self.registry, query, "background", self.trace, ["background"])
-        if asset_name is None:
-            return None
-        return ArenaEnvGraphNodeSpec(
-            id=self._agent_node_id(query),
-            name=asset_name,
-            type=ArenaEnvGraphNodeType.BACKGROUND,
-        )
+    def _resolve_asset_node(
+        self,
+        query: str,
+        trace_prefix: str,
+        node_type: ArenaEnvGraphNodeType,
+        required_tags: list[str],
+        preferred_tags: list[str] | None = None,
+        *,
+        instance_name: str | None = None,
+    ) -> ArenaEnvGraphNodeSpec | None:
+        """Match ``query`` to a registered asset and build the corresponding graph node, or None.
 
-    def _resolve_embodiment_node(self, query: str) -> ArenaEnvGraphNodeSpec | None:
-        asset_name = match_asset(self.registry, query, "embodiment", self.trace, ["embodiment"], ["ik"])
+        Args:
+            query: Agent-emitted asset reference (e.g. 'banana', 'maple table').
+            trace_prefix: Trace stage prefix passed to ``match_asset`` (e.g. 'item', 'background').
+            node_type: Node type to tag the resulting node with.
+            required_tags: Tags an asset must carry to be a match candidate.
+            preferred_tags: Tags that bias fuzzy matching when set.
+            instance_name: Overrides ``query`` as the node id for duplicate items.
+        """
+        asset_name = match_asset(self.registry, query, trace_prefix, self.trace, required_tags, preferred_tags)
         if asset_name is None:
             return None
         return ArenaEnvGraphNodeSpec(
-            id=self._agent_node_id(query),
+            id=self._agent_node_id(query, instance_name=instance_name),
             name=asset_name,
-            type=ArenaEnvGraphNodeType.EMBODIMENT,
-        )
-
-    def _resolve_item_node(self, item: Item) -> ArenaEnvGraphNodeSpec | None:
-        asset_name = match_asset(self.registry, item.query, "item", self.trace, ["object"], item.category_tags)
-        if asset_name is None:
-            return None
-        return ArenaEnvGraphNodeSpec(
-            id=self._agent_node_id(item.query, instance_name=item.instance_name),
-            name=asset_name,
-            type=ArenaEnvGraphNodeType.OBJECT,
+            type=node_type,
         )
 
     def _build_initial_state_spec(
-        self, graph: list[SpatialRelationSpec], known_ids: set[str]
+        self, graph: list[SpatialRelationSpec], known_ids: set[str], query_to_instances: dict[str, list[str]]
     ) -> ArenaEnvGraphStateSpec:
         constraints: list[ArenaEnvGraphSpatialRelationSpec] = []
         for index, rel in enumerate(graph):
-            constraint = self._build_spatial_constraint(rel, index, known_ids)
+            constraint = self._build_spatial_constraint(rel, index, known_ids, query_to_instances)
             if constraint is not None:
                 constraints.append(constraint)
         return ArenaEnvGraphStateSpec(
@@ -160,52 +189,119 @@ class IntentCompiler:
         )
 
     def _build_spatial_constraint(
-        self, rel: SpatialRelationSpec, index: int, known_ids: set[str]
+        self, rel: SpatialRelationSpec, index: int, known_ids: set[str], query_to_instances: dict[str, list[str]]
     ) -> ArenaEnvGraphSpatialRelationSpec | None:
         # rel.kind is guaranteed registered by SpatialRelationSpec._validate_kind_and_arity.
-        stage_prefix = "relation.initial"
-        if rel.subject not in known_ids:
-            self.trace.append(
-                IntentResolutionTraceEvent(f"{stage_prefix}.unknown_subject", rel.subject, None, note=rel.kind)
-            )
-            return None
-        if rel.reference is not None and rel.reference not in known_ids:
-            self.trace.append(
-                IntentResolutionTraceEvent(f"{stage_prefix}.unknown_reference", rel.reference, None, note=rel.kind)
-            )
+        # Resolve the subject endpoint; drop the whole constraint if it names no node.
+        subject = self._resolve_relation_endpoint_to_node_id(
+            rel.subject, "subject", rel.kind, known_ids, query_to_instances
+        )
+        if subject is None:
             return None
 
-        reference_part = f"_{rel.reference}" if rel.reference is not None else ""
-        constraint_id = f"{INITIAL_STATE_SPEC_ID}_{index}_{rel.kind}{reference_part}_{rel.subject}"
-        self.trace.append(IntentResolutionTraceEvent(f"{stage_prefix}.ok", rel.subject, rel.reference, note=rel.kind))
+        # Binary relations carry a reference; unary ones leave it None. Resolve it when present
+        # and, as with the subject, drop the constraint if it fails to resolve.
+        reference = rel.reference
+        if rel.reference is not None:
+            reference = self._resolve_relation_endpoint_to_node_id(
+                rel.reference, "reference", rel.kind, known_ids, query_to_instances
+            )
+            if reference is None:
+                return None
+
+        # Build a stable, human-readable id (reference segment omitted for unary relations).
+        reference_part = f"_{reference}" if reference is not None else ""
+        constraint_id = f"{INITIAL_STATE_SPEC_ID}_{index}_{rel.kind}{reference_part}_{subject}"
+        self.trace.append(IntentResolutionTraceEvent("relation.initial.ok", subject, reference, note=rel.kind))
         return ArenaEnvGraphSpatialRelationSpec(
             id=constraint_id,
             kind=rel.kind,
-            subject=rel.subject,
-            reference=rel.reference,
+            subject=subject,
+            reference=reference,
             params=dict(rel.params),
         )
 
-    def _trace_tasks(self, tasks: list[TaskSpec], known_ids: set[str]) -> None:
-        """Emit trace events for each task: one ``task.resolve`` event and one
-        ``task.unknown_param`` error event for every string param value that does
-        not reference a resolved node ID."""
+    def _resolve_reference_to_node_id(
+        self,
+        ref: str,
+        known_ids: set[str],
+        query_to_instances: dict[str, list[str]],
+        *,
+        resolved_stage: str,
+        unknown_stage: str,
+        note: str,
+    ) -> str | None:
+        """Resolve a reference to a node id: ``ref`` itself if known, else one sampled instance.
+
+        Returns ``None`` when nothing matches. Traces ``resolved_stage`` on a sample and
+        ``unknown_stage`` on a miss (an already-known ref is returned untraced).
+
+        Args:
+            ref: The agent-emitted reference (relation endpoint or task param value).
+            known_ids: The set of resolved graph node ids.
+            query_to_instances: Map from item query to the node ids it produced.
+            resolved_stage: Trace stage recorded when a shared query is sampled.
+            unknown_stage: Trace stage recorded on a miss.
+            note: Free-form note attached to the trace event.
+        """
+        if ref in known_ids:
+            return ref
+        chosen = self._sample_one_instance_for_query(ref, query_to_instances)
+        stage = unknown_stage if chosen is None else resolved_stage
+        self.trace.append(IntentResolutionTraceEvent(stage, ref, chosen, note=note))
+        return chosen
+
+    def _resolve_relation_endpoint_to_node_id(
+        self, ref: str, role: str, kind: str, known_ids: set[str], query_to_instances: dict[str, list[str]]
+    ) -> str | None:
+        """Resolve one relation endpoint (subject or reference) to a node id, tracing the outcome.
+
+        Args:
+            ref: The agent-emitted endpoint string.
+            role: ``"subject"`` or ``"reference"``; selects the trace stage suffix.
+            kind: The relation kind, recorded on the trace event.
+            known_ids: The set of resolved graph node ids.
+            query_to_instances: Map from item query to the node ids it produced.
+        """
+        return self._resolve_reference_to_node_id(
+            ref,
+            known_ids,
+            query_to_instances,
+            resolved_stage=f"relation.initial.resolved_{role}",
+            unknown_stage=f"relation.initial.unknown_{role}",
+            note=kind,
+        )
+
+    def _resolve_task_params_to_node_ids(
+        self, tasks: list[TaskSpec], known_ids: set[str], query_to_instances: dict[str, list[str]]
+    ) -> list[TaskSpec]:
+        """Resolve object-valued task params in place to concrete node ids.
+
+        Each string param is resolved to the node id it references, picking one
+        instance at random when the query is shared by several. A param that
+        resolves to no node is left unchanged and flagged with a ``task.unknown_param``
+        error trace (so :attr:`has_resolution_errors` reports it).
+
+        Args:
+            tasks: Agent-emitted task specs.
+            known_ids: The set of resolved graph node ids.
+            query_to_instances: Map from item query to the node ids it produced.
+        """
         for task in tasks:
             self.trace.append(
-                IntentResolutionTraceEvent(
-                    "task.resolve",
-                    task.kind,
-                    task.kind,
-                    note=f"params={task.params}",
-                )
+                IntentResolutionTraceEvent("task.resolve", task.kind, task.kind, note=f"params={task.params}")
             )
             for param_name, param_value in task.params.items():
-                if isinstance(param_value, str) and param_value not in known_ids:
-                    self.trace.append(
-                        IntentResolutionTraceEvent(
-                            "task.unknown_param",
-                            param_value,
-                            None,
-                            note=f"param={param_name}, task kind={task.kind}",
-                        )
-                    )
+                if not isinstance(param_value, str):
+                    continue
+                chosen = self._resolve_reference_to_node_id(
+                    param_value,
+                    known_ids,
+                    query_to_instances,
+                    resolved_stage="task.resolved_param",
+                    unknown_stage="task.unknown_param",
+                    note=f"param={param_name}, task kind={task.kind}",
+                )
+                if chosen is not None:
+                    task.params[param_name] = chosen
+        return tasks

--- a/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_conversion_utils.py
@@ -155,11 +155,18 @@ def _instantiate_assets_from_nodes(
             # Standard nodes (object / background / embodiment): look up the registered class
             # by name and instantiate with the spec's verbatim kwargs.
             asset_class = asset_registry.get_asset_by_name(node_spec.name)
-            params = dict(node_spec.params)
+
             # Embodiment cameras are enabled thru the flag passed to the env builder.
             if node_spec.type == ArenaEnvGraphNodeType.EMBODIMENT and enable_cameras:
-                params.setdefault("enable_cameras", True)
-            assets_by_node_id[node_spec.id] = asset_class(**params)
+                node_spec.params.setdefault("enable_cameras", True)
+
+            # Bind the asset's name to the unique node id so multiple instances of the same
+            # registered asset (e.g. 5 bananas) don't collapse to one name/prim_path and
+            # overwrite each other in the Scene (which keys assets by name).
+            if node_spec.type == ArenaEnvGraphNodeType.OBJECT and "instance_name" not in node_spec.params:
+                node_spec.params["instance_name"] = node_spec.id
+            assets_by_node_id[node_spec.id] = asset_class(**node_spec.params)
+
     return assets_by_node_id
 
 

--- a/isaaclab_arena/environments/arena_env_graph_types.py
+++ b/isaaclab_arena/environments/arena_env_graph_types.py
@@ -104,8 +104,10 @@ class TaskSpec(BaseModel):
     params: dict[str, Any] = Field(
         default_factory=dict,
         description=(
-            "Constructor kwargs for the task (listed in TASKS). "
-            "Values are Item.query strings or the background name for scene parameters."
+            "Constructor kwargs for the task (listed in TASKS). Each object param must "
+            "name exactly one node: its instance_name if set, else its query. If several "
+            "match (e.g. 5 bananas), pick one (e.g. 'banana_1'). Scene params use the "
+            "background name."
         ),
     )
     description: str | None = Field(
@@ -147,18 +149,18 @@ class SpatialRelationSpec(BaseModel):
     subject: str = Field(
         min_length=1,
         description=(
-            "Object (Item.query) this relation applies to. For binary relations "
-            "(e.g. 'on'), this is the object placed relative to ``reference``. "
-            "For unary relations (e.g. 'is_anchor', 'position_limits'), this is "
-            "the anchored or constrained object."
+            "Node id this relation applies to — its instance_name if set, else its query. "
+            "For binary relations (e.g. 'on'), it's the object placed relative to "
+            "``reference``. For unary relations (e.g. 'is_anchor', 'position_limits'), "
+            "it's the anchored or constrained object."
         ),
     )
     reference: str | None = Field(
         default=None,
         description=(
-            "Reference (Item.query or background name) for binary relations only "
-            "— e.g. for 'on', the surface the subject rests on. Must be null "
-            "for unary relations."
+            "Reference node id (an item's instance_name/query or the background name) "
+            "for binary relations only — e.g. for 'on', the surface the subject rests "
+            "on. Must be null for unary relations."
         ),
     )
     # TODO(qianl): free-form ``dict`` emits ``additionalProperties: true``,

--- a/isaaclab_arena/tests/test_intent_compiler.py
+++ b/isaaclab_arena/tests/test_intent_compiler.py
@@ -30,7 +30,6 @@ def _make_compiler(assets: list[FakeAsset] | None = None) -> IntentCompiler:
 
 
 def _make_scene(
-    *,
     background: str = "maple_table",
     embodiment: str = "franka_ik",
     items: list[Item] | None = None,

--- a/isaaclab_arena/tests/test_intent_compiler.py
+++ b/isaaclab_arena/tests/test_intent_compiler.py
@@ -321,6 +321,41 @@ def test_multiple_tasks_preserved_in_order():
     assert [t.description for t in spec.tasks] == ["d1", "d2", "d3"]
 
 
+def test_bare_query_resolved_to_one_instance():
+    items = [Item(query="bowl", category_tags=["bowl"], instance_name=f"bowl_{i}") for i in range(1, 4)]
+    instance_ids = {"bowl_1", "bowl_2", "bowl_3"}
+    initial = [
+        SpatialRelationSpec(kind="is_anchor", subject="maple_table"),
+        SpatialRelationSpec(kind="on", subject="bowl", reference="maple_table"),
+    ]
+    tasks = [
+        TaskSpec(
+            kind="PickAndPlaceTask",
+            params={
+                "pick_up_object": "bowl",
+                "destination_location": "bowl",
+                "background_scene": "maple_table",
+            },
+            description="d",
+        )
+    ]
+    compiler = _make_compiler()
+    spec = compiler.compile(_make_scene(items=items, initial_state_graph=initial, tasks=tasks))
+
+    assert compiler.has_resolution_errors is False
+
+    on_bowl = spec.initial_state_spec.spatial_constraints[1]
+    assert on_bowl.subject in instance_ids
+
+    task = spec.tasks[0]
+    assert task.params["pick_up_object"] in instance_ids
+    assert task.params["destination_location"] in instance_ids
+    assert task.params["background_scene"] == "maple_table"
+
+    assert any(e.stage == "task.resolved_param" for e in compiler.trace)
+    assert any(e.stage == "relation.initial.resolved_subject" for e in compiler.trace)
+
+
 def test_task_unknown_param_emits_error_trace():
     items = [Item(query="bowl", category_tags=["bowl"])]
     tasks = [
@@ -338,3 +373,50 @@ def test_task_unknown_param_emits_error_trace():
     compiler.compile(_make_scene(items=items, tasks=tasks))
     assert compiler.has_resolution_errors is True
     assert "task.unknown_param" in [e.stage for e in compiler.resolution_errors]
+
+
+def test_task_param_already_node_id_preserved_without_resolve_trace():
+    # A param that already names a resolved node passes through unchanged and emits neither a
+    # ``task.resolved_param`` nor a ``task.unknown_param`` trace (only a known id, nothing to sample).
+    items = [Item(query="bowl", category_tags=["bowl"])]
+    tasks = [
+        TaskSpec(
+            kind="PickAndPlaceTask",
+            params={
+                "pick_up_object": "bowl",
+                "destination_location": "bowl",
+                "background_scene": "maple_table",
+            },
+            description="d",
+        )
+    ]
+    compiler = _make_compiler()
+    spec = compiler.compile(_make_scene(items=items, tasks=tasks))
+    assert spec.tasks[0].params == {
+        "pick_up_object": "bowl",
+        "destination_location": "bowl",
+        "background_scene": "maple_table",
+    }
+    stages = [e.stage for e in compiler.trace]
+    assert "task.resolved_param" not in stages
+    assert "task.unknown_param" not in stages
+    assert compiler.has_resolution_errors is False
+
+
+def test_non_string_task_param_passed_through_untouched():
+    # Only string params are candidates for node-id resolution; scalars are left as-is.
+    items = [Item(query="bowl", category_tags=["bowl"])]
+    tasks = [
+        TaskSpec(
+            kind="PickAndPlaceTask",
+            params={
+                "pick_up_object": "bowl",
+                "destination_location": "bowl",
+                "background_scene": "maple_table",
+                "episode_length_s": 20.0,
+            },
+            description="d",
+        )
+    ]
+    spec = _make_compiler().compile(_make_scene(items=items, tasks=tasks))
+    assert spec.tasks[0].params["episode_length_s"] == 20.0


### PR DESCRIPTION
## Summary
Support duplicate asset instances in agentic env gen

## Detailed description
- Reason: agentic env gen collapsed multiple instances of the same registered asset down to 1 in the spawned scene, because every instance shared the asset's default name/prim_path and `Scene` keys assets by name.

- Changed:
1. bind each object's name to its unique graph node id during graph→scene conversion 
2. modify prompt guidance such that agent assigns a unique `instance_name` per duplicate item and references items by node id everywhere 
3. consolidate asset-node building and reference→node-id resolution and to resolve task params in place

- Impact: scenes now spawn every declared instance; no behavior change for single-instance scenes. 
 
!!! Note: task-param resolution still treats all string params as node refs .