### PR TITLE
Ignore Isaac Sim core dumps in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 /.git
 /.agents
 /.claude
+# Isaac Sim crash core dumps — ~3GB each; otherwise pulled into the image by `COPY *.*`
+core.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,4 @@
 /.agents
 /.claude
 # Isaac Sim crash core dumps — ~3GB each; otherwise pulled into the image by `COPY *.*`
-core.*
+/core.*


### PR DESCRIPTION
## Summary
IsaacSim SimApp Crash core dumps (core.*, ~3GB each) accumulate in the repo root and were pulled into the image by 'COPY *.*', bloating it by tens of GB. Exclude them via .dockerignore.