### PR TITLE
Add Hydra experiment configuration example

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,30 @@
+# Isaac Lab-Arena
+
+Isaac Lab-Arena defines composable robotics environments and evaluates policies against them.
+
+## Language
+
+**Environment Configuration**:
+Declarative values that specialize one environment provider for an Arena Experiment.
+_Avoid_: Hydra environment, environment wrapper
+
+**Environment Provider**:
+A named recipe that turns an environment configuration into an assembled Arena environment.
+_Avoid_: Runtime environment, Hydra environment
+
+**Arena Environment**:
+An assembled embodiment, scene, and task ready to be passed to an environment builder.
+_Avoid_: Environment configuration, environment provider
+
+**Gym Environment**:
+The instantiated simulation interface used for reset and step operations.
+_Avoid_: Arena environment configuration
+
+**Arena Experiment**:
+A portable, declarative evaluation condition pairing an environment configuration with a policy,
+rollout, variations, and repetition count. It contains no dispatch state or results.
+_Avoid_: Job, runtime execution, simulation application
+
+**Evaluation Job**:
+A runtime work item derived from an Arena Experiment and tracked through its execution lifecycle.
+_Avoid_: Experiment configuration, suite

--- a/isaaclab_arena/evaluation/__init__.py
+++ b/isaaclab_arena/evaluation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena policy-evaluation configuration and runners."""

--- a/isaaclab_arena/evaluation/arena_experiment_cfg.py
+++ b/isaaclab_arena/evaluation/arena_experiment_cfg.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed configuration for Arena experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from isaaclab_arena.environments.arena_environment_cfg import ArenaEnvironmentCfg
+
+
+@dataclass
+class EnvironmentBuilderCfg:
+    """Configure how Arena builds the selected environment."""
+
+    num_envs: int = 1
+    env_spacing: float = 30.0
+    seed: int = 42
+    solve_relations: bool = True
+    placement_seed: int | None = None
+    resolve_on_reset: bool | None = None
+    random_yaw_init: bool = False
+    disable_fabric: bool = False
+    mimic: bool = False
+    presets: str | None = None
+
+    def __post_init__(self) -> None:
+        assert self.num_envs > 0, "num_envs must be greater than zero"
+
+
+@dataclass
+class RolloutCfg:
+    """Configure an evaluation rollout."""
+
+    num_steps: int = 2
+
+    def __post_init__(self) -> None:
+        assert self.num_steps > 0, "num_steps must be greater than zero"
+
+
+@dataclass
+class PolicyCfg:
+    """Select and configure an evaluation policy."""
+
+    type: str = "zero_action"
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        assert self.type, "policy type must not be empty"
+
+
+@dataclass
+class ArenaExperimentCfg:
+    """Configure one portable Arena evaluation experiment."""
+
+    name: str
+    environment: ArenaEnvironmentCfg
+    """Concrete registered environment configuration selected during composition."""
+    environment_builder: EnvironmentBuilderCfg = field(default_factory=EnvironmentBuilderCfg)
+    policy: PolicyCfg = field(default_factory=PolicyCfg)
+    rollout: RolloutCfg = field(default_factory=RolloutCfg)
+    num_rebuilds: int = 1
+    variations: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        assert self.name, "experiment name must not be empty"
+        assert self.num_rebuilds > 0, "num_rebuilds must be greater than zero"

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -212,6 +212,133 @@ def _run_in_chunks(args_cli: argparse.Namespace, master_cfg: dict) -> None:
             sys.exit(returncode)
 
 
+def evaluate_jobs(
+    args_cli: argparse.Namespace,
+    jobs: list[Job | dict],
+    *,
+    environment_loader=None,
+) -> None:
+    """Evaluate jobs inside an active ``SimulationAppContext``.
+
+    Args:
+        args_cli: Evaluation-runner options shared by every job.
+        jobs: Resolved jobs or legacy job dictionaries.
+        environment_loader: Optional callable that builds one job's environment.
+    """
+    job_manager = JobManager(jobs)
+    metrics_logger = MetricsLogger()
+
+    job_manager.print_jobs_info()
+
+    # One reverse-dated run directory shared by all jobs; each job gets a subdirectory within it.
+    # Always dated so every run produces its own report dir, recording or not.
+    # TODO(alexmillane): Currently each chunk produces its own output directory.
+    # We should use the same output directory for all chunks in the future.
+    run_output_dir = timestamped_run_dir(args_cli.output_base_dir)
+
+    if args_cli.record_viewport_video:
+        os.makedirs(run_output_dir, exist_ok=True)
+        print(f"[INFO] Video recording enabled. Videos will be saved to: {run_output_dir}")
+
+    for job in job_manager:
+        if job is None:
+            continue
+        env = None
+        policy = None
+
+        metrics_per_run: list[MetricsDataCollection] = []
+
+        # num_episodes is the total across rebuilds, so split it over the rebuilds.
+        num_episodes_per_rebuild = _split_episodes_across_rebuilds(job.num_episodes, job.num_rebuilds, job.name)
+
+        # Rebuild the environment and re-run the rollout job.num_rebuilds times, then
+        # aggregate the metrics across rebuilds into a single result.
+        for rebuild_idx in range(job.num_rebuilds):
+            try:
+                job_output_dir = os.path.join(run_output_dir, job.name)
+
+                # Per-job video output directory; cameras are tagged with the rebuild index.
+                video_cfg = VideoRecordingCfg(
+                    record_viewport_video=args_cli.record_viewport_video,
+                    record_camera_video=args_cli.record_camera_video,
+                    video_base_dir=job_output_dir,
+                    camera_name_prefix=f"robot-cam-rebuild{rebuild_idx}",
+                )
+                if environment_loader is None:
+                    env = load_env(
+                        job.arena_env_args,
+                        job.name,
+                        variations=job.variations,
+                        render_mode=video_cfg.render_mode,
+                        language_instruction=job.language_instruction,
+                    )
+                else:
+                    env = environment_loader(job, video_cfg.render_mode)
+
+                # Write per-episode results to disk.
+                # TODO: Aggregate the per-episode records across rebuilds into a single file,
+                # as is done for the metrics below.
+                results_path = os.path.join(job_output_dir, f"episode_results_rebuild{rebuild_idx}.jsonl")
+                env.unwrapped.episode_recorder.set_job_name(job.name)
+                env.unwrapped.episode_recorder.set_output_path(results_path)
+
+                policy = get_policy_from_job(job)
+
+                # Episodes allotted to this rebuild (None when the job is length-driven by steps).
+                num_episodes_this_rebuild = num_episodes_per_rebuild[rebuild_idx]
+
+                # Resolve simulation length: num_steps and num_episodes are mutually exclusive.
+                # Priority: job config -> policy length -> CLI default
+                if job.num_steps is None and num_episodes_this_rebuild is None:
+                    if policy.has_length():
+                        job.num_steps = policy.length()
+                    else:
+                        job.num_steps = args_cli.num_steps
+
+                env = wrap_env_for_video(env, video_cfg, job.num_steps, num_episodes_this_rebuild)
+
+                metrics = rollout_policy(
+                    env,
+                    policy,
+                    num_steps=job.num_steps,
+                    num_episodes=num_episodes_this_rebuild,
+                )
+
+                job_manager.complete_job(job, metrics=metrics, status=Status.COMPLETED)
+
+                # users may not specify metrics for a task, although it's not recommended
+                if metrics is not None:
+                    metrics_per_run.append(metrics)
+
+            except Exception as e:
+                job_manager.complete_job(job, metrics={}, status=Status.FAILED)
+                print(f"Job {job.name} failed with error: {e}")
+                print(f"Traceback: {traceback.format_exc()}")
+                if not args_cli.continue_on_error:
+                    raise
+
+            finally:
+                try:
+                    _close_job_resources(policy, env)
+                finally:
+                    policy = None
+                    env = None
+                    collect_garbage_and_clear_cuda_cache()
+
+        # Aggregate the metrics from the different experiments into a single view.
+        if metrics_per_run:
+            aggregated_metrics = aggregate_metrics(metrics_per_run)
+            metrics_logger.append_job_metrics(job.name, aggregated_metrics)
+
+    job_manager.print_jobs_info()
+    metrics_logger.print_metrics()
+
+    # Write HTML report.
+    report_path = build_report(run_output_dir)
+    if args_cli.serve_evaluation_report:
+        serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
+
+
 def main():
     args_parser = get_isaaclab_arena_cli_parser()
     args_cli, unknown = args_parser.parse_known_args()
@@ -252,115 +379,7 @@ def main():
     enable_cameras_if_required(eval_jobs_config, args_cli)
 
     with SimulationAppContext(args_cli):
-        job_manager = JobManager(eval_jobs_config["jobs"])
-        metrics_logger = MetricsLogger()
-
-        job_manager.print_jobs_info()
-
-        # One reverse-dated run directory shared by all jobs; each job gets a subdirectory within it.
-        # Always dated so every run produces its own report dir, recording or not.
-        # TODO(alexmillane): Currently each chunk produces its own output directory.
-        # We should use the same output directory for all chunks in the future.
-        run_output_dir = timestamped_run_dir(args_cli.output_base_dir)
-
-        if args_cli.record_viewport_video:
-            os.makedirs(run_output_dir, exist_ok=True)
-            print(f"[INFO] Video recording enabled. Videos will be saved to: {run_output_dir}")
-
-        for job in job_manager:
-            if job is None:
-                continue
-            env = None
-            policy = None
-
-            metrics_per_run: list[MetricsDataCollection] = []
-
-            # num_episodes is the total across rebuilds, so split it over the rebuilds.
-            num_episodes_per_rebuild = _split_episodes_across_rebuilds(job.num_episodes, job.num_rebuilds, job.name)
-
-            # Rebuild the environment and re-run the rollout job.num_rebuilds times, then
-            # aggregate the metrics across rebuilds into a single result.
-            for rebuild_idx in range(job.num_rebuilds):
-                try:
-                    job_output_dir = os.path.join(run_output_dir, job.name)
-
-                    # Per-job video output directory; cameras are tagged with the rebuild index.
-                    video_cfg = VideoRecordingCfg(
-                        record_viewport_video=args_cli.record_viewport_video,
-                        record_camera_video=args_cli.record_camera_video,
-                        video_base_dir=job_output_dir,
-                        camera_name_prefix=f"robot-cam-rebuild{rebuild_idx}",
-                    )
-                    env = load_env(
-                        job.arena_env_args,
-                        job.name,
-                        variations=job.variations,
-                        render_mode=video_cfg.render_mode,
-                        language_instruction=job.language_instruction,
-                    )
-
-                    # Write per-episode results to disk.
-                    # TODO: Aggregate the per-episode records across rebuilds into a single file,
-                    # as is done for the metrics below.
-                    results_path = os.path.join(job_output_dir, f"episode_results_rebuild{rebuild_idx}.jsonl")
-                    env.unwrapped.episode_recorder.set_job_name(job.name)
-                    env.unwrapped.episode_recorder.set_output_path(results_path)
-
-                    policy = get_policy_from_job(job)
-
-                    # Episodes allotted to this rebuild (None when the job is length-driven by steps).
-                    num_episodes_this_rebuild = num_episodes_per_rebuild[rebuild_idx]
-
-                    # Resolve simulation length: num_steps and num_episodes are mutually exclusive.
-                    # Priority: job config -> policy length -> CLI default
-                    if job.num_steps is None and num_episodes_this_rebuild is None:
-                        if policy.has_length():
-                            job.num_steps = policy.length()
-                        else:
-                            job.num_steps = args_cli.num_steps
-
-                    env = wrap_env_for_video(env, video_cfg, job.num_steps, num_episodes_this_rebuild)
-
-                    metrics = rollout_policy(
-                        env,
-                        policy,
-                        num_steps=job.num_steps,
-                        num_episodes=num_episodes_this_rebuild,
-                    )
-
-                    job_manager.complete_job(job, metrics=metrics, status=Status.COMPLETED)
-
-                    # users may not specify metrics for a task, although it's not recommended
-                    if metrics is not None:
-                        metrics_per_run.append(metrics)
-
-                except Exception as e:
-                    job_manager.complete_job(job, metrics={}, status=Status.FAILED)
-                    print(f"Job {job.name} failed with error: {e}")
-                    print(f"Traceback: {traceback.format_exc()}")
-                    if not args_cli.continue_on_error:
-                        raise
-
-                finally:
-                    try:
-                        _close_job_resources(policy, env)
-                    finally:
-                        policy = None
-                        env = None
-                        collect_garbage_and_clear_cuda_cache()
-
-            # Aggregate the metrics from the different experiments into a single view.
-            if metrics_per_run:
-                aggregated_metrics = aggregate_metrics(metrics_per_run)
-                metrics_logger.append_job_metrics(job.name, aggregated_metrics)
-
-        job_manager.print_jobs_info()
-        metrics_logger.print_metrics()
-
-        # Write HTML report.
-        report_path = build_report(run_output_dir)
-        if args_cli.serve_evaluation_report:
-            serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
+        evaluate_jobs(args_cli, eval_jobs_config["jobs"])
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_eval_runner.py
+++ b/isaaclab_arena/tests/test_eval_runner.py
@@ -5,6 +5,8 @@
 
 import json
 import os
+from argparse import Namespace
+from pathlib import Path
 
 import pytest
 
@@ -14,6 +16,79 @@ from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function, r
 HEADLESS = True
 NUM_STEPS = 2
 DEFAULT_VISUALIZER = "kit"
+
+
+def test_evaluate_jobs_uses_injected_environment_loader(monkeypatch, tmp_path):
+    from isaaclab_arena.evaluation import eval_runner
+    from isaaclab_arena.evaluation.job_manager import Job, Status
+
+    class FakeEpisodeRecorder:
+        def set_job_name(self, name):
+            self.job_name = name
+
+        def set_output_path(self, path):
+            self.output_path = path
+
+    class FakeEnvironment:
+        def __init__(self):
+            self.unwrapped = Namespace(episode_recorder=FakeEpisodeRecorder())
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class FakePolicy:
+        def __init__(self):
+            self.closed = False
+
+        def has_length(self):
+            return False
+
+        def close(self):
+            self.closed = True
+
+    environment = FakeEnvironment()
+    policy = FakePolicy()
+    captured = {"loader_calls": [], "rollouts": []}
+
+    def fake_environment_loader(job, render_mode):
+        captured["loader_calls"].append((job, render_mode))
+        return environment
+
+    def fake_rollout(env, selected_policy, num_steps, num_episodes):
+        captured["rollouts"].append((env, selected_policy, num_steps, num_episodes))
+
+    monkeypatch.setattr(eval_runner, "get_policy_from_job", lambda job: policy)
+    monkeypatch.setattr(eval_runner, "rollout_policy", fake_rollout)
+    monkeypatch.setattr(eval_runner, "wrap_env_for_video", lambda env, *args: env)
+    monkeypatch.setattr(eval_runner, "timestamped_run_dir", lambda output_dir: str(tmp_path))
+    monkeypatch.setattr(eval_runner, "build_report", lambda output_dir: Path(output_dir) / "index.html")
+    monkeypatch.setattr(eval_runner, "teardown_simulation_app", lambda **kwargs: None)
+    monkeypatch.setattr(eval_runner, "collect_garbage_and_clear_cuda_cache", lambda: None)
+
+    job = Job(
+        name="typed_hydra_job",
+        num_envs=1,
+        arena_env_args=[],
+        policy_type="zero_action",
+        num_steps=1,
+    )
+    args_cli = Namespace(
+        output_base_dir=str(tmp_path),
+        record_viewport_video=False,
+        record_camera_video=False,
+        continue_on_error=False,
+        serve_evaluation_report=False,
+        evaluation_report_port=8000,
+    )
+
+    eval_runner.evaluate_jobs(args_cli, [job], environment_loader=fake_environment_loader)
+
+    assert captured["loader_calls"] == [(job, None)]
+    assert captured["rollouts"] == [(environment, policy, 1, None)]
+    assert job.status is Status.COMPLETED
+    assert environment.closed
+    assert policy.closed
 
 
 def write_jobs_config_to_file(jobs: list[dict], tmp_file_path: str):

--- a/isaaclab_arena/tests/test_hydra_configuration_example.py
+++ b/isaaclab_arena/tests/test_hydra_configuration_example.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the minimal Hydra environment-configuration example."""
+
+from pathlib import Path
+
+import pytest
+from hydra.errors import ConfigCompositionException
+
+from isaaclab_arena.assets.registries import EnvironmentRegistry
+from isaaclab_arena.evaluation.arena_experiment_cfg import ArenaExperimentCfg, EnvironmentBuilderCfg
+from isaaclab_arena_environments.pick_and_place_maple_table_environment import (
+    PickAndPlaceMapleTableEnvironment,
+    PickAndPlaceMapleTableEnvironmentCfg,
+)
+from isaaclab_arena_examples.hydra_configuration.run import (
+    _arena_experiment_cfg_to_eval_job,
+    _arena_experiment_cfg_to_legacy_builder_namespace,
+    _resolve_legacy_eval_runner_namespace,
+    compose_from_command_line,
+    compose_hydra_example_experiments,
+)
+
+EXAMPLE_CONFIG_PATH = (
+    Path(__file__).parents[2] / "isaaclab_arena_examples" / "hydra_configuration" / "hydra_example_suite.yaml"
+)
+
+
+def test_hydra_example_experiments_port_variations_and_control():
+    experiments = compose_hydra_example_experiments(EXAMPLE_CONFIG_PATH)
+
+    assert [experiment.name for experiment in experiments] == ["variations_demo", "baseline_no_variations"]
+    assert all(isinstance(experiment, ArenaExperimentCfg) for experiment in experiments)
+    assert all(isinstance(experiment.environment, PickAndPlaceMapleTableEnvironmentCfg) for experiment in experiments)
+    assert all(experiment.environment.name == "pick_and_place_maple_table" for experiment in experiments)
+    assert all(experiment.environment.enable_cameras for experiment in experiments)
+    assert all(experiment.environment.embodiment_asset_name == "droid_rel_joint_pos" for experiment in experiments)
+    assert all(
+        experiment.environment.high_dynamic_range_image_name == "home_office_robolab" for experiment in experiments
+    )
+    assert all(
+        experiment.environment.pick_up_object_asset_name == "rubiks_cube_hot3d_robolab" for experiment in experiments
+    )
+    assert all(
+        experiment.environment.destination_location_asset_name == "bowl_ycb_robolab" for experiment in experiments
+    )
+    assert experiments[0].environment is not experiments[1].environment
+    assert all(experiment.policy.type == "zero_action" for experiment in experiments)
+    assert all(experiment.rollout.num_steps == 10 for experiment in experiments)
+    assert all(experiment.num_rebuilds == 1 for experiment in experiments)
+    assert experiments[0].variations == {
+        "light.hdr_image.enabled": True,
+        "light.intensity.enabled": True,
+        "droid_rel_joint_pos.camera_extrinsics_wrist_camera.enabled": True,
+    }
+    assert experiments[1].variations == {}
+
+
+def test_hydra_example_experiments_accept_typed_shared_environment_override():
+    experiments = compose_hydra_example_experiments(EXAMPLE_CONFIG_PATH, ["environment.light_intensity=825"])
+
+    assert [experiment.environment.light_intensity for experiment in experiments] == [825.0, 825.0]
+
+
+def test_hydra_example_experiments_preserve_add_operator_for_shared_override():
+    experiments = compose_hydra_example_experiments(EXAMPLE_CONFIG_PATH, ["+policy.parameters.checkpoint=/tmp/model"])
+
+    assert [experiment.policy.parameters["checkpoint"] for experiment in experiments] == [
+        "/tmp/model",
+        "/tmp/model",
+    ]
+
+
+def test_hydra_example_cli_keeps_dispatcher_flags_out_of_experiment_configuration():
+    experiments, dispatcher_arguments = compose_from_command_line([
+        str(EXAMPLE_CONFIG_PATH),
+        "--device",
+        "cuda:1",
+        "--viz",
+        "kit",
+        "rollout.num_steps=1",
+    ])
+    eval_arguments = _resolve_legacy_eval_runner_namespace(
+        experiments,
+        dispatcher_arguments.device,
+        dispatcher_arguments.visualizer,
+    )
+
+    assert dispatcher_arguments.device == "cuda:1"
+    assert dispatcher_arguments.visualizer == "kit"
+    assert [experiment.rollout.num_steps for experiment in experiments] == [1, 1]
+    assert eval_arguments.device == "cuda:1"
+    assert eval_arguments.visualizer == "kit"
+    assert eval_arguments.enable_cameras
+
+
+def test_hydra_example_cli_requires_a_yaml_path():
+    with pytest.raises(SystemExit):
+        compose_from_command_line([])
+
+
+def test_dispatcher_aggregates_camera_requirements_without_mutating_experiments():
+    no_cameras = ArenaExperimentCfg(
+        name="no_cameras",
+        environment=PickAndPlaceMapleTableEnvironmentCfg(),
+    )
+    with_cameras = ArenaExperimentCfg(
+        name="with_cameras",
+        environment=PickAndPlaceMapleTableEnvironmentCfg(enable_cameras=True),
+    )
+
+    eval_arguments = _resolve_legacy_eval_runner_namespace([no_cameras, with_cameras], "cuda:0", None)
+
+    assert eval_arguments.enable_cameras
+    assert not no_cameras.environment.enable_cameras
+    assert with_cameras.environment.enable_cameras
+
+
+def test_hydra_example_experiments_reject_unknown_environment_option():
+    with pytest.raises(ConfigCompositionException, match="unknown_option"):
+        compose_hydra_example_experiments(EXAMPLE_CONFIG_PATH, ["environment.unknown_option=true"])
+
+
+def test_hydra_example_experiments_apply_python_defaults_to_minimal_yaml(tmp_path):
+    config_path = tmp_path / "minimal_experiments.yaml"
+    config_path.write_text("""\
+experiments:
+  - name: maple_table_experiment
+    environment:
+      name: pick_and_place_maple_table
+""")
+
+    experiments = compose_hydra_example_experiments(config_path)
+
+    assert [experiment.name for experiment in experiments] == ["maple_table_experiment"]
+    assert isinstance(experiments[0].environment, PickAndPlaceMapleTableEnvironmentCfg)
+
+
+def test_hydra_example_experiments_resolve_environment_configuration_through_registry():
+    experiments = compose_hydra_example_experiments(EXAMPLE_CONFIG_PATH)
+
+    provider = EnvironmentRegistry().get_component_by_name(experiments[0].environment.name)
+
+    assert provider is PickAndPlaceMapleTableEnvironment
+    assert provider.cfg_type is PickAndPlaceMapleTableEnvironmentCfg
+
+
+def test_hydra_example_experiments_require_an_environment_name(tmp_path):
+    config_path = tmp_path / "missing_environment_name.yaml"
+    config_path.write_text("""\
+experiments:
+  - name: maple_table_experiment
+    environment: {}
+""")
+
+    with pytest.raises(AssertionError, match="environment.name must be a string"):
+        compose_hydra_example_experiments(config_path)
+
+
+def test_hydra_example_experiments_reject_unknown_yaml_environment_option(tmp_path):
+    config_path = tmp_path / "invalid_experiments.yaml"
+    config_path.write_text("""\
+experiments:
+  - name: maple_table_experiment
+    environment:
+      name: pick_and_place_maple_table
+      unknown_option: true
+""")
+
+    with pytest.raises(ConfigCompositionException, match="unknown_option"):
+        compose_hydra_example_experiments(config_path)
+
+
+def test_hydra_example_experiments_reject_duplicate_names(tmp_path):
+    config_path = tmp_path / "duplicate_experiments.yaml"
+    config_path.write_text("""\
+experiments:
+  - name: duplicate
+    environment:
+      name: pick_and_place_maple_table
+  - name: duplicate
+    environment:
+      name: pick_and_place_maple_table
+""")
+
+    with pytest.raises(AssertionError, match="experiment names must be unique"):
+        compose_hydra_example_experiments(config_path)
+
+
+def test_arena_experiment_cfg_maps_to_legacy_builder_namespace():
+    experiment = ArenaExperimentCfg(
+        name="builder_arguments",
+        environment=PickAndPlaceMapleTableEnvironmentCfg(),
+        environment_builder=EnvironmentBuilderCfg(
+            num_envs=3,
+            env_spacing=12.5,
+            seed=7,
+            solve_relations=False,
+            placement_seed=9,
+            resolve_on_reset=False,
+            random_yaw_init=True,
+            disable_fabric=True,
+            mimic=True,
+            presets="layout.yaml",
+        ),
+    )
+
+    namespace = _arena_experiment_cfg_to_legacy_builder_namespace(experiment, "cuda:2", "pick up the cube")
+
+    assert vars(namespace) == {
+        "num_envs": 3,
+        "env_spacing": 12.5,
+        "seed": 7,
+        "solve_relations": False,
+        "placement_seed": 9,
+        "resolve_on_reset": False,
+        "random_yaw_init": True,
+        "disable_fabric": True,
+        "mimic": True,
+        "presets": "layout.yaml",
+        "device": "cuda:2",
+        "language_instruction": "pick up the cube",
+    }
+
+
+def test_hydra_experiments_map_to_eval_jobs_without_environment_cli_round_trip():
+    experiments = compose_hydra_example_experiments(
+        EXAMPLE_CONFIG_PATH,
+        [
+            "environment_builder.num_envs=3",
+            "policy.type=zero_action",
+            "rollout.num_steps=7",
+        ],
+    )
+
+    eval_jobs = [_arena_experiment_cfg_to_eval_job(experiment) for experiment in experiments]
+
+    assert [job.name for job in eval_jobs] == ["variations_demo", "baseline_no_variations"]
+    assert all(job.num_envs == 3 for job in eval_jobs)
+    assert all(job.num_steps == 7 for job in eval_jobs)
+    assert all(job.num_rebuilds == 1 for job in eval_jobs)
+    assert all(job.policy_type == "zero_action" for job in eval_jobs)
+    assert all(job.policy_config_dict == {} for job in eval_jobs)
+    assert all(job.arena_env_args == [] for job in eval_jobs)
+    assert set(eval_jobs[0].variations) == {
+        "light.hdr_image.enabled=true",
+        "light.intensity.enabled=true",
+        "droid_rel_joint_pos.camera_extrinsics_wrist_camera.enabled=true",
+    }
+    assert eval_jobs[1].variations == []

