### PR TITLE
Add objects_in_proximity to PickAndPlaceTask success termination

### DIFF
--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -24,7 +24,7 @@ from isaaclab_arena.metrics.success_rate import SuccessRateMetric
 from isaaclab_arena.tasks.common.mimic_default_params import MIMIC_DATAGEN_CONFIG_DEFAULTS
 from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.tasks.task_transition import Relocate, TaskTransition
-from isaaclab_arena.tasks.terminations import SuccessMode, check_success, object_on_destination
+from isaaclab_arena.tasks.terminations import SuccessMode, check_success, object_on_destination, objects_in_proximity
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 
 
@@ -32,8 +32,8 @@ from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 @register_task
 class PickAndPlaceTask(TaskBase):
     """Pick-and-place task. Success fires when the pick-up object contacts the destination
-    with low velocity. Failure (object_dropped) fires when the object falls below the
-    background's ``object_min_z``.
+    with low velocity and is within axis-aligned proximity of the destination. Failure
+    (object_dropped) fires when the object falls below the background's ``object_min_z``.
 
     The default Mimic cfg is ``PickPlaceMimicEnvCfg``. When a task needs a different cfg
     shape (different arm subtask sequences, different per-subtask numerical knobs,
@@ -57,6 +57,9 @@ class PickAndPlaceTask(TaskBase):
         task_description: str | None = None,
         force_threshold: float = 0.1,
         velocity_threshold: float = 0.1,
+        max_x_separation: float = 0.15,
+        max_y_separation: float = 0.15,
+        max_z_separation: float = 0.15,
         mimic_env_cfg_factory: Callable[[ArmMode], MimicEnvCfg] | None = None,
     ):
         super().__init__(episode_length_s=episode_length_s)
@@ -71,6 +74,9 @@ class PickAndPlaceTask(TaskBase):
         )
         self.force_threshold = force_threshold
         self.velocity_threshold = velocity_threshold
+        self.max_x_separation = max_x_separation
+        self.max_y_separation = max_y_separation
+        self.max_z_separation = max_z_separation
         self.mimic_env_cfg_factory = mimic_env_cfg_factory
         self.events_cfg = None
         self.termination_cfg = self.make_termination_cfg()
@@ -99,6 +105,16 @@ class PickAndPlaceTask(TaskBase):
                             "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
                             "force_threshold": self.force_threshold,
                             "velocity_threshold": self.velocity_threshold,
+                        },
+                    ),
+                    TerminationTermCfg(
+                        func=objects_in_proximity,
+                        params={
+                            "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                            "target_object_cfg": SceneEntityCfg(self.destination_location.name),
+                            "max_x_separation": self.max_x_separation,
+                            "max_y_separation": self.max_y_separation,
+                            "max_z_separation": self.max_z_separation,
                         },
                     ),
                 ],

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -104,7 +104,7 @@ class PickAndPlaceTask(TaskBase):
             ),
         ]
         if self.max_separation is not None:
-            # TODO(qianl): replace objects_in_proximity with object_centroid_in_container
+            # TODO(qianl): replace objects_in_proximity with object_centroid_in_proximity
             # for tighter container placement checks.
             # TODO (qianl): current implementation doesn't support ObjectReference as target_object_cfg.
             max_x_separation, max_y_separation, max_z_separation = self.max_separation

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -57,9 +57,9 @@ class PickAndPlaceTask(TaskBase):
         task_description: str | None = None,
         force_threshold: float = 0.1,
         velocity_threshold: float = 0.1,
-        max_x_separation: float = 0.15,
-        max_y_separation: float = 0.15,
-        max_z_separation: float = 0.15,
+        max_x_separation: float = 0.5,
+        max_y_separation: float = 0.5,
+        max_z_separation: float = 0.5,
         mimic_env_cfg_factory: Callable[[ArmMode], MimicEnvCfg] | None = None,
     ):
         super().__init__(episode_length_s=episode_length_s)
@@ -107,6 +107,8 @@ class PickAndPlaceTask(TaskBase):
                             "velocity_threshold": self.velocity_threshold,
                         },
                     ),
+                    # TODO(qianl): replace objects_in_proximity with object_centroid_in_container
+                    # for tighter container placement checks.
                     TerminationTermCfg(
                         func=objects_in_proximity,
                         params={

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -57,9 +57,9 @@ class PickAndPlaceTask(TaskBase):
         task_description: str | None = None,
         force_threshold: float = 0.1,
         velocity_threshold: float = 0.1,
-        max_x_separation: float = 0.5,
-        max_y_separation: float = 0.5,
-        max_z_separation: float = 0.5,
+        max_x_separation: float = float("inf"),
+        max_y_separation: float = float("inf"),
+        max_z_separation: float = float("inf"),
         mimic_env_cfg_factory: Callable[[ArmMode], MimicEnvCfg] | None = None,
     ):
         super().__init__(episode_length_s=episode_length_s)

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -32,8 +32,9 @@ from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
 @register_task
 class PickAndPlaceTask(TaskBase):
     """Pick-and-place task. Success fires when the pick-up object contacts the destination
