### PR TITLE
Sensitivity: MVP milestone-one analysis plots (parked)

### DIFF
--- a/eval/mvp_milestone_one_plots/README.md
+++ b/eval/mvp_milestone_one_plots/README.md
@@ -1,0 +1,57 @@
+# Sensitivity analysis — MVP milestone one plots
+
+Parked analysis artifacts from the first sensitivity-analysis milestone (June 2026): policy
+success rates and wrist-camera sensitivity for two policies, **pi** and **gn16**, across four
+manipulation tasks.
+
+The raw eval datasets (`episode_results.jsonl`) are intentionally **not** committed (kept on the
+host / mounted, per the repo's no-datasets rule). Only the scripts and generated plots are parked
+here. The scripts read the extracted datasets from `eval/<dataset>/...` and are run from the repo
+root inside the container.
+
+## Contents
+
+- `success_rate_pi_vs_gn16.png` — per-task success rate, pi vs gn16 (headline result).
+- `compare_pi_vs_gn16_camera.png` — wrist-camera posterior marginals (success-conditioned),
+  pi vs gn16, per axis (horizontal / vertical / depth).
+- `per_task_marginals/` — single-policy sensitivity reports per dataset (posterior marginals),
+  plus the success-vs-failure contrast for tools_container.
+- `scripts/success_barplot.py`, `scripts/compare_overlay.py` — the generators (paths point at
+  `eval/<dataset>/`).
+
+## Success rates
+
+| Task | pi | gn16 | ratio |
+|------|-----|------|-------|
+| bagel_on_plate | 65.4% (n=2000) | 8.5% (n=1000) | 7.7x |
+| objects_in_box | 55.3% (n=1800) | 15.3% (n=1000) | 3.6x |
+| two_bin_sort | 23.5% (n=1600) | 2.8% (n=1000) | 8.4x |
+| mustard_on_box* | 25.6% (n=1000) | 2.5% (n=1000) | - |
+
+pi outperforms gn16 on every task (3.6x–8.4x). gn16's best task is objects_in_box.
+
+\* The mustard row is **not a matched comparison**: pi ran `mustard_raisin` over 5 backgrounds,
+gn16 ran the `mustard_raisin_box` variant on `home_office` only. Shown for reference, not a clean
+model A/B. The other three rows are matched (same task and background per policy).
+
+## Source eval runs (pi | gn16)
+
+| Task | pi zip | gn16 zip |
+|------|--------|----------|
+| bagel_on_plate | 0625_2k_bagel_plate_banana_bowl_linked | 0625_1k_bagel_plate_banana_bowl_gn16 |
+| objects_in_box | 0625_2k_bin_mug_marker_bowl_linked_pi | 0625_1k_bin_mug_marker_bowl_gn16 |
+| two_bin_sort | 0625_1.6k_two_bin_pi | 06_25_1k_two_bin_gn16 |
+| mustard_on_box | 0625_1k_mustard_raisin_pi | 0625_1k_mustard_raisin_box_gn16 |
+
+## Sensitivity takeaways
+
+- All tasks vary the wrist-camera extrinsics (3-vector) and HDR background. Camera sensitivity is
+  read from the success-conditioned posterior marginal: concentration tighter than the uniform
+  prior means that axis matters.
+- Both policies broadly favor the camera near nominal. For pi the only axis with real
+  concentration is **vertical**; horizontal/depth are near-prior (insensitive). gn16's runs are in
+  the low-success regime (few successes), so its camera sensitivity is largely unresolved — the
+  bumps in its curves are sampling noise, not established preferences.
+- `P(displacement | success)` is normalized per policy, so these curves carry **no** information
+  about relative success rates between policies — read shape only (see the success-rate plot for
+  rates).

--- a/eval/mvp_milestone_one_plots/compare_pi_vs_gn16_camera.png
+++ b/eval/mvp_milestone_one_plots/compare_pi_vs_gn16_camera.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af91d9a7576fe936caba86363e932b62070f04143a0e6a90a71733f967352b81
+size 200479

--- a/eval/mvp_milestone_one_plots/per_task_marginals/bagel_gn16.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/bagel_gn16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ecdf0250e6ad340e75ded3072592f6ad2b4ea0b9410ab1c601f85da92aee5ed
+size 133544

--- a/eval/mvp_milestone_one_plots/per_task_marginals/mustard_box_gn16.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/mustard_box_gn16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cdfe83d23c6ea18b996b205c34084254ad2bd6af24d779235d686bfc82ab0e9
+size 129450

--- a/eval/mvp_milestone_one_plots/per_task_marginals/mustard_pi_5backgrounds.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/mustard_pi_5backgrounds.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a0c70327440ca52039d09f1e5940ddae91b75ec100d9e0cccb07b73ec88bb75
+size 202046

--- a/eval/mvp_milestone_one_plots/per_task_marginals/objects_in_box_gn16.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/objects_in_box_gn16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1d0054fb9bc1bfd727d5d212abfdc74970269b9ec9da973797cdd43e3c3ed6a
+size 135849

--- a/eval/mvp_milestone_one_plots/per_task_marginals/tools_container_gn16_failure.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/tools_container_gn16_failure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51d908fd10f0f187b5131cdfd73998a6278232ca7a8ebd135ef728e2fdf7f43f
+size 122187

--- a/eval/mvp_milestone_one_plots/per_task_marginals/tools_container_gn16_success.png
+++ b/eval/mvp_milestone_one_plots/per_task_marginals/tools_container_gn16_success.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58664cfa4dd107daf12e5a99621a48556e30e54c54886716a3a10459014e3635
+size 132251

--- a/eval/mvp_milestone_one_plots/scripts/compare_overlay.py
+++ b/eval/mvp_milestone_one_plots/scripts/compare_overlay.py
@@ -1,0 +1,58 @@
+# Overlay the wrist-camera posterior marginals of two datasets/models on shared axes.
+# Throwaway comparison script (not part of the package).
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from scipy.stats import gaussian_kde
+
+from isaaclab_arena.analysis.sensitivity.analyzer import SensitivityAnalyzer
+from isaaclab_arena.analysis.sensitivity.episode_results_reader import dataset_from_episode_results
+
+RUNS = [
+    ("pi", "eval/0625_1k_mustard_raisin_pi_combined.jsonl", "steelblue"),
+    ("gn16", "eval/0625_1k_mustard_raisin_box_gn16_combined.jsonl", "indianred"),
+]
+AXES = [f"droid_abs_joint_pos.camera_extrinsics_wrist_camera[{i}]" for i in range(3)]
+# Camera ROS frame x_right / y_down / z_forward -> horizontal / vertical / depth.
+AXIS_LABELS = ["horizontal (x)", "vertical (y)", "depth (z)"]
+GRID = np.linspace(-0.05, 0.05, 200)  # shared ±0.05 sweep range for both runs
+
+# Fit each run once and sample its success-conditioned posterior.
+samples_by_run = {}
+for label, path, _ in RUNS:
+    torch.manual_seed(0)
+    dataset = dataset_from_episode_results(path)
+    analyzer = SensitivityAnalyzer(dataset)
+    analyzer.fit()
+    samples = analyzer.sample_posterior(dataset.default_observation()).cpu().numpy()
+    cols = dataset.factor_columns
+    n_succ = int(dataset.x[:, 0].sum())
+    samples_by_run[label] = (samples, cols, n_succ)
+
+figure, axes = plt.subplots(1, 3, figsize=(18, 4.5), squeeze=False)
+for axis_index, axis_name in enumerate(AXES):
+    ax = axes[0][axis_index]
+    for label, _, color in RUNS:
+        samples, cols, n_succ = samples_by_run[label]
+        values = samples[:, cols[axis_name]].squeeze(-1)
+        density = gaussian_kde(values)(GRID)
+        ax.plot(GRID, density, color=color, linewidth=2, label=label)
+        ax.fill_between(GRID, 0, density, color=color, alpha=0.12)
+    ax.axhline(1.0 / 0.1, color="grey", linestyle="--", linewidth=1.3, label="prior (uniform)")
+    ax.set_xlabel(f"wrist camera {AXIS_LABELS[axis_index]} displacement", fontsize=13)
+    ax.set_ylabel("posterior density", fontsize=13)
+    ax.set_xlim(-0.05, 0.05)
+    ax.set_ylim(bottom=0)
+    ax.grid(alpha=0.3)
+    ax.tick_params(labelsize=11)
+    ax.legend(fontsize=11)
+
+figure.suptitle(
+    "Wrist-camera posterior marginals (conditioned on success): pi vs gn16",
+    fontsize=16,
+    fontweight="bold",
+)
+figure.tight_layout(rect=[0, 0, 1, 0.95])
+out = "eval/compare_pi_vs_gn16_camera.png"
+figure.savefig(out, dpi=150, bbox_inches="tight")
+print(f"[INFO] wrote {out}")

--- a/eval/mvp_milestone_one_plots/scripts/success_barplot.py
+++ b/eval/mvp_milestone_one_plots/scripts/success_barplot.py
@@ -1,0 +1,70 @@
+# Grouped bar chart: per-task success rate, pi vs gn16. Throwaway analysis script.
+import glob
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# task label -> (pi glob, gn16 glob)
+TASKS = [
+    (
+        "bagel_on_plate",
+        "eval/0625_2k_bagel_plate_banana_bowl_linked/overnight2_runs/*/episode_results_rank0.jsonl",
+        "eval/0625_1k_bagel_plate_banana_bowl_gn16/*/*/episode_results_rank0.jsonl",
+    ),
+    (
+        "objects_in_box",
+        "eval/0625_2k_bin_mug_marker_bowl_linked_pi/runs_jsonl/*/episode_results_rank0.jsonl",
+        "eval/0625_1k_bin_mug_marker_bowl_gn16/*/*/episode_results_rank0.jsonl",
+    ),
+    (
+        "two_bin_sort",
+        "eval/0625_1.6k_two_bin_pi/*/*/episode_results_rank0.jsonl",
+        "eval/06_25_1k_two_bin_gn16/**/episode_results_rank0.jsonl",
+    ),
+    (
+        "mustard_on_box",
+        "eval/0625_1k_mustard_raisin_pi/chunk*/episode_results_rank0.jsonl",
+        "eval/0625_1k_mustard_raisin_box_gn16/*/*/episode_results_rank0.jsonl",
+    ),
+]
+
+
+def rate(pattern):
+    rows = [json.loads(line) for f in sorted(glob.glob(pattern, recursive=True)) for line in open(f) if line.strip()]
+    n = len(rows)
+    s = sum(bool(r["success"]) for r in rows)
+    return s / n, n
+
+
+labels = [t[0] for t in TASKS]
+pi = [rate(t[1]) for t in TASKS]
+gn = [rate(t[2]) for t in TASKS]
+for lbl, (pp, pn), (gp, gn_) in zip(labels, pi, gn):
+    print(f"{lbl:26s} pi {pp:.1%} (n={pn})   gn16 {gp:.1%} (n={gn_})")
+
+x = np.arange(len(TASKS))
+width = 0.38
+figure, ax = plt.subplots(figsize=(11, 5.5))
+b1 = ax.bar(x - width / 2, [100 * p for p, _ in pi], width, color="steelblue", label="pi")
+b2 = ax.bar(x + width / 2, [100 * p for p, _ in gn], width, color="indianred", label="gn16")
+
+for bars, data in ((b1, pi), (b2, gn)):
+    for rect, (p, n) in zip(bars, data):
+        ax.annotate(
+            f"{p:.1%}\n(n={n})", (rect.get_x() + rect.get_width() / 2, rect.get_height()),
+            textcoords="offset points", xytext=(0, 3), ha="center", fontsize=10,
+        )
+
+ax.set_xticks(x)
+ax.set_xticklabels(labels, fontsize=12)
+ax.set_ylabel("success rate (%)", fontsize=13)
+ax.set_ylim(0, 75)
+ax.set_title("Policy success rate by task: pi vs gn16", fontsize=15, fontweight="bold")
+ax.tick_params(axis="y", labelsize=11)
+ax.legend(fontsize=12)
+ax.grid(alpha=0.3, axis="y")
+figure.tight_layout()
+out = "eval/success_rate_pi_vs_gn16.png"
+figure.savefig(out, dpi=150, bbox_inches="tight")
+print(f"[INFO] wrote {out}")

--- a/eval/mvp_milestone_one_plots/success_rate_pi_vs_gn16.png
+++ b/eval/mvp_milestone_one_plots/success_rate_pi_vs_gn16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56724e09795f29f20337c9ab875bc754a0e4590d417553a931b6bc57167324de
+size 78315


### PR DESCRIPTION
## Summary
Park MVP milestone-one sensitivity plots

## Detailed description
- Reason: preserve the first milestone's analysis (pi vs gn16 success rates and wrist-camera sensitivity) so the figures and their generator scripts aren't lost as local scratch.
- What: adds eval/mvp_milestone_one_plots/ — the per-task success-rate bar chart, the wrist-camera posterior overlay, per-task sensitivity reports, the two generator scripts, and a README with the findings table.
- Impact: artifacts only; no package code changes. Raw eval datasets are deliberately not committed (kept on host per repo policy). Draft / parked, not intended to merge as-is.