--- a/isaaclab_arena/tests/test_hydra_configuration_example_subprocess.py
+++ b/isaaclab_arena/tests/test_hydra_configuration_example_subprocess.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Subprocess smoke test for the runnable Hydra configuration example."""
+
+import pytest
+
+from isaaclab_arena.tests.utils.constants import TestConstants
+from isaaclab_arena.tests.utils.subprocess import run_subprocess
+
+
+@pytest.mark.with_subprocess
+def test_hydra_configuration_example_runs_two_experiments():
+    result = run_subprocess(
+        [
+            TestConstants.python_path,
+            "-m",
+            "isaaclab_arena_examples.hydra_configuration.run",
+            "isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml",
+            "--viz",
+            "none",
+            "rollout.num_steps=1",
+        ],
+        capture_output=True,
+    )
+
+    assert result is not None
+    assert result.stdout.index("Running job variations_demo") < result.stdout.index(
+        "Running job baseline_no_variations"
+    )
+    assert "[hydra-example] completed jobs=['variations_demo', 'baseline_no_variations']" in result.stdout

--- a/isaaclab_arena_environments/example_environment_base.py
+++ b/isaaclab_arena_environments/example_environment_base.py
@@ -20,6 +20,7 @@ EnvironmentCfgT = TypeVar("EnvironmentCfgT", bound=ArenaEnvironmentCfg)
 class ExampleEnvironmentBase(ABC, Generic[EnvironmentCfgT]):
 
     name: str | None = None
+    cfg_type: type[EnvironmentCfgT] | None = None
 
     def __init__(self):
         from isaaclab_arena.assets.registries import AssetRegistry, DeviceRegistry, HDRImageRegistry

--- a/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
+++ b/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
@@ -36,6 +36,7 @@ class PickAndPlaceMapleTableEnvironment(ExampleEnvironmentBase[PickAndPlaceMaple
     """Registered provider for the Maple-table pick-and-place environment."""
 
     name: str = "pick_and_place_maple_table"
+    cfg_type = PickAndPlaceMapleTableEnvironmentCfg
 
     def get_env(self, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
         """Translate the legacy CLI namespace and build the environment."""

--- a/isaaclab_arena_examples/hydra_configuration/README.md
+++ b/isaaclab_arena_examples/hydra_configuration/README.md
@@ -1,0 +1,103 @@
+# Hydra environment configuration example
+
+This example proves one small path end to end:
+
+```text
+hydra_example_suite.yaml
+  -> EnvironmentRegistry name lookup
+     -> registered environment provider + concrete Cfg type
+  -> Hydra environment config-group composition
+  -> two independently composed ArenaExperimentCfg values
+  -> two eval_runner Jobs
+     (generic evaluation fields and variations; no environment CLI tokens)
+  -> eval_runner.evaluate_jobs()
+     -> PickAndPlaceMapleTableEnvironmentCfg from each experiment
+     -> registered PickAndPlaceMapleTableEnvironment.build(cfg)
+     -> IsaacLabArenaEnvironment -> ArenaEnvBuilder
+     -> existing policy, rollout, cleanup, metrics, and report flow
+```
+
+The first YAML experiment ports
+`isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json` into the typed
+configuration shape. Its environment, zero-action policy, rollout, camera, HDR, rebuild, and three
+variation settings are preserved. The second experiment is the matching no-variations control and
+keeps the example exercising sequential experiments in one simulation app.
+
+`PickAndPlaceMapleTableEnvironmentCfg` is pure structured data. The registered
+`PickAndPlaceMapleTableEnvironment` provider advertises that Cfg type and owns `build(cfg)`. The
+returned `IsaacLabArenaEnvironment` is the assembled environment consumed by `ArenaEnvBuilder`.
+
+The existing argparse frontend remains compatible: `get_env()` translates its legacy Namespace
+into the same Cfg and delegates to `build()`. Once that frontend is migrated, `get_env()`,
+`add_cli_args()`, and the Namespace translation can disappear without changing the Cfg or builder.
+
+The YAML's top-level `experiments` list is only a composition envelope. Each experiment identifies
+its environment by the registry name under `environment.name`; it contains no Hydra `defaults`
+list. The frontend projects registered providers that expose a Cfg type into Hydra's `environment`
+config group and constructs the composition defaults in memory. Hydra then replaces the experiment
+schema's required `environment` field with the selected concrete node before applying that
+experiment's YAML values.
+
+The reusable `ArenaExperimentCfg`, `PolicyCfg`, `RolloutCfg`, and `EnvironmentBuilderCfg` types live
+in core evaluation code. `ArenaExperimentCfg` depends only on the core `ArenaEnvironmentCfg`, not on
+Maple-table. Adding another environment requires a registered provider with a concrete Cfg type;
+the experiment composer does not need another environment-specific branch. Simulator-dependent
+construction remains inside `build()`, so every experiment is composed and validated before the
+simulator starts.
+
+The frontend then converts each typed experiment's generic evaluation fields into an eval-runner
+`Job` and injects an environment loader that resolves the matching provider through
+`EnvironmentRegistry` and calls `build(cfg)`. The generated Jobs deliberately have no
+`arena_env_args`, so this path does not introduce a dataclass-to-CLI round trip. Core evaluation
+code does not import the example package; the existing JSON/argparse frontend continues to use
+`load_env()`.
+
+`run.py` separates Hydra composition, existing-API adapters, and dispatcher integration explicitly.
+Hydra composes core `ArenaExperimentCfg` values. The named adapters convert experiments to the
+`Job` and `argparse.Namespace` shapes still expected by `eval_runner` and `ArenaEnvBuilder`. The
+dispatcher separately owns process-wide camera aggregation, provider lookup, environment
+construction, and sequential execution. Those responsibilities remain when the consumers
+eventually accept the core Cfg types directly; only their compatibility translations can disappear.
+
+The legacy JSON's `enable_cameras` value remains part of each typed environment configuration.
+Before this example dispatcher launches one shared `SimulationApp`, it enables process-wide camera
+support when any experiment requires it. A future dispatcher can instead group compatible
+experiments or send their Jobs to separate workers without changing `ArenaExperimentCfg`.
+Environment CLI names such as `embodiment` and `hdr` become typed fields such as
+`embodiment_asset_name` and `high_dynamic_range_image_name`. The dotted keys under `variations`
+remain experiment data and are passed into the existing `ArenaEnvBuilder` Hydra-variation channel
+when the eval-runner `Job` is created.
+
+Run the co-located configuration inside the Arena development container:
+
+```bash
+/isaac-sim/python.sh -m isaaclab_arena_examples.hydra_configuration.run \
+  isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml
+```
+
+The YAML path is a required positional argument; `run.py` has no implicit suite configuration.
+
+Like the existing eval runner, this writes episode results and an HTML report beneath
+`/eval/output`.
+
+Pass Isaac Lab's visualizer flag to open the Kit window:
+
+```bash
+/isaac-sim/python.sh -m isaaclab_arena_examples.hydra_configuration.run \
+  isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml \
+  --viz kit
+```
+
+Hydra overrides are applied independently to every configured experiment:
+
+```bash
+/isaac-sim/python.sh -m isaaclab_arena_examples.hydra_configuration.run \
+  isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml \
+  environment.light_intensity=750 rollout.num_steps=10
+```
+
+The current `run.py` dispatcher evaluates both experiments sequentially inside one simulation app.
+Sharing that app is an execution choice, not part of the experiment configuration model. The
+example reuses the eval runner's variation, policy, rollout, cleanup, metrics, and HTML reporting
+paths; the source rebuild count is preserved. Recording, chunking, migrating additional registered
+environments to typed Cfg providers, and broader policy selection remain for later work.

--- a/isaaclab_arena_examples/hydra_configuration/__init__.py
+++ b/isaaclab_arena_examples/hydra_configuration/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal Hydra configuration example for an Isaac Lab Arena environment."""

