### PR TITLE
Add Validation Checks for NextTo and NotNextTo

### DIFF
--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -13,9 +13,12 @@ from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_en
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
 from isaaclab_arena.relations.placement_validation import PlacementCheck, PlacementValidationResults
+from isaaclab_arena.relations.relation_loss_strategies import SIDE_CONFIGS
 from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relations import (
     IsAnchor,
+    NextTo,
+    NotNextTo,
     On,
     RandomAroundSolution,
     RotateAroundSolution,
@@ -639,29 +642,148 @@ class ObjectPlacer:
                     return False
         return True
 
+    def _validate_next_to_relations(
+        self,
+        positions: dict[ObjectBase, tuple[float, float, float]],
+        env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
+    ) -> bool:
+        """Validate each NextTo relation: child on the requested side, facing edge within
+        next_to_tolerance_m of distance_m from the parent edge. Mirrors NextToLossStrategy's
+        side/distance geometry; cross_position_ratio is a soft preference and is not gated.
+
+        Args:
+            positions: Solved positions for each object.
+            env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
+        """
+        tol = self.params.next_to_tolerance_m
+        for obj in positions:
+            for rel in obj.get_relations():
+                if not isinstance(rel, NextTo):
+                    continue
+                parent = rel.parent
+                if parent not in positions:
+                    continue
+                cfg = SIDE_CONFIGS[rel.side]
+                primary, direction = int(cfg.primary_axis), int(cfg.direction)
+                child_local = env_bboxes[obj]
+                parent_world = env_bboxes[parent].translated(positions[parent])
+                child_primary = positions[obj][primary]
+
+                if direction > 0:
+                    parent_edge = parent_world.max_point[0, primary].item()
+                    child_offset = child_local.min_point[0, primary].item()
+                    half_plane_violation = max(0.0, parent_edge - child_primary)
+                else:
+                    parent_edge = parent_world.min_point[0, primary].item()
+                    child_offset = child_local.max_point[0, primary].item()
+                    half_plane_violation = max(0.0, child_primary - parent_edge)
+
+                target_primary = parent_edge + direction * rel.distance_m - child_offset
+                distance_violation = abs(child_primary - target_primary)
+
+                if half_plane_violation > tol or distance_violation > tol:
+                    if self.params.verbose:
+                        print(
+                            f"NextTo: '{obj.name}' next_to({parent.name}) violated"
+                            f" (side={half_plane_violation:.4f}, distance={distance_violation:.4f} m; tol={tol})"
+                        )
+                    return False
+        return True
+
+    def _validate_not_next_to_relations(
+        self,
+        positions: dict[ObjectBase, tuple[float, float, float]],
+        env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
+    ) -> bool:
+        """Validate each NotNextTo relation: child has cleared the keep-out zone beside the parent
+        (within next_to_tolerance_m) via either route — back over the edge or past the footprint end.
+        Mirrors NotNextToLossStrategy, using its margin_m.
+
+        Args:
+            positions: Solved positions for each object.
+            env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
+        """
+        tol = self.params.next_to_tolerance_m
+        for obj in positions:
+            for rel in obj.get_relations():
+                if not isinstance(rel, NotNextTo):
+                    continue
+                parent = rel.parent
+                if parent not in positions:
+                    continue
+                margin_m = self._not_next_to_margin(rel)
+                cfg = SIDE_CONFIGS[rel.side]
+                primary, band, direction = int(cfg.primary_axis), int(cfg.band_axis), int(cfg.direction)
+                child_local = env_bboxes[obj]
+                parent_world = env_bboxes[parent].translated(positions[parent])
+                child_primary = positions[obj][primary]
+                child_cross = positions[obj][band]
+
+                if direction > 0:
+                    parent_edge = parent_world.max_point[0, primary].item()
+                    safe_edge = parent_edge - margin_m
+                    remaining_side = max(0.0, child_primary - safe_edge)
+                else:
+                    parent_edge = parent_world.min_point[0, primary].item()
+                    safe_edge = parent_edge + margin_m
+                    remaining_side = max(0.0, safe_edge - child_primary)
+
+                valid_band_min = parent_world.min_point[0, band].item() - child_local.min_point[0, band].item()
+                valid_band_max = parent_world.max_point[0, band].item() - child_local.max_point[0, band].item()
+                safe_band_min = valid_band_min - margin_m
+                safe_band_max = valid_band_max + margin_m
+                remaining_cross = min(max(0.0, child_cross - safe_band_min), max(0.0, safe_band_max - child_cross))
+
+                if min(remaining_side, remaining_cross) > tol:
+                    if self.params.verbose:
+                        print(
+                            f"NotNextTo: '{obj.name}' not_next_to({parent.name}) violated"
+                            f" (remaining_side={remaining_side:.4f}, remaining_cross={remaining_cross:.4f} m;"
+                            f" margin={margin_m}, tol={tol})"
+                        )
+                    return False
+        return True
+
+    def _not_next_to_margin(self, relation: NotNextTo) -> float:
+        """Keep-out margin_m from the registered NotNextTo loss strategy (stays in sync with the solver)."""
+        strategy = self._solver.params.strategies.get(type(relation))
+        assert strategy is not None and hasattr(
+            strategy, "margin_m"
+        ), f"NotNextTo validation needs a registered loss strategy with margin_m; got {strategy!r}"
+        return strategy.margin_m
+
     def _validate_placement(
         self,
         positions: dict[ObjectBase, tuple[float, float, float]],
         env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
     ) -> PlacementValidationResults:
-        """Validate that no two objects overlap in 3D and On relations are satisfied.
+        """Validate that no two objects overlap in 3D and On / NextTo / NotNextTo relations are satisfied.
 
         Args:
             positions: Dictionary mapping objects to their solved (x, y, z) positions.
             env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
 
         Returns:
-            PlacementValidationResults with the overlap and on-relation checks.
+            PlacementValidationResults with the overlap and relation checks.
         """
         no_overlap = self._validate_no_overlap(positions, env_bboxes)
         on_relation = self._validate_on_relations(positions, env_bboxes)
+        next_to = self._validate_next_to_relations(positions, env_bboxes)
+        not_next_to = self._validate_not_next_to_relations(positions, env_bboxes)
 
         return PlacementValidationResults(
             validation_results={
                 PlacementCheck.NO_OVERLAP: no_overlap,
                 PlacementCheck.ON_RELATION: on_relation,
+                PlacementCheck.NEXT_TO: next_to,
+                PlacementCheck.NOT_NEXT_TO: not_next_to,
             },
-            required_checks={PlacementCheck.NO_OVERLAP, PlacementCheck.ON_RELATION},
+            required_checks={
+                PlacementCheck.NO_OVERLAP,
+                PlacementCheck.ON_RELATION,
+                PlacementCheck.NEXT_TO,
+                PlacementCheck.NOT_NEXT_TO,
+            },
         )
 
     def _apply_poses(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -13,7 +13,7 @@ from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_en
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
 from isaaclab_arena.relations.placement_validation import PlacementCheck, PlacementValidationResults
-from isaaclab_arena.relations.relation_loss_strategies import SIDE_CONFIGS
+from isaaclab_arena.relations.relation_loss_strategies import SIDE_CONFIGS, next_to_violations, not_next_to_violations
 from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relations import (
     IsAnchor,
@@ -647,15 +647,14 @@ class ObjectPlacer:
         positions: dict[ObjectBase, tuple[float, float, float]],
         env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
     ) -> bool:
-        """Validate each NextTo relation: child on the requested side, facing edge within
-        next_to_tolerance_m of distance_m from the parent edge. Mirrors NextToLossStrategy's
-        side/distance geometry; cross_position_ratio is a soft preference and is not gated.
+        """Validate each NextTo relation: child on the requested side, facing edge within the
+        relation's tolerance_m of distance_m from the parent edge. Shares next_to_violations with
+        NextToLossStrategy; cross_position_ratio is a soft preference and is not gated.
 
         Args:
             positions: Solved positions for each object.
             env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
         """
-        tolerance_m = self.params.next_to_tolerance_m
         for obj in positions:
             for rel in obj.get_relations():
                 if not isinstance(rel, NextTo):
@@ -664,29 +663,17 @@ class ObjectPlacer:
                 if parent not in positions:
                     continue
                 cfg = SIDE_CONFIGS[rel.side]
-                primary, direction = int(cfg.primary_axis), int(cfg.direction)
-                child_local = env_bboxes[obj]
+                child_bbox = env_bboxes[obj]
+                child_pos = child_bbox.min_point.new_tensor([positions[obj]])
                 parent_world = env_bboxes[parent].translated(positions[parent])
-                child_primary = positions[obj][primary]
+                half_plane, distance = next_to_violations(cfg, child_pos, child_bbox, parent_world, rel.distance_m)
 
-                if direction > 0:
-                    parent_edge = parent_world.max_point[0, primary].item()
-                    child_offset = child_local.min_point[0, primary].item()
-                    half_plane_violation = max(0.0, parent_edge - child_primary)
-                else:
-                    parent_edge = parent_world.min_point[0, primary].item()
-                    child_offset = child_local.max_point[0, primary].item()
-                    half_plane_violation = max(0.0, child_primary - parent_edge)
-
-                target_primary = parent_edge + direction * rel.distance_m - child_offset
-                distance_violation = abs(child_primary - target_primary)
-
-                if half_plane_violation > tolerance_m or distance_violation > tolerance_m:
+                if half_plane.item() > rel.tolerance_m or distance.item() > rel.tolerance_m:
                     if self.params.verbose:
                         print(
                             f"NextTo: '{obj.name}' next_to({parent.name}) violated"
-                            f" (side={half_plane_violation:.4f}, distance={distance_violation:.4f} m;"
-                            f" tolerance_m={tolerance_m})"
+                            f" (side={half_plane.item():.4f}, distance={distance.item():.4f} m;"
+                            f" tolerance_m={rel.tolerance_m})"
                         )
                     return False
         return True
@@ -697,14 +684,13 @@ class ObjectPlacer:
         env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
     ) -> bool:
         """Validate each NotNextTo relation: child has cleared the keep-out zone beside the parent
-        (within next_to_tolerance_m) via either route — back over the edge or past the footprint end.
-        Mirrors NotNextToLossStrategy, using its margin_m.
+        (within the relation's tolerance_m) via either route — back over the edge or past the
+        footprint end. Shares not_next_to_violations with NotNextToLossStrategy, using its margin_m.
 
         Args:
             positions: Solved positions for each object.
             env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
         """
