### PR TITLE
Fix relation-solver bboxes to match Isaac Lab USD spawn scaling

### DIFF
--- a/isaaclab_arena/tests/test_usd_bbox_helpers.py
+++ b/isaaclab_arena/tests/test_usd_bbox_helpers.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+HEADLESS = True
+EPS = 1e-4
+
+
+def _write_cube_asset_usd(
+    path: pathlib.Path,
+    cube_size: float,
+    root_scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> None:
+    from pxr import Gf, Usd, UsdGeom
+
+    stage = Usd.Stage.CreateNew(path.as_posix())
+    cube = UsdGeom.Cube.Define(stage, "/Cube")
+    cube.GetSizeAttr().Set(cube_size)
+    stage.SetDefaultPrim(cube.GetPrim())
+    if root_scale != (1.0, 1.0, 1.0):
+        xformable = UsdGeom.Xformable(cube.GetPrim())
+        scale_op = xformable.AddScaleOp(UsdGeom.XformOp.PrecisionDouble, "xformOp:scale")
+        scale_op.Set(Gf.Vec3d(*root_scale))
+    stage.GetRootLayer().Save()
+
+
+def _bbox_size(path: pathlib.Path, scale: tuple[float, float, float]) -> tuple[float, float, float]:
+    from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
+
+    bbox = compute_local_bounding_box_from_usd(path.as_posix(), scale=scale)
+    size = bbox.size[0]
+    return (float(size[0]), float(size[1]), float(size[2]))
+
+
+def _test_compute_local_bounding_box_from_usd(simulation_app, asset_dir: pathlib.Path) -> bool:
+    unit_cube = asset_dir / "unit_cube.usd"
+    scaled_root_cube = asset_dir / "scaled_root_cube.usd"
+    _write_cube_asset_usd(unit_cube, cube_size=1.0)
+    _write_cube_asset_usd(scaled_root_cube, cube_size=1.0, root_scale=(0.5, 0.5, 0.5))
+
+    # Spawn scale only — no in-file scale.
+    size = _bbox_size(unit_cube, scale=(2.0, 2.0, 2.0))
+    assert all(abs(dim - 2.0) < EPS for dim in size), size
+
+    # Default-prim root scale is unbaked before spawn scale is applied.
+    size = _bbox_size(scaled_root_cube, scale=(1.0, 1.0, 1.0))
+    assert all(abs(dim - 1.0) < EPS for dim in size), size
+
+    size = _bbox_size(scaled_root_cube, scale=(2.0, 2.0, 2.0))
+    assert all(abs(dim - 2.0) < EPS for dim in size), size
+
+    # grey_bin-style asset: root scale in file + matching Object.scale at spawn.
+    grey_bin_style = asset_dir / "grey_bin_style.usd"
+    _write_cube_asset_usd(grey_bin_style, cube_size=1.0, root_scale=(0.007, 0.007, 0.007))
+    size = _bbox_size(grey_bin_style, scale=(0.007, 0.007, 0.007))
+    assert all(abs(dim - 0.007) < EPS for dim in size), size
+
+    return True
+
+
+def test_compute_local_bounding_box_from_usd(tmp_path: pathlib.Path):
+    result = run_simulation_app_function(
+        _test_compute_local_bounding_box_from_usd,
+        headless=HEADLESS,
+        asset_dir=tmp_path,
+    )
+    assert result, "Test failed"

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -24,7 +24,7 @@ def _write_cube_asset_usd(
     stage.SetDefaultPrim(cube.GetPrim())
     if root_scale != (1.0, 1.0, 1.0):
         xformable = UsdGeom.Xformable(cube.GetPrim())
-        scale_op = xformable.AddScaleOp(UsdGeom.XformOp.PrecisionDouble, "xformOp:scale")
+        scale_op = xformable.AddScaleOp(UsdGeom.XformOp.PrecisionDouble)
         scale_op.Set(Gf.Vec3d(*root_scale))
     stage.GetRootLayer().Save()
 

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -104,45 +104,60 @@ def get_asset_usd_path_from_prim_path(prim_path: str, stage: Usd.Stage) -> str |
     return None
 
 
+def _read_default_prim_scale(prim: Usd.Prim) -> tuple[float, float, float]:
+    """Return the default prim's root ``xformOp:scale``, or identity if absent."""
+    if not prim.IsA(UsdGeom.Xformable):
+        return (1.0, 1.0, 1.0)
+    for op in UsdGeom.Xformable(prim).GetOrderedXformOps():
+        if op.GetOpType() == UsdGeom.XformOp.TypeScale:
+            value = op.Get()
+            if value is not None:
+                return (float(value[0]), float(value[1]), float(value[2]))
+    return (1.0, 1.0, 1.0)
+
+
 def compute_local_bounding_box_from_usd(
     usd_path: str,
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
 ) -> AxisAlignedBoundingBox:
-    """Compute the local bounding box of a USD asset (relative to USD origin).
+    """Compute the local bounding box matching Isaac Lab ``UsdFileCfg`` spawn size.
+
+    Opening a USD directly includes the default prim's root ``xformOp:scale`` in
+    ``ComputeWorldBound``, but Isaac Lab's ``create_prim(..., usd_path=..., scale=...)``
+    does **not** compose that authored root scale when the file is referenced at
+    spawn time — only ``Object.scale`` on the spawn wrapper applies. Assets such as
+    ``grey_bin.usd`` rely on ``Object.scale`` for correct sim size even when the file
+    also carries a root scale used by offline authoring tools.
+
+    This helper therefore unbakes the default prim's root scale from the on-disk
+    bounds, then applies ``Object.scale`` once so relation-solver bboxes match what
+    is actually spawned.
 
     Args:
         usd_path: Path to the USD file.
-        scale: Scale to apply to the asset (x, y, z).
+        scale: Spawn-time scale passed to ``UsdFileCfg`` / ``Object.scale``.
 
     Returns:
-        AxisAlignedBoundingBox containing the min and max points relative to USD origin.
+        AxisAlignedBoundingBox containing local min and max points.
     """
     stage = Usd.Stage.Open(usd_path)
     if not stage:
         raise ValueError(f"Failed to open USD file: {usd_path}")
 
-    # Get the default prim (or pseudo root if no default prim)
     default_prim = stage.GetDefaultPrim()
     if not default_prim:
         default_prim = stage.GetPseudoRoot()
 
-    # Compute the bounding box using USD's built-in functionality
-    bbox_cache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), includedPurposes=[UsdGeom.Tokens.default_])
-    bbox = bbox_cache.ComputeWorldBound(default_prim)
+    bbox = compute_local_bounding_box_from_prim(stage, default_prim.GetPath().pathString)
 
-    # Get the range (bounding box)
-    bbox_range = bbox.ComputeAlignedBox()
-    min_point = bbox_range.GetMin()
-    max_point = bbox_range.GetMax()
+    file_scale = _read_default_prim_scale(default_prim)
+    if file_scale != (1.0, 1.0, 1.0):
+        inv_scale = (1.0 / file_scale[0], 1.0 / file_scale[1], 1.0 / file_scale[2])
+        bbox = bbox.scaled(inv_scale)
 
-    # Apply scale
-    min_point = Gf.Vec3d(min_point[0] * scale[0], min_point[1] * scale[1], min_point[2] * scale[2])
-    max_point = Gf.Vec3d(max_point[0] * scale[0], max_point[1] * scale[1], max_point[2] * scale[2])
-
-    return AxisAlignedBoundingBox(
-        min_point=(min_point[0], min_point[1], min_point[2]),
-        max_point=(max_point[0], max_point[1], max_point[2]),
-    )
+    if scale != (1.0, 1.0, 1.0):
+        bbox = bbox.scaled(scale)
+    return bbox
 
 
 def compute_local_bounding_box_from_prim(

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -122,16 +122,12 @@ def compute_local_bounding_box_from_usd(
 ) -> AxisAlignedBoundingBox:
     """Compute the local bounding box matching Isaac Lab ``UsdFileCfg`` spawn size.
 
-    Opening a USD directly includes the default prim's root ``xformOp:scale`` in
-    ``ComputeWorldBound``, but Isaac Lab's ``create_prim(..., usd_path=..., scale=...)``
-    does **not** compose that authored root scale when the file is referenced at
-    spawn time — only ``Object.scale`` on the spawn wrapper applies. Assets such as
-    ``grey_bin.usd`` rely on ``Object.scale`` for correct sim size even when the file
-    also carries a root scale used by offline authoring tools.
-
-    This helper therefore unbakes the default prim's root scale from the on-disk
-    bounds, then applies ``Object.scale`` once so relation-solver bboxes match what
-    is actually spawned.
+    Opening a USD directly includes the default prim's root ``xformOp:scale``
+    in ``ComputeWorldBound``, but Isaac Lab's spawner ignores it and only
+    Object.scale on the spawn wrapper applies.
+    This helper unbakes the default prim's root scale from the USD, then
+    applies ``Object.scale`` once so relation-solver bboxes match what is
+    actually spawned.
 
     Args:
         usd_path: Path to the USD file.
@@ -150,13 +146,12 @@ def compute_local_bounding_box_from_usd(
 
     bbox = compute_local_bounding_box_from_prim(stage, default_prim.GetPath().pathString)
 
-    file_scale = _read_default_prim_scale(default_prim)
-    if file_scale != (1.0, 1.0, 1.0):
-        inv_scale = (1.0 / file_scale[0], 1.0 / file_scale[1], 1.0 / file_scale[2])
-        bbox = bbox.scaled(inv_scale)
-
-    if scale != (1.0, 1.0, 1.0):
-        bbox = bbox.scaled(scale)
+    usd_scale = _read_default_prim_scale(default_prim)
+    assert not any(
+        s == 0.0 for s in usd_scale
+    ), f"Default prim {default_prim.GetPath().pathString} has scale {usd_scale}"
+    composed_scale = (scale[0] / usd_scale[0], scale[1] / usd_scale[1], scale[2] / usd_scale[2])
+    bbox = bbox.scaled(composed_scale)
     return bbox
 
 


### PR DESCRIPTION
## Summary
Unbake default-prim root xformOp:scale before applying Object.scale so placement bounds match create_prim reference spawn (e.g. grey_bin_robolab).

## Detailed description
- What was the reason for the change?
For USD with default non-identity scale, relation solver treats arena object scale multiplicatively while isaac lab spawner treats it as overwrite. This leads to relation solver using incorrect AABB.
- What has been changed?
Update relation solver to treat scale the same way as spawn.
- What is the impact of this change?
Now relation solver scale matches the spawned asset in Lab.

Before (solver succeed but has actual collision due to wrong AABB for grey box with non-identity scale {ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/grey_bin.usd)
<img width="577" height="325" alt="image" src="https://github.com/user-attachments/assets/9f9d7e11-bec0-4c7f-9404-5f42b8a46bf4" />

After
<img width="575" height="402" alt="image" src="https://github.com/user-attachments/assets/2d1a7451-bfb5-424d-a098-fce9a7320b15" />
