### PR TITLE
Add unified success check termination function

### DIFF
--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -24,7 +24,7 @@ from isaaclab_arena.metrics.success_rate import SuccessRateMetric
 from isaaclab_arena.tasks.common.mimic_default_params import MIMIC_DATAGEN_CONFIG_DEFAULTS
 from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.tasks.task_transition import Relocate, TaskTransition
-from isaaclab_arena.tasks.terminations import object_on_destination
+from isaaclab_arena.tasks.terminations import SuccessMode, check_success, object_on_destination
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
@@ -88,12 +88,20 @@ class PickAndPlaceTask(TaskBase):
 
     def make_termination_cfg(self):
         success = TerminationTermCfg(
-            func=object_on_destination,
+            func=check_success,
             params={
-                "object_cfg": SceneEntityCfg(self.pick_up_object.name),
-                "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
-                "force_threshold": self.force_threshold,
-                "velocity_threshold": self.velocity_threshold,
+                "mode": SuccessMode.ALL,
+                "predicates": [
+                    TerminationTermCfg(
+                        func=object_on_destination,
+                        params={
+                            "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                            "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
+                            "force_threshold": self.force_threshold,
+                            "velocity_threshold": self.velocity_threshold,
+                        },
+                    ),
+                ],
             },
         )
         object_dropped = TerminationTermCfg(

--- a/isaaclab_arena/tasks/terminations.py
+++ b/isaaclab_arena/tasks/terminations.py
@@ -54,18 +54,12 @@ def check_success(
         A boolean tensor of shape (num_envs,) indicating success.
     """
 
-    assert predicates, "check_success requires at least one predicate."
+    if not predicates:
+        raise ValueError("check_success requires at least one predicate.")
     valid_modes = [m.value for m in SuccessMode]
-    assert (
-        isinstance(mode, str) and mode.upper() in valid_modes
-    ), f"Unknown mode '{mode}'. Expected one of {valid_modes}."
+    if not (isinstance(mode, str) and mode.upper() in valid_modes):
+        raise ValueError(f"Unknown mode '{mode}'. Expected one of {valid_modes}.")
     mode = SuccessMode(mode.upper())
-
-    if mode is SuccessMode.CHOOSE:
-        assert k is not None, "mode SuccessMode.CHOOSE requires 'k' to be provided."
-        assert (
-            1 <= k <= len(predicates)
-        ), f"'k' must be in [1, {len(predicates)}] for {len(predicates)} predicates, got {k}."
 
     results = torch.stack([predicate.func(env, **predicate.params) for predicate in predicates], dim=0)
 
@@ -73,6 +67,11 @@ def check_success(
         return results.all(dim=0)
     if mode is SuccessMode.ANY:
         return results.any(dim=0)
+
+    if k is None:
+        raise ValueError("mode SuccessMode.CHOOSE requires 'k' to be provided.")
+    if not (1 <= k <= len(predicates)):
+        raise ValueError(f"'k' must be in [1, {len(predicates)}] for {len(predicates)} predicates, got {k}.")
     return results.sum(dim=0) >= k
 
 

--- a/isaaclab_arena/tasks/terminations.py
+++ b/isaaclab_arena/tasks/terminations.py
@@ -5,14 +5,75 @@
 
 import math
 import torch
+from enum import Enum
 
 import warp as wp
 from isaaclab.assets import RigidObject
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.envs.mdp.terminations import root_height_below_minimum
-from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
 from isaaclab.sensors.contact_sensor.contact_sensor import ContactSensor
 from isaaclab.utils.math import combine_frame_transforms
+
+
+class SuccessMode(str, Enum):
+    """How `check_success` combines its results."""
+
+    ALL = "ALL"
+    """Success needs every predicate to be True."""
+
+    ANY = "ANY"
+    """Success needs at least one predicate to be True."""
+
+    CHOOSE = "CHOOSE"
+    """Success needs at least k predicates to be True."""
+
+
+def check_success(
+    env: ManagerBasedRLEnv,
+    predicates: list[TerminationTermCfg],
+    mode: SuccessMode | str = SuccessMode.ALL,
+    k: int | None = None,
+) -> torch.Tensor:
+    """Compose multiple termination predicates into a single success signal.
+
+    Each predicate is wrapped in a termination term and its `func` is evaluated with its
+    `params` to produce a boolean tensor of shape (num_envs,). The results are then combined according to `mode`.
+
+    - ALL: True where every predicate is True (logical AND).
+    - ANY: True where at least one predicate is True (logical OR).
+    - CHOOSE: True where at least k predicates are True.
+
+    Args:
+        env: The RL environment instance.
+        predicates: Termination term configs to evaluate and combine.
+        mode: How to combine the predicate results (SuccessMode or string).
+        k: Number of predicates that must be True when `mode` is SuccessMode.CHOOSE.
+
+    Returns:
+        A boolean tensor of shape (num_envs,) indicating success.
+    """
+
+    assert predicates, "check_success requires at least one predicate."
+    valid_modes = [m.value for m in SuccessMode]
+    assert (
+        isinstance(mode, str) and mode.upper() in valid_modes
+    ), f"Unknown mode '{mode}'. Expected one of {valid_modes}."
+    mode = SuccessMode(mode.upper())
+
+    if mode is SuccessMode.CHOOSE:
+        assert k is not None, "mode SuccessMode.CHOOSE requires 'k' to be provided."
+        assert (
+            1 <= k <= len(predicates)
+        ), f"'k' must be in [1, {len(predicates)}] for {len(predicates)} predicates, got {k}."
+
+    results = torch.stack([predicate.func(env, **predicate.params) for predicate in predicates], dim=0)
+
+    if mode is SuccessMode.ALL:
+        return results.all(dim=0)
+    if mode is SuccessMode.ANY:
+        return results.any(dim=0)
+    return results.sum(dim=0) >= k
 
 
 # NOTE(alexmillane, 2025.09.15): The velocity threshold is set high because some stationary


### PR DESCRIPTION
## Summary
Adds a new unified termination function (`check_success`) that can be composed of multiple termination predicates. Allows tasks to compose multiple termination funcs together without needing to create a new func.

Individual termination predicates are composed one of 3 ways:

- ALL (all must be true)
- ANY (at least one must be true)
- CHOOSE (at least k must be true)  

Updates PickAndPlace task to use the `check_success`
