### PR TITLE
Scale relation collision checks with BVH

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,61 @@
+# Relation solver benchmarks
+
+`benchmark_relation_solver.py` measures the collision-heavy parts of the relation solver without starting Isaac Sim.
+It uses deterministic `DummyObject` scenes and reports median and p95 wall time plus incremental peak CUDA memory.
+
+Run it inside this clone's Arena container:
+
+```bash
+/isaac-sim/python.sh benchmarks/benchmark_relation_solver.py
+```
+
+The benchmark contains three phases:
+
+- `collision_forward`: AABB extent construction, pair enumeration/stacking, and the collision-loss forward pass.
+- `collision_forward_backward`: the collision forward pass plus autograd.
+- `solve`: a fixed-iteration `RelationSolver.solve()` call, including all relation losses and optimizer work.
+
+Both dense and sparse initial layouts are included. CUDA scenes with at least 64 collision objects use the grouped BVH
+broad phase, while small, CPU, debug, and densely overlapping scenes use dense vectorization. The `selected` column is
+the total number of directed pair instances selected across the candidate batch.
+
+## Recording a baseline
+
+Use fixed iterations so convergence does not confound the comparison. This larger sweep exercises the direct-placement
+batch size of 10 and the normal placement-pool batch size of 50:
+
+```bash
+/isaac-sim/python.sh benchmarks/benchmark_relation_solver.py \
+  --object-counts 8 16 32 64 \
+  --batch-sizes 1 10 50 \
+  --iterations 100 \
+  --warmups 5 \
+  --repeats 30 \
+  --output outputs/benchmarks/relation_solver_main.json
+```
+
+Run the same command on an implementation branch and compare it to the recorded baseline:
+
+```bash
+/isaac-sim/python.sh benchmarks/benchmark_relation_solver.py \
+  --object-counts 8 16 32 64 \
+  --batch-sizes 1 10 50 \
+  --iterations 100 \
+  --warmups 5 \
+  --repeats 30 \
+  --baseline outputs/benchmarks/relation_solver_main.json \
+  --output outputs/benchmarks/relation_solver_candidate.json
+```
+
+`speedup` is `baseline median / current median`, so values greater than 1 are faster. The comparison rejects results from
+different devices or Torch/CUDA versions. JSON output records the Git commit, branch, dirty-worktree status, device,
+Torch/CUDA versions, configuration, raw samples, summary statistics, initial pair count, and initial collision loss.
+
+For CPU measurements, hide CUDA from the process:
+
+```bash
+CUDA_VISIBLE_DEVICES="" /isaac-sim/python.sh benchmarks/benchmark_relation_solver.py
+```
+
+Performance results are intentionally not pytest assertions. Machine load, GPU model, driver state, and thermal behavior
+make fixed timing thresholds unsuitable for the correctness test suite.