--- a/isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml
+++ b/isaaclab_arena_examples/hydra_configuration/hydra_example_suite.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The first experiment ports droid_pnp_variations_config.json. The second is its control condition
+# and demonstrates sequential experiments in one SimulationApp. environment.name selects a
+# registered Cfg; Hydra composition details stay in run.py. List order is dispatch order.
+experiments:
+  - name: variations_demo
+    environment:
+      name: pick_and_place_maple_table
+      enable_cameras: true
+      embodiment_asset_name: droid_rel_joint_pos
+      high_dynamic_range_image_name: home_office_robolab
+      pick_up_object_asset_name: rubiks_cube_hot3d_robolab
+      destination_location_asset_name: bowl_ycb_robolab
+    policy:
+      type: zero_action
+      parameters: {}
+    rollout:
+      num_steps: 10
+    num_rebuilds: 1
+    variations:
+      light.hdr_image.enabled: true
+      light.intensity.enabled: true
+      droid_rel_joint_pos.camera_extrinsics_wrist_camera.enabled: true
+
+  - name: baseline_no_variations
+    environment:
+      name: pick_and_place_maple_table
+      enable_cameras: true
+      embodiment_asset_name: droid_rel_joint_pos
+      high_dynamic_range_image_name: home_office_robolab
+      pick_up_object_asset_name: rubiks_cube_hot3d_robolab
+      destination_location_asset_name: bowl_ycb_robolab
+    policy:
+      type: zero_action
+      parameters: {}
+    rollout:
+      num_steps: 10
+    num_rebuilds: 1

