### PR TITLE
 Default episode_length_s to 20s for all tasks

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -338,8 +338,7 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
-            # Tasks always resolve to a concrete episode length; apply it to RL/eval envs.
-            # Mimic/data-gen keeps its own (longer) cfg default so demos are not truncated.
+            # Tasks always resolve to a concrete episode length.
             env_cfg.episode_length_s = episode_length_s
         else:
             assert not isinstance(embodiment, NoEmbodiment), "Mimic mode requires an embodiment to be specified"

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -338,6 +338,9 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
+            # Tasks always resolve to a concrete episode length; apply it to RL/eval envs.
+            # Mimic/data-gen keeps its own (longer) cfg default so demos are not truncated.
+            env_cfg.episode_length_s = episode_length_s
         else:
             assert not isinstance(embodiment, NoEmbodiment), "Mimic mode requires an embodiment to be specified"
             assert not isinstance(task, NoTask), "Mimic mode requires a task to be specified"
@@ -366,9 +369,6 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
-
-        # Tasks always resolve to a concrete episode length
-        env_cfg.episode_length_s = episode_length_s
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -338,8 +338,6 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
-            if episode_length_s is not None:
-                env_cfg.episode_length_s = episode_length_s
         else:
             assert not isinstance(embodiment, NoEmbodiment), "Mimic mode requires an embodiment to be specified"
             assert not isinstance(task, NoTask), "Mimic mode requires a task to be specified"
@@ -368,6 +366,9 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
+
+        # Tasks always resolve to a concrete episode length
+        env_cfg.episode_length_s = episode_length_s
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -93,4 +93,7 @@ class IsaacArenaManagerBasedMimicEnvCfg(IsaacLabArenaManagerBasedRLEnvCfg, Mimic
     # datagen_config: DataGenConfig = DataGenConfig()
     # subtask_configs: dict[str, list[SubTaskConfig]] = {}
     # task_constraint_configs: list[SubTaskConstraintConfig] = []
-    pass
+
+    # Data generation keeps the longer historical default so demos are not truncated; the task's
+    # (shorter) episode length is only applied to non-mimic RL/eval envs by the env builder.
+    episode_length_s: float = 50.0

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -81,7 +81,6 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
         ),
     )
     decimation: int = 4
-    episode_length_s: float = 50.0
     wait_for_textures: bool = False
 
 

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,8 +17,10 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
+    DEFAULT_EPISODE_LENGTH_S: float = 20.0
+
     def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
-        self.episode_length_s = episode_length_s
+        self.episode_length_s = episode_length_s if episode_length_s is not None else self.DEFAULT_EPISODE_LENGTH_S
         self.task_description = task_description
 
     @abstractmethod
@@ -59,7 +61,7 @@ class TaskBase(ABC):
     def get_viewer_cfg(self) -> ViewerCfg:
         return ViewerCfg()
 
-    def get_episode_length_s(self) -> float | None:
+    def get_episode_length_s(self) -> float:
         return self.episode_length_s
 
     def get_task_description(self) -> str | None:

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,11 +17,10 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
+    DEFAULT_EPISODE_LENGTH_S: float = 20.0
+
     def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
-        # Coalesce None -> 20s here (not via a param default): subclasses declare
-        # `episode_length_s: float | None = None` and forward it verbatim, so a bare param default
-        # would be bypassed and leave episode_length_s = None for tasks built without an explicit value.
-        self.episode_length_s = episode_length_s if episode_length_s is not None else 20.0
+        self.episode_length_s = episode_length_s if episode_length_s is not None else self.DEFAULT_EPISODE_LENGTH_S
         self.task_description = task_description
 
     @abstractmethod

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -18,11 +18,7 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 class TaskBase(ABC):
 
     def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
-        # Default to 20s when unset (subclasses forward None, so this stays the single coalescing
-        # point rather than a per-signature default). The env builder applies this to RL/eval envs;
-        # mimic/data-gen envs ignore it and keep their own 50s cfg default. NOTE: this 20s literal is
-        # kept in sync by hand with the intent compiler's generation default
-        # (agentic_environment_generation/default_params.py::DEFAULT_EPISODE_LENGTH_S).
+        # Default to 20s when unset.
         self.episode_length_s = episode_length_s if episode_length_s is not None else 20.0
         self.task_description = task_description
 

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,8 +17,11 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
-    def __init__(self, episode_length_s: float = 20.0, task_description: str | None = None):
-        self.episode_length_s = episode_length_s
+    def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
+        # Coalesce None -> 20s here (not via a param default): subclasses declare
+        # `episode_length_s: float | None = None` and forward it verbatim, so a bare param default
+        # would be bypassed and leave episode_length_s = None for tasks built without an explicit value.
+        self.episode_length_s = episode_length_s if episode_length_s is not None else 20.0
         self.task_description = task_description
 
     @abstractmethod

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,6 +17,10 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
+    # Runtime fallback episode length (seconds) when a task is built without one. The env builder
+    # applies this to RL/eval envs; mimic/data-gen envs ignore it and keep their own 50s cfg default.
+    # NOTE: kept in sync by hand with the intent compiler's generation default
+    # (agentic_environment_generation/default_params.py::DEFAULT_EPISODE_LENGTH_S).
     DEFAULT_EPISODE_LENGTH_S: float = 20.0
 
     def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,9 +17,8 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
-    def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
-        # Default to 20s when unset.
-        self.episode_length_s = episode_length_s if episode_length_s is not None else 20.0
+    def __init__(self, episode_length_s: float = 20.0, task_description: str | None = None):
+        self.episode_length_s = episode_length_s
         self.task_description = task_description
 
     @abstractmethod

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -17,14 +17,13 @@ from isaaclab_arena.tasks.task_transition import TaskTransition
 
 class TaskBase(ABC):
 