--- a/benchmarks/benchmark_relation_solver.py
+++ b/benchmarks/benchmark_relation_solver.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark relation-solver collision work across object and candidate counts."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import math
+import platform
+import statistics
+import subprocess
+import time
+import torch
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from isaaclab_arena.assets.dummy_object import DummyObject
+from isaaclab_arena.relations.relation_solver import RelationSolver
+from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+from isaaclab_arena.relations.relation_solver_state import RelationSolverState
+from isaaclab_arena.relations.relations import IsAnchor, On
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.pose import Pose
+
+PHASE_COLLISION_FORWARD = "collision_forward"
+PHASE_COLLISION_FORWARD_BACKWARD = "collision_forward_backward"
+PHASE_SOLVE = "solve"
+PHASES = (PHASE_COLLISION_FORWARD, PHASE_COLLISION_FORWARD_BACKWARD, PHASE_SOLVE)
+LAYOUTS = ("dense", "sparse")
+
+
+@dataclass
+class Measurement:
+    """Summary statistics for repeated operation timings."""
+
+    samples_ms: list[float]
+    peak_memory_mib_samples: list[float]
+    median_ms: float
+    p95_ms: float
+    min_ms: float
+    max_ms: float
+    stddev_ms: float
+    median_peak_memory_mib: float | None
+
+
+@dataclass
+class BenchmarkResult:
+    """One benchmark result for a phase and scene configuration."""
+
+    phase: str
+    layout: str
+    num_movable_objects: int
+    batch_size: int
+    eligible_directed_pairs: int
+    initial_selected_directed_pair_instances: int
+    iterations_per_sample: int
+    warmups: int
+    repeats: int
+    samples_ms: list[float]
+    peak_memory_mib_samples: list[float]
+    initial_collision_loss_mean: float
+    median_ms: float
+    p95_ms: float
+    min_ms: float
+    max_ms: float
+    stddev_ms: float
+    median_ms_per_iteration: float
+    median_peak_memory_mib: float | None
+    baseline_median_ms: float | None = None
+    speedup_vs_baseline: float | None = None
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value}")
+    return parsed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--object-counts",
+        type=_positive_int,
+        nargs="+",
+        default=[8, 16, 32],
+        help="Movable-object counts to benchmark (default: 8 16 32).",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        type=_positive_int,
+        nargs="+",
+        default=[1, 10, 50],
+        help="Candidate batch sizes to benchmark (default: 1 10 50).",
+    )
+    parser.add_argument(
+        "--layouts",
+        choices=LAYOUTS,
+        nargs="+",
+        default=list(LAYOUTS),
+        help="Initial layouts to benchmark (default: dense sparse).",
+    )
+    parser.add_argument(
+        "--phases",
+        choices=PHASES,
+        nargs="+",
+        default=list(PHASES),
+        help="Benchmark phases to run.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=_positive_int,
+        default=25,
+        help="Fixed solver iterations per solve sample (default: 25).",
+    )
+    parser.add_argument("--warmups", type=_positive_int, default=3, help="Warmup samples per case (default: 3).")
+    parser.add_argument("--repeats", type=_positive_int, default=10, help="Measured samples per case (default: 10).")
+    parser.add_argument("--output", type=Path, help="Optional JSON output path.")
+    parser.add_argument("--baseline", type=Path, help="Optional prior JSON result to compare against.")
+    return parser.parse_args()
+
+
+def _run_git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _device_metadata(device: torch.device) -> dict[str, str | bool | None]:
+    if device.type == "cuda":
+        device_name = torch.cuda.get_device_name(device)
+        cuda_version = torch.version.cuda
+    else:
+        device_name = platform.processor() or platform.machine()
+        cuda_version = None
+    return {
+        "device": str(device),
+        "device_name": device_name,
+        "cuda_available": torch.cuda.is_available(),
+        "cuda_version": cuda_version,
+    }
+
+
+def _metadata(device: torch.device, args: argparse.Namespace) -> dict:
+    return {
+        "timestamp_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "hostname": platform.node(),
+        "git_commit": _run_git("rev-parse", "HEAD"),
+        "git_branch": _run_git("branch", "--show-current"),
+        "git_dirty": bool(_run_git("status", "--porcelain")),
+        "python_version": platform.python_version(),
+        "torch_version": torch.__version__,
+        **_device_metadata(device),
+        "configuration": {
+            "object_counts": args.object_counts,
+            "batch_sizes": args.batch_sizes,
+            "layouts": args.layouts,
+            "phases": args.phases,
+            "iterations": args.iterations,
+            "warmups": args.warmups,
+            "repeats": args.repeats,
+        },
+    }
+
+
+def _synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _measure(
+    operation: Callable[[], object],
+    device: torch.device,
+    warmups: int,
+    repeats: int,
+) -> Measurement:
+    for _ in range(warmups):
+        result = operation()
+        _synchronize(device)
+        del result
+
+    elapsed_ms: list[float] = []
+    peak_memory_bytes: list[int] = []
+    for _ in range(repeats):
+        _synchronize(device)
+        if device.type == "cuda":
+            baseline_memory = torch.cuda.memory_allocated(device)
+            torch.cuda.reset_peak_memory_stats(device)
+        start = time.perf_counter()
+        result = operation()
+        _synchronize(device)
+        elapsed_ms.append((time.perf_counter() - start) * 1e3)
+        del result
+        if device.type == "cuda":
+            peak_memory = torch.cuda.max_memory_allocated(device)
+            peak_memory_bytes.append(max(0, peak_memory - baseline_memory))
+
+    median_peak_memory_mib = None
+    peak_memory_mib_samples = [value / (1024**2) for value in peak_memory_bytes]
+    if peak_memory_bytes:
+        median_peak_memory_mib = statistics.median(peak_memory_mib_samples)
+    return Measurement(
+        samples_ms=elapsed_ms,
+        peak_memory_mib_samples=peak_memory_mib_samples,
+        median_ms=statistics.median(elapsed_ms),
+        p95_ms=_percentile(elapsed_ms, 0.95),
+        min_ms=min(elapsed_ms),
+        max_ms=max(elapsed_ms),
+        stddev_ms=statistics.pstdev(elapsed_ms),
+        median_peak_memory_mib=median_peak_memory_mib,
+    )
+
+
+def _make_scene(
+    num_movable_objects: int,
+    batch_size: int,
+    layout: str,
+) -> tuple[list[DummyObject], list[dict[DummyObject, tuple[float, float, float]]]]:
+    box_size = 0.1
+    box_half = box_size / 2
+    grid_width = math.ceil(math.sqrt(num_movable_objects))
+    sparse_spacing = box_size * 2
+    table_half_extent = max(1.0, grid_width * sparse_spacing)
+
+    table = DummyObject(
+        name="table",
+        bounding_box=AxisAlignedBoundingBox(
+            min_point=(-table_half_extent, -table_half_extent, 0.0),
+            max_point=(table_half_extent, table_half_extent, 0.1),
+        ),
+    )
+    table.set_initial_pose(Pose.identity())
+    table.add_relation(IsAnchor())
+
+    movable_objects: list[DummyObject] = []
+    for object_idx in range(num_movable_objects):
+        obj = DummyObject(
+            name=f"box_{object_idx}",
+            bounding_box=AxisAlignedBoundingBox(
+                min_point=(-box_half, -box_half, -box_half),
+                max_point=(box_half, box_half, box_half),
+            ),
+        )
+        obj.add_relation(On(table, clearance_m=0.01))
+        movable_objects.append(obj)
+
+    objects = [table, *movable_objects]
+    initial_positions: list[dict[DummyObject, tuple[float, float, float]]] = []
+    for candidate_idx in range(batch_size):
+        positions: dict[DummyObject, tuple[float, float, float]] = {table: (0.0, 0.0, 0.0)}
+        candidate_offset = ((candidate_idx % 7) - 3) * 1e-4
+        for object_idx, obj in enumerate(movable_objects):
+            if layout == "dense":
+                angle = 2 * math.pi * object_idx / num_movable_objects
+                x = 0.1 * box_size * math.cos(angle) + candidate_offset
+                y = 0.1 * box_size * math.sin(angle) - candidate_offset
+            else:
+                row, column = divmod(object_idx, grid_width)
+                x = (column - (grid_width - 1) / 2) * sparse_spacing + candidate_offset
+                y = (row - (grid_width - 1) / 2) * sparse_spacing - candidate_offset
+            positions[obj] = (x, y, 0.1 + 0.01 + box_half)
+        initial_positions.append(positions)
+    return objects, initial_positions
+
+
+def _make_solver(max_iters: int) -> RelationSolver:
+    return RelationSolver(
+        params=RelationSolverParams(
+            max_iters=max_iters,
+            convergence_threshold=-1.0,
+            verbose=False,
+            profile=False,
+            save_position_history=False,
+        )
+    )
+
+
+def _preflight_case(
+    objects: list[DummyObject],
+    initial_positions: list[dict[DummyObject, tuple[float, float, float]]],
+    device: torch.device,
+) -> tuple[int, float]:
+    solver = _make_solver(max_iters=0)
+    state = RelationSolverState(objects, initial_positions, device=device)
+    with torch.no_grad():
+        loss = solver._compute_no_overlap_loss(state)  # pyright: ignore[reportPrivateUsage]
+    selected_pair_instances = solver._last_selected_no_overlap_pair_count  # pyright: ignore[reportPrivateUsage]
+    return selected_pair_instances, loss.mean().item()
+
+
+def _benchmark_phase(
+    phase: str,
+    objects: list[DummyObject],
+    initial_positions: list[dict[DummyObject, tuple[float, float, float]]],
+    device: torch.device,
+    iterations: int,
+    warmups: int,
+    repeats: int,
+) -> tuple[Measurement, int]:
+    if phase == PHASE_SOLVE:
+
+        def operation() -> object:
+            solver = _make_solver(max_iters=iterations)
+            return solver.solve(objects, initial_positions)
+
+        return _measure(operation, device, warmups, repeats), iterations
+
+    solver = _make_solver(max_iters=0)
+    state = RelationSolverState(objects, initial_positions, device=device)
+    if phase == PHASE_COLLISION_FORWARD:
+
+        def operation() -> object:
+            with torch.no_grad():
+                return solver._compute_no_overlap_loss(state)  # pyright: ignore[reportPrivateUsage]
+
+    elif phase == PHASE_COLLISION_FORWARD_BACKWARD:
+        optimizable_positions = state.optimizable_positions
+        assert optimizable_positions is not None
+
+        def operation() -> object:
+            optimizable_positions.grad = None
+            loss = solver._compute_no_overlap_loss(state).sum()  # pyright: ignore[reportPrivateUsage]
+            loss.backward()
+            return loss.detach()
+
+    else:
+        raise ValueError(f"Unknown benchmark phase: {phase}")
+
+    return _measure(operation, device, warmups, repeats), 1
+
+
+def _result_key(result: BenchmarkResult | dict) -> tuple[str, str, int, int, int, int, int]:
+    if isinstance(result, BenchmarkResult):
+        return (
+            result.phase,
+            result.layout,
+            result.num_movable_objects,
+            result.batch_size,
+            result.iterations_per_sample,
+            result.warmups,
+            result.repeats,
+        )
+    return (
+        result["phase"],
+        result["layout"],
+        result["num_movable_objects"],
+        result["batch_size"],
+        result["iterations_per_sample"],
+        result["warmups"],
+        result["repeats"],
+    )
+
+
+def _add_baseline_comparisons(results: list[BenchmarkResult], baseline_path: Path, current_metadata: dict) -> None:
+    baseline_payload = json.loads(baseline_path.read_text())
+    baseline_metadata = baseline_payload["metadata"]
+    compatibility_fields = ("device", "device_name", "torch_version", "cuda_version")
+    mismatches = [
+        f"{field}: baseline={baseline_metadata.get(field)!r}, current={current_metadata.get(field)!r}"
+        for field in compatibility_fields
+        if baseline_metadata.get(field) != current_metadata.get(field)
+    ]
+    if mismatches:
+        raise ValueError("Baseline environment is incompatible:\n  " + "\n  ".join(mismatches))
+    baseline_by_key = {_result_key(result): result for result in baseline_payload["results"]}
+    for result in results:
+        baseline = baseline_by_key.get(_result_key(result))
+        if baseline is None:
+            continue
+        result.baseline_median_ms = baseline["median_ms"]
+        result.speedup_vs_baseline = result.baseline_median_ms / result.median_ms
+
+
+def _print_results(results: list[BenchmarkResult]) -> None:
+    header = (
+        f"{'phase':<28} {'layout':<7} {'objects':>7} {'batch':>5} {'selected':>8} "
+        f"{'median ms':>10} {'p95 ms':>10} {'ms/iter':>10} {'peak MiB':>10} {'speedup':>9}"
+    )
+    print(header)
+    print("-" * len(header))
+    for result in results:
+        peak_memory = "-" if result.median_peak_memory_mib is None else f"{result.median_peak_memory_mib:.2f}"
+        speedup = "-" if result.speedup_vs_baseline is None else f"{result.speedup_vs_baseline:.3f}x"
+        print(
+            f"{result.phase:<28} {result.layout:<7} {result.num_movable_objects:>7} "
+            f"{result.batch_size:>5} {result.initial_selected_directed_pair_instances:>8} "
+            f"{result.median_ms:>10.3f} {result.p95_ms:>10.3f} "
+            f"{result.median_ms_per_iteration:>10.3f} {peak_memory:>10} {speedup:>9}"
+        )
+
+
+def main() -> None:
+    """Run the configured benchmark matrix and optionally write JSON results."""
+    args = _parse_args()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    metadata = _metadata(device, args)
+    results: list[BenchmarkResult] = []
+
+    for layout in args.layouts:
+        for num_movable_objects in args.object_counts:
+            assert num_movable_objects >= 2, "object counts must be at least 2 to benchmark object-object collisions."
+            eligible_directed_pairs = num_movable_objects * (num_movable_objects - 1)
+            for batch_size in args.batch_sizes:
+                objects, initial_positions = _make_scene(num_movable_objects, batch_size, layout)
+                initial_selected_pairs, initial_collision_loss = _preflight_case(objects, initial_positions, device)
+                for phase in args.phases:
+                    measurement, iterations_per_sample = _benchmark_phase(
+                        phase,
+                        objects,
+                        initial_positions,
+                        device,
+                        args.iterations,
+                        args.warmups,
+                        args.repeats,
+                    )
+                    results.append(
+                        BenchmarkResult(
+                            phase=phase,
+                            layout=layout,
+                            num_movable_objects=num_movable_objects,
+                            batch_size=batch_size,
+                            eligible_directed_pairs=eligible_directed_pairs,
+                            initial_selected_directed_pair_instances=initial_selected_pairs,
+                            iterations_per_sample=iterations_per_sample,
+                            warmups=args.warmups,
+                            repeats=args.repeats,
+                            samples_ms=measurement.samples_ms,
+                            peak_memory_mib_samples=measurement.peak_memory_mib_samples,
+                            initial_collision_loss_mean=initial_collision_loss,
+                            median_ms=measurement.median_ms,
+                            p95_ms=measurement.p95_ms,
+                            min_ms=measurement.min_ms,
+                            max_ms=measurement.max_ms,
+                            stddev_ms=measurement.stddev_ms,
+                            median_ms_per_iteration=measurement.median_ms / iterations_per_sample,
+                            median_peak_memory_mib=measurement.median_peak_memory_mib,
+                        )
+                    )
+
+    if args.baseline is not None:
+        _add_baseline_comparisons(results, args.baseline, metadata)
+    _print_results(results)
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 2,
+            "metadata": metadata,
+            "results": [asdict(result) for result in results],
+        }
+        args.output.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"\nWrote benchmark results to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena/relations/loss_primitives.py
+++ b/isaaclab_arena/relations/loss_primitives.py
@@ -42,9 +42,9 @@ def single_boundary_linear_loss(
 
     # Convert boundary to tensor if needed
     if not isinstance(boundary, torch.Tensor):
-        boundary = torch.tensor(boundary, dtype=value.dtype, device=value.device)
+        boundary = torch.full((), boundary, dtype=value.dtype, device=value.device)
 
-    zero = torch.tensor(0.0, dtype=value.dtype, device=value.device)
+    zero = torch.zeros((), dtype=value.dtype, device=value.device)
 
     if penalty_side == "greater":
         # Penalize if value > boundary
@@ -119,7 +119,7 @@ def single_point_linear_loss(
 
     # Convert target to tensor if needed (float is allowed per type hint)
     if not isinstance(target, torch.Tensor):
-        target = torch.tensor(target, dtype=value.dtype, device=value.device)
+        target = torch.full((), target, dtype=value.dtype, device=value.device)
 
     return slope * torch.abs(value - target)
 
@@ -130,6 +130,8 @@ def interval_overlap_axis_loss(
     parent_min: torch.Tensor | float,
     parent_max: torch.Tensor | float,
     slope: float = 1.0,
+    *,
+    assume_valid_extents: bool = False,
 ) -> torch.Tensor:
     """ReLU-style interval overlap: zero when separated, slope * overlap length otherwise.
 
@@ -143,20 +145,26 @@ def interval_overlap_axis_loss(
         parent_min: Parent interval min (tensor or float).
         parent_max: Parent interval max (tensor or float).
         slope: Gradient magnitude (default: 1.0).
+        assume_valid_extents: Skip interval-order validation after a caller has
+            validated static bounding-box extents.
 
     Returns:
         Zero when intervals are separated; otherwise slope * overlap length.
     """
     assert isinstance(child_min, torch.Tensor), f"child_min must be a torch.Tensor, got {type(child_min)}"
     assert isinstance(child_max, torch.Tensor), f"child_max must be a torch.Tensor, got {type(child_max)}"
-    assert torch.all(child_min <= child_max), "child_min must be <= child_max for valid interval [child_min, child_max]"
+    if not assume_valid_extents:
+        assert torch.all(
+            child_min <= child_max
+        ), "child_min must be <= child_max for valid interval [child_min, child_max]"
     if not isinstance(parent_min, torch.Tensor):
-        parent_min = torch.tensor(parent_min, dtype=child_min.dtype, device=child_min.device)
+        parent_min = torch.full((), parent_min, dtype=child_min.dtype, device=child_min.device)
     if not isinstance(parent_max, torch.Tensor):
-        parent_max = torch.tensor(parent_max, dtype=child_max.dtype, device=child_max.device)
-    assert torch.all(
-        parent_min <= parent_max
-    ), "parent_min must be <= parent_max for valid interval [parent_min, parent_max]"
+        parent_max = torch.full((), parent_max, dtype=child_max.dtype, device=child_max.device)
+    if not assume_valid_extents:
+        assert torch.all(
+            parent_min <= parent_max
+        ), "parent_min must be <= parent_max for valid interval [parent_min, parent_max]"
     overlap_high = torch.minimum(child_max, parent_max)
     overlap_low = torch.maximum(child_min, parent_min)
     return single_boundary_linear_loss(overlap_high, overlap_low, slope=slope, penalty_side="greater")

--- a/isaaclab_arena/relations/relation_loss_strategies.py
+++ b/isaaclab_arena/relations/relation_loss_strategies.py
@@ -475,6 +475,8 @@ class NoCollisionLossStrategy:
         subject_max: torch.Tensor,
         obstacle_min: torch.Tensor,
         obstacle_max: torch.Tensor,
+        *,
+        assume_valid_extents: bool = False,
     ) -> torch.Tensor:
         """Overlap-volume no-overlap loss for boxes already reduced to world-space extents.
 
@@ -486,6 +488,8 @@ class NoCollisionLossStrategy:
             subject_max: World-space max extent of the subject box, shape (..., 3).
             obstacle_min: World-space min extent of the obstacle box, shape (..., 3).
             obstacle_max: World-space max extent of the obstacle box, shape (..., 3).
+            assume_valid_extents: Skip interval-order validation after a caller has
+                validated static bounding-box extents.
 
         Returns:
             Per-box-pair loss with the same leading dimensions as the inputs.
@@ -494,13 +498,25 @@ class NoCollisionLossStrategy:
         obstacle_min = obstacle_min - clearance_m
         obstacle_max = obstacle_max + clearance_m
         overlap_x = interval_overlap_axis_loss(
-            subject_min[..., 0], subject_max[..., 0], obstacle_min[..., 0], obstacle_max[..., 0]
+            subject_min[..., 0],
+            subject_max[..., 0],
+            obstacle_min[..., 0],
+            obstacle_max[..., 0],
+            assume_valid_extents=assume_valid_extents,
         )
         overlap_y = interval_overlap_axis_loss(
-            subject_min[..., 1], subject_max[..., 1], obstacle_min[..., 1], obstacle_max[..., 1]
+            subject_min[..., 1],
+            subject_max[..., 1],
+            obstacle_min[..., 1],
+            obstacle_max[..., 1],
+            assume_valid_extents=assume_valid_extents,
         )
         overlap_z = interval_overlap_axis_loss(
-            subject_min[..., 2], subject_max[..., 2], obstacle_min[..., 2], obstacle_max[..., 2]
+            subject_min[..., 2],
+            subject_max[..., 2],
+            obstacle_min[..., 2],
+            obstacle_max[..., 2],
+            assume_valid_extents=assume_valid_extents,
         )
         return self.slope * (overlap_x * overlap_y * overlap_z)
 

--- a/isaaclab_arena/relations/relation_loss_strategies.py
+++ b/isaaclab_arena/relations/relation_loss_strategies.py
@@ -482,13 +482,13 @@ class NoCollisionLossStrategy:
 
         Args:
             clearance_m: Minimum clearance between boxes in meters.
-            subject_min: World-space min extent of the subject box, shape (num_pairs, batch_size, 3).
-            subject_max: World-space max extent of the subject box, shape (num_pairs, batch_size, 3).
-            obstacle_min: World-space min extent of the obstacle box, shape (num_pairs, batch_size, 3).
-            obstacle_max: World-space max extent of the obstacle box, shape (num_pairs, batch_size, 3).
+            subject_min: World-space min extent of the subject box, shape (..., 3).
+            subject_max: World-space max extent of the subject box, shape (..., 3).
+            obstacle_min: World-space min extent of the obstacle box, shape (..., 3).
+            obstacle_max: World-space max extent of the obstacle box, shape (..., 3).
 
         Returns:
-            Per-pair, per-env loss of shape (num_pairs, batch_size).
+            Per-box-pair loss with the same leading dimensions as the inputs.
         """
         assert clearance_m >= 0, f"clearance_m must be non-negative, got {clearance_m}"
         obstacle_min = obstacle_min - clearance_m

--- a/isaaclab_arena/relations/relation_solver.py
+++ b/isaaclab_arena/relations/relation_solver.py
@@ -10,6 +10,8 @@ import torch
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+import warp as wp
+
 from isaaclab_arena.relations.relation_loss_strategies import (
     NoCollisionLossStrategy,
     RelationLossStrategy,
@@ -37,6 +39,184 @@ class NoOverlapPair:
     obstacle_max: torch.Tensor
 
 
+@wp.kernel
+def _query_bvh_pairs(
+    bvh_id: wp.uint64,
+    lower_bounds: wp.array(dtype=wp.vec3),
+    upper_bounds: wp.array(dtype=wp.vec3),
+    num_objects: int,
+    clearance_m: float,
+    pair_first: wp.array(dtype=int),
+    pair_second: wp.array(dtype=int),
+    pair_count: wp.array(dtype=int),
+):
+    """Write every unordered, same-environment overlap once."""
+    flat_index = wp.tid()
+    env_index = flat_index // num_objects
+    root = wp.bvh_get_group_root(bvh_id, env_index)
+    padding = wp.vec3(clearance_m, clearance_m, clearance_m)
+    query = wp.bvh_query_aabb(
+        bvh_id,
+        lower_bounds[flat_index] - padding,
+        upper_bounds[flat_index] + padding,
+        root,
+    )
+    hit = int(0)
+    while wp.bvh_query_next(query, hit):
+        if hit > flat_index:
+            output_index = wp.atomic_add(pair_count, 0, 1)
+            pair_first[output_index] = flat_index
+            pair_second[output_index] = hit
+
+
+def _select_no_overlap_pairs_bvh(
+    world_min: torch.Tensor,
+    world_max: torch.Tensor,
+    num_non_anchors: int,
+    num_anchors: int,
+    on_pair_keys: torch.Tensor,
+    clearance_m: float,
+    dense_pair_instance_threshold: float,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, bool]:
+    """Select directed collision pair instances with a grouped GPU BVH.
+
+    Args:
+        world_min: World-space minimum extents, shape (batch_size, num_objects, 3).
+        world_max: World-space maximum extents, shape (batch_size, num_objects, 3).
+        num_non_anchors: Number of movable objects at the start of the object axis.
+        num_anchors: Number of fixed anchors following the movable objects.
+        on_pair_keys: Sorted canonical object-pair keys excluded by On relations.
+        clearance_m: Minimum clearance between boxes in meters.
+        dense_pair_instance_threshold: Directed-candidate count at which the caller
+            should use dense vectorization.
+
+    Returns:
+        Environment, subject, and obstacle indices, plus whether to use the dense path.
+    """
+    batch_size, num_objects, _ = world_min.shape
+    assert num_objects == num_non_anchors + num_anchors
+    device = world_min.device
+    empty = torch.empty(0, dtype=torch.long, device=device)
+
+    with torch.no_grad():
+        capacity = batch_size * num_objects * (num_objects - 1) // 2
+        assert capacity <= torch.iinfo(torch.int32).max, "BVH pair capacity exceeds int32 indexing."
+        if capacity == 0:
+            return empty, empty, empty, False
+
+        flat_min = world_min.detach().contiguous().view(-1, 3)
+        flat_max = world_max.detach().contiguous().view(-1, 3)
+        group_ids = torch.arange(batch_size, dtype=torch.int32, device=device).repeat_interleave(num_objects)
+        pair_first_flat = torch.empty(capacity, dtype=torch.int32, device=device)
+        pair_second_flat = torch.empty(capacity, dtype=torch.int32, device=device)
+        pair_count = torch.zeros(1, dtype=torch.int32, device=device)
+
+        wp.init()
+        lower_bounds_wp = wp.from_torch(flat_min, dtype=wp.vec3)
+        upper_bounds_wp = wp.from_torch(flat_max, dtype=wp.vec3)
+        group_ids_wp = wp.from_torch(group_ids)
+        pair_first_wp = wp.from_torch(pair_first_flat)
+        pair_second_wp = wp.from_torch(pair_second_flat)
+        pair_count_wp = wp.from_torch(pair_count)
+        warp_stream = wp.stream_from_torch(torch.cuda.current_stream(device))
+        with wp.ScopedStream(warp_stream):
+            bvh = wp.Bvh(
+                lower_bounds_wp,
+                upper_bounds_wp,
+                groups=group_ids_wp,
+                constructor="lbvh",
+                leaf_size=1,
+            )
+            wp.launch(
+                _query_bvh_pairs,
+                dim=batch_size * num_objects,
+                inputs=[
+                    bvh.id,
+                    lower_bounds_wp,
+                    upper_bounds_wp,
+                    num_objects,
+                    clearance_m + 1.0e-6,
+                    pair_first_wp,
+                    pair_second_wp,
+                    pair_count_wp,
+                ],
+                device=lower_bounds_wp.device,
+            )
+
+        num_candidates = int(pair_count.item())
+        if num_candidates == 0:
+            return empty, empty, empty, False
+        if 2 * num_candidates >= dense_pair_instance_threshold:
+            return empty, empty, empty, True
+
+        flat_first = pair_first_flat[:num_candidates].long()
+        flat_second = pair_second_flat[:num_candidates].long()
+        env_indices = torch.div(flat_first, num_objects, rounding_mode="floor")
+        first_indices = flat_first.remainder(num_objects)
+        second_indices = flat_second.remainder(num_objects)
+
+        first_is_movable = first_indices < num_non_anchors
+        second_is_movable = second_indices < num_non_anchors
+        has_movable = first_is_movable | second_is_movable
+        env_indices = env_indices[has_movable]
+        first_indices = first_indices[has_movable]
+        second_indices = second_indices[has_movable]
+        first_is_movable = first_is_movable[has_movable]
+        second_is_movable = second_is_movable[has_movable]
+        if first_indices.numel() == 0:
+            return empty, empty, empty, False
+
+        canonical_first = torch.minimum(first_indices, second_indices)
+        canonical_second = torch.maximum(first_indices, second_indices)
+        candidate_keys = canonical_first * num_objects + canonical_second
+        if on_pair_keys.numel() > 0:
+            on_positions = torch.searchsorted(on_pair_keys, candidate_keys)
+            safe_positions = on_positions.clamp_max(on_pair_keys.numel() - 1)
+            keep = (on_positions == on_pair_keys.numel()) | (on_pair_keys[safe_positions] != candidate_keys)
+            env_indices = env_indices[keep]
+            first_indices = first_indices[keep]
+            second_indices = second_indices[keep]
+            first_is_movable = first_is_movable[keep]
+            second_is_movable = second_is_movable[keep]
+            if first_indices.numel() == 0:
+                return empty, empty, empty, False
+
+        both_movable = first_is_movable & second_is_movable
+        cross_role = first_is_movable ^ second_is_movable
+
+        cross_env = env_indices[cross_role]
+        cross_subject = torch.where(first_is_movable[cross_role], first_indices[cross_role], second_indices[cross_role])
+        cross_obstacle = torch.where(
+            first_is_movable[cross_role], second_indices[cross_role], first_indices[cross_role]
+        )
+        cross_order = cross_subject * num_anchors + (cross_obstacle - num_non_anchors)
+
+        movable_env = env_indices[both_movable]
+        movable_first = torch.minimum(first_indices[both_movable], second_indices[both_movable])
+        movable_second = torch.maximum(first_indices[both_movable], second_indices[both_movable])
+        undirected_order = (
+            movable_first * (2 * num_non_anchors - movable_first - 1) // 2 + movable_second - movable_first - 1
+        )
+        movable_order = num_non_anchors * num_anchors + 2 * undirected_order
+
+        directed_env = torch.cat([cross_env, movable_env, movable_env])
+        subject_indices = torch.cat([cross_subject, movable_first, movable_second])
+        obstacle_indices = torch.cat([cross_obstacle, movable_second, movable_first])
+        pair_order = torch.cat([cross_order, movable_order, movable_order + 1])
+        if subject_indices.numel() == 0:
+            return empty, empty, empty, False
+
+        # Match the old pair order within each environment so the segment reduction
+        # has a stable input order even though only selected pair instances remain.
+        uncompressed_pair_count = num_non_anchors * num_anchors + num_non_anchors * (num_non_anchors - 1)
+        order = torch.argsort(directed_env * uncompressed_pair_count + pair_order)
+        directed_env = directed_env[order]
+        subject_indices = subject_indices[order]
+        obstacle_indices = obstacle_indices[order]
+
+        return directed_env, subject_indices, obstacle_indices, False
+
+
 class RelationSolver:
     """Differentiable solver for 3D spatial relations of IsaacLab Arena Objects
 
@@ -46,6 +226,12 @@ class RelationSolver:
 
     POSITION_HISTORY_SAVE_INTERVAL = 10
     """Save position snapshot every N iterations (when save_position_history is enabled)."""
+
+    DENSE_NO_OVERLAP_PAIR_FRACTION = 0.5
+    """Use the dense collision path when at least this fraction of eligible pairs is selected."""
+
+    MIN_BVH_OBJECTS = 64
+    """Use dense vectorization below this object count, where broad-phase overhead dominates."""
 
     def __init__(
         self,
@@ -62,6 +248,7 @@ class RelationSolver:
         self._last_position_history: list = []
         self._last_loss_per_env: torch.Tensor | None = None
         self._last_no_overlap_pair_count: int = 0
+        self._last_selected_no_overlap_pair_count: int = 0
 
     def _get_strategy(self, relation: RelationBase) -> RelationLossStrategy | UnaryRelationLossStrategy:
         """Look up the appropriate strategy for a relation type.
@@ -167,16 +354,125 @@ class RelationSolver:
         Returns:
             Per-environment loss tensor of shape (batch_size,).
         """
-        device = state.device
-        batch_size = state.batch_size
-        zero_loss = torch.zeros(batch_size, device=device, dtype=torch.float32)
+        if debug:
+            return self._compute_no_overlap_loss_dense(state, debug=True)
 
+        device = state.device
         non_anchor_objects = state.optimizable_objects
         anchor_objects = list(state.anchor_objects)
+
+        collision_objects = [*non_anchor_objects, *anchor_objects]
+        object_indices = {obj: index for index, obj in enumerate(collision_objects)}
+        num_non_anchors = len(non_anchor_objects)
+        num_anchors = len(anchor_objects)
 
         # Skip no-overlap for On pairs: the On loss already pushes the child
         # onto the parent surface, so penalizing bbox overlap between them
         # would fight that constraint and cause oscillation.
+        on_pair_keys: set[int] = set()
+        for obj in collision_objects:
+            for rel in obj.get_relations():
+                if isinstance(rel, On) and rel.parent in object_indices:
+                    first = object_indices[obj]
+                    second = object_indices[rel.parent]
+                    first, second = min(first, second), max(first, second)
+                    on_pair_keys.add(first * len(collision_objects) + second)
+
+        pair_count = num_non_anchors * num_anchors + num_non_anchors * (num_non_anchors - 1)
+        for pair_key in on_pair_keys:
+            first, second = divmod(pair_key, len(collision_objects))
+            if second < num_non_anchors:
+                pair_count -= 2
+            elif first < num_non_anchors:
+                pair_count -= 1
+        self._last_no_overlap_pair_count = pair_count
+
+        optimizable_positions = state.optimizable_positions
+        assert optimizable_positions is not None
+        zero_loss = optimizable_positions.sum(dim=(1, 2)) * 0.0
+        if pair_count == 0:
+            self._last_selected_no_overlap_pair_count = 0
+            return zero_loss
+        if device.type != "cuda" or len(collision_objects) < self.MIN_BVH_OBJECTS:
+            return self._compute_no_overlap_loss_dense(state)
+
+        # World-space (min, max) extents once per object, shape (batch, 3). Non-anchor
+        # extents carry gradient through the object's position; anchor extents are constant.
+        world_min: list[torch.Tensor] = []
+        world_max: list[torch.Tensor] = []
+        for obj in non_anchor_objects:
+            pos = state.get_position(obj)
+            bbox = state.get_bbox(obj)
+            world_min.append(pos + bbox.min_point)
+            world_max.append(pos + bbox.max_point)
+        for anchor in anchor_objects:
+            anchor_world_bbox = anchor.get_world_bounding_box().to(device)
+            world_min.append(anchor_world_bbox.min_point.expand(state.batch_size, 3))
+            world_max.append(anchor_world_bbox.max_point.expand(state.batch_size, 3))
+
+        # (batch_size, num_objects, 3). Pair selection is discrete and deliberately
+        # detached; selected extents are gathered again below to retain gradients.
+        world_min_tensor = torch.stack(world_min, dim=1)
+        world_max_tensor = torch.stack(world_max, dim=1)
+        precomputed_extents = {obj: (world_min[index], world_max[index]) for index, obj in enumerate(collision_objects)}
+        assert torch.all(world_min_tensor <= world_max_tensor), "Object bounding boxes must have min <= max."
+        common_overlap = (
+            world_min_tensor.max(dim=1).values <= world_max_tensor.min(dim=1).values + self.params.clearance_m
+        ).all()
+        if bool(common_overlap):
+            return self._compute_no_overlap_loss_dense(state, extents=precomputed_extents)
+        on_pair_key_tensor = torch.tensor(sorted(on_pair_keys), dtype=torch.long, device=device)
+        env_indices, subject_indices, obstacle_indices, use_dense = _select_no_overlap_pairs_bvh(
+            world_min_tensor,
+            world_max_tensor,
+            num_non_anchors,
+            num_anchors,
+            on_pair_key_tensor,
+            self.params.clearance_m,
+            self.DENSE_NO_OVERLAP_PAIR_FRACTION * pair_count * state.batch_size,
+        )
+        if use_dense:
+            return self._compute_no_overlap_loss_dense(state, extents=precomputed_extents)
+
+        selected_pair_count = subject_indices.numel()
+        self._last_selected_no_overlap_pair_count = selected_pair_count
+        if selected_pair_count == 0:
+            return zero_loss
+
+        # Dense vectorization wins when most pairs overlap; it also retains the old
+        # allocation and reduction order for that worst-case broad-phase workload.
+        if selected_pair_count >= self.DENSE_NO_OVERLAP_PAIR_FRACTION * pair_count * state.batch_size:
+            return self._compute_no_overlap_loss_dense(state, extents=precomputed_extents)
+
+        subject_min = world_min_tensor[env_indices, subject_indices]
+        subject_max = world_max_tensor[env_indices, subject_indices]
+        obstacle_min = world_min_tensor[env_indices, obstacle_indices].detach()
+        obstacle_max = world_max_tensor[env_indices, obstacle_indices].detach()
+        pair_loss = self._no_collision_strategy.compute_loss_batched(
+            self.params.clearance_m, subject_min, subject_max, obstacle_min, obstacle_max
+        )
+
+        # Pair rows are sorted by environment and original pair order. A contiguous
+        # segment reduction avoids CUDA atomic-add nondeterminism from index_add.
+        pairs_per_env = torch.bincount(env_indices, minlength=state.batch_size)
+        return zero_loss + torch.segment_reduce(pair_loss, reduce="sum", lengths=pairs_per_env)
+
+    def _compute_no_overlap_loss_dense(
+        self,
+        state: RelationSolverState,
+        debug: bool = False,
+        extents: dict[ObjectBase, tuple[torch.Tensor, torch.Tensor]] | None = None,
+    ) -> torch.Tensor:
+        """Compute the original dense all-pairs no-overlap loss."""
+        device = state.device
+        batch_size = state.batch_size
+        optimizable_positions = state.optimizable_positions
+        assert optimizable_positions is not None
+        zero_loss = optimizable_positions.sum(dim=(1, 2)) * 0.0
+
+        non_anchor_objects = state.optimizable_objects
+        anchor_objects = list(state.anchor_objects)
+
         on_pairs: set[tuple[int, int]] = set()
         for obj in [*non_anchor_objects, *anchor_objects]:
             for rel in obj.get_relations():
@@ -184,19 +480,18 @@ class RelationSolver:
                     on_pairs.add((id(obj), id(rel.parent)))
                     on_pairs.add((id(rel.parent), id(obj)))
 
-        # World-space (min, max) extents once per object, shape (batch, 3). Non-anchor
-        # extents carry gradient through the object's position; anchor extents are constant.
-        extents: dict[ObjectBase, tuple[torch.Tensor, torch.Tensor]] = {}
-        for obj in non_anchor_objects:
-            pos = state.get_position(obj)
-            bbox = state.get_bbox(obj)
-            extents[obj] = (pos + bbox.min_point, pos + bbox.max_point)
-        for anchor in anchor_objects:
-            anchor_world_bbox = anchor.get_world_bounding_box().to(device)
-            extents[anchor] = (
-                anchor_world_bbox.min_point.expand(batch_size, 3),
-                anchor_world_bbox.max_point.expand(batch_size, 3),
-            )
+        if extents is None:
+            extents = {}
+            for obj in non_anchor_objects:
+                pos = state.get_position(obj)
+                bbox = state.get_bbox(obj)
+                extents[obj] = (pos + bbox.min_point, pos + bbox.max_point)
+            for anchor in anchor_objects:
+                anchor_world_bbox = anchor.get_world_bounding_box().to(device)
+                extents[anchor] = (
+                    anchor_world_bbox.min_point.expand(batch_size, 3),
+                    anchor_world_bbox.max_point.expand(batch_size, 3),
+                )
 
         pairs: list[NoOverlapPair] = []
         pair_names: list[tuple[str, str]] = []  # for the debug=True print
@@ -225,6 +520,7 @@ class RelationSolver:
                 pair_names.append((other.name, child.name))
 
         self._last_no_overlap_pair_count = len(pairs)
+        self._last_selected_no_overlap_pair_count = len(pairs) * batch_size
         if not pairs:
             return zero_loss
 

--- a/isaaclab_arena/relations/relation_solver.py
+++ b/isaaclab_arena/relations/relation_solver.py
@@ -311,7 +311,7 @@ class RelationSolver:
                     relation_strategy = cast(RelationLossStrategy, strategy)
                     parent = relation.parent
                     if parent in state.anchor_objects:
-                        parent_world_bbox = parent.get_world_bounding_box().to(device)
+                        parent_world_bbox = state.get_anchor_world_bbox(parent)
                     else:
                         parent_pos = state.get_position(parent)
                         parent_bbox = state.get_bbox(parent)
@@ -333,7 +333,7 @@ class RelationSolver:
         # Add built-in no-overlap loss between all object pairs
         total_loss = total_loss + self._compute_no_overlap_loss(state, debug)
 
-        self._last_loss_per_env = total_loss.detach().clone()
+        self._last_loss_per_env = total_loss.detach()
         return total_loss.mean()
 
     def _compute_no_overlap_loss(
@@ -406,7 +406,7 @@ class RelationSolver:
             world_min.append(pos + bbox.min_point)
             world_max.append(pos + bbox.max_point)
         for anchor in anchor_objects:
-            anchor_world_bbox = anchor.get_world_bounding_box().to(device)
+            anchor_world_bbox = state.get_anchor_world_bbox(anchor)
             world_min.append(anchor_world_bbox.min_point.expand(state.batch_size, 3))
             world_max.append(anchor_world_bbox.max_point.expand(state.batch_size, 3))
 
@@ -415,7 +415,9 @@ class RelationSolver:
         world_min_tensor = torch.stack(world_min, dim=1)
         world_max_tensor = torch.stack(world_max, dim=1)
         precomputed_extents = {obj: (world_min[index], world_max[index]) for index, obj in enumerate(collision_objects)}
-        assert torch.all(world_min_tensor <= world_max_tensor), "Object bounding boxes must have min <= max."
+        # No re-validation here: world_min/world_max are built by translating
+        # (pos + bbox.min/max) or expanding the extents RelationSolverState already
+        # validated once at construction, and both operations preserve min <= max.
         common_overlap = (
             world_min_tensor.max(dim=1).values <= world_max_tensor.min(dim=1).values + self.params.clearance_m
         ).all()
@@ -449,7 +451,12 @@ class RelationSolver:
         obstacle_min = world_min_tensor[env_indices, obstacle_indices].detach()
         obstacle_max = world_max_tensor[env_indices, obstacle_indices].detach()
         pair_loss = self._no_collision_strategy.compute_loss_batched(
-            self.params.clearance_m, subject_min, subject_max, obstacle_min, obstacle_max
+            self.params.clearance_m,
+            subject_min,
+            subject_max,
+            obstacle_min,
+            obstacle_max,
+            assume_valid_extents=True,
         )
 
         # Pair rows are sorted by environment and original pair order. A contiguous
@@ -464,7 +471,6 @@ class RelationSolver:
         extents: dict[ObjectBase, tuple[torch.Tensor, torch.Tensor]] | None = None,
     ) -> torch.Tensor:
         """Compute the original dense all-pairs no-overlap loss."""
-        device = state.device
         batch_size = state.batch_size
         optimizable_positions = state.optimizable_positions
         assert optimizable_positions is not None
@@ -487,7 +493,7 @@ class RelationSolver:
                 bbox = state.get_bbox(obj)
                 extents[obj] = (pos + bbox.min_point, pos + bbox.max_point)
             for anchor in anchor_objects:
-                anchor_world_bbox = anchor.get_world_bounding_box().to(device)
+                anchor_world_bbox = state.get_anchor_world_bbox(anchor)
                 extents[anchor] = (
                     anchor_world_bbox.min_point.expand(batch_size, 3),
                     anchor_world_bbox.max_point.expand(batch_size, 3),
@@ -531,7 +537,12 @@ class RelationSolver:
         obstacle_max = torch.stack([p.obstacle_max for p in pairs], dim=0)
 
         pair_loss = self._no_collision_strategy.compute_loss_batched(
-            self.params.clearance_m, subject_min, subject_max, obstacle_min, obstacle_max
+            self.params.clearance_m,
+            subject_min,
+            subject_max,
+            obstacle_min,
+            obstacle_max,
+            assume_valid_extents=True,
         )
 
         if debug:
@@ -587,9 +598,10 @@ class RelationSolver:
         # Setup optimizer (only for optimizable positions)
         optimizer = torch.optim.Adam([state.optimizable_positions], lr=self.params.lr)
 
-        # Compute initial loss so _last_loss_per_env is always populated, even when max_iters=0.
-        with torch.no_grad():
-            self._compute_total_loss(state)
+        # Populate loss metadata for the zero-iteration inspection mode.
+        if self.params.max_iters == 0:
+            with torch.no_grad():
+                self._compute_total_loss(state)
 
         # Optimization loop
         loss_history = []
@@ -603,17 +615,18 @@ class RelationSolver:
 
             # Compute total loss
             loss = self._compute_total_loss(state)
-            loss_history.append(loss.item())
+            loss_value = loss.item()
+            loss_history.append(loss_value)
 
             # Backprop and update (only optimizable positions will update)
             loss.backward()
             optimizer.step()
 
             if self.params.verbose and iter % 100 == 0:
-                print(f"Iter {iter}: loss = {loss.item():.6f}")
+                print(f"Iter {iter}: loss = {loss_value:.6f}")
 
             # Check convergence
-            if loss.item() < self.params.convergence_threshold:
+            if loss_value < self.params.convergence_threshold:
                 if self.params.verbose:
                     print(f"Converged at iteration {iter}")
                 break

--- a/isaaclab_arena/relations/relation_solver_state.py
+++ b/isaaclab_arena/relations/relation_solver_state.py
@@ -72,8 +72,12 @@ class RelationSolverState:
         self._anchor_indices: set[int] = {self._obj_to_idx[obj] for obj in self._anchor_objects}
         # Anchors must be identical across envs (they are fixed reference points).
         for idx in self._anchor_indices:
-            for env_idx in range(1, self._batch_size):
-                assert torch.allclose(all_positions[0, idx], all_positions[env_idx, idx]), (
+            anchor_positions = all_positions[:, idx]
+            reference_position = anchor_positions[0].expand_as(anchor_positions)
+            if not torch.allclose(reference_position, anchor_positions):
+                matching_rows = torch.isclose(reference_position, anchor_positions).all(dim=1)
+                env_idx = int(torch.nonzero(~matching_rows, as_tuple=False)[0].item())
+                assert False, (
                     f"Anchor '{objects[idx].name}' has different positions across envs "
                     f"(env 0: {all_positions[0, idx].tolist()}, env {env_idx}: {all_positions[env_idx, idx].tolist()})"
                 )
@@ -99,7 +103,19 @@ class RelationSolverState:
             self._opt_idx_tensor = None
             self._optimizable_positions = None
 
-        self._env_bboxes = env_bboxes
+        self._bboxes: dict[ObjectBase, AxisAlignedBoundingBox] = {}
+        for obj in objects:
+            bbox = env_bboxes[obj] if env_bboxes is not None and obj in env_bboxes else obj.get_bounding_box()
+            assert torch.all(bbox.min_point <= bbox.max_point), f"Object '{obj.name}' has invalid bounding-box extents."
+            self._bboxes[obj] = bbox.to(self._device)
+
+        self._anchor_world_bboxes: dict[ObjectBase, AxisAlignedBoundingBox] = {}
+        for anchor in self._anchor_objects:
+            world_bbox = anchor.get_world_bounding_box()
+            assert torch.all(
+                world_bbox.min_point <= world_bbox.max_point
+            ), f"Anchor '{anchor.name}' has invalid world bounding-box extents."
+            self._anchor_world_bboxes[anchor] = world_bbox.to(self._device)
 
     @property
     def device(self) -> torch.device:
@@ -151,10 +167,12 @@ class RelationSolverState:
         return self._optimizable_positions[:, opt_idx, :]
 
     def get_bbox(self, obj: ObjectBase) -> AxisAlignedBoundingBox:
-        """Return the local bounding box for obj, moved to the state's device."""
-        if self._env_bboxes is not None and obj in self._env_bboxes:
-            return self._env_bboxes[obj].to(self._device)
-        return obj.get_bounding_box().to(self._device)
+        """Return the cached local bounding box for obj on the state's device."""
+        return self._bboxes[obj]
+
+    def get_anchor_world_bbox(self, obj: ObjectBase) -> AxisAlignedBoundingBox:
+        """Return the cached world bounding box for an anchor object."""
+        return self._anchor_world_bboxes[obj]
 
     def get_all_positions_snapshot(self) -> list[tuple[float, float, float]]:
         """Get detached copy of all positions for history tracking.
@@ -162,7 +180,8 @@ class RelationSolverState:
         Returns:
             List of (x, y, z) positions for each object (in original order). Uses env 0.
         """
-        return [tuple(self.get_position(obj)[0].detach().tolist()) for obj in self._all_objects]
+        positions = self._reconstruct_all_positions()[0].detach().cpu().tolist()
+        return [tuple(position) for position in positions]
 
     def get_final_positions(self) -> list[dict[ObjectBase, tuple[float, float, float]]]:
         """Get final positions as a list of dicts, one per env.

--- a/isaaclab_arena/tests/test_no_collision_loss.py
+++ b/isaaclab_arena/tests/test_no_collision_loss.py
@@ -8,6 +8,8 @@
 import math
 import torch
 
+import pytest
+
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.relations.loss_primitives import interval_overlap_axis_loss
 from isaaclab_arena.relations.relation_loss_strategies import NoCollisionLossStrategy
@@ -533,6 +535,176 @@ def test_vectorized_no_overlap_matches_reference_multiple_anchors():
     ]
     # 2 boxes x 2 anchors = 4 anchor pairs + box_a/box_b pair both directions = 6 pairs.
     _assert_vectorized_matches_reference(objects, initial_positions, expect_positive=True, expected_pair_count=6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BVH coverage.")
+def test_sparse_no_overlap_selection_matches_reference_and_prunes_pairs():
+    """Sparse broad-phase selection preserves loss/gradients while dropping distant pair instances."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+    boxes = [_create_box(f"box_{index}") for index in range(4)]
+    for box in boxes:
+        box.add_relation(On(table, clearance_m=0.01))
+    objects = [table, *boxes]
+    initial_positions = [
+        {
+            table: (0.0, 0.0, 0.0),
+            boxes[0]: (0.0, 0.0, 0.11),
+            boxes[1]: (0.1, 0.0, 0.11),
+            boxes[2]: (2.0, 2.0, 0.11),
+            boxes[3]: (4.0, 4.0, 0.11),
+        },
+        {
+            table: (0.0, 0.0, 0.0),
+            boxes[0]: (0.0, 0.0, 0.11),
+            boxes[1]: (2.0, 2.0, 0.11),
+            boxes[2]: (4.0, 4.0, 0.11),
+            boxes[3]: (6.0, 6.0, 0.11),
+        },
+    ]
+    solver = RelationSolver(params=RelationSolverParams(verbose=False))
+    solver.MIN_BVH_OBJECTS = 0
+    solver.DENSE_NO_OVERLAP_PAIR_FRACTION = 10.0
+
+    state_new = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+    loss_new = solver._compute_no_overlap_loss(state_new)  # pyright: ignore[reportPrivateUsage]
+    loss_new.sum().backward()
+    grad_new = state_new.optimizable_positions.grad.clone()
+
+    state_ref = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+    loss_ref = _reference_pairwise_no_overlap_loss(solver, state_ref)
+    loss_ref.sum().backward()
+
+    assert solver._last_no_overlap_pair_count == 12  # pyright: ignore[reportPrivateUsage]
+    assert solver._last_selected_no_overlap_pair_count == 2  # pyright: ignore[reportPrivateUsage]
+    assert torch.allclose(loss_new, loss_ref, atol=1e-6)
+    assert torch.allclose(grad_new, state_ref.optimizable_positions.grad, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BVH coverage.")
+def test_sparse_no_overlap_selection_keeps_touching_pair_gradient():
+    """A pair exactly at the clearance boundary remains selected for its boundary gradient."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+    boxes = [_create_box(f"box_{index}") for index in range(4)]
+    for box in boxes:
+        box.add_relation(On(table, clearance_m=0.01))
+    objects = [table, *boxes]
+    initial_positions = [{
+        table: (0.0, 0.0, 0.0),
+        boxes[0]: (0.0, 0.0, 0.11),
+        boxes[1]: (0.2, 0.0, 0.11),
+        boxes[2]: (2.0, 2.0, 0.11),
+        boxes[3]: (4.0, 4.0, 0.11),
+    }]
+    solver = RelationSolver(params=RelationSolverParams(clearance_m=0.0, verbose=False))
+    solver.MIN_BVH_OBJECTS = 0
+    solver.DENSE_NO_OVERLAP_PAIR_FRACTION = 10.0
+    state = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+
+    loss = solver._compute_no_overlap_loss(state)  # pyright: ignore[reportPrivateUsage]
+    loss.sum().backward()
+
+    assert torch.allclose(loss, torch.zeros_like(loss))
+    assert solver._last_selected_no_overlap_pair_count == 2  # pyright: ignore[reportPrivateUsage]
+    assert state.optimizable_positions.grad[0, :2, 0].abs().gt(0).all()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BVH coverage.")
+def test_sparse_no_overlap_empty_selection_retains_backward_graph():
+    """A collision-free sparse scene returns differentiable zeros for optimizer backward."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+    boxes = [_create_box(f"box_{index}") for index in range(3)]
+    for box in boxes:
+        box.add_relation(On(table, clearance_m=0.01))
+    objects = [table, *boxes]
+    initial_positions = [{
+        table: (0.0, 0.0, 0.0),
+        boxes[0]: (0.0, 0.0, 0.11),
+        boxes[1]: (2.0, 2.0, 0.11),
+        boxes[2]: (4.0, 4.0, 0.11),
+    }]
+    solver = RelationSolver(params=RelationSolverParams(verbose=False))
+    solver.MIN_BVH_OBJECTS = 0
+    solver.DENSE_NO_OVERLAP_PAIR_FRACTION = 10.0
+    state = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+
+    loss = solver._compute_no_overlap_loss(state)  # pyright: ignore[reportPrivateUsage]
+    loss.sum().backward()
+
+    assert torch.allclose(loss, torch.zeros_like(loss))
+    assert solver._last_no_overlap_pair_count == 6  # pyright: ignore[reportPrivateUsage]
+    assert solver._last_selected_no_overlap_pair_count == 0  # pyright: ignore[reportPrivateUsage]
+    assert torch.allclose(state.optimizable_positions.grad, torch.zeros_like(state.optimizable_positions))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for repeatability coverage.")
+def test_sparse_no_overlap_cuda_reduction_is_repeatable():
+    """Sparse per-environment reduction produces bitwise-repeatable CUDA losses."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+    boxes = [_create_box(f"box_{index}") for index in range(4)]
+    for box in boxes:
+        box.add_relation(On(table, clearance_m=0.01))
+    objects = [table, *boxes]
+    initial_positions = [
+        {
+            table: (0.0, 0.0, 0.0),
+            boxes[0]: (candidate * 1e-4, 0.0, 0.11),
+            boxes[1]: (0.05 + candidate * 1e-4, 0.0, 0.11),
+            boxes[2]: (0.12 + candidate * 1e-4, 0.0, 0.11),
+            boxes[3]: (4.0, 4.0, 0.11),
+        }
+        for candidate in range(50)
+    ]
+    solver = RelationSolver(params=RelationSolverParams(verbose=False))
+    solver.MIN_BVH_OBJECTS = 0
+    solver.DENSE_NO_OVERLAP_PAIR_FRACTION = 10.0
+    state = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+
+    with torch.no_grad():
+        losses = [solver._compute_no_overlap_loss(state) for _ in range(5)]  # pyright: ignore[reportPrivateUsage]
+    torch.cuda.synchronize()
+
+    assert all(torch.equal(losses[0], loss) for loss in losses[1:])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BVH coverage.")
+def test_bvh_no_overlap_isolates_batched_environments_at_scale():
+    """Grouped BVH queries neither cross environments nor duplicate unordered hits."""
+    table = _create_table()
+    table.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    table.add_relation(IsAnchor())
+    boxes = [_create_box(f"box_{index}") for index in range(64)]
+    for box in boxes:
+        box.add_relation(On(table, clearance_m=0.01))
+    objects = [table, *boxes]
+    initial_positions = []
+    for env_index in range(2):
+        positions = {table: (0.0, 0.0, 0.0)}
+        positions.update({box: (10.0 * index, 0.0, 0.11) for index, box in enumerate(boxes)})
+        pair_start = 2 * env_index
+        positions[boxes[pair_start]] = (-20.0, 0.0, 0.11)
+        positions[boxes[pair_start + 1]] = (-19.9, 0.0, 0.11)
+        initial_positions.append(positions)
+
+    solver = RelationSolver(params=RelationSolverParams(verbose=False))
+    solver.DENSE_NO_OVERLAP_PAIR_FRACTION = 10.0
+    state = RelationSolverState(objects, initial_positions, device=torch.device("cuda"))
+
+    loss = solver._compute_no_overlap_loss(state)  # pyright: ignore[reportPrivateUsage]
+    loss.sum().backward()
+
+    assert solver._last_selected_no_overlap_pair_count == 4  # pyright: ignore[reportPrivateUsage]
+    assert loss.gt(0).all()
+    nonzero_gradient = state.optimizable_positions.grad.abs().sum(dim=2).gt(0)
+    assert nonzero_gradient[0].nonzero().flatten().tolist() == [0, 1]
+    assert nonzero_gradient[1].nonzero().flatten().tolist() == [2, 3]
 
 
 def test_vectorized_no_overlap_empty_pairs_returns_zero():

--- a/isaaclab_arena/tests/test_no_collision_loss.py
+++ b/isaaclab_arena/tests/test_no_collision_loss.py
@@ -802,6 +802,16 @@ def test_compute_loss_batched_direct():
     assert torch.isclose(loss[1, 0], torch.tensor(0.0), atol=1e-6)
 
 
+def test_compute_loss_batched_validates_extents_by_default():
+    """Direct collision-loss callers retain interval validation."""
+    strategy = NoCollisionLossStrategy()
+    invalid_min = torch.tensor([[1.0, 0.0, 0.0]])
+    invalid_max = torch.tensor([[0.0, 1.0, 1.0]])
+
+    with pytest.raises(AssertionError, match="child_min must be <= child_max"):
+        strategy.compute_loss_batched(0.0, invalid_min, invalid_max, invalid_min, invalid_max)
+
+
 def test_relation_solver_multi_env_returns_list_of_dicts():
     """Test that solver returns list[dict] when given list[dict] input."""
     table, box_a, box_b = _create_no_collision_scene()

--- a/isaaclab_arena/tests/test_relation_loss.py
+++ b/isaaclab_arena/tests/test_relation_loss.py
@@ -84,6 +84,16 @@ def test_single_boundary_linear_loss_less_side_penalizes_correctly():
     assert loss_below > 0.0
 
 
+def test_single_boundary_linear_loss_preserves_boundary_gradient():
+    """The maximum tie at the boundary splits the gradient equally."""
+    value = torch.tensor(0.05, requires_grad=True)
+
+    loss = single_boundary_linear_loss(value, 0.05, slope=10.0, penalty_side="greater")
+    loss.backward()
+
+    assert torch.equal(value.grad, torch.tensor(5.0))
+
+
 def test_linear_band_loss_inside_band_returns_zero():
     """Test that loss is zero when value is within bounds."""
     lower_bound = 0.04


### PR DESCRIPTION
## Summary
Scale relation collision checks with BVH

## Detailed description
- Avoid quadratic narrow-phase work in sparse CUDA scenes with grouped per-environment BVHs.
- Preserve existing collision semantics and dense/small-scene behavior with focused correctness tests.
- Add reproducible benchmarks for runtime, memory, and scaling comparisons.
