### PR TITLE
Add 11 new robolab pick and place envs

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -677,6 +677,15 @@ class GreenContainer(LibraryObject):
 
 
 @register_asset
+class PurpleCrate(LibraryObject):
+    """A purple KLT container."""
+
+    name = "purple_crate"
+    tags = ["object", "container"]
+    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/KLT_Bin/small_KLT.usd"
+
+
+@register_asset
 class BlueBlockBasicRobolab(LibraryObject):
     # TODO(cvolk): pick_and_place success termination does not consistently trigger
     # with this asset even when the block is placed in the destination.

--- a/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: banana_bowl
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: banana
+  name: banana_ycb_robolab
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: banana
+    destination_location: bowl
+    background_scene: maple_table_robolab
+  description: pick up the banana and place it in the bowl
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: banana
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_banana
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: banana
+    reference: bowl
+    params: {}
+    id: state_spec_1_banana_on_bowl
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
@@ -27,6 +27,7 @@ tasks:
     pick_up_object: banana
     destination_location: bowl
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: pick up the banana and place it in the bowl
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
@@ -68,6 +68,7 @@ tasks:
     destination_location: grey_bin
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
   description: pick up the coffee pot and place it into the grey bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bin_condiments
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: coffee_pot
+  name: coffee_pot_hot3d_robolab
+  type: object
+  params: {}
+- id: grey_bin
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: mug
+  name: mug
+  type: object
+  params: {}
+- id: mustard
+  name: mustard_bottle_hope_robolab
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+- id: ranch_dressing
+  name: ranch_dressing_hope_robolab
+  type: object
+  params: {}
+- id: bbq_sauce_bottle_1
+  name: bbq_sauce_bottle_hope_robolab
+  type: object
+  params: {}
+- id: bbq_sauce_bottle_2
+  name: bbq_sauce_bottle_hope_robolab
+  type: object
+  params: {}
+- id: oatmeal_raisin_cookies
+  name: oatmeal_raisin_cookies_hope_robolab
+  type: object
+  params: {}
+- id: canned_tuna
+  name: canned_tuna_hope_robolab
+  type: object
+  params: {}
+- id: soft_scrub
+  name: soft_scrub_ycb_robolab
+  type: object
+  params: {}
+- id: wood_block
+  name: wood_block_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: coffee_pot
+    destination_location: grey_bin
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: pick up the coffee pot and place it into the grey bin
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: coffee_pot
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_coffee_pot
+  - kind: 'on'
+    subject: grey_bin
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_grey_bin
+  - kind: 'on'
+    subject: mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_mug
+  - kind: 'on'
+    subject: mustard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_mustard
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: ranch_dressing
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_ranch_dressing
+  - kind: 'on'
+    subject: bbq_sauce_bottle_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_bbq_sauce_bottle_1
+  - kind: 'on'
+    subject: bbq_sauce_bottle_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_bbq_sauce_bottle_2
+  - kind: 'on'
+    subject: oatmeal_raisin_cookies
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_oatmeal_raisin_cookies
+  - kind: 'on'
+    subject: canned_tuna
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_canned_tuna
+  - kind: 'on'
+    subject: soft_scrub
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_soft_scrub
+  - kind: 'on'
+    subject: wood_block
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_wood_block
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: coffee_pot
+    reference: grey_bin
+    params: {}
+    id: state_spec_1_coffee_pot_on_grey_bin
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
@@ -35,6 +35,7 @@ tasks:
     pick_up_object: bbq_sauce_bottle
     destination_location: purple_crate
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: place the bbq sauce bottle into the purple crate on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bottles_crate
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: bbq_sauce_bottle
+  name: bbq_sauce_bottle_hope_robolab
+  type: object
+  params: {}
+- id: purple_crate
+  name: purple_crate
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: salad_dressing_bottle
+  name: salad_dressing_bottle_hot3d_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: bbq_sauce_bottle
+    destination_location: purple_crate
+    background_scene: maple_table_robolab
+  description: place the bbq sauce bottle into the purple crate on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: bbq_sauce_bottle
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_bbq_sauce_bottle
+  - kind: 'on'
+    subject: purple_crate
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_purple_crate
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: salad_dressing_bottle
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_salad_dressing_bottle
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: bbq_sauce_bottle
+    reference: purple_crate
+    params: {}
+    id: state_spec_1_bbq_sauce_bottle_on_purple_crate
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
@@ -36,6 +36,7 @@ tasks:
     destination_location: purple_crate
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
   description: place the bbq sauce bottle into the purple crate on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