-    # Runtime fallback episode length (seconds) when a task is built without one. The env builder
-    # applies this to RL/eval envs; mimic/data-gen envs ignore it and keep their own 50s cfg default.
-    # NOTE: kept in sync by hand with the intent compiler's generation default
-    # (agentic_environment_generation/default_params.py::DEFAULT_EPISODE_LENGTH_S).
-    DEFAULT_EPISODE_LENGTH_S: float = 20.0
-
     def __init__(self, episode_length_s: float | None = None, task_description: str | None = None):
-        self.episode_length_s = episode_length_s if episode_length_s is not None else self.DEFAULT_EPISODE_LENGTH_S
+        # Default to 20s when unset (subclasses forward None, so this stays the single coalescing
+        # point rather than a per-signature default). The env builder applies this to RL/eval envs;
+        # mimic/data-gen envs ignore it and keep their own 50s cfg default. NOTE: this 20s literal is
+        # kept in sync by hand with the intent compiler's generation default
+        # (agentic_environment_generation/default_params.py::DEFAULT_EPISODE_LENGTH_S).
+        self.episode_length_s = episode_length_s if episode_length_s is not None else 20.0
         self.task_description = task_description
 
     @abstractmethod

--- a/isaaclab_arena/tests/test_task_base.py
+++ b/isaaclab_arena/tests/test_task_base.py
@@ -3,45 +3,43 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Data-only unit tests for TaskBase defaults (no SimulationApp required)."""
+"""Regression tests for TaskBase episode-length defaults."""
 
-from __future__ import annotations
-
-from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
 
 
-class _StubTask(TaskBase):
-    """Minimal concrete task that mirrors the real subclasses' constructor pattern.
+def _test_episode_length_defaults(simulation_app) -> bool:
+    from isaaclab_arena.tasks.task_base import TaskBase
 
-    Like PickAndPlaceTask et al., it declares ``episode_length_s: float | None = None`` and forwards
-    it verbatim to ``super().__init__`` — the case that must still coalesce to the 20s default.
-    """
+    class _StubTask(TaskBase):
+        """Mirrors the real subclasses: declares ``episode_length_s: float | None = None`` and forwards it."""
 
-    def __init__(self, episode_length_s: float | None = None):
-        super().__init__(episode_length_s=episode_length_s)
+        def __init__(self, episode_length_s: float | None = None):
+            super().__init__(episode_length_s=episode_length_s)
 
-    def get_scene_cfg(self):
-        return None
+        def get_scene_cfg(self):
+            return None
 
-    def get_termination_cfg(self):
-        return None
+        def get_termination_cfg(self):
+            return None
 
-    def get_events_cfg(self):
-        return None
+        def get_events_cfg(self):
+            return None
 
-    def get_mimic_env_cfg(self, arm_mode):
-        return None
+        def get_mimic_env_cfg(self, arm_mode):
+            return None
 
-    def get_metrics(self):
-        return []
+        def get_metrics(self):
+            return []
 
-
-def test_episode_length_defaults_to_20s_when_subclass_forwards_none():
-    # Regression guard: a bare `episode_length_s: float = 20.0` param default would be bypassed by
-    # subclasses forwarding None, leaving episode_length_s = None and breaking episode-length setup.
+    # Regression: a bare ``episode_length_s: float = 20.0`` param default is bypassed by subclasses
+    # forwarding None, which would leave episode_length_s = None and break episode-length setup.
     assert _StubTask().get_episode_length_s() == 20.0
     assert _StubTask(episode_length_s=None).get_episode_length_s() == 20.0
-
-
-def test_explicit_episode_length_is_preserved():
     assert _StubTask(episode_length_s=5.0).get_episode_length_s() == 5.0
+    return True
+
+
+def test_episode_length_defaults():
+    result = run_simulation_app_function(_test_episode_length_defaults)
+    assert result

--- a/isaaclab_arena/tests/test_task_base.py
+++ b/isaaclab_arena/tests/test_task_base.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Data-only unit tests for TaskBase defaults (no SimulationApp required)."""
+
+from __future__ import annotations
+
+from isaaclab_arena.tasks.task_base import TaskBase
+
+
+class _StubTask(TaskBase):
+    """Minimal concrete task that mirrors the real subclasses' constructor pattern.
+
+    Like PickAndPlaceTask et al., it declares ``episode_length_s: float | None = None`` and forwards
+    it verbatim to ``super().__init__`` — the case that must still coalesce to the 20s default.
+    """
+
+    def __init__(self, episode_length_s: float | None = None):
+        super().__init__(episode_length_s=episode_length_s)
+
+    def get_scene_cfg(self):
+        return None
+
+    def get_termination_cfg(self):
+        return None
+
+    def get_events_cfg(self):
+        return None
+
+    def get_mimic_env_cfg(self, arm_mode):
+        return None
+
+    def get_metrics(self):
+        return []
+
+
+def test_episode_length_defaults_to_20s_when_subclass_forwards_none():
+    # Regression guard: a bare `episode_length_s: float = 20.0` param default would be bypassed by
+    # subclasses forwarding None, leaving episode_length_s = None and breaking episode-length setup.
+    assert _StubTask().get_episode_length_s() == 20.0
+    assert _StubTask(episode_length_s=None).get_episode_length_s() == 20.0
+
+
+def test_explicit_episode_length_is_preserved():
+    assert _StubTask(episode_length_s=5.0).get_episode_length_s() == 5.0


### PR DESCRIPTION
## Summary
 Default episode_length_s to 20s for all tasks

## Detailed description
- Default `episode_length_s` to 20 s for all tasks via `TaskBase` instead of the per-env-cfg fallback (50s).
- Does not affect envs used in IL-interop and RL-interop example workflows