-        tolerance_m = self.params.next_to_tolerance_m
         for obj in positions:
             for rel in obj.get_relations():
                 if not isinstance(rel, NotNextTo):
@@ -712,35 +698,22 @@ class ObjectPlacer:
                 parent = rel.parent
                 if parent not in positions:
                     continue
-                margin_m = self._not_next_to_margin(rel)
                 cfg = SIDE_CONFIGS[rel.side]
-                primary, band, direction = int(cfg.primary_axis), int(cfg.band_axis), int(cfg.direction)
-                child_local = env_bboxes[obj]
+                margin_m = self._not_next_to_margin(rel)
+                child_bbox = env_bboxes[obj]
+                child_pos = child_bbox.min_point.new_tensor([positions[obj]])
                 parent_world = env_bboxes[parent].translated(positions[parent])
-                child_primary = positions[obj][primary]
-                child_cross = positions[obj][band]
+                remaining_side, remaining_cross = not_next_to_violations(
+                    cfg, child_pos, child_bbox, parent_world, margin_m
+                )
 
-                if direction > 0:
-                    parent_edge = parent_world.max_point[0, primary].item()
-                    safe_edge = parent_edge - margin_m
-                    remaining_side = max(0.0, child_primary - safe_edge)
-                else:
-                    parent_edge = parent_world.min_point[0, primary].item()
-                    safe_edge = parent_edge + margin_m
-                    remaining_side = max(0.0, safe_edge - child_primary)
-
-                valid_band_min = parent_world.min_point[0, band].item() - child_local.min_point[0, band].item()
-                valid_band_max = parent_world.max_point[0, band].item() - child_local.max_point[0, band].item()
-                safe_band_min = valid_band_min - margin_m
-                safe_band_max = valid_band_max + margin_m
-                remaining_cross = min(max(0.0, child_cross - safe_band_min), max(0.0, safe_band_max - child_cross))
-
-                if min(remaining_side, remaining_cross) > tolerance_m:
+                if min(remaining_side.item(), remaining_cross.item()) > rel.tolerance_m:
                     if self.params.verbose:
                         print(
                             f"NotNextTo: '{obj.name}' not_next_to({parent.name}) violated"
-                            f" (remaining_side={remaining_side:.4f}, remaining_cross={remaining_cross:.4f} m;"
-                            f" margin_m={margin_m}, tolerance_m={tolerance_m})"
+                            f" (remaining_side={remaining_side.item():.4f},"
+                            f" remaining_cross={remaining_cross.item():.4f} m;"
+                            f" margin_m={margin_m}, tolerance_m={rel.tolerance_m})"
                         )
                     return False
         return True

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -655,7 +655,7 @@ class ObjectPlacer:
             positions: Solved positions for each object.
             env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
         """
-        tol = self.params.next_to_tolerance_m
+        tolerance_m = self.params.next_to_tolerance_m
         for obj in positions:
             for rel in obj.get_relations():
                 if not isinstance(rel, NextTo):
@@ -681,11 +681,12 @@ class ObjectPlacer:
                 target_primary = parent_edge + direction * rel.distance_m - child_offset
                 distance_violation = abs(child_primary - target_primary)
 
-                if half_plane_violation > tol or distance_violation > tol:
+                if half_plane_violation > tolerance_m or distance_violation > tolerance_m:
                     if self.params.verbose:
                         print(
                             f"NextTo: '{obj.name}' next_to({parent.name}) violated"
-                            f" (side={half_plane_violation:.4f}, distance={distance_violation:.4f} m; tol={tol})"
+                            f" (side={half_plane_violation:.4f}, distance={distance_violation:.4f} m;"
+                            f" tolerance_m={tolerance_m})"
                         )
                     return False
         return True
@@ -703,7 +704,7 @@ class ObjectPlacer:
             positions: Solved positions for each object.
             env_bboxes: Per-object bboxes for the current env, each with shape (1, 3).
         """
