### PR TITLE
Increase osmo default cpu memory

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/asset_matcher.py
+++ b/isaaclab_arena/agentic_environment_generation/asset_matcher.py
@@ -66,7 +66,7 @@ def match_asset(
 
         required_tags: Tags every candidate must carry (e.g. ``["object"]``).
         preferred_tags: Additional tags that narrow the first-pass pool
-            (e.g. item ``category_tags`` or ``["ik"]`` for embodiments).
+            (e.g. item ``category_tags`` or ``["default"]`` for embodiments).
             When ``None`` or empty, stage 2 is skipped and matching falls
             through directly to the required-tag pool.
 

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -330,6 +330,8 @@ initial_state_graph (subject=object, reference=background) to anchor them.
 - params values are node ids or the background name, not registry asset names.
 - NODE IDS: an item's id is its instance_name if set, else its query. For multiple
   items of the same kind, give each a unique instance_name and use those exact ids everywhere.
+- Use underscore_connected identifiers for every query and instance_name (e.g.
+  'bbq_sauce_bottle', not 'bbq sauce bottle') so node ids are valid Python identifiers.
 - Every relation subject/reference and object task param must name one node id — never
   a bare query that maps to several instances. Each must name exactly one;
   if the prompt doesn't say which, pick any.

--- a/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_intent_spec.py
@@ -87,7 +87,7 @@ class EnvironmentIntentSpec(BaseModel):
         description=(
             "Robot embodiment to control. Use a bare family name ('franka', "
             "'droid', 'g1', 'gr1') when the prompt does not specify a "
-            "control mode — the resolver defaults each to its IK variant. "
+            "control mode — the resolver defaults each to its default-tagged variant. "
             "Use a full registered name (e.g. 'franka_joint_pos') only when "
             "the prompt explicitly requests joint control."
         ),

--- a/isaaclab_arena/agentic_environment_generation/intent_compiler.py
+++ b/isaaclab_arena/agentic_environment_generation/intent_compiler.py
@@ -89,7 +89,7 @@ class IntentCompiler:
             trace_prefix="embodiment",
             node_type=ArenaEnvGraphNodeType.EMBODIMENT,
             required_tags=["embodiment"],
-            preferred_tags=["ik"],
+            preferred_tags=["default"],
         )
         if embodiment_node is not None:
             nodes.append(embodiment_node)

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -79,15 +79,6 @@ class CrackerBox(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/003_cracker_box.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class MustardBottle(LibraryObject):
@@ -98,15 +89,6 @@ class MustardBottle(LibraryObject):
     name = "mustard_bottle"
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/006_mustard_bottle.usd"
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -119,15 +101,6 @@ class SugarBox(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/004_sugar_box.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class TomatoSoupCan(LibraryObject):
@@ -139,15 +112,6 @@ class TomatoSoupCan(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/005_tomato_soup_can.usd"
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class PowerDrill(LibraryObject):
@@ -158,15 +122,6 @@ class PowerDrill(LibraryObject):
     name = "power_drill"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/power_drill_physics/power_drill_physics.usd"
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -266,15 +221,6 @@ class OfficeTable(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/nut_pour_task/nut_pour_assets/table.usd"
     scale = (1.0, 1.0, 0.7)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class BlueSortingBin(LibraryObject):
@@ -286,15 +232,6 @@ class BlueSortingBin(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/exhaust_pipe_task/exhaust_pipe_assets/blue_sorting_bin.usd"
     scale = (4.0, 2.0, 1.0)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -308,15 +245,6 @@ class BlueExhaustPipe(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Mimic/exhaust_pipe_task/exhaust_pipe_assets/blue_exhaust_pipe.usd"
     scale = (0.55, 0.55, 1.4)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class BrownBox(LibraryObject):
@@ -329,15 +257,6 @@ class BrownBox(LibraryObject):
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/brown_box/brown_box.usd"
     scale = (1.0, 1.0, 1.0)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
-
 
 @register_asset
 class Mug(LibraryObject, Placeable):
@@ -348,7 +267,6 @@ class Mug(LibraryObject, Placeable):
     name = "mug"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Objects/Mug/mug.usd"
-    object_type = ObjectType.RIGID
     scale = (1.0, 1.0, 1.0)
 
     # Placeable affordance parameters
@@ -415,7 +333,6 @@ class Sphere(LibraryObject):
 
     name = "sphere"
     tags = ["object"]
-    object_type = ObjectType.RIGID
     scale = (1.0, 1.0, 1.0)
     default_spawner_cfg = sim_utils.SphereCfg(
         radius=0.1,
@@ -533,16 +450,6 @@ class DexCube(LibraryObject):
     tags = ["object"]
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd"
     scale = (0.8, 0.8, 0.8)
-    object_type = ObjectType.RIGID
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -680,16 +587,6 @@ class Broccoli(LibraryObject):
     name = "broccoli"
     tags = ["object", "vegetable", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", registry_name=["broccoli"], file_type="USD")
-    object_type = ObjectType.RIGID
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -701,17 +598,7 @@ class SweetPotato(LibraryObject):
     name = "sweet_potato"
     tags = ["object", "vegetable", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="SweetPotato005", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (1.5, 1.5, 1.5)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -723,17 +610,7 @@ class Jug(LibraryObject):
     name = "jug"
     tags = ["object", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="Jug005", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (2.0, 2.0, 2.0)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -745,17 +622,7 @@ class BeerBottle(LibraryObject):
     name = "beer_bottle"
     tags = ["object", "graspable"]
     usd_path = LightwheelLazyPath(registry_type="objects", file_name="beer016", file_type="USD")
-    object_type = ObjectType.RIGID
     scale = (1.2, 1.2, 1.2)
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -769,17 +636,7 @@ class RedCube(LibraryObject):
 
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/red_block.usd"
 
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/RedCube"
     scale = (0.02, 0.02, 0.02)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -792,17 +649,7 @@ class GreenCube(LibraryObject):
     tags = ["object"]
 
     usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/green_block.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/GreenCube"
     scale = (0.02, 0.02, 0.02)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -814,17 +661,7 @@ class RedContainer(LibraryObject):
     name = "red_container"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/isaac_container/container_h20_red.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/red_container"
     scale = (0.5, 0.5, 0.5)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset
@@ -836,17 +673,7 @@ class GreenContainer(LibraryObject):
     name = "green_container"
     tags = ["object"]
     usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/isaac_container/container_h20_green.usd"
-    object_type = ObjectType.RIGID
-    default_prim_path = "{ENV_REGEX_NS}/green_container"
     scale = (0.5, 0.5, 0.5)
-
-    def __init__(
-        self,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-        scale: tuple[float, float, float] | None = None,
-    ):
-        super().__init__(prim_path=prim_path, initial_pose=initial_pose, scale=scale)
 
 
 @register_asset

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -677,6 +677,15 @@ class GreenContainer(LibraryObject):
 
 
 @register_asset
+class PurpleCrate(LibraryObject):
+    """A purple KLT container."""
+
+    name = "purple_crate"
+    tags = ["object", "container"]
+    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/KLT_Bin/small_KLT.usd"
+
+
+@register_asset
 class BlueBlockBasicRobolab(LibraryObject):
     # TODO(cvolk): pick_and_place success termination does not consistently trigger
     # with this asset even when the block is placed in the destination.

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -100,7 +100,6 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
     """Embodiment for the DROID setup with differential inverse kinematics action controller."""
 
     name = "droid_differential_ik"
-    tags = ["embodiment", "ik"]
     default_arm_mode = ArmMode.SINGLE_ARM
 
     def __init__(
@@ -139,6 +138,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
     """Embodiment for the DROID setup with absolute joint position actions."""
 
     name = "droid_abs_joint_pos"
+    tags = ["embodiment", "default"]
     default_arm_mode = ArmMode.SINGLE_ARM
 
     def __init__(

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -101,7 +101,7 @@ class FrankaIKEmbodiment(FrankaEmbodimentBase):
     """Franka with differential IK (relative) arm control and high-PD defaults."""
 
     name = "franka_ik"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -142,7 +142,7 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
     """
 
     name = "g1_wbc_pink"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/embodiments/gr1t2/gr1t2.py
+++ b/isaaclab_arena/embodiments/gr1t2/gr1t2.py
@@ -158,7 +158,7 @@ class GR1T2PinkEmbodiment(GR1T2EmbodimentBase):
     """
 
     name = "gr1_pink"
-    tags = ["embodiment", "ik"]
+    tags = ["embodiment", "default"]
 
     def __init__(
         self,

--- a/isaaclab_arena/tests/_asset_matcher_test_helpers.py
+++ b/isaaclab_arena/tests/_asset_matcher_test_helpers.py
@@ -62,7 +62,7 @@ def default_assets() -> list[FakeAsset]:
     """
     return [
         FakeAsset(name="maple_table", tags=["background"]),
-        FakeAsset(name="franka_ik", tags=["embodiment", "ik"]),
+        FakeAsset(name="franka_ik", tags=["embodiment", "default"]),
         FakeAsset(name="franka_joint_pos", tags=["embodiment"]),
         FakeAsset(name="bowl_ycb_robolab", tags=["object", "bowl"]),
         FakeAsset(name="avocado01_fruits_robolab", tags=["object", "fruit"]),

--- a/isaaclab_arena/tests/test_asset_matcher.py
+++ b/isaaclab_arena/tests/test_asset_matcher.py
@@ -13,7 +13,7 @@ Covers :func:`~asset_matcher.match_asset` resolution strategies:
   - Fuzzy (difflib) fallback
   - Required-tag pool fuzzy fallback when no preferred tags are supplied
   - Miss behaviour
-  - Embodiment bare-family expansion via the ``["embodiment", "ik"]`` tag pool
+  - Embodiment bare-family expansion via the ``["embodiment", "default"]`` tag pool
   - Empty required-tag pools
 """
 
@@ -77,35 +77,35 @@ def test_background_fuzzy_match_without_preferred_tags():
 
 def test_embodiment_exact_match():
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka_ik", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka_ik", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_ik"
     assert any(e.stage == "embodiment.exact" for e in trace)
 
 
-def test_embodiment_joint_pos_not_fuzzy_matched_to_ik():
-    # Exact hit on the required-tag pool must run before the ik-narrowed
+def test_embodiment_joint_pos_not_fuzzy_matched_to_default():
+    # Exact hit on the required-tag pool must run before the default-narrowed
     # preferred pool, so joint-position control is not fuzzy-matched to franka_ik.
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka_joint_pos", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka_joint_pos", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_joint_pos"
     trace_stages = [e.stage for e in trace]
     assert "embodiment.exact" in trace_stages
     assert "embodiment.preferred_tags.fuzzy" not in trace_stages
 
 
-def test_embodiment_ik_default_for_bare_family():
-    # Bare family names (e.g. "franka") are expanded to the IK variant by
-    # narrowing embodiment candidates by the "ik" tag and picking the shortest
+def test_embodiment_default_for_bare_family():
+    # Bare family names (e.g. "franka") are expanded to the default variant by
+    # narrowing embodiment candidates by the "default" tag and picking the shortest
     # match.
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "franka", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "franka", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen == "franka_ik"
     assert any(e.stage == "embodiment.preferred_tags.substring" for e in trace)
 
 
 def test_embodiment_unknown_records_miss():
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(), "totally_unknown_robot", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(), "totally_unknown_robot", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen is None
     assert any(e.stage == "embodiment.required_tags.miss" for e in trace)
 
@@ -127,7 +127,7 @@ def test_embodiment_required_tag_pool_empty():
         FakeAsset(name="cracker_box", tags=["object"]),
     ]
     trace: list[IntentResolutionTraceEvent] = []
-    chosen = match_asset(make_registry(assets), "franka_ik", "embodiment", trace, ["embodiment"], ["ik"])
+    chosen = match_asset(make_registry(assets), "franka_ik", "embodiment", trace, ["embodiment"], ["default"])
     assert chosen is None
     assert any(e.stage == "embodiment.required_tags.empty_pool" for e in trace)
 

--- a/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/banana_bowl_linked.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: mustard_raisin_box
+env_name: banana_bowl
 nodes:
 - id: maple_table_robolab
   name: maple_table_robolab
@@ -13,22 +13,22 @@ nodes:
   name: droid_abs_joint_pos
   type: embodiment
   params: {}
-- id: mustard_bottle
-  name: mustard_bottle_hope_robolab
+- id: banana
+  name: banana_ycb_robolab
   type: object
   params: {}
-- id: raisin_box
-  name: raisin_box_hope_robolab
+- id: bowl
+  name: bowl_ycb_robolab
   type: object
   params: {}
 tasks:
 - kind: PickAndPlaceTask
   params:
-    pick_up_object: mustard_bottle
-    destination_location: raisin_box
+    pick_up_object: banana
+    destination_location: bowl
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: Pick up the mustard bottle and place it on the raisin box.
+  description: pick up the banana and place it in the bowl
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -41,30 +41,23 @@ state_specs:
     params: {}
     id: state_initial_0_is_anchor_maple_table_robolab
   - kind: 'on'
-    subject: mustard_bottle
+    subject: bowl
     reference: maple_table_robolab
     params: {}
-    id: state_initial_1_on_maple_table_robolab_mustard_bottle
+    id: state_initial_1_on_maple_table_robolab_bowl
   - kind: 'on'
-    subject: raisin_box
+    subject: banana
     reference: maple_table_robolab
     params: {}
-    id: state_initial_2_on_maple_table_robolab_raisin_box
-  # TODO: support rotate around solution from the agent intent spec
-  - kind: 'rotate_around_solution'
-    subject: raisin_box
-    params: {
-      pitch_rad: 1.57
-    }
-    id: state_initial_3_rotate_around_solution_raisin_box
+    id: state_initial_2_on_maple_table_robolab_banana
   task_constraints: []
 - id: state_spec_1
   is_delta: true
   spatial_constraints:
   - kind: 'on'
-    subject: mustard_bottle
-    reference: raisin_box
+    subject: banana
+    reference: bowl
     params: {}
-    id: state_spec_1_mustard_bottle_on_raisin_box
+    id: state_spec_1_banana_on_bowl
   task_constraints: []
 cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bin_condiments_linked.yaml
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bin_condiments
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: coffee_pot
+  name: coffee_pot_hot3d_robolab
+  type: object
+  params: {}
+- id: grey_bin
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: mug
+  name: mug
+  type: object
+  params: {}
+- id: mustard
+  name: mustard_bottle_hope_robolab
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+- id: ranch_dressing
+  name: ranch_dressing_hope_robolab
+  type: object
+  params: {}
+- id: bbq_sauce_bottle_1
+  name: bbq_sauce_bottle_hope_robolab
+  type: object
+  params: {}
+- id: bbq_sauce_bottle_2
+  name: bbq_sauce_bottle_hope_robolab
+  type: object
+  params: {}
+- id: oatmeal_raisin_cookies
+  name: oatmeal_raisin_cookies_hope_robolab
+  type: object
+  params: {}
+- id: canned_tuna
+  name: canned_tuna_hope_robolab
+  type: object
+  params: {}
+- id: soft_scrub
+  name: soft_scrub_ycb_robolab
+  type: object
+  params: {}
+- id: wood_block
+  name: wood_block_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: coffee_pot
+    destination_location: grey_bin
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
+  description: pick up the coffee pot and place it into the grey bin
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: coffee_pot
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_coffee_pot
+  - kind: 'on'
+    subject: grey_bin
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_grey_bin
+  - kind: 'on'
+    subject: mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_mug
+  - kind: 'on'
+    subject: mustard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_mustard
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: ranch_dressing
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_ranch_dressing
+  - kind: 'on'
+    subject: bbq_sauce_bottle_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_bbq_sauce_bottle_1
+  - kind: 'on'
+    subject: bbq_sauce_bottle_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_bbq_sauce_bottle_2
+  - kind: 'on'
+    subject: oatmeal_raisin_cookies
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_oatmeal_raisin_cookies
+  - kind: 'on'
+    subject: canned_tuna
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_canned_tuna
+  - kind: 'on'
+    subject: soft_scrub
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_soft_scrub
+  - kind: 'on'
+    subject: wood_block
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_wood_block
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: coffee_pot
+    reference: grey_bin
+    params: {}
+    id: state_spec_1_coffee_pot_on_grey_bin
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
+++ b/isaaclab_arena_environments/robolab/bottles_crate_linked.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: mustard_raisin_box
+env_name: bottles_crate
 nodes:
 - id: maple_table_robolab
   name: maple_table_robolab
@@ -13,22 +13,31 @@ nodes:
   name: droid_abs_joint_pos
   type: embodiment
   params: {}
-- id: mustard_bottle
-  name: mustard_bottle_hope_robolab
+- id: bbq_sauce_bottle
+  name: bbq_sauce_bottle_hope_robolab
   type: object
   params: {}
-- id: raisin_box
-  name: raisin_box_hope_robolab
+- id: purple_crate
+  name: purple_crate
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: salad_dressing_bottle
+  name: salad_dressing_bottle_hot3d_robolab
   type: object
   params: {}
 tasks:
 - kind: PickAndPlaceTask
   params:
-    pick_up_object: mustard_bottle
-    destination_location: raisin_box
+    pick_up_object: bbq_sauce_bottle
+    destination_location: purple_crate
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: Pick up the mustard bottle and place it on the raisin box.
+    max_separation: [0.1, 0.1, 0.1]
+  description: place the bbq sauce bottle into the purple crate on the table
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -41,30 +50,33 @@ state_specs:
     params: {}
     id: state_initial_0_is_anchor_maple_table_robolab
   - kind: 'on'
-    subject: mustard_bottle
+    subject: bbq_sauce_bottle
     reference: maple_table_robolab
     params: {}
-    id: state_initial_1_on_maple_table_robolab_mustard_bottle
+    id: state_initial_1_on_maple_table_robolab_bbq_sauce_bottle
   - kind: 'on'
-    subject: raisin_box
+    subject: purple_crate
     reference: maple_table_robolab
     params: {}
-    id: state_initial_2_on_maple_table_robolab_raisin_box
-  # TODO: support rotate around solution from the agent intent spec
-  - kind: 'rotate_around_solution'
-    subject: raisin_box
-    params: {
-      pitch_rad: 1.57
-    }
-    id: state_initial_3_rotate_around_solution_raisin_box
+    id: state_initial_2_on_maple_table_robolab_purple_crate
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: salad_dressing_bottle
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_salad_dressing_bottle
   task_constraints: []
 - id: state_spec_1
   is_delta: true
   spatial_constraints:
   - kind: 'on'
-    subject: mustard_bottle
-    reference: raisin_box
+    subject: bbq_sauce_bottle
+    reference: purple_crate
     params: {}
-    id: state_spec_1_mustard_bottle_on_raisin_box
+    id: state_spec_1_bbq_sauce_bottle_on_purple_crate
   task_constraints: []
 cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
+++ b/isaaclab_arena_environments/robolab/butter_raisin_box_linked.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: mustard_raisin_box
+env_name: butter_raisin_box
 nodes:
 - id: maple_table_robolab
   name: maple_table_robolab
@@ -13,22 +13,22 @@ nodes:
   name: droid_abs_joint_pos
   type: embodiment
   params: {}
-- id: mustard_bottle
-  name: mustard_bottle_hope_robolab
+- id: butter_hope_robolab
+  name: butter_hope_robolab
   type: object
   params: {}
-- id: raisin_box
+- id: raisin_box_hope_robolab
   name: raisin_box_hope_robolab
   type: object
   params: {}
 tasks:
 - kind: PickAndPlaceTask
   params:
-    pick_up_object: mustard_bottle
-    destination_location: raisin_box
+    pick_up_object: butter_hope_robolab
+    destination_location: raisin_box_hope_robolab
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: Pick up the mustard bottle and place it on the raisin box.
+  description: pick up the butter box and place it on top of the raisin box
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -41,18 +41,18 @@ state_specs:
     params: {}
     id: state_initial_0_is_anchor_maple_table_robolab
   - kind: 'on'
-    subject: mustard_bottle
+    subject: butter_hope_robolab
     reference: maple_table_robolab
     params: {}
-    id: state_initial_1_on_maple_table_robolab_mustard_bottle
+    id: state_initial_1_on_maple_table_robolab_butter_hope_robolab
   - kind: 'on'
-    subject: raisin_box
+    subject: raisin_box_hope_robolab
     reference: maple_table_robolab
     params: {}
-    id: state_initial_2_on_maple_table_robolab_raisin_box
+    id: state_initial_2_on_maple_table_robolab_raisin_box_hope_robolab
   # TODO: support rotate around solution from the agent intent spec
   - kind: 'rotate_around_solution'
-    subject: raisin_box
+    subject: raisin_box_hope_robolab
     params: {
       pitch_rad: 1.57
     }
@@ -62,9 +62,9 @@ state_specs:
   is_delta: true
   spatial_constraints:
   - kind: 'on'
-    subject: mustard_bottle
-    reference: raisin_box
+    subject: butter_hope_robolab
+    reference: raisin_box_hope_robolab
     params: {}
-    id: state_spec_1_mustard_bottle_on_raisin_box
+    id: state_spec_1_butter_hope_robolab_on_raisin_box_hope_robolab
   task_constraints: []
 cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/clutter_fruit_bottle_bluebin_linked.yaml
@@ -1,0 +1,191 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clutter_fruit_bottle_bluebin
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: pumpkin_large
+  name: pumpkinlarge_vomp_robolab
+  type: object
+  params:
+    scale: [1.25, 1.25, 1.25]
+- id: pumpkin_small
+  name: pumpkinsmall_vomp_robolab
+  type: object
+  params: {}
+- id: lemon_1
+  name: lemon_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lemon_2
+  name: lemon_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lime_1
+  name: lime01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: lime_2
+  name: lime01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: orange_1
+  name: orange_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: orange_2
+  name: orange_01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: pomegranate
+  name: pomegranate01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: white_packer_bottle
+  name: whitepackerbottle_a01_vomp_robolab
+  type: object
+  params: {}
+- id: avocado
+  name: avocado01_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: crabbypenholder
+  name: crabbypenholder_vomp_robolab
+  type: object
+  params: {}
+- id: serving_bowl
+  name: serving_bowl_vomp_robolab
+  type: object
+  params: {}
+- id: utilityjug
+  name: utilityjug_a01_vomp_robolab
+  type: object
+  params: {}
+- id: red_onion
+  name: red_onion_fruits_veggies_robolab
+  type: object
+  params: {}
+- id: container_f24
+  name: container_f24_vomp_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: pumpkin_large
+    destination_location: container_f24
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
+  description: pick up the large pumpkin and place it into the bin
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: pumpkin_large
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_pumpkin_large
+  - kind: 'on'
+    subject: pumpkin_small
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_pumpkin_small
+  - kind: 'on'
+    subject: lemon_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_lemon_1
+  - kind: 'on'
+    subject: lemon_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_lemon_2
+  - kind: 'on'
+    subject: lime_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_lime_1
+  - kind: 'on'
+    subject: lime_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_lime_2
+  - kind: 'on'
+    subject: orange_1
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_orange_1
+  - kind: 'on'
+    subject: orange_2
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_orange_2
+  - kind: 'on'
+    subject: pomegranate
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_pomegranate
+  - kind: 'on'
+    subject: white_packer_bottle
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_white_packer_bottle
+  - kind: 'on'
+    subject: avocado
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_avocado
+  - kind: 'on'
+    subject: crabbypenholder
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_crabbypenholder
+  - kind: 'on'
+    subject: serving_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_serving_bowl
+  - kind: 'on'
+    subject: utilityjug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_14_on_maple_table_robolab_utilityjug
+  - kind: 'on'
+    subject: red_onion
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_15_on_maple_table_robolab_red_onion
+  - kind: 'on'
+    subject: container_f24
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_16_on_maple_table_robolab_container_f24
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: pumpkin_large
+    reference: container_f24
+    params: {}
+    id: state_spec_1_pumpkin_large_on_container_f24
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
+++ b/isaaclab_arena_environments/robolab/foodpacking_1bin_1box_1can_linked.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: mustard_raisin_box
+env_name: foodpacking_1bin_1box_1can
 nodes:
 - id: maple_table_robolab
   name: maple_table_robolab
@@ -13,22 +13,31 @@ nodes:
   name: droid_abs_joint_pos
   type: embodiment
   params: {}
-- id: mustard_bottle
+- id: cheez_it_box
+  name: cheez_it_ycb_robolab
+  type: object
+  params: {}
+- id: bin_a06
+  name: bin_a06_vomp_robolab
+  type: object
+  params: {}
+- id: mustard
   name: mustard_bottle_hope_robolab
   type: object
   params: {}
-- id: raisin_box
-  name: raisin_box_hope_robolab
+- id: tomato_soup_can
+  name: tomato_soup_can
   type: object
   params: {}
 tasks:
 - kind: PickAndPlaceTask
   params:
-    pick_up_object: mustard_bottle
-    destination_location: raisin_box
+    pick_up_object: cheez_it_box
+    destination_location: bin_a06
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: Pick up the mustard bottle and place it on the raisin box.
+    max_separation: [0.1, 0.1, 0.1]
+  description: pick up the cheez it box and place it into the bin
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -41,30 +50,40 @@ state_specs:
     params: {}
     id: state_initial_0_is_anchor_maple_table_robolab
   - kind: 'on'
-    subject: mustard_bottle
+    subject: cheez_it_box
     reference: maple_table_robolab
     params: {}
-    id: state_initial_1_on_maple_table_robolab_mustard_bottle
+    id: state_initial_1_on_maple_table_robolab_cheez_it_box
   - kind: 'on'
-    subject: raisin_box
+    subject: bin_a06
     reference: maple_table_robolab
     params: {}
-    id: state_initial_2_on_maple_table_robolab_raisin_box
+    id: state_initial_2_on_maple_table_robolab_bin_a06
+  - kind: 'on'
+    subject: mustard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_mustard
+  - kind: 'on'
+    subject: tomato_soup_can
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_tomato_soup_can
   # TODO: support rotate around solution from the agent intent spec
   - kind: 'rotate_around_solution'
-    subject: raisin_box
+    subject: tomato_soup_can
     params: {
-      pitch_rad: 1.57
+      roll_rad: -1.57
     }
-    id: state_initial_3_rotate_around_solution_raisin_box
+    id: state_initial_5_rotate_around_solution_tomato_soup_can
   task_constraints: []
 - id: state_spec_1
   is_delta: true
   spatial_constraints:
   - kind: 'on'
-    subject: mustard_bottle
-    reference: raisin_box
+    subject: cheez_it_box
+    reference: bin_a06
     params: {}
-    id: state_spec_1_mustard_bottle_on_raisin_box
+    id: state_spec_1_cheez_it_box_on_bin_a06
   task_constraints: []
 cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_banana_bowl_linked.yaml
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube_banana_bowl
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: banana
+  name: banana_ycb_robolab
+  type: object
+  params: {}
+- id: cube
+  name: dex_cube
+  type: object
+  params: {}
+- id: bowl
+  name: bowl_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: banana
+    destination_location: bowl
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: pick up the banana and place it in the bowl
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: cube
+    destination_location: bowl
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: pick up the cube and place it in the bowl
+  id: task_1_PickAndPlaceTask
+  initial_state_spec_id: state_spec_1
+  success_state_spec_id: state_spec_2
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_bowl
+  - kind: 'on'
+    subject: banana
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_banana
+  - kind: 'on'
+    subject: cube
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_cube
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: banana
+    reference: bowl
+    params: {}
+    id: state_spec_1_banana_on_bowl
+  task_constraints: []
+- id: state_spec_2
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: cube
+    reference: bowl
+    params: {}
+    id: state_spec_2_cube_on_bowl
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
+++ b/isaaclab_arena_environments/robolab/rubiks_cube_bowl_linked.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: mustard_raisin_box
+env_name: rubiks_cube_bowl
 nodes:
 - id: maple_table_robolab
   name: maple_table_robolab
@@ -13,22 +13,22 @@ nodes:
   name: droid_abs_joint_pos
   type: embodiment
   params: {}
-- id: mustard_bottle
-  name: mustard_bottle_hope_robolab
+- id: rubiks_cube
+  name: rubiks_cube_hot3d_robolab
   type: object
   params: {}
-- id: raisin_box
-  name: raisin_box_hope_robolab
+- id: bowl
+  name: bowl_ycb_robolab
   type: object
   params: {}
 tasks:
 - kind: PickAndPlaceTask
   params:
-    pick_up_object: mustard_bottle
-    destination_location: raisin_box
+    pick_up_object: rubiks_cube
+    destination_location: bowl
     background_scene: maple_table_robolab
     episode_length_s: 20.0
-  description: Pick up the mustard bottle and place it on the raisin box.
+  description: put the rubiks cube in the bowl
   id: task_0_PickAndPlaceTask
   initial_state_spec_id: state_initial
   success_state_spec_id: state_spec_1
@@ -41,30 +41,23 @@ state_specs:
     params: {}
     id: state_initial_0_is_anchor_maple_table_robolab
   - kind: 'on'
-    subject: mustard_bottle
+    subject: bowl
     reference: maple_table_robolab
     params: {}
-    id: state_initial_1_on_maple_table_robolab_mustard_bottle
+    id: state_initial_1_on_maple_table_robolab_bowl
   - kind: 'on'
-    subject: raisin_box
+    subject: rubiks_cube
     reference: maple_table_robolab
     params: {}
-    id: state_initial_2_on_maple_table_robolab_raisin_box
-  # TODO: support rotate around solution from the agent intent spec
-  - kind: 'rotate_around_solution'
-    subject: raisin_box
-    params: {
-      pitch_rad: 1.57
-    }
-    id: state_initial_3_rotate_around_solution_raisin_box
+    id: state_initial_2_on_maple_table_robolab_rubiks_cube
   task_constraints: []
 - id: state_spec_1
   is_delta: true
   spatial_constraints:
   - kind: 'on'
-    subject: mustard_bottle
-    reference: raisin_box
+    subject: rubiks_cube
+    reference: bowl
     params: {}
-    id: state_spec_1_mustard_bottle_on_raisin_box
+    id: state_spec_1_rubiks_cube_on_bowl
   task_constraints: []
 cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_bin_linked.yaml
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk_bin
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: lizard_figurine
+  name: lizard_figurine_hot3d_robolab
+  type: object
+  params: {}
+- id: grey_bin
+  name: grey_bin_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params:
+    scale: [0.5, 0.5, 0.5]
+- id: spoon_big
+  name: spoon_big_vomp_robolab
+  type: object
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: granola_bar
+  name: granola_bars_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: lizard_figurine
+    destination_location: grey_bin
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+    max_separation: [0.1, 0.1, 0.1]
+  description: place the lizard figurine into the grey bin on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_lizard_figurine
+  - kind: 'on'
+    subject: grey_bin
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_grey_bin
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: spoon_big
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_spoon_big
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: granola_bar
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_granola_bar
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: grey_bin
+    params: {}
+    id: state_spec_1_lizard_figurine_on_grey_bin
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_linked.yaml
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: keyboard
+  name: keyboard_hot3d_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: lizard_figurine
+  name: lizard_figurine_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: rubiks_cube
+  name: rubiks_cube_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params:
+    scale: [0.5, 0.5, 0.5]
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: oatmeal_raisin_cookies
+  name: oatmeal_raisin_cookies_hope_robolab
+  type: object
+  params: {}
+- id: granola_bar
+  name: granola_bars_hope_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: computer_mouse
+    destination_location: keyboard
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: place the computer mouse on the keyboard
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: keyboard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_keyboard
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: lizard_figurine
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_lizard_figurine
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: rubiks_cube
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_rubiks_cube
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: oatmeal_raisin_cookies
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_oatmeal_raisin_cookies
+  - kind: 'on'
+    subject: granola_bar
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_granola_bar
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: computer_mouse
+    reference: keyboard
+    params: {}
+    id: state_spec_1_computer_mouse_on_keyboard
+  task_constraints: []
+cli_override_specs: []

--- a/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
+++ b/isaaclab_arena_environments/robolab/workdesk_snacks_linked.yaml
@@ -1,0 +1,163 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: workdesk_snacks
+nodes:
+- id: maple_table_robolab
+  name: maple_table_robolab
+  type: background
+  params: {}
+- id: droid
+  name: droid_abs_joint_pos
+  type: embodiment
+  params: {}
+- id: apple
+  name: apple_01_objaverse_robolab
+  type: object
+  params: {}
+- id: plasticpail
+  name: plasticpail_a02_vomp_robolab
+  type: object
+  params: {}
+- id: ceramic_mug
+  name: ceramic_mug_hot3d_robolab
+  type: object
+  params: {}
+- id: glasses
+  name: glasses_hot3d_robolab
+  type: object
+  params: {}
+- id: keyboard
+  name: keyboard_hot3d_robolab
+  type: object
+  params: {}
+- id: marker
+  name: marker_hot3d_robolab
+  type: object
+  params: {}
+- id: remote_control
+  name: remote_control_hot3d_robolab
+  type: object
+  params: {}
+- id: smartphone
+  name: smartphone_hot3d_robolab
+  type: object
+  params: {}
+- id: wooden_bowl
+  name: wooden_bowl_hot3d_robolab
+  type: object
+  params:
+    scale: [0.5, 0.5, 0.5]
+- id: spoon_big
+  name: spoon_big_vomp_robolab
+  type: object
+  params: {}
+- id: computer_mouse
+  name: computer_mouse_hot3d_robolab
+  type: object
+  params: {}
+- id: yogurt_cup
+  name: yogurt_cup_hope_robolab
+  type: object
+  params: {}
+- id: pitcher
+  name: pitcher_ycb_robolab
+  type: object
+  params: {}
+tasks:
+- kind: PickAndPlaceTask
+  params:
+    pick_up_object: apple
+    destination_location: plasticpail
+    background_scene: maple_table_robolab
+    episode_length_s: 20.0
+  description: place the apple into the plasticpail on the table
+  id: task_0_PickAndPlaceTask
+  initial_state_spec_id: state_initial
+  success_state_spec_id: state_spec_1
+state_specs:
+- id: state_initial
+  is_delta: false
+  spatial_constraints:
+  - kind: is_anchor
+    subject: maple_table_robolab
+    params: {}
+    id: state_initial_0_is_anchor_maple_table_robolab
+  - kind: 'on'
+    subject: apple
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_1_on_maple_table_robolab_apple
+  - kind: 'on'
+    subject: plasticpail
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_2_on_maple_table_robolab_plasticpail
+  - kind: 'on'
+    subject: ceramic_mug
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_3_on_maple_table_robolab_ceramic_mug
+  - kind: 'on'
+    subject: glasses
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_4_on_maple_table_robolab_glasses
+  - kind: 'on'
+    subject: keyboard
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_5_on_maple_table_robolab_keyboard
+  - kind: 'on'
+    subject: marker
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_6_on_maple_table_robolab_marker
+  - kind: 'on'
+    subject: remote_control
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_7_on_maple_table_robolab_remote_control
+  - kind: 'on'
+    subject: smartphone
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_8_on_maple_table_robolab_smartphone
+  - kind: 'on'
+    subject: wooden_bowl
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_9_on_maple_table_robolab_wooden_bowl
+  - kind: 'on'
+    subject: spoon_big
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_10_on_maple_table_robolab_spoon_big
+  - kind: 'on'
+    subject: computer_mouse
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_11_on_maple_table_robolab_computer_mouse
+  - kind: 'on'
+    subject: yogurt_cup
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_12_on_maple_table_robolab_yogurt_cup
+  - kind: 'on'
+    subject: pitcher
+    reference: maple_table_robolab
+    params: {}
+    id: state_initial_13_on_maple_table_robolab_pitcher
+  task_constraints: []
+- id: state_spec_1
+  is_delta: true
+  spatial_constraints:
+  - kind: 'on'
+    subject: apple
+    reference: plasticpail
+    params: {}
+    id: state_spec_1_apple_on_plasticpail
+  task_constraints: []
+cli_override_specs: []

--- a/osmo/workflows/workflow.py
+++ b/osmo/workflows/workflow.py
@@ -83,7 +83,7 @@ class Workflow:
         resources = parser.add_argument_group("resources")
         resources.add_argument("--cpus", type=int, default=15)
         resources.add_argument("--gpus", type=int, default=1)
-        resources.add_argument("--memory", default="128Gi")
+        resources.add_argument("--memory", default="256Gi")
         resources.add_argument("--storage", default="200Gi")
         resources.add_argument("--platform", default="ovx-l40s")
 

--- a/osmo/workflows/workflow.py
+++ b/osmo/workflows/workflow.py
@@ -83,7 +83,7 @@ class Workflow:
         resources = parser.add_argument_group("resources")
         resources.add_argument("--cpus", type=int, default=15)
         resources.add_argument("--gpus", type=int, default=1)
-        resources.add_argument("--memory", default="64Gi")
+        resources.add_argument("--memory", default="128Gi")
         resources.add_argument("--storage", default="200Gi")
         resources.add_argument("--platform", default="ovx-l40s")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,4 +88,4 @@ reportPrivateUsage = "warning"
 skip = '*.usd,*.svg,*.png,_isaac_sim*,*.bib,*.css,*/_build'
 quiet-level = 0
 # the world list should always have words in lower case
-ignore-words-list = "haa,slq,collapsable,buss"
+ignore-words-list = "haa,slq,collapsable,buss,crate"


### PR DESCRIPTION
## Summary
Increase default CPU memory allowed on OSMO workflows.

## Detailed description
- We're CPU-memory-bound on OSMO
- We increase the CPU memory to allow to run moar envs.
- This increases the CPU limit to 128Gb, which is approximately 1/8 of the total available memory on an L40s node (989Gb), such that we use an amount that is inline with the number of GPUs we use (1 out of 8 per node per task).