@@ -49,6 +49,13 @@ state_specs:
     reference: maple_table_robolab
     params: {}
     id: state_initial_2_on_maple_table_robolab_raisin_box_hope_robolab
+  # TODO: support rotate around solution from the agent intent spec
+  - kind: 'rotate_around_solution'
+    subject: raisin_box_hope_robolab
+    params: {
+      pitch_rad: 1.57
+    }
+    id: state_initial_3_rotate_around_solution_raisin_box
   task_constraints: []
 - id: state_spec_1
   is_delta: true

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: butter_raisin_box
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: butter_hope_robolab
+  name: butter_hope_robolab
+  type: object
+  params: {}
+- id: raisin_box_hope_robolab
+  name: raisin_box_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: butter_hope_robolab
+    destination_location: raisin_box_hope_robolab
+    background_scene: maple_table_robolab
+  description: pick up the butter box and place it on top of the raisin box
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: butter_hope_robolab
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_butter_hope_robolab
+  - kind: 'on'
+    subject: raisin_box_hope_robolab
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_raisin_box_hope_robolab
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: butter_hope_robolab
+    reference: raisin_box_hope_robolab
+    params: {}
+    id: state_spec_1_butter_hope_robolab_on_raisin_box_hope_robolab
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
@@ -27,6 +27,7 @@ tasks:
     pick_up_object: butter_hope_robolab
     destination_location: raisin_box_hope_robolab
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: pick up the butter box and place it on top of the raisin box
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
@@ -16,7 +16,8 @@ nodes:
 - id: pumpkin_large
   name: pumpkinlarge_vomp_robolab
   type: object
-  params: {}
+  params:
+    scale: [1.25, 1.25, 1.25]
 - id: pumpkin_small
   name: pumpkinsmall_vomp_robolab
   type: object

--- a/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
@@ -1,0 +1,188 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clutter_fruit_bottle_bluebin
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: pumpkin_large
+  name: pumpkinlarge_vomp_robolab
+  type: object
+  params: {}
+- id: pumpkin_small
+  name: pumpkinsmall_vomp_robolab
+  type: object
+  params: {}
+- id: lemon_1
+  name: lemon_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lemon_2
+  name: lemon_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lime_1
+  name: lime01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lime_2
+  name: lime01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: orange_1
+  name: orange_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: orange_2
+  name: orange_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: pomegranate
+  name: pomegranate01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: white_packer_bottle
+  name: whitepackerbottle_a01_vomp_robolab
+  type: object
+  params: {}
+- id: avocado
+  name: avocado01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: crabbypenholder
+  name: crabbypenholder_vomp_robolab
+  type: object
+  params: {}
+- id: serving_bowl
+  name: serving_bowl_vomp_robolab
+  type: object
+  params: {}
+- id: utilityjug
+  name: utilityjug_a01_vomp_robolab
+  type: object
+  params: {}
+- id: red_onion
+  name: red_onion_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: container_f24
+  name: container_f24_vomp_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: pumpkin_large
+    destination_location: container_f24
+    background_scene: maple_table_robolab
+  description: pick up the large pumpkin and place it into the container_f24 bin
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: pumpkin_large
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_pumpkin_large
+  - kind: 'on'
+    subject: pumpkin_small
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_pumpkin_small
+  - kind: 'on'
+    subject: lemon_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_lemon_1
+  - kind: 'on'
+    subject: lemon_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_lemon_2
+  - kind: 'on'
+    subject: lime_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_lime_1
+  - kind: 'on'
+    subject: lime_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_lime_2
+  - kind: 'on'
+    subject: orange_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_orange_1
+  - kind: 'on'
+    subject: orange_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_orange_2
+  - kind: 'on'
+    subject: pomegranate
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_pomegranate
+  - kind: 'on'
+    subject: white_packer_bottle
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_white_packer_bottle
+  - kind: 'on'
+    subject: avocado
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_avocado
+  - kind: 'on'
+    subject: crabbypenholder
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_crabbypenholder
+  - kind: 'on'
+    subject: serving_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_serving_bowl
+  - kind: 'on'
+    subject: utilityjug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_14_on_maple_table_robolab_utilityjug
+  - kind: 'on'
+    subject: red_onion
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_15_on_maple_table_robolab_red_onion
+  - kind: 'on'
+    subject: container_f24
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_16_on_maple_table_robolab_container_f24
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: pumpkin_large
+    reference: container_f24
+    params: {}
+    id: state_spec_1_pumpkin_large_on_container_f24
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
@@ -84,7 +84,8 @@ tasks:
     pick_up_object: pumpkin_large
     destination_location: container_f24
     background_scene: maple_table_robolab