-        tol = self.params.next_to_tolerance_m
+        tolerance_m = self.params.next_to_tolerance_m
         for obj in positions:
             for rel in obj.get_relations():
                 if not isinstance(rel, NotNextTo):
@@ -734,22 +735,19 @@ class ObjectPlacer:
                 safe_band_max = valid_band_max + margin_m
                 remaining_cross = min(max(0.0, child_cross - safe_band_min), max(0.0, safe_band_max - child_cross))
 
-                if min(remaining_side, remaining_cross) > tol:
+                if min(remaining_side, remaining_cross) > tolerance_m:
                     if self.params.verbose:
                         print(
                             f"NotNextTo: '{obj.name}' not_next_to({parent.name}) violated"
                             f" (remaining_side={remaining_side:.4f}, remaining_cross={remaining_cross:.4f} m;"
-                            f" margin={margin_m}, tol={tol})"
+                            f" margin_m={margin_m}, tolerance_m={tolerance_m})"
                         )
                     return False
         return True
 
     def _not_next_to_margin(self, relation: NotNextTo) -> float:
         """Keep-out margin_m from the registered NotNextTo loss strategy (stays in sync with the solver)."""
-        strategy = self._solver.params.strategies.get(type(relation))
-        assert strategy is not None and hasattr(
-            strategy, "margin_m"
-        ), f"NotNextTo validation needs a registered loss strategy with margin_m; got {strategy!r}"
+        strategy = self._solver.params.strategies[type(relation)]
         return strategy.margin_m
 
     def _validate_placement(

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -36,6 +36,10 @@ class ObjectPlacerParams:
     """Tolerance (meters) for On-relation Z validation. Valid Z band is extended to
     (parent_top - tolerance, parent_top + clearance_m + tolerance]. Default 5e-3 accommodates solver residual."""
 
+    next_to_tolerance_m: float = 1e-2
+    """Tolerance (meters) absorbing solver residual in NextTo / NotNextTo validation: slack on the
+    side/offset checks (NextTo) and on clearing the keep-out zone (NotNextTo)."""
+
     resolve_on_reset: bool = True
     """If True, draw fresh layouts from the placement pool on each environment reset.
     If False, solve initial positions once and reuse them across all resets."""

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -36,10 +36,6 @@ class ObjectPlacerParams:
     """Tolerance (meters) for On-relation Z validation. Valid Z band is extended to
     (parent_top - tolerance, parent_top + clearance_m + tolerance]. Default 5e-3 accommodates solver residual."""
 
-    next_to_tolerance_m: float = 1e-2
-    """Tolerance (meters) absorbing solver residual in NextTo / NotNextTo validation: slack on the
-    side/offset checks (NextTo) and on clearing the keep-out zone (NotNextTo)."""
-
     resolve_on_reset: bool = True
     """If True, draw fresh layouts from the placement pool on each environment reset.
     If False, solve initial positions once and reuse them across all resets."""

--- a/isaaclab_arena/relations/placement_validation.py
+++ b/isaaclab_arena/relations/placement_validation.py
@@ -21,11 +21,11 @@ class PlacementCheck(StrEnum):
 
     NEXT_TO = "next_to"
     """Build-time check: every ``NextTo`` relation holds — child on the requested side at the target
-    offset, within ``next_to_tolerance_m``."""
+    offset, within the relation's ``tolerance_m``."""
 
     NOT_NEXT_TO = "not_next_to"
     """Build-time check: every ``NotNextTo`` relation holds — child has cleared the keep-out zone
-    beside the parent, within ``next_to_tolerance_m``."""
+    beside the parent, within the relation's ``tolerance_m``."""
 
     PHYSICS_SETTLED = "physics_settled"
     """Run-time check: after stepping physics the movable objects' velocities fall

--- a/isaaclab_arena/relations/placement_validation.py
+++ b/isaaclab_arena/relations/placement_validation.py
@@ -19,6 +19,14 @@ class PlacementCheck(StrEnum):
     """Build-time check: every ``On`` relation holds — the child rests on its parent within the
     configured Z tolerance."""
 
+    NEXT_TO = "next_to"
+    """Build-time check: every ``NextTo`` relation holds — child on the requested side at the target
+    offset, within ``next_to_tolerance_m``."""
+
+    NOT_NEXT_TO = "not_next_to"
+    """Build-time check: every ``NotNextTo`` relation holds — child has cleared the keep-out zone
+    beside the parent, within ``next_to_tolerance_m``."""
+
     PHYSICS_SETTLED = "physics_settled"
     """Run-time check: after stepping physics the movable objects' velocities fall
     below threshold, i.e. the layout is stable and does not drift or topple."""

--- a/isaaclab_arena/relations/relation_loss_strategies.py
+++ b/isaaclab_arena/relations/relation_loss_strategies.py
@@ -65,6 +65,93 @@ SIDE_CONFIGS: dict[Side, SideConfig] = {
 }
 
 
+def next_to_violations(
+    cfg: SideConfig,
+    child_pos: torch.Tensor,
+    child_bbox: AxisAlignedBoundingBox,
+    parent_world_bbox: AxisAlignedBoundingBox,
+    distance_m: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Side and distance violation magnitudes (meters, >= 0) for a NextTo relation.
+
+    Shared by NextToLossStrategy (scaled by slope into the loss) and the placement validator
+    (thresholded against tolerance), so loss and validation can't disagree on the geometry.
+
+    Args:
+        cfg: Side configuration (primary/band axis and direction) for the relation's side.
+        child_pos: Child position, shape (N, 3), in world coords.
+        child_bbox: Child local bounding box (N=1).
+        parent_world_bbox: Parent bounding box in world coords.
+        distance_m: Target distance from the parent edge.
+
+    Returns:
+        (half_plane, distance) tensors of shape (N,), each >= 0 and zero when satisfied.
+    """
+    if cfg.direction == Direction.POSITIVE:
+        parent_edge = parent_world_bbox.max_point[:, cfg.primary_axis]
+        child_offset = child_bbox.min_point[:, cfg.primary_axis]
+        penalty_side = "less"
+    else:
+        parent_edge = parent_world_bbox.min_point[:, cfg.primary_axis]
+        child_offset = child_bbox.max_point[:, cfg.primary_axis]
+        penalty_side = "greater"
+
+    primary = child_pos[:, cfg.primary_axis]
+    half_plane = single_boundary_linear_loss(primary, parent_edge, slope=1.0, penalty_side=penalty_side)
+    target_pos = parent_edge + cfg.direction * distance_m - child_offset
+    distance = single_point_linear_loss(primary, target_pos, slope=1.0)
+    return half_plane, distance
+
+
+def not_next_to_violations(
+    cfg: SideConfig,
+    child_pos: torch.Tensor,
+    child_bbox: AxisAlignedBoundingBox,
+    parent_world_bbox: AxisAlignedBoundingBox,
+    margin_m: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-route escape distances (meters, >= 0) for a NotNextTo relation.
+
+    Shared by NotNextToLossStrategy and the placement validator. The child clears the keep-out zone
+    once either route reaches zero: ``remaining_side`` (cross back over the edge) or
+    ``remaining_cross`` (slide past either footprint end), both by ``margin_m``.
+
+    Args:
+        cfg: Side configuration for the relation's side.
+        child_pos: Child position, shape (N, 3), in world coords.
+        child_bbox: Child local bounding box (N=1).
+        parent_world_bbox: Parent bounding box in world coords.
+        margin_m: Distance past the edge/footprint required to clear the zone.
+
+    Returns:
+        (remaining_side, remaining_cross) tensors of shape (N,), each >= 0.
+    """
+    if cfg.direction == Direction.POSITIVE:
+        parent_edge = parent_world_bbox.max_point[:, cfg.primary_axis]
+        blocked_side_penalty = "greater"
+    else:
+        parent_edge = parent_world_bbox.min_point[:, cfg.primary_axis]
+        blocked_side_penalty = "less"
+
+    parent_band_min = parent_world_bbox.min_point[:, cfg.band_axis]
+    parent_band_max = parent_world_bbox.max_point[:, cfg.band_axis]
+    valid_band_min = parent_band_min - child_bbox.min_point[:, cfg.band_axis]
+    valid_band_max = parent_band_max - child_bbox.max_point[:, cfg.band_axis]
+
+    primary = child_pos[:, cfg.primary_axis]
+    cross = child_pos[:, cfg.band_axis]
+
+    safe_edge = parent_edge - cfg.direction * margin_m
+    remaining_side = single_boundary_linear_loss(primary, safe_edge, slope=1.0, penalty_side=blocked_side_penalty)
+    safe_band_min = valid_band_min - margin_m
+    safe_band_max = valid_band_max + margin_m
+    remaining_cross = torch.minimum(
+        single_boundary_linear_loss(cross, safe_band_min, slope=1.0, penalty_side="greater"),
+        single_boundary_linear_loss(cross, safe_band_max, slope=1.0, penalty_side="less"),
+    )
+    return remaining_side, remaining_cross
+
+
 class UnaryRelationLossStrategy(ABC):
     """Abstract base class for unary relations (no parent object)."""
 
@@ -162,23 +249,10 @@ class NextToLossStrategy(RelationLossStrategy):
         distance = relation.distance_m
         assert distance >= 0.0, f"NextTo distance must be non-negative, got {distance}"
 
-        # Parent world extents from the world bounding box
-        if cfg.direction == Direction.POSITIVE:
-            parent_edge = parent_world_bbox.max_point[:, cfg.primary_axis]
-            child_offset = child_bbox.min_point[:, cfg.primary_axis]
-            penalty_side = "less"
-        else:
-            parent_edge = parent_world_bbox.min_point[:, cfg.primary_axis]
-            child_offset = child_bbox.max_point[:, cfg.primary_axis]
-            penalty_side = "greater"
-
-        # 1. Half-plane loss: child must be on correct side of parent edge
-        half_plane_loss = single_boundary_linear_loss(
-            child_pos[:, cfg.primary_axis],
-            parent_edge,
-            slope=self.slope,
-            penalty_side=penalty_side,
-        )
+        # 1. & 3. Side (half-plane) and distance share their geometry with the placement validator.
+        half_plane_raw, distance_raw = next_to_violations(cfg, child_pos, child_bbox, parent_world_bbox, distance)
+        half_plane_loss = self.slope * half_plane_raw
+        distance_loss = self.slope * distance_raw
 
         # 2. Band position loss: child placed at target position within parent's perpendicular extent
         parent_band_min = parent_world_bbox.min_point[:, cfg.band_axis]
@@ -188,25 +262,13 @@ class NextToLossStrategy(RelationLossStrategy):
         # Convert cross_position_ratio [-1, 1] to interpolation factor [0, 1]: -1 = min, 0 = center, 1 = max
         t = (relation.cross_position_ratio + 1.0) / 2.0
         target_band_pos = valid_band_min + t * (valid_band_max - valid_band_min)
-        band_loss = single_point_linear_loss(
-            child_pos[:, cfg.band_axis],
-            target_band_pos,
-            slope=self.slope,
-        )
-
-        # 3. Distance loss: child edge at target distance from parent edge
-        # For direction +1: target = parent_max + distance - child_min
-        # For direction -1: target = parent_min - distance - child_max
-        target_pos = parent_edge + cfg.direction * distance - child_offset
-        distance_loss = single_point_linear_loss(child_pos[:, cfg.primary_axis], target_pos, slope=self.slope)
+        band_loss = single_point_linear_loss(child_pos[:, cfg.band_axis], target_band_pos, slope=self.slope)
 
         if self.debug and child_pos.shape[0] == 1:
-            axis_name = cfg.primary_axis.name
             band_axis_name = cfg.band_axis.name
             print(
-                f"    [NextTo] {relation.side.value}: child_{axis_name.lower()}="
-                f"{child_pos[0, cfg.primary_axis].item():.4f}, parent_edge={parent_edge[0].item():.4f},"
-                f" loss={half_plane_loss[0].item():.6f}"
+                f"    [NextTo] {relation.side.value}: half_plane={half_plane_raw[0].item():.6f},"
+                f" distance={distance_raw[0].item():.6f} (m)"
             )
             print(
                 f"    [NextTo] {band_axis_name} band: child_{band_axis_name.lower()}="
@@ -214,11 +276,6 @@ class NextToLossStrategy(RelationLossStrategy):
                 f" (cross_position_ratio={relation.cross_position_ratio:.2f},"
                 f" range=[{valid_band_min[0].item():.4f}, {valid_band_max[0].item():.4f}]),"
                 f" loss={band_loss[0].item():.6f}"
-            )
-            print(
-                f"    [NextTo] Distance: child_{axis_name.lower()}="
-                f"{child_pos[0, cfg.primary_axis].item():.4f}, target={target_pos[0].item():.4f},"
-                f" loss={distance_loss[0].item():.6f}"
             )
 
         total_loss = half_plane_loss + band_loss + distance_loss
@@ -368,35 +425,11 @@ class NotNextToLossStrategy(RelationLossStrategy):
 
         cfg = SIDE_CONFIGS[relation.side]
 
-        # Blocked edge and the side the child must leave (> edge for POSITIVE, < for NEGATIVE).
-        if cfg.direction == Direction.POSITIVE:
-            parent_edge = parent_world_bbox.max_point[:, cfg.primary_axis]
-            blocked_side_penalty = "greater"
-        else:
-            parent_edge = parent_world_bbox.min_point[:, cfg.primary_axis]
-            blocked_side_penalty = "less"
-
-        # Footprint band, shrunk by the child's extent so its whole bbox must clear it.
-        parent_band_min = parent_world_bbox.min_point[:, cfg.band_axis]
-        parent_band_max = parent_world_bbox.max_point[:, cfg.band_axis]
-        valid_band_min = parent_band_min - child_bbox.min_point[:, cfg.band_axis]
-        valid_band_max = parent_band_max - child_bbox.max_point[:, cfg.band_axis]
-
-        primary = child_pos[:, cfg.primary_axis]
-        cross = child_pos[:, cfg.band_axis]
-
-        # Each route's `remaining` = distance still to travel to clear it by margin_m (0 once cleared).
-        # Route 1, cross back over the edge: distance onto the blocked side past the one safe line.
-        safe_edge = parent_edge - cfg.direction * self.margin_m
-        remaining_side = single_boundary_linear_loss(primary, safe_edge, slope=1.0, penalty_side=blocked_side_penalty)
-        # Route 2, slide off the footprint: there are two safe lines (one margin_m past each end);
-        # take the distance to the nearer one. min over the two ends -> a tent peaking at the centre,
-        # which caps the loss and keeps the blocked axis flat.
-        safe_band_min = valid_band_min - self.margin_m
-        safe_band_max = valid_band_max + self.margin_m
-        remaining_cross = torch.minimum(
-            single_boundary_linear_loss(cross, safe_band_min, slope=1.0, penalty_side="greater"),
-            single_boundary_linear_loss(cross, safe_band_max, slope=1.0, penalty_side="less"),
+        # Per-route escape distances share their geometry with the placement validator.
+        # Route 1 crosses back over the edge; route 2 slides past either footprint end. Each
+        # `remaining` is the distance still to travel to clear that route by margin_m (0 once cleared).
+        remaining_side, remaining_cross = not_next_to_violations(
+            cfg, child_pos, child_bbox, parent_world_bbox, self.margin_m
         )
 
         # Clearing either route is enough.

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -92,6 +92,7 @@ class NextTo(Relation):
         distance_m: float = 0.05,
         side: Side | str = Side.POSITIVE_X,
         cross_position_ratio: float = 0.0,
+        tolerance_m: float = 1e-2,
     ):
         """
         Args:
@@ -104,15 +105,20 @@ class NextTo(Relation):
                 The cross axis depends on the side: for POSITIVE_X / NEGATIVE_X
                 the cross axis is Y; for POSITIVE_Y / NEGATIVE_Y it is X.
                 Default: 0.0 (centered).
+            tolerance_m: Slack (meters) for placement validation: the child passes when its side and
+                distance violations are each within this value. Raise it to accept the side but care
+                less about the exact distance. cross_position_ratio is a soft preference, not gated.
         """
         super().__init__(parent, relation_loss_weight)
         assert distance_m > 0.0, f"Distance must be positive, got {distance_m}"
         assert (
             -1.0 <= cross_position_ratio <= 1.0
         ), f"cross_position_ratio must be in [-1, 1], got {cross_position_ratio}"
+        assert tolerance_m >= 0.0, f"tolerance_m must be non-negative, got {tolerance_m}"
         self.distance_m = distance_m
         self.side = Side(side)
         self.cross_position_ratio = cross_position_ratio
+        self.tolerance_m = tolerance_m
 
 
 @register_object_relation
@@ -173,15 +179,20 @@ class NotNextTo(Relation):
         parent: ObjectBase,
         relation_loss_weight: float = 1.0,
         side: Side | str = Side.POSITIVE_X,
+        tolerance_m: float = 1e-2,
     ):
         """
         Args:
             parent: The parent asset whose adjacent half-plane is forbidden.
             relation_loss_weight: Weight for the relationship loss function.
             side: Which side of the parent is blocked (default: Side.POSITIVE_X).
+            tolerance_m: Slack (meters) for placement validation: the child passes when it has cleared
+                the keep-out zone to within this value.
         """
         super().__init__(parent, relation_loss_weight)
+        assert tolerance_m >= 0.0, f"tolerance_m must be non-negative, got {tolerance_m}"
         self.side = Side(side)
+        self.tolerance_m = tolerance_m
 
 
 @register_object_relation

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -295,6 +295,17 @@ def test_next_to_wrong_offset_fails():
     assert placer._validate_next_to_relations(positions, _env_bboxes(positions)) is False
 
 
+def test_next_to_tolerance_is_per_relation():
+    # Same wrong offset as above, but a looser per-relation tolerance_m accepts it: callers that care
+    # about the side, not the exact distance, can relax the gate without touching the placer params.
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NextTo(parent, distance_m=0.05, side=Side.POSITIVE_X, tolerance_m=0.2))
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.45, 0.0, 0.0)}
+    assert placer._validate_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
 def test_next_to_cross_position_not_gated_passes():
     # Correct side and distance but off-center along the edge: cross position is not a validity gate.
     placer = ObjectPlacer(params=ObjectPlacerParams())
@@ -335,6 +346,16 @@ def test_not_next_to_slid_off_footprint_passes():
     child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X))
     # Past the +X edge but slid well past the +Y footprint end: cleared via the cross route.
     positions = {parent: (0.0, 0.0, 0.0), child: (0.25, 0.5, 0.0)}
+    assert placer._validate_not_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
+def test_not_next_to_tolerance_is_per_relation():
+    # Same in-zone placement as the failing case, but a looser per-relation tolerance_m accepts it.
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X, tolerance_m=0.2))
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.25, 0.0, 0.0)}
     assert placer._validate_not_next_to_relations(positions, _env_bboxes(positions)) is True
 
 

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -349,3 +349,16 @@ def test_validate_placement_rejects_not_next_to_violation():
     results = placer._validate_placement(positions, _env_bboxes(positions))
     assert results.do_all_required_validation_checks_pass() is False
     assert PlacementCheck.NOT_NEXT_TO in results.get_failed_validation_check_names
+
+
+def test_validate_placement_rejects_next_to_violation():
+    """NEXT_TO gates overall validation: a wrong-offset NextTo placement fails."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NextTo(parent, distance_m=0.05, side=Side.POSITIVE_X, cross_position_ratio=0.0))
+    # Offset wrong by 0.10, but lifted in Z so NO_OVERLAP and ON_RELATION still pass.
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.45, 0.0, 5.0)}
+    results = placer._validate_placement(positions, _env_bboxes(positions))
+    assert results.do_all_required_validation_checks_pass() is False
+    assert PlacementCheck.NEXT_TO in results.get_failed_validation_check_names

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -11,7 +11,8 @@ import torch
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
-from isaaclab_arena.relations.relations import On, RotateAroundSolution
+from isaaclab_arena.relations.placement_validation import PlacementCheck
+from isaaclab_arena.relations.relations import NextTo, NotNextTo, On, RotateAroundSolution, Side
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
@@ -268,3 +269,83 @@ def test_on_relation_edge_margin_inside_rim_but_in_margin_gap_fails():
 def test_on_relation_edge_margin_too_large_for_surface_rejected():
     # Desk free span 0.8 caps the margin at 0.4; 0.5 inverts the inset band so containment fails.
     assert _validate_box_on_desk(edge_margin_m=0.5, box_x=0.0) is False
