### PR TITLE
Add greptile.json: review non-draft PRs once, not per commit

### DIFF
--- a/.greptile-update-test
+++ b/.greptile-update-test
@@ -1,1 +1,0 @@
-temporary — remove after testing

--- a/.greptile-update-test
+++ b/.greptile-update-test
@@ -1,0 +1,1 @@
+temporary — remove after testing

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,4 @@
+{
+  "triggerOnDrafts": false,
+  "triggerOnUpdates": false
+}


### PR DESCRIPTION
Configure Greptile to review each PR once (on open / ready-for-review) instead of on every commit, and to skip drafts.

- `triggerOnUpdates: false` — no re-review on new commits (Greptile defaults this on); the initial review still happens.
- `triggerOnDrafts: false` — do not review draft PRs (Greptile default; set explicitly).
- Keeps review noise to one pass per PR, matching how we want the repo's review bots to behave.