-  description: pick up the large pumpkin and place it into the container_f24 bin
+    episode_length_s: 20.0
+  description: pick up the large pumpkin and place it into the bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1

--- a/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
@@ -85,6 +85,7 @@ tasks:
     destination_location: container_f24
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
   description: pick up the large pumpkin and place it into the bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
+++ b/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
@@ -67,6 +67,13 @@ state_specs:
     reference: maple_table_robolab
     params: {}
     id: state_initial_4_on_maple_table_robolab_tomato_soup_can
+  # TODO: support rotate around solution from the agent intent spec
+  - kind: 'rotate_around_solution'
+    subject: tomato_soup_can
+    params: {
+      roll_rad: -1.57
+    }
+    id: state_initial_5_rotate_around_solution_tomato_soup_can
   task_constraints: []
 - id: state_spec_1
   is_delta: true

--- a/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
+++ b/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
@@ -35,7 +35,8 @@ tasks:
     pick_up_object: cheez_it_box
     destination_location: bin_a06
     background_scene: maple_table_robolab
-  description: pick up the cheez it box and place it into the bin a06
+    episode_length_s: 20.0
+  description: pick up the cheez it box and place it into the bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1

--- a/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
+++ b/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: foodpacking_1bin_1box_1can
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: cheez_it_box
+  name: cheez_it_ycb_robolab
+  type: object
+  params: {}
+- id: bin_a06
+  name: bin_a06_vomp_robolab
+  type: object
+  params: {}
+- id: mustard
+  name: mustard_bottle_hope_robolab
+  type: object
+  params: {}
+- id: tomato_soup_can
+  name: tomato_soup_can
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: cheez_it_box
+    destination_location: bin_a06
+    background_scene: maple_table_robolab
+  description: pick up the cheez it box and place it into the bin a06
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: cheez_it_box
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_cheez_it_box
+  - kind: 'on'
+    subject: bin_a06
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_bin_a06
+  - kind: 'on'
+    subject: mustard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_mustard
+  - kind: 'on'
+    subject: tomato_soup_can
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_tomato_soup_can
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: cheez_it_box
+    reference: bin_a06
+    params: {}
+    id: state_spec_1_cheez_it_box_on_bin_a06
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
+++ b/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
@@ -36,6 +36,7 @@ tasks:
     destination_location: bin_a06
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
   description: pick up the cheez it box and place it into the bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/mustard_raisin_box_linked.yaml
+++ b/isaaclab_arena_environments/robolab/mustard_raisin_box_linked.yaml
@@ -54,7 +54,7 @@ state_specs:
   - kind: 'rotate_around_solution'
     subject: raisin_box
     params: {
-      pitch_rad: 90.0
+      pitch_rad: 1.57
     }
     id: state_initial_3_rotate_around_solution_raisin_box
   task_constraints: []