--- a/isaaclab_arena_examples/hydra_configuration/run.py
+++ b/isaaclab_arena_examples/hydra_configuration/run.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compose typed Hydra experiments and dispatch them through Arena's evaluation APIs.
+
+Hydra composes the core ``ArenaExperimentCfg`` type. Explicit compatibility
+adapters translate experiments to the ``Job`` and ``argparse.Namespace``
+objects still consumed by the current evaluation loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import sys
+from pathlib import Path
+
+from hydra import compose, initialize
+from hydra.core.config_store import ConfigStore
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+from isaaclab_arena.assets.registries import EnvironmentRegistry
+from isaaclab_arena.environments.arena_environment_cfg import ArenaEnvironmentCfg
+from isaaclab_arena.evaluation.arena_experiment_cfg import ArenaExperimentCfg
+from isaaclab_arena.evaluation.eval_runner import evaluate_jobs
+from isaaclab_arena.evaluation.job_manager import Job
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+from isaaclab_arena_environments.cli import ensure_environments_registered
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+# Hydra composition
+
+
+def _typed_environment_providers() -> dict[str, type[ExampleEnvironmentBase]]:
+    """Return registered environment providers that expose a structured config type."""
+    ensure_environments_registered()
+    registry = EnvironmentRegistry()
+    providers = {}
+    for environment_name in registry.get_all_keys():
+        provider = registry.get_component_by_name(environment_name)
+        cfg_type = getattr(provider, "cfg_type", None)
+        if cfg_type is None:
+            continue
+        assert issubclass(cfg_type, ArenaEnvironmentCfg)
+        providers[environment_name] = provider
+    return providers
+
+
+def compose_hydra_example_experiments(
+    config_path: str | Path,
+    overrides: list[str] | None = None,
+) -> list[ArenaExperimentCfg]:
+    """Compose every YAML entry as an independent typed experiment.
+
+    Args:
+        config_path: Path to the YAML document containing the ordered experiment list.
+        overrides: Optional Hydra override tokens applied independently to every experiment.
+
+    Returns:
+        The typed experiments in dispatch order.
+    """
+    path = Path(config_path).resolve()
+    assert path.is_file(), f"Hydra example config does not exist: {path}"
+    assert path.suffix == ".yaml", f"Hydra example config must be a .yaml file: {path}"
+    config_name = path.stem.replace("-", "_")
+    experiment_schema_config_name = f"_{config_name}_experiment_schema"
+    hydra_config_name_prefix = f"_{config_name}_experiment"
+
+    document = OmegaConf.load(path)
+    assert isinstance(document, DictConfig), "Hydra example config must be a mapping"
+    assert set(document) == {"experiments"}, "Hydra example config must contain only an 'experiments' list"
+    experiment_nodes = document["experiments"]
+    assert isinstance(experiment_nodes, ListConfig), "experiments must be a list"
+    assert experiment_nodes, "experiments must not be empty"
+
+    environment_providers = _typed_environment_providers()
+    config_store = ConfigStore.instance()
+    config_store.store(name=experiment_schema_config_name, node=ArenaExperimentCfg)
+    for environment_name, provider in environment_providers.items():
+        cfg_type = provider.cfg_type
+        assert cfg_type is not None
+        config_store.store(group="environment", name=environment_name, node=cfg_type)
+
+    hydra_experiment_config_names = []
+    for index, experiment_node in enumerate(experiment_nodes):
+        assert isinstance(experiment_node, DictConfig), f"experiments[{index}] must be a mapping"
+        environment = experiment_node.get("environment")
+        assert isinstance(environment, DictConfig), f"experiments[{index}].environment must be a mapping"
+        environment_name = environment.get("name")
+        assert isinstance(environment_name, str), f"experiments[{index}].environment.name must be a string"
+        assert (
+            environment_name in environment_providers
+        ), f"experiments[{index}].environment.name '{environment_name}' does not provide typed configuration"
+
+        experiment_data = OmegaConf.to_container(experiment_node, resolve=False)
+        assert isinstance(experiment_data, dict)
+        hydra_experiment_node = {
+            "defaults": [
+                experiment_schema_config_name,
+                {"environment": environment_name},
+                "_self_",
+            ],
+            **experiment_data,
+        }
+        hydra_experiment_config_name = f"{hydra_config_name_prefix}_{index}"
+        config_store.store(name=hydra_experiment_config_name, node=hydra_experiment_node)
+        hydra_experiment_config_names.append(hydra_experiment_config_name)
+
+    experiments = []
+    with initialize(version_base=None, config_path=None):
+        for experiment_config_name in hydra_experiment_config_names:
+            experiment = OmegaConf.to_object(
+                compose(config_name=experiment_config_name, overrides=list(overrides or []))
+            )
+            assert isinstance(experiment, ArenaExperimentCfg)
+            provider = environment_providers.get(experiment.environment.name)
+            assert (
+                provider is not None
+            ), f"Environment '{experiment.environment.name}' is not registered with a typed config"
+            assert provider.cfg_type is not None
+            assert isinstance(experiment.environment, provider.cfg_type)
+            experiments.append(experiment)
+
+    experiment_names = [experiment.name for experiment in experiments]
+    assert len(experiment_names) == len(set(experiment_names)), "experiment names must be unique"
+    return experiments
+
+
+# Existing evaluation API adapters
+# Keep these conversions at the edge so Hydra composition remains typed.
+
+
+def _arena_experiment_cfg_to_legacy_builder_namespace(
+    experiment_configuration: ArenaExperimentCfg,
+    device: str,
+    language_instruction: str | None = None,
+) -> argparse.Namespace:
+    """Translate a typed experiment to the Namespace still required by ArenaEnvBuilder."""
+    builder = experiment_configuration.environment_builder
+    return argparse.Namespace(
+        num_envs=builder.num_envs,
+        env_spacing=builder.env_spacing,
+        seed=builder.seed,
+        solve_relations=builder.solve_relations,
+        placement_seed=builder.placement_seed,
+        resolve_on_reset=builder.resolve_on_reset,
+        random_yaw_init=builder.random_yaw_init,
+        disable_fabric=builder.disable_fabric,
+        mimic=builder.mimic,
+        presets=builder.presets,
+        device=device,
+        language_instruction=language_instruction,
+    )
+
+
+def _arena_experiment_cfg_to_eval_job(experiment_configuration: ArenaExperimentCfg) -> Job:
+    """Translate a typed experiment to eval_runner's existing ``Job`` model."""
+    return Job(
+        name=experiment_configuration.name,
+        num_envs=experiment_configuration.environment_builder.num_envs,
+        arena_env_args=[],
+        policy_type=experiment_configuration.policy.type,
+        policy_config_dict=experiment_configuration.policy.parameters,
+        num_steps=experiment_configuration.rollout.num_steps,
+        num_rebuilds=experiment_configuration.num_rebuilds,
+        variations=Job.convert_variations_dict_to_hydra_overrides(experiment_configuration.variations),
+    )
+
+
+# Dispatcher integration
+# Process-wide settings and runtime construction are dispatcher responsibilities.
+
+
+def _resolve_legacy_eval_runner_namespace(
+    experiment_configurations: list[ArenaExperimentCfg],
+    device: str,
+    visualizer: str | None,
+) -> argparse.Namespace:
+    """Resolve process-wide settings in the Namespace expected by eval_runner."""
+    return argparse.Namespace(
+        device=device,
+        enable_cameras=any(experiment.environment.enable_cameras for experiment in experiment_configurations),
+        visualizer=visualizer,
+        num_steps=None,
+        output_base_dir="/eval/output",
+        record_viewport_video=False,
+        record_camera_video=False,
+        serve_evaluation_report=False,
+        evaluation_report_port=8000,
+        continue_on_error=False,
+    )
+
+
+def _load_environment_from_arena_experiment_cfg(
+    experiment_configurations_by_name: dict[str, ArenaExperimentCfg],
+    device: str,
+    job: Job,
+    render_mode: str | None,
+):
+    """Build one typed environment through the existing ArenaEnvBuilder API."""
+    # Isaac Sim must be launched before importing modules that load USD/PhysX bindings.
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    experiment_configuration = experiment_configurations_by_name[job.name]
+    environment_configuration = experiment_configuration.environment
+    environment_providers = _typed_environment_providers()
+    assert environment_configuration.name in environment_providers
+    environment_provider = environment_providers[environment_configuration.name]()
+    assert environment_provider.cfg_type is not None
+    assert isinstance(environment_configuration, environment_provider.cfg_type)
+    arena_environment = environment_provider.build(environment_configuration)
+    legacy_builder_namespace = _arena_experiment_cfg_to_legacy_builder_namespace(
+        experiment_configuration,
+        device,
+        job.language_instruction,
+    )
+    arena_builder = ArenaEnvBuilder(
+        arena_environment,
+        legacy_builder_namespace,
+        hydra_overrides=job.variations,
+    )
+    _, env_cfg, env_kwargs = arena_builder.build_registered()
+    if env_cfg.recorders is not None:
+        env_cfg.recorders.dataset_filename = f"dataset_{job.name}"
+    return arena_builder.make_registered(env_cfg, env_kwargs, render_mode=render_mode)
+
+
+def run(
+    experiment_configurations: list[ArenaExperimentCfg],
+    *,
+    device: str = "cuda:0",
+    visualizer: str | None = None,
+) -> None:
+    """Dispatch the configured experiments sequentially through one simulation app."""
+    experiment_names = [experiment.name for experiment in experiment_configurations]
+    assert experiment_names, "experiments must not be empty"
+    assert len(experiment_names) == len(set(experiment_names)), "experiment names must be unique"
+    print(f"[hydra-example] experiments={experiment_names}", flush=True)
+
+    eval_runner_namespace = _resolve_legacy_eval_runner_namespace(
+        experiment_configurations,
+        device,
+        visualizer,
+    )
+    eval_jobs = [_arena_experiment_cfg_to_eval_job(experiment) for experiment in experiment_configurations]
+    experiment_configurations_by_name = {experiment.name: experiment for experiment in experiment_configurations}
+    with SimulationAppContext(eval_runner_namespace):
+        environment_loader = functools.partial(
+            _load_environment_from_arena_experiment_cfg,
+            experiment_configurations_by_name,
+            eval_runner_namespace.device,
+        )
+        evaluate_jobs(
+            eval_runner_namespace,
+            eval_jobs,
+            environment_loader=environment_loader,
+        )
+        completed_job_names = [job.name for job in eval_jobs]
+        print(f"[hydra-example] completed jobs={completed_job_names}", flush=True)
+
+
+def compose_from_command_line(
+    arguments: list[str],
+) -> tuple[list[ArenaExperimentCfg], argparse.Namespace]:
+    """Parse dispatcher flags and compose every experiment from the remaining Hydra overrides."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config_path", type=Path, help="YAML file containing the experiments to dispatch.")
+    parser.add_argument("--device", default="cuda:0", help="Isaac Sim device used by this dispatcher.")
+    parser.add_argument("--visualizer", "--viz", help="Isaac Lab visualizer backend, for example 'kit'.")
+    # argparse owns only this frontend's process flags. All remaining tokens are Hydra overrides.
+    dispatcher_arguments, hydra_overrides = parser.parse_known_args(arguments)
+    experiments = compose_hydra_example_experiments(dispatcher_arguments.config_path, hydra_overrides)
+    return experiments, dispatcher_arguments
+
+
+def main() -> None:
+    """Compose the portable experiments and dispatch them sequentially."""
+    experiment_configurations, dispatcher_arguments = compose_from_command_line(sys.argv[1:])
+    run(
+        experiment_configurations,
+        device=dispatcher_arguments.device,
+        visualizer=dispatcher_arguments.visualizer,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ from setuptools import find_packages, setup
 ISAACLAB_ARENA_VERSION_NUMBER = "1.0.0"
 
 RUNTIME_DEPS = [
+    "hydra-core",
+    "omegaconf",
     "typing_extensions",
     "onnxruntime",
     "vuer[all]",
@@ -51,6 +53,9 @@ setup(
     install_requires=RUNTIME_DEPS,
     extras_require={
         "dev": DEV_DEPS,
+    },
+    package_data={
+        "isaaclab_arena_examples.hydra_configuration": ["*.yaml", "README.md"],
     },
     zip_safe=False,
 )


### PR DESCRIPTION
## Summary
Add Hydra experiment configuration example

## Detailed description
- Build on the typed Maple-table provider introduced by #858.
- Compose ordered Arena experiments from a required YAML path through EnvironmentRegistry-backed Hydra schemas.
- Keep Experiment-to-Job and typed-Cfg-to-Namespace compatibility adapters explicit at the eval-runner boundary.
- Cover typed composition, invalid input, registry resolution, and sequential simulator execution.