### PR TITLE
Cache openpi checkpoint

### DIFF
--- a/isaaclab_arena_openpi/docker/run_openpi_server.sh
+++ b/isaaclab_arena_openpi/docker/run_openpi_server.sh
@@ -68,10 +68,29 @@ case "$VARIANT" in
         ;;
 esac
 
+# Persist the ~11GB checkpoint that openpi pulls from gs:// across runs. Without
+# this, --rm discards the in-container cache every time.
+OPENPI_CACHE_DIR="${OPENPI_CACHE_DIR:-$HOME/.cache/openpi}"
+
+# Single EXIT handler: remove the build tempdir (if any) and, once the server has
+# run, reset cache ownership back to us. The server runs as root in the container,
+# so files it writes to the mount are root-owned on the host; we chown them back
+# via a throwaway root container, which avoids needing host sudo.
+TMPDIR=""
+SERVER_RAN=false
+cleanup() {
+    [ -n "$TMPDIR" ] && rm -rf "$TMPDIR"
+    if [ "$SERVER_RAN" = true ]; then
+        docker run --rm -v "${OPENPI_CACHE_DIR}:/cache/openpi" \
+            "${IMAGE_NAME}:${IMAGE_TAG}" \
+            chown -R "$(id -u):$(id -g)" /cache/openpi || true
+    fi
+}
+trap cleanup EXIT
+
 if [ "$FORCE_REBUILD" = true ] || \
    [ -z "$(docker images -q "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null)" ]; then
     TMPDIR=$(mktemp -d)
-    trap 'rm -rf "$TMPDIR"' EXIT
 
     if [ -n "$SRC_DIR" ]; then
         OPENPI_DIR="$SRC_DIR"
@@ -103,8 +122,13 @@ fi
 
 echo "Running ${IMAGE_NAME}:${IMAGE_TAG} (variant: ${VARIANT})"
 
+mkdir -p "$OPENPI_CACHE_DIR"
+SERVER_RAN=true
+
 docker run --rm -it --gpus all --network=host \
+    -e OPENPI_DATA_HOME=/cache/openpi \
     -e XLA_PYTHON_CLIENT_MEM_FRACTION=0.5 \
+    -v "${OPENPI_CACHE_DIR}:/cache/openpi" \
     "${IMAGE_NAME}:${IMAGE_TAG}" \
     uv run scripts/serve_policy.py policy:checkpoint \
         --policy.config="${POLICY_CONFIG}" \

--- a/isaaclab_arena_openpi/docker/run_openpi_server.sh
+++ b/isaaclab_arena_openpi/docker/run_openpi_server.sh
@@ -68,18 +68,14 @@ case "$VARIANT" in
         ;;
 esac
 
-# Persist the ~11GB checkpoint that openpi pulls from gs:// across runs. Without
-# this, --rm discards the in-container cache every time.
+# Cache the ~11GB checkpoint that openpi pulls from gs:// across runs.
 OPENPI_CACHE_DIR="${OPENPI_CACHE_DIR:-$HOME/.cache/openpi}"
 
-# Single EXIT handler: remove the build tempdir (if any) and, once the server has
-# run, reset cache ownership back to us. The server runs as root in the container,
-# so files it writes to the mount are root-owned on the host; we chown them back
-# via a throwaway root container, which avoids needing host sudo.
-TMPDIR=""
+# Single EXIT handler: remove the build tempdir and reset cache ownership back to us.
+BUILD_TMPDIR=""
 SERVER_RAN=false
 cleanup() {
-    [ -n "$TMPDIR" ] && rm -rf "$TMPDIR"
+    [ -n "$BUILD_TMPDIR" ] && rm -rf "$BUILD_TMPDIR"
     if [ "$SERVER_RAN" = true ]; then
         docker run --rm -v "${OPENPI_CACHE_DIR}:/cache/openpi" \
             "${IMAGE_NAME}:${IMAGE_TAG}" \
@@ -90,14 +86,14 @@ trap cleanup EXIT
 
 if [ "$FORCE_REBUILD" = true ] || \
    [ -z "$(docker images -q "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null)" ]; then
-    TMPDIR=$(mktemp -d)
+    BUILD_TMPDIR=$(mktemp -d)
 
     if [ -n "$SRC_DIR" ]; then
         OPENPI_DIR="$SRC_DIR"
         echo "Using local openpi checkout at ${OPENPI_DIR}"
     else
         PINNED_COMMIT="$(tr -d '[:space:]' < "${SCRIPT_DIR}/OPENPI_COMMIT")"
-        OPENPI_DIR="$TMPDIR/openpi"
+        OPENPI_DIR="$BUILD_TMPDIR/openpi"
         echo "Cloning openpi at ${PINNED_COMMIT} ..."
         # Partial clone: skip blob objects, git fetches them on demand at checkout.
         # Cuts the one-time clone size on a ~GB-scale repo without changing what we end up with.
@@ -107,13 +103,13 @@ if [ "$FORCE_REBUILD" = true ] || \
 
     # Upstream's Dockerfile installs deps but expects source to be volume-mounted.
     # Append a COPY step so the image is self-contained.
-    cat "$OPENPI_DIR/scripts/docker/serve_policy.Dockerfile" > "$TMPDIR/Dockerfile"
-    echo "COPY . /app" >> "$TMPDIR/Dockerfile"
+    cat "$OPENPI_DIR/scripts/docker/serve_policy.Dockerfile" > "$BUILD_TMPDIR/Dockerfile"
+    echo "COPY . /app" >> "$BUILD_TMPDIR/Dockerfile"
 
     echo "Building ${IMAGE_NAME}:${IMAGE_TAG}"
     docker build \
         --network=host \
-        -f "$TMPDIR/Dockerfile" \
+        -f "$BUILD_TMPDIR/Dockerfile" \
         -t "${IMAGE_NAME}:${IMAGE_TAG}" \
         "$OPENPI_DIR"
 else


### PR DESCRIPTION
## Summary
Cache downloading of openpi checkpoint

## Detailed description
- `~/.cache/openpi` is mounted in the openpi container so we don't have to re-download the 11Gb checkpoint file on restart.
- Downloaded file is owned by root. It can still be read by non-root, but for sanitary reasons we still add an exit handler that `chown`s it back to the client user.
-  Note that cleanup would be avoided if we run the container at client user instead of root. This approach was abandoned due to an increasing number of surfaced permission errors (would require more changes)
