### PR TITLE
Fix agentic asset defaults

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/asset_matcher.py
+++ b/isaaclab_arena/agentic_environment_generation/asset_matcher.py
@@ -66,7 +66,7 @@ def match_asset(
 
         required_tags: Tags every candidate must carry (e.g. ``["object"]``).
         preferred_tags: Additional tags that narrow the first-pass pool
-            (e.g. item ``category_tags`` or ``["ik"]`` for embodiments).
+            (e.g. item ``category_tags`` or ``["default"]`` for embodiments).
             When ``None`` or empty, stage 2 is skipped and matching falls
             through directly to the required-tag pool.
 

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -330,6 +330,8 @@ initial_state_graph (subject=object, reference=background) to anchor them.
 - params values are node ids or the background name, not registry asset names.
 - NODE IDS: an item's id is its instance_name if set, else its query. For multiple
   items of the same kind, give each a unique instance_name and use those exact ids everywhere.
+- Use underscore_connected identifiers for every query and instance_name (e.g.
+  'bbq_sauce_bottle', not 'bbq sauce bottle') so node ids are valid Python identifiers.
 - Every relation subject/reference and object task param must name one node id — never
   a bare query that maps to several instances. Each must name exactly one;
   if the prompt doesn't say which, pick any.

--- a/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
@@ -87,7 +87,7 @@ class EnvironmentIntentSpec(BaseModel):
         description=(
             "Robot embodiment to control. Use a bare family name ('franka', "
             "'droid', 'g1', 'gr1') when the prompt does not specify a "
-            "control mode — the resolver defaults each to its IK variant. "
+            "control mode — the resolver defaults each to its default-tagged variant. "
             "Use a full registered name (e.g. 'franka_joint_pos') only when "
             "the prompt explicitly requests joint control."
         ),

--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -89,7 +89,7 @@ class IntentCompiler:
             trace_prefix="embodiment",
             node_type=ArenaEnvGraphNodeType.EMBODIMENT,
             required_tags=["embodiment"],
-            preferred_tags=["ik"],
+            preferred_tags=["default"],
         )
         if embodiment_node is not None:
             nodes.append(embodiment_node)

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -79,15 +79,6 @@ class CrackerBox(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/003_cracker_box.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class MustardBottle(LibraryObject):
@@ -98,15 +89,6 @@ class MustardBottle(LibraryObject):
     name = "mustard_bottle"
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/006_mustard_bottle.usd"
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -119,15 +101,6 @@ class SugarBox(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/004_sugar_box.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class TomatoSoupCan(LibraryObject):
@@ -139,15 +112,6 @@ class TomatoSoupCan(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/005_tomato_soup_can.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class PowerDrill(LibraryObject):
@@ -158,15 +122,6 @@ class PowerDrill(LibraryObject):
     name = "power_drill"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/power_drill_physics/power_drill_physics.usd"
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -266,15 +221,6 @@ class OfficeTable(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/nut_pour_task/nut_pour_assets/table.usd"
     scale = (1.0, 1.0, 0.7)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class BlueSortingBin(LibraryObject):
@@ -286,15 +232,6 @@ class BlueSortingBin(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/exhaust_pipe_task/exhaust_pipe_assets/blue_sorting_bin.usd"
     scale = (4.0, 2.0, 1.0)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -308,15 +245,6 @@ class BlueExhaustPipe(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/exhaust_pipe_task/exhaust_pipe_assets/blue_exhaust_pipe.usd"
     scale = (0.55, 0.55, 1.4)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class BrownBox(LibraryObject):
@@ -329,15 +257,6 @@ class BrownBox(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/brown_box/brown_box.usd"
     scale = (1.0, 1.0, 1.0)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class Mug(LibraryObject, Placeable):
@@ -348,7 +267,6 @@ class Mug(LibraryObject, Placeable):
     name = "mug"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Objects/Mug/mug.usd"
-    object_type = ObjectType.RIGID
     scale = (1.0, 1.0, 1.0)
 
     # Placeable affordance parameters
@@ -415,7 +333,6 @@ class Sphere(LibraryObject):
 
     name = "sphere"
     tags = ["object"]
-    object_type = ObjectType.RIGID
     scale = (1.0, 1.0, 1.0)
     default_spawner_cfg = sim_utils.SphereCfg(
         radius=0.1,
@@ -533,16 +450,6 @@ class DexCube(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd"
     scale = (0.8, 0.8, 0.8)
-    object_type = ObjectType.RIGID
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -680,16 +587,6 @@ class Broccoli(LibraryObject):
     name = "broccoli"
     tags = ["object", "vegetable", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", registry_name=["broccoli"], file_type="USD")
-    object_type = ObjectType.RIGID
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -701,17 +598,7 @@ class SweetPotato(LibraryObject):
     name = "sweet_potato"
     tags = ["object", "vegetable", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="SweetPotato005", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (1.5, 1.5, 1.5)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -723,17 +610,7 @@ class Jug(LibraryObject):
     name = "jug"
     tags = ["object", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="Jug005", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (2.0, 2.0, 2.0)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -745,17 +622,7 @@ class BeerBottle(LibraryObject):
     name = "beer_bottle"
     tags = ["object", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="beer016", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (1.2, 1.2, 1.2)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -769,17 +636,7 @@ class RedCube(LibraryObject):
 
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/red_block.usd"
 
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/RedCube"
     scale = (0.02, 0.02, 0.02)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -792,17 +649,7 @@ class GreenCube(LibraryObject):
     tags = ["object"]
 
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/green_block.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/GreenCube"
     scale = (0.02, 0.02, 0.02)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -814,17 +661,7 @@ class RedContainer(LibraryObject):
     name = "red_container"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/isaac_container/container_h20_red.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/red_container"
     scale = (0.5, 0.5, 0.5)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -836,17 +673,7 @@ class GreenContainer(LibraryObject):
     name = "green_container"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/isaac_container/container_h20_green.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/green_container"
     scale = (0.5, 0.5, 0.5)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -100,7 +100,6 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
     """Embodiment for the DROID setup with differential inverse kinematics action controller."""
 
     name = "droid_differential_ik"
-    tags = ["embodiment", "ik"]
     default_arm_mode = ArmMode.SINGLE_ARM
 
     def __init__(
@@ -139,6 +138,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
     """Embodiment for the DROID setup with absolute joint position actions."""
 
     name = "droid_abs_joint_pos"
+    tags = ["embodiment", "default"]
     default_arm_mode = ArmMode.SINGLE_ARM
 
     def __init__(

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -101,7 +101,7 @@ class FrankaIKEmbodiment(FrankaEmbodimentBase):
     """Franka with differential IK (relative) arm control and high-PD defaults."""
 
     name = "franka_ik"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -142,7 +142,7 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
     """
 
     name = "g1_wbc_pink"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/embodiments/gr1t2/gr1t2.py
+++ b/isaaclab_arena/embodiments/gr1t2/gr1t2.py
@@ -158,7 +158,7 @@ class GR1T2PinkEmbodiment(GR1T2EmbodimentBase):
     """
 
     name = "gr1_pink"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/tests/_asset_matcher_test_helpers.py
+++ b/isaaclab_arena/tests/_asset_matcher_test_helpers.py
@@ -62,7 +62,7 @@ def default_assets() -> list[FakeAsset]:
     """
     return [
         FakeAsset(name="maple_table", tags=["background"]),
-        FakeAsset(name="franka_ik", tags=["embodiment", "ik"]),
+        FakeAsset(name="franka_ik", tags=["embodiment", "default"]),
         FakeAsset(name="franka_joint_pos", tags=["embodiment"]),
         FakeAsset(name="bowl_ycb_robolab", tags=["object", "bowl"]),
         FakeAsset(name="avocado01_fruits_robolab", tags=["object", "fruit"]),

--- a/isaaclab_arena/tests/test_asset_matcher.py
+++ b/isaaclab_arena/tests/test_asset_matcher.py
@@ -13,7 +13,7 @@ Covers :func:`~asset_matcher.match_asset` resolution strategies:
   - Fuzzy (difflib) fallback
   - Required-tag pool fuzzy fallback when no preferred tags are supplied
   - Miss behaviour
-  - Embodiment bare-family expansion via the ``["embodiment", "ik"]`` tag pool
+  - Embodiment bare-family expansion via the ``["embodiment", "default"]`` tag pool
   - Empty required-tag pools
 """
 
@@ -77,35 +77,35 @@ def test_background_fuzzy_match_without_preferred_tags():
 
 def test_embodiment_exact_match():
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka_ik", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka_ik", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_ik"
     assert any(e.stage == "embodiment.exact" for e in trace)
 
 
-def test_embodiment_joint_pos_not_fuzzy_matched_to_ik():
-    # Exact hit on the required-tag pool must run before the ik-narrowed
+def test_embodiment_joint_pos_not_fuzzy_matched_to_default():
+    # Exact hit on the required-tag pool must run before the default-narrowed
     # preferred pool, so joint-position control is not fuzzy-matched to franka_ik.
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka_joint_pos", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka_joint_pos", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_joint_pos"
     trace_stages = [e.stage for e in trace]
     assert "embodiment.exact" in trace_stages
     assert "embodiment.preferred_tags.fuzzy" not in trace_stages
 
 
-def test_embodiment_ik_default_for_bare_family():
-    # Bare family names (e.g. "franka") are expanded to the IK variant by
-    # narrowing embodiment candidates by the "ik" tag and picking the shortest
+def test_embodiment_default_for_bare_family():
+    # Bare family names (e.g. "franka") are expanded to the default variant by
+    # narrowing embodiment candidates by the "default" tag and picking the shortest
     # match.
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_ik"
     assert any(e.stage == "embodiment.preferred_tags.substring" for e in trace)
 
 
 def test_embodiment_unknown_records_miss():
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "totally_unknown_robot", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "totally_unknown_robot", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen is None
     assert any(e.stage == "embodiment.required_tags.miss" for e in trace)
 
@@ -127,7 +127,7 @@ def test_embodiment_required_tag_pool_empty():
         FakeAsset(name="cracker_box", tags=["object"]),
     ]
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(assets), "franka_ik", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(assets), "franka_ik", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen is None
     assert any(e.stage == "embodiment.required_tags.empty_pool" for e in trace)
 


### PR DESCRIPTION
## Summary
Fix agentic asset defaults

## Detailed description
- Switched agent embodiment preference from `ik` to `default`.
- Moved the DROID default tag to `droid_abs_joint_pos`.
- Removed redundant object-library initializers so instance names propagate.
- Added prompt guidance for identifier-safe generated node ids.