+
+
+# --- NextTo validation (parent box XY in [-0.2, 0.2], child box half-extent 0.1) ---
+# Side + offset only (cross position is a soft preference, not gated).
+# Zero-loss +X placement: child x = parent_max(0.2) + distance(0.05) - child_min(-0.1) = 0.35.
+
+
+def test_next_to_satisfied_passes():
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NextTo(parent, distance_m=0.05, side=Side.POSITIVE_X, cross_position_ratio=0.0))
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.35, 0.0, 0.0)}
+    assert placer._validate_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
+def test_next_to_wrong_offset_fails():
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NextTo(parent, distance_m=0.05, side=Side.POSITIVE_X, cross_position_ratio=0.0))
+    # x=0.45 → distance off by 0.10, well past the default 0.01 tolerance.
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.45, 0.0, 0.0)}
+    assert placer._validate_next_to_relations(positions, _env_bboxes(positions)) is False
+
+
+def test_next_to_cross_position_not_gated_passes():
+    # Correct side and distance but off-center along the edge: cross position is not a validity gate.
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NextTo(parent, distance_m=0.05, side=Side.POSITIVE_X, cross_position_ratio=0.0))
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.35, 0.2, 0.0)}
+    assert placer._validate_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
+# --- NotNextTo validation (parent box XY in [-0.2, 0.2]; default keep-out margin_m = 0.1) ---
+
+
+def test_not_next_to_inside_zone_fails():
+    """Child parked just past the +X edge, still within the footprint — the 'few cm further right' case."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X))
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.25, 0.0, 0.0)}
+    assert placer._validate_not_next_to_relations(positions, _env_bboxes(positions)) is False
+
+
+def test_not_next_to_crossed_back_over_edge_passes():
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X))
+    # Far on the -X side: cleared the keep-out via the edge route.
+    positions = {parent: (0.0, 0.0, 0.0), child: (-0.5, 0.0, 0.0)}
+    assert placer._validate_not_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
+def test_not_next_to_slid_off_footprint_passes():
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X))
+    # Past the +X edge but slid well past the +Y footprint end: cleared via the cross route.
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.25, 0.5, 0.0)}
+    assert placer._validate_not_next_to_relations(positions, _env_bboxes(positions)) is True
+
+
+def test_validate_placement_rejects_not_next_to_violation():
+    """NOT_NEXT_TO gates overall validation: an in-zone NotNextTo placement fails."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    parent = _make_box("parent", size=0.4)
+    child = _make_box("child", size=0.2)
+    child.add_relation(NotNextTo(parent, side=Side.POSITIVE_X))
+    # In the keep-out zone in XY, but lifted in Z so NO_OVERLAP and ON_RELATION still pass.
+    positions = {parent: (0.0, 0.0, 0.0), child: (0.25, 0.0, 5.0)}
+    results = placer._validate_placement(positions, _env_bboxes(positions))
+    assert results.do_all_required_validation_checks_pass() is False
+    assert PlacementCheck.NOT_NEXT_TO in results.get_failed_validation_check_names


### PR DESCRIPTION
## Summary
Add NextTo/NotNextTo placement checks

## Detailed description
- `NextTo`/`NotNextTo` only fed the solver loss and were never validated, so a non-converged solve could leave the child mis-placed and still be reported valid.
- Added a validator for each in `_validate_placement`'s `required_checks`: `NextTo` confirms side + offset, `NotNextTo` confirms the keep-out is clear. Both mirror the loss geometry.
- Invalid `NextTo`/`NotNextTo` layouts are now filtered out by `PooledObjectPlacer`.