--- a/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube_banana_bowl
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: banana
+  name: banana_ycb_robolab
+  type: object
+  params: {}
+- id: cube
+  name: dex_cube
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: banana
+    destination_location: bowl
+    background_scene: maple_table_robolab
+  description: pick up the banana and place it in the bowl
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: cube
+    destination_location: bowl
+    background_scene: maple_table_robolab
+  description: pick up the cube and place it in the bowl
+  id: task_1_PickAndPlaceTask
+  initial_state_spec_id: state_spec_1
+  success_state_spec_id: state_spec_2
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: banana
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_banana
+  - kind: 'on'
+    subject: cube
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_cube
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: banana
+    reference: bowl
+    params: {}
+    id: state_spec_1_banana_on_bowl
+  task_constraints: []
+- id: state_spec_2
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: cube
+    reference: bowl
+    params: {}
+    id: state_spec_2_cube_on_bowl
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
@@ -31,6 +31,7 @@ tasks:
     pick_up_object: banana
     destination_location: bowl
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: pick up the banana and place it in the bowl
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
@@ -40,6 +41,7 @@ tasks:
     pick_up_object: cube
     destination_location: bowl
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: pick up the cube and place it in the bowl
   id: task_1_PickAndPlaceTask
   initial_state_spec_id: state_spec_1

--- a/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
@@ -27,6 +27,7 @@ tasks:
     pick_up_object: rubiks_cube
     destination_location: bowl
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: put the rubiks cube in the bowl
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube_bowl
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: rubiks_cube
+  name: rubiks_cube_hot3d_robolab
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: rubiks_cube
+    destination_location: bowl
+    background_scene: maple_table_robolab
+  description: put the rubiks cube in the bowl
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: rubiks_cube
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_rubiks_cube
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: rubiks_cube
+    reference: bowl
+    params: {}
+    id: state_spec_1_rubiks_cube_on_bowl
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk_bin
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: lizard_figurine
+  name: lizard_figurine_hot3d_robolab
+  type: object
+  params: {}
+- id: grey_bin
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params: {}
+- id: spoon_big
+  name: spoon_big_vomp_robolab
+  type: object
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: granola_bar
+  name: granola_bars_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: lizard_figurine
+    destination_location: grey_bin
+    background_scene: maple_table_robolab
+  description: place the lizard figurine into the grey bin on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_lizard_figurine
+  - kind: 'on'
+    subject: grey_bin
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_grey_bin
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: spoon_big
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_spoon_big
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: granola_bar
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_granola_bar
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: grey_bin
+    params: {}
+    id: state_spec_1_lizard_figurine_on_grey_bin
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
@@ -69,6 +69,7 @@ tasks:
     destination_location: grey_bin
     background_scene: maple_table_robolab
     episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
   description: place the lizard figurine into the grey bin on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
@@ -68,6 +68,7 @@ tasks:
     pick_up_object: lizard_figurine
     destination_location: grey_bin
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: place the lizard figurine into the grey bin on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
@@ -44,7 +44,8 @@ nodes:
 - id: wooden_bowl
   name: wooden_bowl_hot3d_robolab
   type: object
-  params: {}
+  params:
+    scale: [0.5, 0.5, 0.5]
 - id: spoon_big
   name: spoon_big_vomp_robolab
   type: object

--- a/isaaclab_arena_environments/robolab/workdesk_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_linked.yaml
@@ -52,7 +52,8 @@ nodes:
 - id: wooden_bowl
   name: wooden_bowl_hot3d_robolab
   type: object
-  params: {}
+  params:
+    scale: [0.5, 0.5, 0.5]
 - id: yogurt_cup
   name: yogurt_cup_hope_robolab
   type: object

