### PR TITLE
Revert CI runner to 2-core machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
 
   build_docs_pre_merge:
     name: Build the docs (pre-merge)
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 30
     needs: [pre_commit]
 
@@ -296,7 +296,7 @@ jobs:
 
   build_and_push_image_post_merge:
     name: Build & push NGC image (post-merge)
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 60
     needs: [test]       # only push if tests passed
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
   pre_commit:
     name: Pre-commit
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 30
 
     container:
@@ -97,7 +97,7 @@ jobs:
 
   test:
     name: Run tests
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 80
     needs: [pre_commit]
     env:
@@ -170,7 +170,7 @@ jobs:
 
   tests_with_subprocess:
     name: Run tests with subprocess
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 60
     needs: [pre_commit]
 
@@ -205,7 +205,7 @@ jobs:
 
   test_gr00t_closedloop_e2e:
     name: GR00T closed-loop E2E
-    runs-on: [self-hosted, gpu-arena]
+    runs-on: [self-hosted, gpu]
     timeout-minutes: 60
     needs: [pre_commit]
     env:


### PR DESCRIPTION
## Summary
To unblock dev during onsite, as 4-core gpu-arena is offline and causing jobs queueing for hours.
Will bring back gpu-arena once it's back.