-    with low velocity and is within axis-aligned proximity of the destination. Failure
-    (object_dropped) fires when the object falls below the background's ``object_min_z``.
+    with low velocity and, when ``max_separation`` is set, is within axis-aligned proximity
+    of the destination. Failure (object_dropped) fires when the object falls below the
+    background's ``object_min_z``.
 
     The default Mimic cfg is ``PickPlaceMimicEnvCfg``. When a task needs a different cfg
     shape (different arm subtask sequences, different per-subtask numerical knobs,
@@ -57,9 +58,7 @@ class PickAndPlaceTask(TaskBase):
         task_description: str | None = None,
         force_threshold: float = 0.1,
         velocity_threshold: float = 0.1,
-        max_x_separation: float = float("inf"),
-        max_y_separation: float = float("inf"),
-        max_z_separation: float = float("inf"),
+        max_separation: tuple[float, float, float] | None = None,
         mimic_env_cfg_factory: Callable[[ArmMode], MimicEnvCfg] | None = None,
     ):
         super().__init__(episode_length_s=episode_length_s)
@@ -74,9 +73,9 @@ class PickAndPlaceTask(TaskBase):
         )
         self.force_threshold = force_threshold
         self.velocity_threshold = velocity_threshold
-        self.max_x_separation = max_x_separation
-        self.max_y_separation = max_y_separation
-        self.max_z_separation = max_z_separation
+        if max_separation is not None:
+            assert len(max_separation) == 3, f"max_separation must be (x, y, z), got {max_separation!r}"
+        self.max_separation = max_separation
         self.mimic_env_cfg_factory = mimic_env_cfg_factory
         self.events_cfg = None
         self.termination_cfg = self.make_termination_cfg()
@@ -93,33 +92,39 @@ class PickAndPlaceTask(TaskBase):
         return self.termination_cfg
 
     def make_termination_cfg(self):
