### PR TITLE
Add two more robolab agent generated envs

### DIFF
--- a/isaaclab_arena/environments/arena_env_graph_task_conversion_utils.py
+++ b/isaaclab_arena/environments/arena_env_graph_task_conversion_utils.py
@@ -49,6 +49,8 @@ def _build_task_from_spec(task_spec: ArenaEnvGraphTaskSpec, assets_by_node_id: d
     """Look up the task class by name, resolve any Asset-typed kwargs, instantiate."""
     task_class = TaskRegistry().get_task_by_name(task_spec.kind)
     task_init_kwargs = _resolve_node_refs_in_task_args(task_class, task_spec.params, assets_by_node_id)
+    if task_spec.description and "task_description" not in task_init_kwargs:
+        task_init_kwargs["task_description"] = task_spec.description
     return task_class(**task_init_kwargs)
 
 

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 DEFAULT_ON_EDGE_MARGIN_M = 0.05
 
 
-class Side(Enum):
+class Side(str, Enum):
     """Axis direction for spatial relationships."""
 
     POSITIVE_X = "positive_x"  # +X
@@ -90,7 +90,7 @@ class NextTo(Relation):
         parent: ObjectBase,
         relation_loss_weight: float = 1.0,
         distance_m: float = 0.05,
-        side: Side = Side.POSITIVE_X,
+        side: Side | str = Side.POSITIVE_X,
         cross_position_ratio: float = 0.0,
     ):
         """
@@ -111,7 +111,7 @@ class NextTo(Relation):
             -1.0 <= cross_position_ratio <= 1.0
         ), f"cross_position_ratio must be in [-1, 1], got {cross_position_ratio}"
         self.distance_m = distance_m
-        self.side = side
+        self.side = Side(side)
         self.cross_position_ratio = cross_position_ratio
 
 
@@ -172,7 +172,7 @@ class NotNextTo(Relation):
         self,
         parent: ObjectBase,
         relation_loss_weight: float = 1.0,
-        side: Side = Side.POSITIVE_X,
+        side: Side | str = Side.POSITIVE_X,
     ):
         """
         Args:
@@ -181,7 +181,7 @@ class NotNextTo(Relation):
             side: Which side of the parent is blocked (default: Side.POSITIVE_X).
         """
         super().__init__(parent, relation_loss_weight)
-        self.side = side
+        self.side = Side(side)
 
 
 @register_object_relation

--- a/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from isaaclab_arena.affordances.affordance_base import AffordanceBase
@@ -156,6 +158,56 @@ def test_resolve_raises_on_non_string_node_id():
 
 
 # --------------------------------- build_task_from_specs ---------------------------------
+
+
+def test_build_task_from_spec_passes_description_as_task_description(monkeypatch):
+    """Graph task ``description`` is forwarded as the constructor ``task_description`` kwarg."""
+    captured: dict[str, Any] = {}
+
+    class FakeTask:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    registry = type("R", (), {"get_task_by_name": lambda self, _name: FakeTask})()
+    monkeypatch.setattr(conversion, "TaskRegistry", lambda: registry)
+
+    from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphTaskSpec
+
+    spec = ArenaEnvGraphTaskSpec(
+        id="task_0",
+        kind="PickAndPlaceTask",
+        params={},
+        description="put the mustard in the left bin",
+        initial_state_spec_id="state_initial",
+        success_state_spec_id="state_spec_1",
+    )
+    conversion._build_task_from_spec(spec, {})
+    assert captured["task_description"] == "put the mustard in the left bin"
+
+
+def test_build_task_from_spec_params_task_description_takes_precedence(monkeypatch):
+    """An explicit ``task_description`` in params overrides the spec ``description`` field."""
+    captured: dict[str, Any] = {}
+
+    class FakeTask:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    registry = type("R", (), {"get_task_by_name": lambda self, _name: FakeTask})()
+    monkeypatch.setattr(conversion, "TaskRegistry", lambda: registry)
+
+    from isaaclab_arena.environments.arena_env_graph_types import ArenaEnvGraphTaskSpec
+
+    spec = ArenaEnvGraphTaskSpec(
+        id="task_0",
+        kind="PickAndPlaceTask",
+        params={"task_description": "from params"},
+        description="from spec description",
+        initial_state_spec_id="state_initial",
+        success_state_spec_id="state_spec_1",
+    )
+    conversion._build_task_from_spec(spec, {})
+    assert captured["task_description"] == "from params"
 
 
 def test_build_task_from_specs_empty_returns_none():

--- a/isaaclab_arena/tests/test_relation_loss_strategies.py
+++ b/isaaclab_arena/tests/test_relation_loss_strategies.py
@@ -280,6 +280,19 @@ def test_next_to_loss_strategy_respects_relation_weight():
     assert torch.isclose(loss_double, 2.0 * loss_normal, rtol=1e-5)
 
 
+def test_next_to_accepts_string_side_from_yaml_params():
+    """YAML graph specs pass side as a string; NextTo must parse it to Side."""
+    parent_obj = _create_table()
+    child_obj = _create_box()
+    relation = NextTo(parent_obj, side="negative_x", distance_m=0.05)
+    strategy = NextToLossStrategy(slope=10.0)
+
+    assert relation.side == Side.NEGATIVE_X
+    child_pos = torch.tensor([-0.25, 0.4, 0.0])
+    loss = strategy.compute_loss(relation, child_pos, child_obj.bounding_box, parent_obj.bounding_box)
+    assert torch.isclose(loss, torch.tensor(0.0), atol=1e-4)
+
+
 def test_next_to_zero_distance_raises():
     """Test that NextTo raises assertion for zero distance (touching not allowed)."""
 
@@ -327,6 +340,20 @@ def test_next_to_loss_strategy_multi_env_shape_and_values():
 # =============================================================================
 # NotNextToLossStrategy tests
 # =============================================================================
+
+
+def test_not_next_to_accepts_string_side_from_yaml_params():
+    """YAML graph specs pass side as a string; NotNextTo must parse it to Side."""
+    parent_obj = _create_table()
+    child_obj = _create_box()
+    relation = NotNextTo(parent_obj, side="negative_x")
+    strategy = NotNextToLossStrategy(slope=10.0, margin_m=0.05)
+
+    assert relation.side == Side.NEGATIVE_X
+    # Cleared to the opposite (+X) side of the blocked -X edge.
+    child_pos = torch.tensor([0.3, 0.4, 0.5])
+    loss = strategy.compute_loss(relation, child_pos, child_obj.bounding_box, parent_obj.bounding_box)
+    assert torch.isclose(loss, torch.tensor(0.0), atol=1e-6)
 
 
 def test_not_next_to_loss_strategy_positive_at_forbidden_spot():

--- a/isaaclab_arena_environments/robolab/tools_container_linked.yaml
+++ b/isaaclab_arena_environments/robolab/tools_container_linked.yaml
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: tools_container
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: container_f24
+  name: container_f24_vomp_robolab
+  type: object
+  params: {}
+- id: bin_b04
+  name: bin_b04_vomp_robolab
+  type: object
+  params: {}
+- id: spring_clamp
+  name: spring_clamp_ycb_robolab
+  type: object
+  params: {}
+- id: hammer_1
+  name: hammer_handal_robolab
+  type: object
+  params: {}
+- id: hammer_2
+  name: hammer_handal_robolab
+  type: object
+  params: {}
+- id: cordless_drill
+  name: cordless_drill_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: spring_clamp
+    destination_location: bin_b04
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: pick up the spring clamp and place it in the right bin (bin_b04)
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: container_f24
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_container_f24
+  - kind: 'on'
+    subject: bin_b04
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_bin_b04
+  - kind: 'on'
+    subject: spring_clamp
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_spring_clamp
+  - kind: 'on'
+    subject: hammer_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_hammer_1
+  - kind: 'on'
+    subject: hammer_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_hammer_2
+  - kind: 'on'
+    subject: cordless_drill
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_cordless_drill
+  - kind: next_to
+    subject: container_f24
+    reference: bin_b04
+    params:
+      side: positive_y
+      distance_m: 0.3
+    id: state_initial_7_next_to_bin_b04_container_f24
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: spring_clamp
+    reference: bin_b04
+    params: {}
+    id: state_spec_1_spring_clamp_on_bin_b04
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/tools_container_linked.yaml
+++ b/isaaclab_arena_environments/robolab/tools_container_linked.yaml
@@ -44,7 +44,7 @@ tasks:
     destination_location: bin_b04
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: pick up the spring clamp and place it in the right bin (bin_b04)
+  description: pick up the spring clamp and place it in the right bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1

--- a/isaaclab_arena_environments/robolab/two_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/two_bin_linked.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: two_bin
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: grey_bin_left
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: grey_bin_right
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: mustard
+  name: mustard_bottle_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: mustard
+    destination_location: grey_bin_left
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: put the mustard in the left bin
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: grey_bin_left
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_grey_bin_left
+  - kind: 'on'
+    subject: grey_bin_right
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_grey_bin_right
+  - kind: 'on'
+    subject: mustard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_mustard
+  - kind: next_to
+    subject: grey_bin_left
+    reference: grey_bin_right
+    params:
+      side: positive_y
+      distance_m: 0.3
+    id: state_initial_4_next_to_grey_bin_right_grey_bin_left
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: mustard
+    reference: grey_bin_left
+    params: {}
+    id: state_spec_1_mustard_on_grey_bin_left
+  task_constraints: []
+cli_override_specs: []


### PR DESCRIPTION
## Summary
Add two more robolab environments with bins next to each other
- MustardInLeftBinTask (two_bin.usda)
- ClampInRightBinTask (tools_container.usda)

## Detailed description
-- Adds two yaml specs including next_to relation, and task with left/right object concept in description
-- Move next_to relation Side adds support for str from spec parameters
-- Task description in spec is passed into the runtime task class

<img width="870" height="512" alt="image" src="https://github.com/user-attachments/assets/c0ad730f-1467-449b-9688-17cdacb7caab" />
<img width="900" height="527" alt="image" src="https://github.com/user-attachments/assets/10f92224-0c03-4c2f-acff-07a35ac11d85" />