--- a/isaaclab_arena_environments/robolab/workdesk_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_linked.yaml
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: keyboard
+  name: keyboard_hot3d_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: lizard_figurine
+  name: lizard_figurine_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: rubiks_cube
+  name: rubiks_cube_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params: {}
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: oatmeal_raisin_cookies
+  name: oatmeal_raisin_cookies_hope_robolab
+  type: object
+  params: {}
+- id: granola_bar
+  name: granola_bars_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: computer_mouse
+    destination_location: keyboard
+    background_scene: maple_table_robolab
+  description: place the computer mouse into the keyboard on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: keyboard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_keyboard
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_lizard_figurine
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: rubiks_cube
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_rubiks_cube
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: oatmeal_raisin_cookies
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_oatmeal_raisin_cookies
+  - kind: 'on'
+    subject: granola_bar
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_14_on_maple_table_robolab_granola_bar
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: computer_mouse
+    reference: keyboard
+    params: {}
+    id: state_spec_1_computer_mouse_on_keyboard
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_linked.yaml
@@ -73,7 +73,7 @@ tasks:
     destination_location: keyboard
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: place the computer mouse into the keyboard on the table
+  description: place the computer mouse on the keyboard
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -139,17 +139,17 @@ state_specs:
     subject: yogurt_cup
     reference: maple_table_robolab
     params: {}
-    id: state_initial_12_on_maple_table_robolab_yogurt_cup
+    id: state_initial_11_on_maple_table_robolab_yogurt_cup
   - kind: 'on'
     subject: oatmeal_raisin_cookies
     reference: maple_table_robolab
     params: {}
-    id: state_initial_13_on_maple_table_robolab_oatmeal_raisin_cookies
+    id: state_initial_12_on_maple_table_robolab_oatmeal_raisin_cookies
   - kind: 'on'
     subject: granola_bar
     reference: maple_table_robolab
     params: {}
-    id: state_initial_14_on_maple_table_robolab_granola_bar
+    id: state_initial_13_on_maple_table_robolab_granola_bar
   task_constraints: []
 - id: state_spec_1
   is_delta: true

--- a/isaaclab_arena_environments/robolab/workdesk_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_linked.yaml
@@ -72,6 +72,7 @@ tasks:
     pick_up_object: computer_mouse
     destination_location: keyboard
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: place the computer mouse into the keyboard on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk_snacks
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: apple
+  name: apple_01_objaverse_robolab
+  type: object
+  params: {}
+- id: plasticpail
+  name: plasticpail_a02_vomp_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: keyboard
+  name: keyboard_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params: {}
+- id: spoon_big
+  name: spoon_big_vomp_robolab
+  type: object
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: pitcher
+  name: pitcher_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: apple
+    destination_location: plasticpail
+    background_scene: maple_table_robolab
+  description: place the apple into the plasticpail on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: apple
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_apple
+  - kind: 'on'
+    subject: plasticpail
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_plasticpail
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: keyboard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_keyboard
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: spoon_big
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_spoon_big
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: pitcher
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_pitcher
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: apple
+    reference: plasticpail
+    params: {}
+    id: state_spec_1_apple_on_plasticpail
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
@@ -48,7 +48,8 @@ nodes:
 - id: wooden_bowl
   name: wooden_bowl_hot3d_robolab
   type: object
-  params: {}
+  params:
+    scale: [0.5, 0.5, 0.5]
 - id: spoon_big
   name: spoon_big_vomp_robolab
   type: object

--- a/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
@@ -72,6 +72,7 @@ tasks:
     pick_up_object: apple
     destination_location: plasticpail
     background_scene: maple_table_robolab
+    episode_length_s: 20.0
   description: place the apple into the plasticpail on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,4 +88,4 @@ reportPrivateUsage = "warning"
 skip = '*.usd,*.svg,*.png,_isaac_sim*,*.bib,*.css,*/_build'
 quiet-level = 0
 # the world list should always have words in lower case
-ignore-words-list = "haa,slq,collapsable,buss"
+ignore-words-list = "haa,slq,collapsable,buss,crate"


### PR DESCRIPTION
## Summary
Add additional robolab pick and place yamls from agentic env gen

## Detailed description
- Add 11 new yamls for robolab tasks. These are generated by agentic env gen with minor editing.
- Add a missing object assset.
- Fix a existing yaml config angle mistake (rad instead of degree)