+        predicates = [
+            TerminationTermCfg(
+                func=object_on_destination,
+                params={
+                    "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                    "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
+                    "force_threshold": self.force_threshold,
+                    "velocity_threshold": self.velocity_threshold,
+                },
+            ),
+        ]
+        if self.max_separation is not None:
+            # TODO(qianl): replace objects_in_proximity with object_centroid_in_container
+            # for tighter container placement checks.
+            # TODO (qianl): current implementation doesn't support ObjectReference as target_object_cfg.
+            max_x_separation, max_y_separation, max_z_separation = self.max_separation
+            predicates.append(
+                TerminationTermCfg(
+                    func=objects_in_proximity,
+                    params={
+                        "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                        "target_object_cfg": SceneEntityCfg(self.destination_location.name),
+                        "max_x_separation": max_x_separation,
+                        "max_y_separation": max_y_separation,
+                        "max_z_separation": max_z_separation,
+                    },
+                )
+            )
         success = TerminationTermCfg(
             func=check_success,
             params={
                 "mode": SuccessMode.ALL,
-                "predicates": [
-                    TerminationTermCfg(
-                        func=object_on_destination,
-                        params={
-                            "object_cfg": SceneEntityCfg(self.pick_up_object.name),
-                            "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
-                            "force_threshold": self.force_threshold,
-                            "velocity_threshold": self.velocity_threshold,
-                        },
-                    ),
-                    # TODO(qianl): replace objects_in_proximity with object_centroid_in_container
-                    # for tighter container placement checks.
-                    TerminationTermCfg(
-                        func=objects_in_proximity,
-                        params={
-                            "object_cfg": SceneEntityCfg(self.pick_up_object.name),
-                            "target_object_cfg": SceneEntityCfg(self.destination_location.name),
-                            "max_x_separation": self.max_x_separation,
-                            "max_y_separation": self.max_y_separation,
-                            "max_z_separation": self.max_z_separation,
-                        },
-                    ),
-                ],
+                "predicates": predicates,
             },
         )
         object_dropped = TerminationTermCfg(

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_grey_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_grey_bin_linked.yaml
@@ -31,6 +31,10 @@ tasks:
     pick_up_object: raisin_box
     destination_location: grey_bin
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
+    max_x_separation: 0.1
+    max_y_separation: 0.1
+    max_z_separation: 0.1
   description: Pick up the red raisin box and place it into the grey bin on the maple
     table.
   id: task_0_PickAndPlaceTask

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_grey_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_grey_bin_linked.yaml
@@ -32,9 +32,7 @@ tasks:
     destination_location: grey_bin
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-    max_x_separation: 0.1
-    max_y_separation: 0.1
-    max_z_separation: 0.1
+    max_separation: [0.1, 0.1, 0.1]
   description: Pick up the red raisin box and place it into the grey bin on the maple
     table.
   id: task_0_PickAndPlaceTask

--- a/isaaclab_arena_environments/robolab/tools_container_linked.yaml
+++ b/isaaclab_arena_environments/robolab/tools_container_linked.yaml
@@ -44,9 +44,7 @@ tasks:
     destination_location: bin_b04
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-    max_x_separation: 0.1
-    max_y_separation: 0.1
-    max_z_separation: 0.1
+    max_separation: [0.1, 0.1, 0.1]
   description: pick up the spring clamp and place it in the right bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/tools_container_linked.yaml
+++ b/isaaclab_arena_environments/robolab/tools_container_linked.yaml
@@ -44,6 +44,9 @@ tasks:
     destination_location: bin_b04
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_x_separation: 0.1
+    max_y_separation: 0.1
+    max_z_separation: 0.1
   description: pick up the spring clamp and place it in the right bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/two_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/two_bin_linked.yaml
@@ -32,9 +32,7 @@ tasks:
     destination_location: grey_bin_left
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-    max_x_separation: 0.1
-    max_y_separation: 0.1
-    max_z_separation: 0.1
+    max_separation: [0.1, 0.1, 0.1]
   description: put the mustard in the left bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/two_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/two_bin_linked.yaml
@@ -32,6 +32,9 @@ tasks:
     destination_location: grey_bin_left
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_x_separation: 0.1
+    max_y_separation: 0.1
+    max_z_separation: 0.1
   description: put the mustard in the left bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial


### PR DESCRIPTION
## Summary
Require proximity for pick-and-place success

## Detailed description
- What was the reason for the change?
Contact-only success can fire when the object grazes the destination edge; add `objects_in_proximity` as a second predicate under `check_success` (ALL).

- What has been changed?
Expose `max_separation` on `PickAndPlaceTask`. Default to None so objects_in_proximity is skipped for backward compatibility; set to 0.1 m on three robolab yamls with bins as the destination.

- What is the impact of this change?
Existing envs keep working with defaults unless center-to-destination distance exceeds the tolerance; tune per env via YAML if needed.