### PR TITLE
Add typed configurations to Arena policies

### DIFF
--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -182,8 +182,8 @@ object with:
   internally to the same CLI-style list the policy runner uses.
 - ``policy_type``: Same as policy runner (registered name or dotted class path).
 - ``policy_config_dict``: Policy configuration (e.g. checkpoint path, model
-  options). Used with ``PolicyBase.from_dict`` if the policy has a typed
-  ``config_class``; the CLI conversion fallback remains for legacy policies.
+  options). Deserialized through the policy's registered config type; the
+  deprecated CLI conversion fallback remains for legacy policies without one.
 - ``num_steps`` or ``num_episodes`` (optional): Simulation length for this job.
   If both are omitted, the runner uses the policy’s length if defined, or a CLI
   default (e.g. ``--num_steps``).

--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -134,8 +134,8 @@ and pass ``--distributed`` so each process uses a different GPU (via ``LOCAL_RAN
 - ``--distributed``: Enable distributed mode; use with ``torchrun`` and set
   device per rank (e.g. ``cuda:{local_rank}``).
 
-The rest of the arguments (environment, embodiment, object, etc.) come from the
-Arena environments CLI and the policy’s own ``add_args_to_parser``.
+The remaining environment arguments come from the Arena environments CLI. For
+registered policies, policy-specific flags are generated from their ``PolicyCfg``.
 
 .. _sequential-batch-eval-runner:
 

--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -182,8 +182,8 @@ object with:
   internally to the same CLI-style list the policy runner uses.
 - ``policy_type``: Same as policy runner (registered name or dotted class path).
 - ``policy_config_dict``: Policy configuration (e.g. checkpoint path, model
-  options). Used with ``PolicyBase.from_dict`` if the policy has a
-  ``config_class``, otherwise converted to CLI args and ``from_args``.
+  options). Used with ``PolicyBase.from_dict`` if the policy has a typed
+  ``config_class``; the CLI conversion fallback remains for legacy policies.
 - ``num_steps`` or ``num_episodes`` (optional): Simulation length for this job.
   If both are omitted, the runner uses the policy’s length if defined, or a CLI
   default (e.g. ``--num_steps``).

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -54,7 +54,7 @@ Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
        device: str = "cuda:0"
 
 
-   @register_policy(cfg_type=MyPolicyCfg)
+   @register_policy
    class MyPolicy(PolicyBase[MyPolicyCfg]):
        name = "my_policy"
 
@@ -80,15 +80,11 @@ The typed registration lets the single-job runner generate CLI flags from
 Config fields named ``device`` or ``num_envs`` reuse the corresponding shared
 runner flags, so their defaults must match the runner defaults.
 
-.. TODO(cvolk, 2026-07-03): Remove this compatibility note with support for untyped downstream policies.
-
 .. note::
 
-   ``policy_runner.py`` remains an argparse frontend, but policies registered
-   with a ``PolicyCfg`` do not implement argparse methods. The runner generates
-   their flags from that config and reconstructs it before creating the policy.
-   Untyped downstream policies temporarily retain the deprecated
-   ``add_args_to_parser`` and ``from_args`` compatibility path.
+   ``policy_runner.py`` remains an argparse frontend, but policies do not
+   implement argparse methods. The runner generates their flags from the
+   registered config and reconstructs it before creating the policy.
 
 More details
 ------------

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -35,7 +35,7 @@ Writing a custom policy
 -----------------------
 
 Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
-``name``, decorate with ``@register_policy``, and implement ``get_action``:
+``name``, register it with its config, and implement ``get_action``:
 
 .. code-block:: python
 
@@ -54,10 +54,9 @@ Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
        device: str = "cuda"
 
 
-   @register_policy
+   @register_policy(cfg_type=MyPolicyCfg)
    class MyPolicy(PolicyBase[MyPolicyCfg]):
        name = "my_policy"
-       config_class = MyPolicyCfg
 
        def __init__(self, config: MyPolicyCfg):
            super().__init__(config)
@@ -67,14 +66,15 @@ Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
            return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
 
 The policy contract itself does not depend on argparse. The current single-job
-CLI still expects concrete policies to provide temporary ``add_args_to_parser``
-and ``from_args`` compatibility adapters:
+CLI still expects concrete policies to provide the deprecated
+``add_args_to_parser`` and ``from_args`` compatibility adapters:
 
 .. code-block:: python
 
    class MyPolicy(PolicyBase[MyPolicyCfg]):
        ...
 
+       # Deprecated compatibility adapter for the current argparse frontend.
        @staticmethod
        def add_args_to_parser(parser):
            # Add any CLI arguments your policy needs, then return the parser
@@ -96,8 +96,9 @@ For policies not registered by name, pass a dotted Python path instead
 (e.g. ``--policy_type mypackage.mypolicy.MyPolicy``). The runner will
 import and instantiate the class directly.
 
-The batch eval runner uses ``config_class`` to instantiate the inherited
-``from_dict()`` path directly, without going through argparse. See
+The typed registration associates the policy with its configuration for legacy
+dictionary-based evaluation. Typed callers can construct ``MyPolicyCfg`` and
+pass it to ``MyPolicy`` directly, without going through argparse. See
 :doc:`concept_evaluation_types` for details.
 
 More details

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -65,41 +65,26 @@ Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
            # Your model inference here
            return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
 
-The policy contract itself does not depend on argparse. The current single-job
-CLI still expects concrete policies to provide the deprecated
-``add_args_to_parser`` and ``from_args`` compatibility adapters:
+Construct the policy by passing its typed configuration directly:
 
 .. code-block:: python
 
-   class MyPolicy(PolicyBase[MyPolicyCfg]):
-       ...
+   policy_cfg = MyPolicyCfg(device="cuda")
+   policy = MyPolicy(policy_cfg)
 
-       # Deprecated compatibility adapter for the current argparse frontend.
-       @staticmethod
-       def add_args_to_parser(parser):
-           # Add any CLI arguments your policy needs, then return the parser
-           return parser
-
-       @staticmethod
-       def from_args(args):
-           return MyPolicy(MyPolicyCfg(device=args.device))
-
-Once registered, select the policy by name on the command line:
-
-.. code-block:: bash
-
-   python isaaclab_arena/evaluation/policy_runner.py \
-     --policy_type my_policy \
-     ...
-
-For policies not registered by name, pass a dotted Python path instead
-(e.g. ``--policy_type mypackage.mypolicy.MyPolicy``). The runner will
-import and instantiate the class directly.
-
-The typed registration associates the policy with its configuration for legacy
-dictionary-based evaluation. Typed callers can construct ``MyPolicyCfg`` and
-pass it to ``MyPolicy`` directly, without going through argparse. See
+The typed registration also lets the batch eval runner convert the current
+``Job.policy_config_dict`` representation into ``MyPolicyCfg``. See
 :doc:`concept_evaluation_types` for details.
+
+.. TODO(cvolk, 2026-07-03): Remove this compatibility note when policy_runner constructs PolicyCfg directly.
+
+.. note::
+
+   ``policy_runner.py`` is still an argparse frontend and cannot yet construct
+   a typed-only custom policy. Existing first-party policies temporarily retain
+   deprecated ``add_args_to_parser`` and ``from_args`` adapters. New policy
+   implementations should use the typed construction shown above rather than
+   adding those adapters.
 
 More details
 ------------

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -10,7 +10,7 @@ runners depend on.
 
 .. code-block:: python
 
-   policy = ZeroActionPolicy(config=ZeroActionPolicyArgs())
+   policy = ZeroActionPolicy(config=ZeroActionPolicyCfg())
    obs, _ = env.reset()
    action = policy.get_action(env, obs)
 
@@ -34,29 +34,46 @@ Arena ships with four policies:
 Writing a custom policy
 -----------------------
 
-Subclass ``PolicyBase``, set a ``name``, decorate with ``@register_policy``,
-and implement ``get_action``:
+Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
+``name``, decorate with ``@register_policy``, and implement ``get_action``:
 
 .. code-block:: python
+
+   from dataclasses import dataclass
 
    import gymnasium as gym
    import torch
    from gymnasium.spaces.dict import Dict as GymSpacesDict
 
    from isaaclab_arena.assets.register import register_policy
-   from isaaclab_arena.policy.policy_base import PolicyBase
+   from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
+
+
+   @dataclass
+   class MyPolicyCfg(PolicyCfg):
+       device: str = "cuda"
 
 
    @register_policy
-   class MyPolicy(PolicyBase):
+   class MyPolicy(PolicyBase[MyPolicyCfg]):
        name = "my_policy"
+       config_class = MyPolicyCfg
 
-       def __init__(self, config):
+       def __init__(self, config: MyPolicyCfg):
            super().__init__(config)
 
        def get_action(self, env: gym.Env, observation: GymSpacesDict) -> torch.Tensor:
            # Your model inference here
            return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
+
+The policy contract itself does not depend on argparse. The current single-job
+CLI still expects concrete policies to provide temporary ``add_args_to_parser``
+and ``from_args`` compatibility adapters:
+
+.. code-block:: python
+
+   class MyPolicy(PolicyBase[MyPolicyCfg]):
+       ...
 
        @staticmethod
        def add_args_to_parser(parser):
@@ -65,7 +82,7 @@ and implement ``get_action``:
 
        @staticmethod
        def from_args(args):
-           return MyPolicy(config=None)
+           return MyPolicy(MyPolicyCfg(device=args.device))
 
 Once registered, select the policy by name on the command line:
 
@@ -79,10 +96,9 @@ For policies not registered by name, pass a dotted Python path instead
 (e.g. ``--policy_type mypackage.mypolicy.MyPolicy``). The runner will
 import and instantiate the class directly.
 
-To use a custom policy in the batch eval runner's JSON config, define a
-``config_class`` dataclass on the policy and implement ``from_dict()``.
-This lets the runner instantiate the policy from a plain dict without
-going through argparse. See :doc:`concept_evaluation_types` for details.
+The batch eval runner uses ``config_class`` to instantiate the inherited
+``from_dict()`` path directly, without going through argparse. See
+:doc:`concept_evaluation_types` for details.
 
 More details
 ------------

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -51,7 +51,7 @@ Define a typed ``PolicyCfg``, subclass ``PolicyBase`` with that config, set a
 
    @dataclass
    class MyPolicyCfg(PolicyCfg):
-       device: str = "cuda"
+       device: str = "cuda:0"
 
 
    @register_policy(cfg_type=MyPolicyCfg)
@@ -69,22 +69,26 @@ Construct the policy by passing its typed configuration directly:
 
 .. code-block:: python
 
-   policy_cfg = MyPolicyCfg(device="cuda")
+   policy_cfg = MyPolicyCfg(device="cuda:0")
    policy = MyPolicy(policy_cfg)
 
-The typed registration also lets the batch eval runner convert the current
-``Job.policy_config_dict`` representation into ``MyPolicyCfg``. See
+The typed registration lets the single-job runner generate CLI flags from
+``MyPolicyCfg`` and lets the batch eval runner convert the current
+``Job.policy_config_dict`` representation into that same type. See
 :doc:`concept_evaluation_types` for details.
 
-.. TODO(cvolk, 2026-07-03): Remove this compatibility note when policy_runner constructs PolicyCfg directly.
+Config fields named ``device`` or ``num_envs`` reuse the corresponding shared
+runner flags, so their defaults must match the runner defaults.
+
+.. TODO(cvolk, 2026-07-03): Remove this compatibility note with support for untyped downstream policies.
 
 .. note::
 
-   ``policy_runner.py`` is still an argparse frontend and cannot yet construct
-   a typed-only custom policy. Existing first-party policies temporarily retain
-   deprecated ``add_args_to_parser`` and ``from_args`` adapters. New policy
-   implementations should use the typed construction shown above rather than
-   adding those adapters.
+   ``policy_runner.py`` remains an argparse frontend, but policies registered
+   with a ``PolicyCfg`` do not implement argparse methods. The runner generates
+   their flags from that config and reconstructs it before creating the policy.
+   Untyped downstream policies temporarily retain the deprecated
+   ``add_args_to_parser`` and ``from_args`` compatibility path.
 
 More details
 ------------

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -62,9 +62,9 @@ def _register_policy(cls: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None
 def register_policy(policy_type: type["PolicyBase"] | None = None, *, cfg_type: type["PolicyCfg"] | None = None):
     """Register a policy and its typed configuration."""
     if cfg_type is None:
-        # TODO(cvolk, 2026-07-03): After policy_runner and eval_runner stop using policy-owned
-        # argparse adapters, remove bare @register_policy support and this warning branch. Make
-        # cfg_type required and keyword-only, and remove the optional policy_type argument.
+        # TODO(cvolk, 2026-07-03): After the policy_runner and eval_runner compatibility
+        # fallbacks for untyped downstream policies are removed, require cfg_type and delete
+        # the optional policy_type argument and this warning branch.
         assert policy_type is not None, "Typed policy registration requires cfg_type"
         warnings.warn(
             "Bare @register_policy is deprecated; use @register_policy(cfg_type=PolicyCfgType)",

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+from typing import TYPE_CHECKING
+
 from isaaclab_arena.assets.registries import (
     AssetRegistry,
     DeviceRegistry,
@@ -13,6 +16,9 @@ from isaaclab_arena.assets.registries import (
     RetargeterRegistry,
     TaskRegistry,
 )
+
+if TYPE_CHECKING:
+    from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
 # Decorator to register an asset with the AssetRegistry.
@@ -44,13 +50,34 @@ def register_retargeter(cls):
     return cls
 
 
-# Decorator to register a policy with the PolicyRegistry.
-def register_policy(cls):
+def _register_policy(cls: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None):
     if PolicyRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Policy {cls.name} is already registered. Doing nothing.")
     else:
-        PolicyRegistry().register(cls, cls.name)
+        PolicyRegistry().register_policy(cls, cfg_type)
     return cls
+
+
+# Decorator to register a policy with the PolicyRegistry.
+def register_policy(policy_type: type["PolicyBase"] | None = None, *, cfg_type: type["PolicyCfg"] | None = None):
+    """Register a policy and its typed configuration."""
+    if cfg_type is None:
+        # TODO(cvolk, 2026-07-03): Remove bare registration with the deprecated policy-owned
+        # argparse paths in policy_runner and eval_runner.
+        assert policy_type is not None, "Typed policy registration requires cfg_type"
+        warnings.warn(
+            "Bare @register_policy is deprecated; use @register_policy(cfg_type=PolicyCfgType)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _register_policy(policy_type, None)
+
+    assert policy_type is None, "Pass the policy config with the cfg_type keyword"
+
+    def decorator(cls):
+        return _register_policy(cls, cfg_type)
+
+    return decorator
 
 
 # Decorator to register an HDRImage with the HDRImageRegistry.

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -62,8 +62,9 @@ def _register_policy(cls: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None
 def register_policy(policy_type: type["PolicyBase"] | None = None, *, cfg_type: type["PolicyCfg"] | None = None):
     """Register a policy and its typed configuration."""
     if cfg_type is None:
-        # TODO(cvolk, 2026-07-03): Remove bare registration with the deprecated policy-owned
-        # argparse paths in policy_runner and eval_runner.
+        # TODO(cvolk, 2026-07-03): After policy_runner and eval_runner stop using policy-owned
+        # argparse adapters, remove bare @register_policy support and this warning branch. Make
+        # cfg_type required and keyword-only, and remove the optional policy_type argument.
         assert policy_type is not None, "Typed policy registration requires cfg_type"
         warnings.warn(
             "Bare @register_policy is deprecated; use @register_policy(cfg_type=PolicyCfgType)",

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import warnings
-from typing import TYPE_CHECKING
+from types import get_original_bases
+from typing import TYPE_CHECKING, get_args, get_origin
 
 from isaaclab_arena.assets.registries import (
     AssetRegistry,
@@ -50,35 +50,16 @@ def register_retargeter(cls):
     return cls
 
 
-def _register_policy(cls: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None):
+# Decorator to register a policy with the PolicyRegistry.
+def register_policy(cls: type["PolicyBase"]):
+    """Register a policy and its typed configuration."""
     if PolicyRegistry().is_registered(cls.name, ensure_loaded=False):
         print(f"WARNING: Policy {cls.name} is already registered. Doing nothing.")
     else:
-        PolicyRegistry().register_policy(cls, cfg_type)
+        # TODO(cvolk, 2026-07-06): Register only the policy class once typed experiment
+        # configs make config-type discovery unnecessary in policy_runner and eval_runner.
+        PolicyRegistry().register_policy(cls, _policy_cfg_type_from_policy(cls))
     return cls
-
-
-# Decorator to register a policy with the PolicyRegistry.
-def register_policy(policy_type: type["PolicyBase"] | None = None, *, cfg_type: type["PolicyCfg"] | None = None):
-    """Register a policy and its typed configuration."""
-    if cfg_type is None:
-        # TODO(cvolk, 2026-07-03): After the policy_runner and eval_runner compatibility
-        # fallbacks for untyped downstream policies are removed, require cfg_type and delete
-        # the optional policy_type argument and this warning branch.
-        assert policy_type is not None, "Typed policy registration requires cfg_type"
-        warnings.warn(
-            "Bare @register_policy is deprecated; use @register_policy(cfg_type=PolicyCfgType)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _register_policy(policy_type, None)
-
-    assert policy_type is None, "Pass the policy config with the cfg_type keyword"
-
-    def decorator(cls):
-        return _register_policy(cls, cfg_type)
-
-    return decorator
 
 
 # Decorator to register an HDRImage with the HDRImageRegistry.
@@ -126,3 +107,25 @@ def agent_ready(cls):
     """Mark a task class as available to the environment-generation agent."""
     cls.agent_ready = True
     return cls
+
+
+# TODO(cvolk, 2026-07-06): Remove this resolver and the PolicyRegistry config-type
+# metadata when policy_runner accepts a PolicyCfg instead of argparse values and
+# eval_runner accepts one instead of Job.policy_config_dict.
+def _policy_cfg_type_from_policy(policy_type: type["PolicyBase"]) -> type["PolicyCfg"]:
+    """Return the concrete config declared by ``PolicyBase[Cfg]``."""
+    # Importing PolicyBase at module load time creates assets.register -> policy package ->
+    # concrete policy -> assets.register. Delay it until a concrete policy is decorated.
+    from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
+
+    policy_bases = [base for base in get_original_bases(policy_type) if get_origin(base) is PolicyBase]
+    assert len(policy_bases) == 1, f"{policy_type.__name__} must directly inherit PolicyBase[ConcretePolicyCfg]"
+
+    cfg_types = get_args(policy_bases[0])
+    assert len(cfg_types) == 1, f"{policy_type.__name__} must declare exactly one policy config"
+
+    cfg_type = cfg_types[0]
+    assert isinstance(cfg_type, type) and issubclass(
+        cfg_type, PolicyCfg
+    ), f"{policy_type.__name__} must use a concrete PolicyCfg subclass"
+    return cfg_type

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.assets.asset import Asset
     from isaaclab_arena.assets.hdr_image import HDRImage
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
-    from isaaclab_arena.policy.policy_base import PolicyBase
+    from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
     from isaaclab_arena.relations.relations import RelationBase
     from isaaclab_arena.tasks.task_base import TaskBase
 
@@ -184,6 +184,20 @@ class RetargeterRegistry(Registry):
 class PolicyRegistry(Registry):
     def __init__(self):
         super().__init__()
+        self._cfg_types: dict[type["PolicyBase"], type["PolicyCfg"]] = {}
+
+    # TODO(cvolk, 2026-07-03): Require cfg_type after deprecated bare policy registration is removed.
+    def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None) -> None:
+        """Register a policy and its config, accepting None only for deprecated callers."""
+        self.register(policy_type, policy_type.name)
+        if cfg_type is not None:
+            self._cfg_types[policy_type] = cfg_type
+
+    # TODO(cvolk, 2026-07-03): Remove when eval_runner receives PolicyCfg instead of Job.policy_config_dict.
+    def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"] | None:
+        """Get the config type used to deserialize Job.policy_config_dict in eval_runner."""
+        ensure_assets_registered()
+        return self._cfg_types.get(policy_type)
 
     def get_policy(self, name: str) -> type["PolicyBase"]:
         """Gets a policy by name.

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -194,9 +194,10 @@ class PolicyRegistry(Registry):
         if cfg_type is not None:
             self._cfg_types[policy_type] = cfg_type
 
-    # TODO(cvolk, 2026-07-03): Remove when eval_runner receives PolicyCfg instead of Job.policy_config_dict.
+    # TODO(cvolk, 2026-07-03): Remove this lookup when policy_runner and eval_runner receive
+    # concrete PolicyCfg objects instead of CLI values and Job.policy_config_dict.
     def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"] | None:
-        """Get the config type used to deserialize Job.policy_config_dict in eval_runner."""
+        """Get the config type used by the temporary policy frontend adapters."""
         ensure_assets_registered()
         return self._cfg_types.get(policy_type)
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -186,7 +186,8 @@ class PolicyRegistry(Registry):
         super().__init__()
         self._cfg_types: dict[type["PolicyBase"], type["PolicyCfg"]] = {}
 
-    # TODO(cvolk, 2026-07-03): Require cfg_type after deprecated bare policy registration is removed.
+    # TODO(cvolk, 2026-07-03): After bare policy registration is removed, make cfg_type
+    # non-optional and remove the None branch.
     def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None) -> None:
         """Register a policy and its config, accepting None only for deprecated callers."""
         self.register(policy_type, policy_type.name)

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -184,22 +184,24 @@ class RetargeterRegistry(Registry):
 class PolicyRegistry(Registry):
     def __init__(self):
         super().__init__()
+        # TODO(cvolk, 2026-07-06): Remove config-type metadata when typed experiment
+        # configs replace policy_runner CLI values and Job.policy_config_dict.
         self._cfg_types: dict[type["PolicyBase"], type["PolicyCfg"]] = {}
 
-    # TODO(cvolk, 2026-07-03): After bare policy registration is removed, make cfg_type
-    # non-optional and remove the None branch.
-    def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"] | None) -> None:
-        """Register a policy and its config, accepting None only for deprecated callers."""
+    # TODO(cvolk, 2026-07-06): Use the generic Registry.register() method once
+    # frontends no longer need the associated policy config type.
+    def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"]) -> None:
+        """Register a policy and its typed configuration."""
         self.register(policy_type, policy_type.name)
-        if cfg_type is not None:
-            self._cfg_types[policy_type] = cfg_type
+        self._cfg_types[policy_type] = cfg_type
 
-    # TODO(cvolk, 2026-07-03): Remove this lookup when policy_runner and eval_runner receive
+    # TODO(cvolk, 2026-07-06): Remove this lookup when policy_runner and eval_runner receive
     # concrete PolicyCfg objects instead of CLI values and Job.policy_config_dict.
-    def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"] | None:
+    def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"]:
         """Get the config type used by the temporary policy frontend adapters."""
         ensure_assets_registered()
-        return self._cfg_types.get(policy_type)
+        assert policy_type in self._cfg_types, f"Policy {policy_type.__name__} must register a PolicyCfg"
+        return self._cfg_types[policy_type]
 
     def get_policy(self, name: str) -> type["PolicyBase"]:
         """Gets a policy by name.

--- a/isaaclab_arena/cli/dataclass_cli.py
+++ b/isaaclab_arena/cli/dataclass_cli.py
@@ -18,49 +18,6 @@ CfgT = TypeVar("CfgT")
 # configuration objects instead of reconstructing them from argparse Namespaces.
 
 
-def _field_default(config_field: Field[Any]) -> Any:
-    """Return one dataclass field's default value, or ``MISSING``."""
-    if config_field.default is not MISSING:
-        return config_field.default
-    if config_field.default_factory is not MISSING:
-        return config_field.default_factory()
-    return MISSING
-
-
-def _unwrap_optional_type(field_type: Any) -> Any:
-    """Return ``T`` from ``T | None`` so argparse can use ``T`` as a converter."""
-    union_members = get_args(field_type)
-    non_none_members = tuple(member for member in union_members if member is not type(None))
-    if len(non_none_members) == 1 and len(non_none_members) != len(union_members):
-        return non_none_members[0]
-    return field_type
-
-
-def _get_argparse_options(config_field: Field[Any], field_type: Any) -> dict[str, Any]:
-    """Describe one generated argparse flag using its dataclass field."""
-    argument_options: dict[str, Any] = {}
-    default = _field_default(config_field)
-    if default is MISSING:
-        argument_options["required"] = True
-    else:
-        argument_options["default"] = default
-
-    cli_value_type = _unwrap_optional_type(field_type)
-    if get_origin(cli_value_type) is list:
-        (list_item_type,) = get_args(cli_value_type)
-        argument_options.update(type=list_item_type, nargs="*")
-    elif get_origin(cli_value_type) is Literal:
-        choices = get_args(cli_value_type)
-        choice_types = {type(choice) for choice in choices}
-        assert len(choice_types) == 1, f"{config_field.name} Literal choices must have one value type"
-        argument_options.update(type=choice_types.pop(), choices=choices)
-    elif cli_value_type is bool:
-        argument_options["action"] = "store_true" if default is False else argparse.BooleanOptionalAction
-    else:
-        argument_options["type"] = cli_value_type
-    return argument_options
-
-
 def add_dataclass_cli_args(
     parser: argparse.ArgumentParser,
     cfg_type: type[CfgT],
@@ -112,3 +69,46 @@ def dataclass_from_cli(cfg_type: type[CfgT], args_cli: argparse.Namespace) -> Cf
         if hasattr(args_cli, config_field.name)
     }
     return cfg_type(**config_values)
+
+
+def _field_default(config_field: Field[Any]) -> Any:
+    """Return one dataclass field's default value, or ``MISSING``."""
+    if config_field.default is not MISSING:
+        return config_field.default
+    if config_field.default_factory is not MISSING:
+        return config_field.default_factory()
+    return MISSING
+
+
+def _unwrap_optional_type(field_type: Any) -> Any:
+    """Return ``T`` from ``T | None`` so argparse can use ``T`` as a converter."""
+    union_members = get_args(field_type)
+    non_none_members = tuple(member for member in union_members if member is not type(None))
+    if len(non_none_members) == 1 and len(non_none_members) != len(union_members):
+        return non_none_members[0]
+    return field_type
+
+
+def _get_argparse_options(config_field: Field[Any], field_type: Any) -> dict[str, Any]:
+    """Describe one generated argparse flag using its dataclass field."""
+    argument_options: dict[str, Any] = {}
+    default = _field_default(config_field)
+    if default is MISSING:
+        argument_options["required"] = True
+    else:
+        argument_options["default"] = default
+
+    cli_value_type = _unwrap_optional_type(field_type)
+    if get_origin(cli_value_type) is list:
+        (list_item_type,) = get_args(cli_value_type)
+        argument_options.update(type=list_item_type, nargs="*")
+    elif get_origin(cli_value_type) is Literal:
+        choices = get_args(cli_value_type)
+        choice_types = {type(choice) for choice in choices}
+        assert len(choice_types) == 1, f"{config_field.name} Literal choices must have one value type"
+        argument_options.update(type=choice_types.pop(), choices=choices)
+    elif cli_value_type is bool:
+        argument_options["action"] = "store_true" if default is False else argparse.BooleanOptionalAction
+    else:
+        argument_options["type"] = cli_value_type
+    return argument_options

--- a/isaaclab_arena/cli/dataclass_cli.py
+++ b/isaaclab_arena/cli/dataclass_cli.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate temporary argparse interfaces from typed dataclass configs."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Collection
+from dataclasses import MISSING, Field, fields, is_dataclass
+from typing import Any, Literal, TypeVar, get_args, get_origin, get_type_hints
+
+CfgT = TypeVar("CfgT")
+
+# TODO(cvolk, 2026-07-03): Delete this module when Arena frontends receive typed
+# configuration objects instead of reconstructing them from argparse Namespaces.
+
+
+def _field_default(config_field: Field[Any]) -> Any:
+    """Return one dataclass field's default value, or ``MISSING``."""
+    if config_field.default is not MISSING:
+        return config_field.default
+    if config_field.default_factory is not MISSING:
+        return config_field.default_factory()
+    return MISSING
+
+
+def _unwrap_optional_type(field_type: Any) -> Any:
+    """Return ``T`` from ``T | None`` so argparse can use ``T`` as a converter."""
+    union_members = get_args(field_type)
+    non_none_members = tuple(member for member in union_members if member is not type(None))
+    if len(non_none_members) == 1 and len(non_none_members) != len(union_members):
+        return non_none_members[0]
+    return field_type
+
+
+def _get_argparse_options(config_field: Field[Any], field_type: Any) -> dict[str, Any]:
+    """Describe one generated argparse flag using its dataclass field."""
+    argument_options: dict[str, Any] = {}
+    default = _field_default(config_field)
+    if default is MISSING:
+        argument_options["required"] = True
+    else:
+        argument_options["default"] = default
+
+    cli_value_type = _unwrap_optional_type(field_type)
+    if get_origin(cli_value_type) is list:
+        (list_item_type,) = get_args(cli_value_type)
+        argument_options.update(type=list_item_type, nargs="*")
+    elif get_origin(cli_value_type) is Literal:
+        choices = get_args(cli_value_type)
+        choice_types = {type(choice) for choice in choices}
+        assert len(choice_types) == 1, f"{config_field.name} Literal choices must have one value type"
+        argument_options.update(type=choice_types.pop(), choices=choices)
+    elif cli_value_type is bool:
+        argument_options["action"] = "store_true" if default is False else argparse.BooleanOptionalAction
+    else:
+        argument_options["type"] = cli_value_type
+    return argument_options
+
+
+def add_dataclass_cli_args(
+    parser: argparse.ArgumentParser,
+    cfg_type: type[CfgT],
+    *,
+    excluded_fields: Collection[str] = (),
+) -> None:
+    """Generate CLI flags for the selected fields of a config dataclass."""
+    assert is_dataclass(cfg_type), f"{cfg_type.__name__} must be a dataclass"
+    resolved_field_types = get_type_hints(cfg_type)
+    for config_field in fields(cfg_type):
+        if config_field.name in excluded_fields:
+            continue
+
+        argument_options = _get_argparse_options(config_field, resolved_field_types[config_field.name])
+        if argument_options.get("required", False):
+            argument_options["help"] = config_field.name.replace("_", " ")
+        else:
+            argument_options["help"] = f"{config_field.name.replace('_', ' ')} (default: %(default)s)"
+        parser.add_argument(f"--{config_field.name}", **argument_options)
+
+
+def assert_cli_defaults_match_dataclass(
+    parser: argparse.ArgumentParser,
+    cfg_type: type[CfgT],
+    field_names: Collection[str],
+) -> None:
+    """Assert that existing parser flags retain their dataclass defaults."""
+    assert is_dataclass(cfg_type), f"{cfg_type.__name__} must be a dataclass"
+    config_fields = {config_field.name: config_field for config_field in fields(cfg_type)}
+    for field_name in field_names:
+        assert field_name in config_fields, f"{cfg_type.__name__} has no field {field_name}"
+        option = f"--{field_name}"
+        assert option in parser._option_string_actions, f"The shared parser must define {option}"
+
+        cfg_default = _field_default(config_fields[field_name])
+        assert cfg_default is not MISSING, f"Shared config field {field_name} must have a default"
+        parser_default = parser._option_string_actions[option].default
+        assert (
+            parser_default == cfg_default
+        ), f"{cfg_type.__name__}.{field_name} defaults to {cfg_default!r}, but {option} defaults to {parser_default!r}"
+
+
+def dataclass_from_cli(cfg_type: type[CfgT], args_cli: argparse.Namespace) -> CfgT:
+    """Create a config dataclass from matching values in an argparse Namespace."""
+    assert is_dataclass(cfg_type), f"{cfg_type.__name__} must be a dataclass"
+    config_values = {
+        config_field.name: getattr(args_cli, config_field.name)
+        for config_field in fields(cfg_type)
+        if hasattr(args_cli, config_field.name)
+    }
+    return cfg_type(**config_values)

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 import tempfile
 import traceback
-import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -91,37 +90,21 @@ def enable_cameras_if_required(eval_jobs_config: dict, args_cli: argparse.Namesp
             break
 
 
+# TODO(cvolk, 2026-07-06): Accept a concrete PolicyCfg from the typed experiment
+# configuration and remove config-type lookup and dictionary construction here.
 def get_policy_from_job(job: Job) -> "PolicyBase":
-    """
-    Create a policy from a job configuration. Two paths are supported:
-    1. JSON → dict → registered PolicyCfg → policy (preferred)
-    2. JSON → dict → CLI args → policy (deprecated compatibility fallback)
-    """
+    """Create a policy from a job's registered typed configuration."""
     # Each job can be evaluated with a different policy checkpoint, or even a different policy type
     policy_cls = get_policy_cls(job.policy_type)
     policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_cls)
 
     policy_config_dict = dict(job.policy_config_dict)
     # Align policy num_envs with env when the policy config supports it (optional key)
-    if policy_cfg_type is not None:
-        config_fields = {f.name for f in dataclasses.fields(policy_cfg_type)}
-        if "num_envs" in config_fields:
-            policy_config_dict["num_envs"] = job.num_envs
+    config_fields = {f.name for f in dataclasses.fields(policy_cfg_type)}
+    if "num_envs" in config_fields:
+        policy_config_dict["num_envs"] = job.num_envs
 
-    if policy_cfg_type is not None:
-        policy = policy_cls(policy_cfg_type(**policy_config_dict))
-    else:
-        # TODO(cvolk, 2026-07-03): Remove this deprecated fallback once every policy registers a typed config.
-        warnings.warn(
-            f"Policy {policy_cls.__name__} uses the deprecated argparse construction path; register a PolicyCfg",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        policy_args_parser = get_isaaclab_arena_cli_parser()
-        policy_added_args_parser = policy_cls.add_args_to_parser(policy_args_parser)
-        policy_args = policy_added_args_parser.parse_args(policy_config_dict)
-        policy = policy_cls.from_args(policy_args)
-    return policy
+    return policy_cls(policy_cfg_type(**policy_config_dict))
 
 
 def _close_policy(policy: "PolicyBase | None") -> None:

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -12,9 +12,11 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
 from isaaclab_arena.evaluation.job_manager import Job, JobManager, Status
@@ -92,24 +94,29 @@ def enable_cameras_if_required(eval_jobs_config: dict, args_cli: argparse.Namesp
 def get_policy_from_job(job: Job) -> "PolicyBase":
     """
     Create a policy from a job configuration. Two paths are supported:
-    1. JSON → dict → PolicyCfg → policy (preferred, if policy has config_class)
-    2. JSON → dict → CLI args → policy (legacy compatibility fallback)
+    1. JSON → dict → registered PolicyCfg → policy (preferred)
+    2. JSON → dict → CLI args → policy (deprecated compatibility fallback)
     """
     # Each job can be evaluated with a different policy checkpoint, or even a different policy type
     policy_cls = get_policy_cls(job.policy_type)
+    policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_cls)
 
     policy_config_dict = dict(job.policy_config_dict)
     # Align policy num_envs with env when the policy config supports it (optional key)
-    if hasattr(policy_cls, "config_class") and policy_cls.config_class is not None:
-        config_fields = {f.name for f in dataclasses.fields(policy_cls.config_class)}
+    if policy_cfg_type is not None:
+        config_fields = {f.name for f in dataclasses.fields(policy_cfg_type)}
         if "num_envs" in config_fields:
             policy_config_dict["num_envs"] = job.num_envs
 
-    # Use direct from_dict if the policy class has config_class defined
-    if hasattr(policy_cls, "config_class") and policy_cls.config_class is not None:
-        # Use the inherited from_dict() method from PolicyBase
-        policy = policy_cls.from_dict(policy_config_dict)
+    if policy_cfg_type is not None:
+        policy = policy_cls(policy_cfg_type(**policy_config_dict))
     else:
+        # TODO(cvolk, 2026-07-03): Remove this deprecated fallback once every policy registers a typed config.
+        warnings.warn(
+            f"Policy {policy_cls.__name__} uses the deprecated argparse construction path; register a PolicyCfg",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         policy_args_parser = get_isaaclab_arena_cli_parser()
         policy_added_args_parser = policy_cls.add_args_to_parser(policy_args_parser)
         policy_args = policy_added_args_parser.parse_args(policy_config_dict)

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -92,8 +92,8 @@ def enable_cameras_if_required(eval_jobs_config: dict, args_cli: argparse.Namesp
 def get_policy_from_job(job: Job) -> "PolicyBase":
     """
     Create a policy from a job configuration. Two paths are supported:
-    1. JSON → dict → ConfigDataclass → init cls (preferred, if policy has config_class)
-    2. JSON → dict → CLI args → init cls (if policy has add_args_to_parser() and from_args())
+    1. JSON → dict → PolicyCfg → policy (preferred, if policy has config_class)
+    2. JSON → dict → CLI args → policy (legacy compatibility fallback)
     """
     # Each job can be evaluated with a different policy checkpoint, or even a different policy type
     policy_cls = get_policy_cls(job.policy_type)

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -14,7 +14,11 @@ from typing import TYPE_CHECKING
 
 from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
-from isaaclab_arena.evaluation.policy_runner_cli import add_policy_runner_arguments
+from isaaclab_arena.evaluation.policy_runner_cli import (
+    add_policy_cli_args,
+    add_policy_runner_arguments,
+    build_policy_from_cli,
+)
 from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -164,11 +168,9 @@ def main():
             f" {policy_cls}"
         )
 
-        # TODO(cvolk, 2026-07-03): Make policy_runner build PolicyCfg, then remove policy-owned
-        # add_args_to_parser and from_args adapters.
-        # Add the example environment arguments + policy-related arguments to the parser
+        # Add the example environment arguments and config-derived policy arguments.
         args_parser = get_isaaclab_arena_environments_cli_parser(args_parser)
-        args_parser = policy_cls.add_args_to_parser(args_parser)
+        args_parser = add_policy_cli_args(args_parser, policy_cls)
         args_cli, hydra_overrides = args_parser.parse_known_args()
         assert_hydra_overrides(hydra_overrides, args_parser)
         # Re-apply per-rank device after parse preventing device got overwritten by the default value
@@ -203,8 +205,8 @@ def main():
         env.unwrapped.episode_recorder.set_job_name("policy_runner")
         env.unwrapped.episode_recorder.set_output_path(results_path)
 
-        # Create the policy from the arguments
-        policy = policy_cls.from_args(args_cli)
+        # Create the policy through the typed config compatibility adapter.
+        policy = build_policy_from_cli(policy_cls, args_cli)
 
         # Simulation length.
         if policy.has_length():

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -12,6 +12,7 @@ import tqdm
 from importlib import import_module
 from typing import TYPE_CHECKING
 
+from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.evaluation.policy_runner_cli import add_policy_runner_arguments
 from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
@@ -36,8 +37,6 @@ def get_policy_cls(policy_type: str) -> type[PolicyBase]:
       the policy_type argument as a string representing the module path and class name.
 
     """
-    from isaaclab_arena.assets.registries import PolicyRegistry
-
     policy_registry = PolicyRegistry()
     if policy_registry.is_registered(policy_type):
         return policy_registry.get_policy(policy_type)
@@ -165,6 +164,8 @@ def main():
             f" {policy_cls}"
         )
 
+        # TODO(cvolk, 2026-07-03): Make policy_runner build PolicyCfg, then remove policy-owned
+        # add_args_to_parser and from_args adapters.
         # Add the example environment arguments + policy-related arguments to the parser
         args_parser = get_isaaclab_arena_environments_cli_parser(args_parser)
         args_parser = policy_cls.add_args_to_parser(args_parser)

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -4,6 +4,82 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import warnings
+from dataclasses import fields
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.assets.registries import PolicyRegistry
+from isaaclab_arena.cli.dataclass_cli import (
+    add_dataclass_cli_args,
+    assert_cli_defaults_match_dataclass,
+    dataclass_from_cli,
+)
+
+if TYPE_CHECKING:
+    from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
+
+
+# Legacy argparse compatibility
+#
+# Registered policy configs are the source of truth. Until policy_runner receives a
+# PolicyCfg directly, these helpers generate its policy flags and reconstruct the same
+# config from the parsed Namespace. Untyped downstream policies temporarily keep their
+# existing add_args_to_parser() and from_args() path.
+# TODO(cvolk, 2026-07-03): Delete this compatibility section when policy_runner
+# receives typed policy configs directly and untyped downstream policies are removed.
+_FIELDS_PROVIDED_BY_SHARED_PARSER = {"device", "num_envs"}
+
+
+def _add_policy_cfg_arguments(
+    parser: argparse.ArgumentParser,
+    policy_cfg_type: type["PolicyCfg"],
+) -> None:
+    """Generate CLI flags from one registered policy config."""
+    cfg_field_names = {config_field.name for config_field in fields(policy_cfg_type)}
+    shared_fields = cfg_field_names.intersection(_FIELDS_PROVIDED_BY_SHARED_PARSER)
+    assert_cli_defaults_match_dataclass(parser, policy_cfg_type, shared_fields)
+    add_dataclass_cli_args(parser, policy_cfg_type, excluded_fields=shared_fields)
+
+
+def add_policy_cli_args(
+    parser: argparse.ArgumentParser,
+    policy_type: type["PolicyBase"],
+) -> argparse.ArgumentParser:
+    """Add generated policy flags or use an untyped policy's legacy adapter."""
+    policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_type)
+    if policy_cfg_type is not None:
+        _add_policy_cfg_arguments(parser, policy_cfg_type)
+        return parser
+
+    # TODO(cvolk, 2026-07-03): Delete this fallback when downstream policies register PolicyCfg.
+    warnings.warn(
+        f"Policy {policy_type.__name__} uses deprecated policy-owned argparse flags; register a PolicyCfg",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return policy_type.add_args_to_parser(parser)
+
+
+def policy_cfg_from_cli(
+    policy_type: type["PolicyBase"],
+    args_cli: argparse.Namespace,
+) -> "PolicyCfg":
+    """Create a registered policy's typed config from parsed CLI values."""
+    policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_type)
+    assert policy_cfg_type is not None, f"Policy {policy_type.__name__} must register a PolicyCfg"
+    return dataclass_from_cli(policy_cfg_type, args_cli)
+
+
+def build_policy_from_cli(
+    policy_type: type["PolicyBase"],
+    args_cli: argparse.Namespace,
+) -> "PolicyBase":
+    """Build a policy through its typed or untyped legacy CLI path."""
+    if PolicyRegistry().get_policy_cfg_type(policy_type) is not None:
+        return policy_type(policy_cfg_from_cli(policy_type, args_cli))
+
+    # TODO(cvolk, 2026-07-03): Delete this fallback when downstream policies register PolicyCfg.
+    return policy_type.from_args(args_cli)
 
 
 def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
-import warnings
 from dataclasses import fields
 from typing import TYPE_CHECKING
 
@@ -23,10 +22,9 @@ if TYPE_CHECKING:
 #
 # Registered policy configs are the source of truth. Until policy_runner receives a
 # PolicyCfg directly, these helpers generate its policy flags and reconstruct the same
-# config from the parsed Namespace. Untyped downstream policies temporarily keep their
-# existing add_args_to_parser() and from_args() path.
-# TODO(cvolk, 2026-07-03): Delete this compatibility section when policy_runner
-# receives typed policy configs directly and untyped downstream policies are removed.
+# config from the parsed Namespace.
+# TODO(cvolk, 2026-07-03): Delete this compatibility section when policy_runner receives
+# typed policy configs directly.
 _FIELDS_PROVIDED_BY_SHARED_PARSER = {"device", "num_envs"}
 
 
@@ -45,19 +43,10 @@ def add_policy_cli_args(
     parser: argparse.ArgumentParser,
     policy_type: type["PolicyBase"],
 ) -> argparse.ArgumentParser:
-    """Add generated policy flags or use an untyped policy's legacy adapter."""
+    """Add CLI flags generated from a policy's registered config."""
     policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_type)
-    if policy_cfg_type is not None:
-        _add_policy_cfg_arguments(parser, policy_cfg_type)
-        return parser
-
-    # TODO(cvolk, 2026-07-03): Delete this fallback when downstream policies register PolicyCfg.
-    warnings.warn(
-        f"Policy {policy_type.__name__} uses deprecated policy-owned argparse flags; register a PolicyCfg",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return policy_type.add_args_to_parser(parser)
+    _add_policy_cfg_arguments(parser, policy_cfg_type)
+    return parser
 
 
 def policy_cfg_from_cli(
@@ -66,7 +55,6 @@ def policy_cfg_from_cli(
 ) -> "PolicyCfg":
     """Create a registered policy's typed config from parsed CLI values."""
     policy_cfg_type = PolicyRegistry().get_policy_cfg_type(policy_type)
-    assert policy_cfg_type is not None, f"Policy {policy_type.__name__} must register a PolicyCfg"
     return dataclass_from_cli(policy_cfg_type, args_cli)
 
 
@@ -74,12 +62,8 @@ def build_policy_from_cli(
     policy_type: type["PolicyBase"],
     args_cli: argparse.Namespace,
 ) -> "PolicyBase":
-    """Build a policy through its typed or untyped legacy CLI path."""
-    if PolicyRegistry().get_policy_cfg_type(policy_type) is not None:
-        return policy_type(policy_cfg_from_cli(policy_type, args_cli))
-
-    # TODO(cvolk, 2026-07-03): Delete this fallback when downstream policies register PolicyCfg.
-    return policy_type.from_args(args_cli)
+    """Build a policy from CLI values through its registered typed config."""
+    return policy_type(policy_cfg_from_cli(policy_type, args_cli))
 
 
 def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -10,7 +10,7 @@ import torch
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from gymnasium.spaces.dict import Dict as GymSpacesDict
-from typing import Any, Generic, Self, TypeVar
+from typing import Generic, TypeVar
 
 
 @dataclass
@@ -24,27 +24,8 @@ PolicyCfgT = TypeVar("PolicyCfgT", bound=PolicyCfg)
 class PolicyBase(ABC, Generic[PolicyCfgT]):
     """Define runtime behavior shared by Arena policies."""
 
-    config_class: type[PolicyCfg] | None = None
-    """Concrete config used by the legacy dictionary-based evaluation path."""
-
     def __init__(self, config: PolicyCfgT):
         self.config = config
-
-    @classmethod
-    def from_dict(cls, config_dict: dict[str, Any]) -> Self:
-        """Create a policy through the legacy dictionary configuration path.
-
-        Args:
-            config_dict: Values used to instantiate ``config_class``.
-
-        Returns:
-            A policy initialized with its typed config.
-        """
-        if cls.config_class is None:
-            raise NotImplementedError(f"{cls.__name__} must define 'config_class' to use from_dict()")
-
-        config = cls.config_class(**config_dict)  # type: ignore[misc]
-        return cls(config)  # type: ignore[call-arg]
 
     @abstractmethod
     def get_action(self, env: gym.Env, observation: GymSpacesDict) -> torch.Tensor:

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -3,54 +3,47 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
+from __future__ import annotations
+
 import gymnasium as gym
 import torch
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from gymnasium.spaces.dict import Dict as GymSpacesDict
-from typing import Any
+from typing import Any, Generic, Self, TypeVar
 
 
-class PolicyBase(ABC):
-    """
-    Base class for policies.
+@dataclass
+class PolicyCfg:
+    """Mark a typed Arena policy configuration."""
 
-    Subclasses should define a `config_class` class variable pointing to their configuration dataclass
-    to enable configuration from dictionaries via the from_dict() method.
-    """
 
-    # Optional: Subclasses can define this to enable from_dict()
-    config_class: type | None = None
+PolicyCfgT = TypeVar("PolicyCfgT", bound=PolicyCfg)
 
-    def __init__(self, config: Any):
-        """
-        Base class for policies.
-        """
+
+class PolicyBase(ABC, Generic[PolicyCfgT]):
+    """Define runtime behavior shared by Arena policies."""
+
+    config_class: type[PolicyCfg] | None = None
+    """Concrete config used by the legacy dictionary-based evaluation path."""
+
+    def __init__(self, config: PolicyCfgT):
         self.config = config
 
     @classmethod
-    def from_dict(cls, config_dict: dict[str, Any]) -> "PolicyBase":
-        """
-        Create a policy instance from a configuration dictionary.
-
-        This method instantiates the policy's config_class from the dict and then
-        creates the policy from that config.
-
-        Path: dict → ConfigDataclass → Policy instance
+    def from_dict(cls, config_dict: dict[str, Any]) -> Self:
+        """Create a policy through the legacy dictionary configuration path.
 
         Args:
-            config_dict: Dictionary containing the configuration fields
+            config_dict: Values used to instantiate ``config_class``.
 
         Returns:
-            Policy instance
+            A policy initialized with its typed config.
         """
         if cls.config_class is None:
             raise NotImplementedError(f"{cls.__name__} must define 'config_class' to use from_dict()")
 
-        # Create config from dict
         config = cls.config_class(**config_dict)  # type: ignore[misc]
-
-        # Create policy from config
         return cls(config)  # type: ignore[call-arg]
 
     @abstractmethod
@@ -94,15 +87,3 @@ class PolicyBase(ABC):
     def is_remote(self) -> bool:
         """Check if policy is run remotely."""
         return False
-
-    @staticmethod
-    @abstractmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """Add policy-specific arguments to the parser."""
-        raise NotImplementedError("Function not implemented yet.")
-
-    @staticmethod
-    @abstractmethod
-    def from_args(args: argparse.Namespace) -> "PolicyBase":
-        """Create a policy from the arguments."""
-        raise NotImplementedError("Function not implemented yet.")

--- a/isaaclab_arena/policy/replay_action_policy.py
+++ b/isaaclab_arena/policy/replay_action_policy.py
@@ -6,68 +6,31 @@
 import argparse
 import gymnasium as gym
 import torch
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from gymnasium.spaces.dict import Dict as GymSpacesDict
 
 from isaaclab.utils.datasets import HDF5DatasetFileHandler
 
 from isaaclab_arena.assets.register import register_policy
-from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
 @dataclass
-class ReplayActionPolicyArgs:
-    """
-    Configuration dataclass for ReplayActionPolicy.
+class ReplayActionPolicyCfg(PolicyCfg):
+    """Configure a policy that replays actions from a recorded episode."""
 
-    This dataclass serves as the single source of truth for policy configuration,
-    supporting both dict-based (from JSON) and CLI-based configuration paths.
+    replay_file_path: str
+    """Path to the HDF5 file containing the episode."""
 
-    Field metadata is used to auto-generate argparse arguments, ensuring consistency
-    between the dataclass definition and CLI argument parsing.
-    """
+    device: str = "cuda"
+    """Device used to load the recorded episode."""
 
-    replay_file_path: str = field(
-        metadata={
-            "help": "Path to the HDF5 file containing the episode",
-            "required": True,
-        }
-    )
-
-    device: str = field(
-        default="cuda",
-        metadata={
-            "help": "Device to use for loading the dataset",
-        },
-    )
-
-    episode_name: str | None = field(
-        default=None,
-        metadata={
-            "help": "Name of the episode to replay. If not provided, the first episode will be replayed",
-        },
-    )
-
-    @classmethod
-    def from_cli_args(cls, args: argparse.Namespace) -> "ReplayActionPolicyArgs":
-        """
-        Create configuration from parsed CLI arguments.
-
-        Args:
-            args: Parsed command line arguments
-
-        Returns:
-            ReplayActionPolicyArgs instance
-        """
-        return cls(
-            replay_file_path=args.replay_file_path,
-            device=args.device,
-            episode_name=args.episode_name,
-        )
+    episode_name: str | None = None
+    """Episode to replay, or the first episode when omitted."""
 
 
 @register_policy
-class ReplayActionPolicy(PolicyBase):
+class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
     """
     Replay the actions from an named episode stored in a HDF5 file.
     If no episode name is provided, the first episode will be replayed.
@@ -75,14 +38,14 @@ class ReplayActionPolicy(PolicyBase):
 
     name = "replay"
     # enable from_dict() from policy_base.PolicyBase
-    config_class = ReplayActionPolicyArgs
+    config_class = ReplayActionPolicyCfg
 
-    def __init__(self, config: ReplayActionPolicyArgs):
+    def __init__(self, config: ReplayActionPolicyCfg):
         """
         Initialize ReplayActionPolicy from a configuration dataclass.
 
         Args:
-            config: ReplayActionPolicyArgs configuration dataclass
+            config: Typed replay policy configuration.
         """
         super().__init__(config)
         self.episode_name = config.episode_name
@@ -137,6 +100,7 @@ class ReplayActionPolicy(PolicyBase):
         """Get the length of the policy (for dataset-driven policies)."""
         return len(self)
 
+    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Add replay action policy specific arguments to the parser."""
@@ -169,5 +133,9 @@ class ReplayActionPolicy(PolicyBase):
         Returns:
             ReplayActionPolicy instance
         """
-        config = ReplayActionPolicyArgs.from_cli_args(args)
+        config = ReplayActionPolicyCfg(
+            replay_file_path=args.replay_file_path,
+            device=args.device,
+            episode_name=args.episode_name,
+        )
         return ReplayActionPolicy(config)

--- a/isaaclab_arena/policy/replay_action_policy.py
+++ b/isaaclab_arena/policy/replay_action_policy.py
@@ -28,7 +28,7 @@ class ReplayActionPolicyCfg(PolicyCfg):
     """Episode to replay, or the first episode when omitted."""
 
 
-@register_policy(cfg_type=ReplayActionPolicyCfg)
+@register_policy
 class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
     """
     Replay the actions from an named episode stored in a HDF5 file.

--- a/isaaclab_arena/policy/replay_action_policy.py
+++ b/isaaclab_arena/policy/replay_action_policy.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 import gymnasium as gym
 import torch
 from dataclasses import dataclass
@@ -22,7 +21,7 @@ class ReplayActionPolicyCfg(PolicyCfg):
     replay_file_path: str
     """Path to the HDF5 file containing the episode."""
 
-    device: str = "cuda"
+    device: str = "cuda:0"
     """Device used to load the recorded episode."""
 
     episode_name: str | None = None
@@ -97,43 +96,3 @@ class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
     def length(self) -> int:
         """Get the length of the policy (for dataset-driven policies)."""
         return len(self)
-
-    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
-    @staticmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """Add replay action policy specific arguments to the parser."""
-        replay_group = parser.add_argument_group("Replay Action Policy", "Arguments for replay action policy")
-        replay_group.add_argument(
-            "--replay_file_path",
-            type=str,
-            required=True,
-            help="Path to the HDF5 file containing the episode",
-        )
-        # Note: --device is already provided by AppLauncher.add_app_launcher_args()
-        replay_group.add_argument(
-            "--episode_name",
-            type=str,
-            default=None,
-            help="Name of the episode to replay. If not provided, the first episode will be replayed",
-        )
-        return parser
-
-    @staticmethod
-    def from_args(args: argparse.Namespace) -> "ReplayActionPolicy":
-        """
-        Create a ReplayActionPolicy instance from parsed CLI arguments.
-
-        Path: CLI args → ConfigDataclass → init cls
-
-        Args:
-            args: Parsed command line arguments
-
-        Returns:
-            ReplayActionPolicy instance
-        """
-        config = ReplayActionPolicyCfg(
-            replay_file_path=args.replay_file_path,
-            device=args.device,
-            episode_name=args.episode_name,
-        )
-        return ReplayActionPolicy(config)

--- a/isaaclab_arena/policy/replay_action_policy.py
+++ b/isaaclab_arena/policy/replay_action_policy.py
@@ -29,7 +29,7 @@ class ReplayActionPolicyCfg(PolicyCfg):
     """Episode to replay, or the first episode when omitted."""
 
 
-@register_policy
+@register_policy(cfg_type=ReplayActionPolicyCfg)
 class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
     """
     Replay the actions from an named episode stored in a HDF5 file.
@@ -37,8 +37,6 @@ class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
     """
 
     name = "replay"
-    # enable from_dict() from policy_base.PolicyBase
-    config_class = ReplayActionPolicyCfg
 
     def __init__(self, config: ReplayActionPolicyCfg):
         """
@@ -100,7 +98,7 @@ class ReplayActionPolicy(PolicyBase[ReplayActionPolicyCfg]):
         """Get the length of the policy (for dataset-driven policies)."""
         return len(self)
 
-    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
+    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Add replay action policy specific arguments to the parser."""

--- a/isaaclab_arena/policy/rsl_rl_action_policy.py
+++ b/isaaclab_arena/policy/rsl_rl_action_policy.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 import gymnasium as gym
 import os
 import torch
@@ -131,27 +130,3 @@ class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
 
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
         pass
-
-    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
-    @staticmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """Add RSL-RL action policy specific arguments to the parser."""
-        rsl_rl_group = parser.add_argument_group("RSL-RL Action Policy", "Arguments for RSL-RL action policy")
-        rsl_rl_group.add_argument(
-            "--checkpoint_path",
-            type=str,
-            required=True,
-            help=(
-                "Path to the checkpoint file. Agent config is loaded automatically from params/agent.yaml in the same"
-                " directory."
-            ),
-        )
-        return parser
-
-    @staticmethod
-    def from_args(args: argparse.Namespace) -> "RslRlActionPolicy":
-        config = RslRlActionPolicyCfg(
-            checkpoint_path=args.checkpoint_path,
-            device=args.device if hasattr(args, "device") else "cuda:0",
-        )
-        return RslRlActionPolicy(config)

--- a/isaaclab_arena/policy/rsl_rl_action_policy.py
+++ b/isaaclab_arena/policy/rsl_rl_action_policy.py
@@ -16,7 +16,7 @@ from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
 from rsl_rl.runners import DistillationRunner, OnPolicyRunner
 
 from isaaclab_arena.assets.register import register_policy
-from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
 class _RslRlInferenceEnvWrapper(RslRlVecEnvWrapper):
@@ -42,7 +42,7 @@ class _RslRlInferenceEnvWrapper(RslRlVecEnvWrapper):
 
 
 @dataclass
-class RslRlActionPolicyConfig:
+class RslRlActionPolicyCfg(PolicyCfg):
     """Configuration dataclass for RSL-RL action policy."""
 
     checkpoint_path: str
@@ -55,16 +55,9 @@ class RslRlActionPolicyConfig:
     device: str = "cuda:0"
     """Device to run the policy on."""
 
-    @classmethod
-    def from_cli_args(cls, args: argparse.Namespace) -> "RslRlActionPolicyConfig":
-        return cls(
-            checkpoint_path=args.checkpoint_path,
-            device=args.device if hasattr(args, "device") else "cuda:0",
-        )
-
 
 @register_policy
-class RslRlActionPolicy(PolicyBase):
+class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     """Policy that uses a trained RSL-RL model for inference.
 
     Loads the checkpoint and agent config (``params/agent.yaml``) produced by
@@ -90,11 +83,11 @@ class RslRlActionPolicy(PolicyBase):
     """
 
     name = "rsl_rl"
-    config_class = RslRlActionPolicyConfig
+    config_class = RslRlActionPolicyCfg
 
-    def __init__(self, config: RslRlActionPolicyConfig):
+    def __init__(self, config: RslRlActionPolicyCfg):
         super().__init__(config)
-        self.config: RslRlActionPolicyConfig = config
+        self.config: RslRlActionPolicyCfg = config
         self._policy = None
         self._runner = None
 
@@ -140,11 +133,7 @@ class RslRlActionPolicy(PolicyBase):
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
         pass
 
-    @classmethod
-    def from_dict(cls, config_dict: dict) -> "RslRlActionPolicy":
-        config = RslRlActionPolicyConfig(**config_dict)
-        return cls(config)
-
+    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Add RSL-RL action policy specific arguments to the parser."""
@@ -162,5 +151,8 @@ class RslRlActionPolicy(PolicyBase):
 
     @staticmethod
     def from_args(args: argparse.Namespace) -> "RslRlActionPolicy":
-        config = RslRlActionPolicyConfig.from_cli_args(args)
+        config = RslRlActionPolicyCfg(
+            checkpoint_path=args.checkpoint_path,
+            device=args.device if hasattr(args, "device") else "cuda:0",
+        )
         return RslRlActionPolicy(config)

--- a/isaaclab_arena/policy/rsl_rl_action_policy.py
+++ b/isaaclab_arena/policy/rsl_rl_action_policy.py
@@ -55,7 +55,7 @@ class RslRlActionPolicyCfg(PolicyCfg):
     """Device to run the policy on."""
 
 
-@register_policy(cfg_type=RslRlActionPolicyCfg)
+@register_policy
 class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     """Policy that uses a trained RSL-RL model for inference.
 

--- a/isaaclab_arena/policy/rsl_rl_action_policy.py
+++ b/isaaclab_arena/policy/rsl_rl_action_policy.py
@@ -56,7 +56,7 @@ class RslRlActionPolicyCfg(PolicyCfg):
     """Device to run the policy on."""
 
 
-@register_policy
+@register_policy(cfg_type=RslRlActionPolicyCfg)
 class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     """Policy that uses a trained RSL-RL model for inference.
 
@@ -83,7 +83,6 @@ class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     """
 
     name = "rsl_rl"
-    config_class = RslRlActionPolicyCfg
 
     def __init__(self, config: RslRlActionPolicyCfg):
         super().__init__(config)
@@ -133,7 +132,7 @@ class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
         pass
 
-    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
+    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Add RSL-RL action policy specific arguments to the parser."""

--- a/isaaclab_arena/policy/zero_action_policy.py
+++ b/isaaclab_arena/policy/zero_action_policy.py
@@ -10,46 +10,27 @@ from dataclasses import dataclass
 from gymnasium.spaces.dict import Dict as GymSpacesDict
 
 from isaaclab_arena.assets.register import register_policy
-from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
 @dataclass
-class ZeroActionPolicyArgs:
-    """
-    Configuration dataclass for ZeroActionPolicy.
-
-    This policy has no configuration parameters, but the dataclass is provided
-    for consistency with other policies following the unified configuration pattern.
-    """
-
-    @classmethod
-    def from_cli_args(cls, args: argparse.Namespace) -> "ZeroActionPolicyArgs":
-        """
-        Create configuration from parsed CLI arguments.
-
-        Args:
-            args: Parsed command line arguments
-
-        Returns:
-            ZeroActionPolicyArgs instance
-        """
-        _ = args  # Unused, but kept for API consistency
-        return cls()
+class ZeroActionPolicyCfg(PolicyCfg):
+    """Configure a policy that always returns zero actions."""
 
 
 @register_policy
-class ZeroActionPolicy(PolicyBase):
+class ZeroActionPolicy(PolicyBase[ZeroActionPolicyCfg]):
 
     name = "zero_action"
     # enable from_dict() from policy_base.PolicyBase
-    config_class = ZeroActionPolicyArgs
+    config_class = ZeroActionPolicyCfg
 
-    def __init__(self, config: ZeroActionPolicyArgs):
+    def __init__(self, config: ZeroActionPolicyCfg):
         """
         Initialize ZeroActionPolicy.
 
         Args:
-            config: ZeroActionPolicyArgs configuration dataclass (optional, not used)
+            config: Typed policy configuration.
         """
         super().__init__(config)
 
@@ -59,6 +40,7 @@ class ZeroActionPolicy(PolicyBase):
         """
         return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
 
+    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """
@@ -88,5 +70,4 @@ class ZeroActionPolicy(PolicyBase):
         Returns:
             ZeroActionPolicy instance
         """
-        config = ZeroActionPolicyArgs.from_cli_args(args)
-        return ZeroActionPolicy(config)
+        return ZeroActionPolicy(ZeroActionPolicyCfg())

--- a/isaaclab_arena/policy/zero_action_policy.py
+++ b/isaaclab_arena/policy/zero_action_policy.py
@@ -17,7 +17,7 @@ class ZeroActionPolicyCfg(PolicyCfg):
     """Configure a policy that always returns zero actions."""
 
 
-@register_policy(cfg_type=ZeroActionPolicyCfg)
+@register_policy
 class ZeroActionPolicy(PolicyBase[ZeroActionPolicyCfg]):
 
     name = "zero_action"

--- a/isaaclab_arena/policy/zero_action_policy.py
+++ b/isaaclab_arena/policy/zero_action_policy.py
@@ -18,12 +18,10 @@ class ZeroActionPolicyCfg(PolicyCfg):
     """Configure a policy that always returns zero actions."""
 
 
-@register_policy
+@register_policy(cfg_type=ZeroActionPolicyCfg)
 class ZeroActionPolicy(PolicyBase[ZeroActionPolicyCfg]):
 
     name = "zero_action"
-    # enable from_dict() from policy_base.PolicyBase
-    config_class = ZeroActionPolicyCfg
 
     def __init__(self, config: ZeroActionPolicyCfg):
         """
@@ -40,7 +38,7 @@ class ZeroActionPolicy(PolicyBase[ZeroActionPolicyCfg]):
         """
         return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
 
-    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
+    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """

--- a/isaaclab_arena/policy/zero_action_policy.py
+++ b/isaaclab_arena/policy/zero_action_policy.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
 import gymnasium as gym
 import torch
 from dataclasses import dataclass
@@ -37,35 +36,3 @@ class ZeroActionPolicy(PolicyBase[ZeroActionPolicyCfg]):
         Always returns a zero action.
         """
         return torch.zeros(env.action_space.shape, device=torch.device(env.unwrapped.device))
-
-    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
-    @staticmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        """
-        Add zero action policy specific arguments to the parser.
-
-        This policy has no configuration parameters, so no arguments are added.
-
-        Args:
-            parser: The argument parser to add arguments to
-
-        Returns:
-            The updated argument parser (unchanged)
-        """
-        # No additional command line arguments for zero action policy
-        return parser
-
-    @staticmethod
-    def from_args(args: argparse.Namespace) -> "ZeroActionPolicy":
-        """
-        Create a ZeroActionPolicy instance from parsed CLI arguments.
-
-        Path: CLI args → ConfigDataclass → init cls
-
-        Args:
-            args: Parsed command line arguments
-
-        Returns:
-            ZeroActionPolicy instance
-        """
-        return ZeroActionPolicy(ZeroActionPolicyCfg())

--- a/isaaclab_arena/tests/test_dataclass_cli.py
+++ b/isaaclab_arena/tests/test_dataclass_cli.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify the shared dataclass-to-argparse compatibility helpers."""
+
+import argparse
+from dataclasses import dataclass, field
+from typing import Literal
+
+from isaaclab_arena.cli.dataclass_cli import add_dataclass_cli_args, dataclass_from_cli
+
+
+@dataclass
+class _ExampleCfg:
+    required_value: str
+    mode: Literal["fast", "safe"] = "fast"
+    enabled: bool = False
+    visible: bool = True
+    labels: list[str] = field(default_factory=list)
+    threshold: float | None = None
+    shared_value: int = 1
+
+
+def test_generated_arguments_reconstruct_typed_dataclass():
+    """Parse representative field types and preserve a shared parser override."""
+    parser = argparse.ArgumentParser(exit_on_error=False)
+    parser.add_argument("--shared_value", type=int, default=1)
+    add_dataclass_cli_args(parser, _ExampleCfg, excluded_fields={"shared_value"})
+
+    args_cli = parser.parse_args([
+        "--required_value",
+        "example",
+        "--mode",
+        "safe",
+        "--enabled",
+        "--no-visible",
+        "--labels",
+        "left",
+        "right",
+        "--threshold",
+        "1.5",
+        "--shared_value",
+        "2",
+    ])
+
+    assert dataclass_from_cli(_ExampleCfg, args_cli) == _ExampleCfg(
+        required_value="example",
+        mode="safe",
+        enabled=True,
+        visible=False,
+        labels=["left", "right"],
+        threshold=1.5,
+        shared_value=2,
+    )

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify the typed policy configuration contract."""
+
+from dataclasses import dataclass, is_dataclass
+
+import pytest
+import torch
+
+from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
+from isaaclab_arena.policy.replay_action_policy import ReplayActionPolicy, ReplayActionPolicyCfg
+from isaaclab_arena.policy.rsl_rl_action_policy import RslRlActionPolicy, RslRlActionPolicyCfg
+from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyCfg
+
+
+@pytest.mark.parametrize(
+    ("policy_type", "cfg_type"),
+    [
+        (ZeroActionPolicy, ZeroActionPolicyCfg),
+        (ReplayActionPolicy, ReplayActionPolicyCfg),
+        (RslRlActionPolicy, RslRlActionPolicyCfg),
+    ],
+)
+def test_core_policies_declare_typed_configs(policy_type, cfg_type):
+    """Check that each registered core policy declares its concrete config."""
+    assert policy_type.config_class is cfg_type
+    assert issubclass(cfg_type, PolicyCfg)
+    assert is_dataclass(cfg_type)
+
+
+@dataclass
+class _ExamplePolicyCfg(PolicyCfg):
+    value: int = 1
+
+
+class _ExamplePolicy(PolicyBase[_ExamplePolicyCfg]):
+    config_class = _ExamplePolicyCfg
+
+    def get_action(self, env, observation) -> torch.Tensor:
+        return torch.tensor([self.config.value])
+
+
+def test_policy_base_constructs_from_typed_config_without_cli_methods():
+    """Keep argparse adapters outside the core policy contract."""
+    policy = _ExamplePolicy.from_dict({"value": 2})
+
+    assert policy.config == _ExamplePolicyCfg(value=2)
+    assert not hasattr(PolicyBase, "add_args_to_parser")
+    assert not hasattr(PolicyBase, "from_args")

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -6,7 +6,7 @@
 """Verify the typed policy configuration contract."""
 
 import torch
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass
 
 import pytest
 
@@ -30,7 +30,6 @@ def test_core_policies_register_typed_configs(policy_type, cfg_type):
     """Check that each core policy is registered with its concrete config."""
     assert PolicyRegistry().get_policy_cfg_type(policy_type) is cfg_type
     assert issubclass(cfg_type, PolicyCfg)
-    assert is_dataclass(cfg_type)
 
 
 @dataclass
@@ -39,23 +38,40 @@ class _ExamplePolicyCfg(PolicyCfg):
 
 
 class _ExamplePolicy(PolicyBase[_ExamplePolicyCfg]):
+    name = "example_policy"
+
     def get_action(self, env, observation) -> torch.Tensor:
         return torch.tensor([self.config.value])
 
 
-def test_policy_constructs_without_deserialization_on_runtime_contract():
-    """Keep deserialization and argparse adapters outside the policy contract."""
-    policy = _ExamplePolicy(_ExamplePolicyCfg(value=2))
+def test_policy_runtime_contract_accepts_typed_config():
+    """Construct and run a policy using only its typed runtime config."""
+    config = _ExamplePolicyCfg(value=2)
+    policy = _ExamplePolicy(config)
 
-    assert policy.config == _ExamplePolicyCfg(value=2)
-    assert not hasattr(PolicyBase, "config_class")
-    assert not hasattr(PolicyBase, "from_dict")
-    assert not hasattr(PolicyBase, "add_args_to_parser")
-    assert not hasattr(PolicyBase, "from_args")
+    assert policy.config is config
+    assert policy.get_action(env=None, observation=None).item() == 2
+
+
+def test_typed_policy_registration_associates_config(monkeypatch):
+    """Pass the policy and its config through the supported decorator form."""
+    registrations = []
+
+    def record_registration(policy_type, cfg_type):
+        registrations.append((policy_type, cfg_type))
+        return policy_type
+
+    monkeypatch.setattr(policy_registration, "_register_policy", record_registration)
+
+    registered_policy = policy_registration.register_policy(cfg_type=_ExamplePolicyCfg)(_ExamplePolicy)
+
+    assert registered_policy is _ExamplePolicy
+    assert registrations == [(_ExamplePolicy, _ExamplePolicyCfg)]
 
 
 def test_bare_policy_registration_is_deprecated(monkeypatch):
     """Keep the untyped registration form only as an explicit compatibility path."""
+    # TODO(cvolk, 2026-07-03): Delete this test when bare @register_policy support is removed.
     monkeypatch.setattr(policy_registration, "_register_policy", lambda policy_type, cfg_type: policy_type)
 
     with pytest.warns(DeprecationWarning, match="Bare @register_policy is deprecated"):

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -5,11 +5,13 @@
 
 """Verify the typed policy configuration contract."""
 
+import torch
 from dataclasses import dataclass, is_dataclass
 
 import pytest
-import torch
 
+import isaaclab_arena.assets.register as policy_registration
+from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 from isaaclab_arena.policy.replay_action_policy import ReplayActionPolicy, ReplayActionPolicyCfg
 from isaaclab_arena.policy.rsl_rl_action_policy import RslRlActionPolicy, RslRlActionPolicyCfg
@@ -24,9 +26,9 @@ from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActio
         (RslRlActionPolicy, RslRlActionPolicyCfg),
     ],
 )
-def test_core_policies_declare_typed_configs(policy_type, cfg_type):
-    """Check that each registered core policy declares its concrete config."""
-    assert policy_type.config_class is cfg_type
+def test_core_policies_register_typed_configs(policy_type, cfg_type):
+    """Check that each core policy is registered with its concrete config."""
+    assert PolicyRegistry().get_policy_cfg_type(policy_type) is cfg_type
     assert issubclass(cfg_type, PolicyCfg)
     assert is_dataclass(cfg_type)
 
@@ -37,16 +39,26 @@ class _ExamplePolicyCfg(PolicyCfg):
 
 
 class _ExamplePolicy(PolicyBase[_ExamplePolicyCfg]):
-    config_class = _ExamplePolicyCfg
-
     def get_action(self, env, observation) -> torch.Tensor:
         return torch.tensor([self.config.value])
 
 
-def test_policy_base_constructs_from_typed_config_without_cli_methods():
-    """Keep argparse adapters outside the core policy contract."""
-    policy = _ExamplePolicy.from_dict({"value": 2})
+def test_policy_constructs_without_deserialization_on_runtime_contract():
+    """Keep deserialization and argparse adapters outside the policy contract."""
+    policy = _ExamplePolicy(_ExamplePolicyCfg(value=2))
 
     assert policy.config == _ExamplePolicyCfg(value=2)
+    assert not hasattr(PolicyBase, "config_class")
+    assert not hasattr(PolicyBase, "from_dict")
     assert not hasattr(PolicyBase, "add_args_to_parser")
     assert not hasattr(PolicyBase, "from_args")
+
+
+def test_bare_policy_registration_is_deprecated(monkeypatch):
+    """Keep the untyped registration form only as an explicit compatibility path."""
+    monkeypatch.setattr(policy_registration, "_register_policy", lambda policy_type, cfg_type: policy_type)
+
+    with pytest.warns(DeprecationWarning, match="Bare @register_policy is deprecated"):
+        registered_policy = policy_registration.register_policy(_ExamplePolicy)
+
+    assert registered_policy is _ExamplePolicy

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -5,6 +5,7 @@
 
 """Verify the typed policy configuration contract."""
 
+import argparse
 import torch
 from dataclasses import dataclass
 
@@ -12,10 +13,15 @@ import pytest
 
 import isaaclab_arena.assets.register as policy_registration
 from isaaclab_arena.assets.registries import PolicyRegistry
+from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.evaluation.policy_runner_cli import add_policy_cli_args, build_policy_from_cli, policy_cfg_from_cli
 from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 from isaaclab_arena.policy.replay_action_policy import ReplayActionPolicy, ReplayActionPolicyCfg
 from isaaclab_arena.policy.rsl_rl_action_policy import RslRlActionPolicy, RslRlActionPolicyCfg
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyCfg
+
+# TODO(cvolk, 2026-07-03): Delete the CLI compatibility tests when policy_runner
+# receives typed policy configs directly.
 
 
 @pytest.mark.parametrize(
@@ -44,6 +50,12 @@ class _ExamplePolicy(PolicyBase[_ExamplePolicyCfg]):
         return torch.tensor([self.config.value])
 
 
+def _policy_parser(policy_type: type[PolicyBase]) -> argparse.ArgumentParser:
+    """Create the shared runner parser and add one policy's generated flags."""
+    parser = get_isaaclab_arena_cli_parser()
+    return add_policy_cli_args(parser, policy_type)
+
+
 def test_policy_runtime_contract_accepts_typed_config():
     """Construct and run a policy using only its typed runtime config."""
     config = _ExamplePolicyCfg(value=2)
@@ -51,6 +63,87 @@ def test_policy_runtime_contract_accepts_typed_config():
 
     assert policy.config is config
     assert policy.get_action(env=None, observation=None).item() == 2
+
+
+@pytest.mark.parametrize(
+    ("policy_type", "cli_args", "expected_cfg"),
+    [
+        (ZeroActionPolicy, [], ZeroActionPolicyCfg()),
+        (
+            ReplayActionPolicy,
+            ["--replay_file_path", "episode.hdf5", "--device", "cpu", "--episode_name", "episode_1"],
+            ReplayActionPolicyCfg(replay_file_path="episode.hdf5", device="cpu", episode_name="episode_1"),
+        ),
+        (
+            RslRlActionPolicy,
+            ["--checkpoint_path", "model.pt"],
+            RslRlActionPolicyCfg(checkpoint_path="model.pt"),
+        ),
+    ],
+)
+def test_core_policy_cli_flags_reconstruct_registered_cfg(policy_type, cli_args, expected_cfg):
+    """Generate core policy flags and reconstruct the registered config type."""
+    parser = _policy_parser(policy_type)
+
+    policy_cfg = policy_cfg_from_cli(policy_type, parser.parse_args(cli_args))
+
+    assert policy_cfg == expected_cfg
+
+
+def test_policy_cli_builds_registered_cfg(monkeypatch):
+    """Build a policy from its registered config and a generated CLI override."""
+    monkeypatch.setattr(
+        PolicyRegistry,
+        "get_policy_cfg_type",
+        lambda self, policy_type: _ExamplePolicyCfg,
+    )
+    parser = _policy_parser(_ExamplePolicy)
+    args_cli = parser.parse_args(["--value", "2"])
+
+    policy = build_policy_from_cli(_ExamplePolicy, args_cli)
+
+    assert policy.config == _ExamplePolicyCfg(value=2)
+
+
+def test_shared_policy_cli_default_must_match_cfg():
+    """Reject drift between shared runner flags and policy config defaults."""
+    parser = argparse.ArgumentParser(exit_on_error=False)
+    parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--num_envs", type=int, default=1)
+
+    with pytest.raises(AssertionError, match="ReplayActionPolicyCfg.device defaults to 'cuda:0'"):
+        add_policy_cli_args(parser, ReplayActionPolicy)
+
+
+def test_registered_policies_do_not_own_argparse_adapters():
+    """Keep argparse generation outside typed policy implementations."""
+    for policy_type in (ZeroActionPolicy, ReplayActionPolicy, RslRlActionPolicy):
+        assert "add_args_to_parser" not in policy_type.__dict__
+        assert "from_args" not in policy_type.__dict__
+
+
+def test_untyped_policy_keeps_deprecated_argparse_fallback(monkeypatch):
+    """Preserve the temporary policy-owned adapter for downstream policies."""
+
+    class LegacyPolicy:
+        name = "legacy_policy"
+
+        @staticmethod
+        def add_args_to_parser(parser):
+            parser.add_argument("--legacy_value", type=int, default=1)
+            return parser
+
+        @staticmethod
+        def from_args(args_cli):
+            return args_cli.legacy_value
+
+    monkeypatch.setattr(PolicyRegistry, "get_policy_cfg_type", lambda self, policy_type: None)
+    parser = argparse.ArgumentParser(exit_on_error=False)
+
+    with pytest.warns(DeprecationWarning, match="deprecated policy-owned argparse flags"):
+        add_policy_cli_args(parser, LegacyPolicy)
+
+    assert build_policy_from_cli(LegacyPolicy, parser.parse_args(["--legacy_value", "2"])) == 2
 
 
 def test_typed_policy_registration_associates_config(monkeypatch):

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -122,52 +122,23 @@ def test_registered_policies_do_not_own_argparse_adapters():
         assert "from_args" not in policy_type.__dict__
 
 
-def test_untyped_policy_keeps_deprecated_argparse_fallback(monkeypatch):
-    """Preserve the temporary policy-owned adapter for downstream policies."""
-
-    class LegacyPolicy:
-        name = "legacy_policy"
-
-        @staticmethod
-        def add_args_to_parser(parser):
-            parser.add_argument("--legacy_value", type=int, default=1)
-            return parser
-
-        @staticmethod
-        def from_args(args_cli):
-            return args_cli.legacy_value
-
-    monkeypatch.setattr(PolicyRegistry, "get_policy_cfg_type", lambda self, policy_type: None)
-    parser = argparse.ArgumentParser(exit_on_error=False)
-
-    with pytest.warns(DeprecationWarning, match="deprecated policy-owned argparse flags"):
-        add_policy_cli_args(parser, LegacyPolicy)
-
-    assert build_policy_from_cli(LegacyPolicy, parser.parse_args(["--legacy_value", "2"])) == 2
-
-
-def test_typed_policy_registration_associates_config(monkeypatch):
-    """Pass the policy and its config through the supported decorator form."""
+def test_policy_registration_infers_config_from_generic(monkeypatch):
+    """Register the concrete config declared by ``PolicyBase[Cfg]``."""
     registrations = []
 
-    def record_registration(policy_type, cfg_type):
+    def record_registration(self, policy_type, cfg_type):
         registrations.append((policy_type, cfg_type))
-        return policy_type
 
-    monkeypatch.setattr(policy_registration, "_register_policy", record_registration)
+    monkeypatch.setattr(PolicyRegistry, "is_registered", lambda self, name, ensure_loaded=False: False)
+    monkeypatch.setattr(PolicyRegistry, "register_policy", record_registration)
 
-    registered_policy = policy_registration.register_policy(cfg_type=_ExamplePolicyCfg)(_ExamplePolicy)
+    registered_policy = policy_registration.register_policy(_ExamplePolicy)
 
     assert registered_policy is _ExamplePolicy
     assert registrations == [(_ExamplePolicy, _ExamplePolicyCfg)]
 
 
-def test_bare_policy_registration_is_deprecated(monkeypatch):
-    """Keep the untyped registration form only as an explicit compatibility path."""
-    # TODO(cvolk, 2026-07-03): Delete this test when bare @register_policy support is removed.
-    monkeypatch.setattr(policy_registration, "_register_policy", lambda policy_type, cfg_type: policy_type)
-
-    with pytest.warns(DeprecationWarning, match="Bare @register_policy is deprecated"):
-        registered_policy = policy_registration.register_policy(_ExamplePolicy)
-
-    assert registered_policy is _ExamplePolicy
+def test_unregistered_policy_config_is_rejected():
+    """Require every policy to register a typed configuration."""
+    with pytest.raises(AssertionError, match="Policy _ExamplePolicy must register a PolicyCfg"):
+        PolicyRegistry().get_policy_cfg_type(_ExamplePolicy)

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import argparse
 import importlib
-from dataclasses import MISSING, Field, fields
-from typing import TYPE_CHECKING, Any, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry
+from isaaclab_arena.cli.dataclass_cli import add_dataclass_cli_args, dataclass_from_cli
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
@@ -43,40 +43,6 @@ def ensure_environments_registered():
 _FIELDS_PROVIDED_BY_SHARED_PARSERS = {"auto", "enable_cameras", "mimic", "num_envs"}
 
 
-def _unwrap_optional_type(field_type: Any) -> Any:
-    """Return ``T`` from ``T | None`` so argparse can use ``T`` as a converter."""
-    union_members = get_args(field_type)
-    non_none_members = tuple(member for member in union_members if member is not type(None))
-    if len(non_none_members) == 1 and len(non_none_members) != len(union_members):
-        return non_none_members[0]
-    return field_type
-
-
-def _get_argparse_options(config_field: Field[Any], field_type: Any) -> dict[str, Any]:
-    """Describe one generated argparse flag using its dataclass field."""
-    argument_options: dict[str, Any] = {}
-
-    if config_field.default is not MISSING:
-        argument_options["default"] = config_field.default
-    elif config_field.default_factory is not MISSING:
-        argument_options["default"] = config_field.default_factory()
-    else:
-        argument_options["required"] = True
-
-    cli_value_type = _unwrap_optional_type(field_type)
-    if get_origin(cli_value_type) is list:
-        (list_item_type,) = get_args(cli_value_type)
-        argument_options.update(type=list_item_type, nargs="*")
-    elif cli_value_type is bool:
-        if argument_options.get("default") is False:
-            argument_options["action"] = "store_true"
-        else:
-            argument_options["action"] = argparse.BooleanOptionalAction
-    else:
-        argument_options["type"] = cli_value_type
-    return argument_options
-
-
 def _get_legacy_argparse_cfg_type(
     environment_factory_type: type[ArenaEnvironmentFactory],
 ) -> type[ArenaEnvironmentCfg]:
@@ -86,21 +52,6 @@ def _get_legacy_argparse_cfg_type(
         environment_cfg_type is not None
     ), f"{environment_factory_type.__name__} must define _legacy_argparse_cfg_type while argparse is supported"
     return environment_cfg_type
-
-
-def _add_environment_config_arguments(
-    parser: argparse.ArgumentParser,
-    environment_cfg_type: type[ArenaEnvironmentCfg],
-) -> None:
-    """Generate one CLI flag for each environment-owned config field."""
-    resolved_field_types = get_type_hints(environment_cfg_type)
-    for config_field in fields(environment_cfg_type):
-        field_name = config_field.name
-        if field_name in _FIELDS_PROVIDED_BY_SHARED_PARSERS:
-            continue
-        argument_options = _get_argparse_options(config_field, resolved_field_types[field_name])
-        argument_options["help"] = f"{field_name.replace('_', ' ')} (default: %(default)s)"
-        parser.add_argument(f"--{field_name}", **argument_options)
 
 
 def add_environment_cli_args(
@@ -113,7 +64,11 @@ def add_environment_cli_args(
         return
 
     environment_cfg_type = _get_legacy_argparse_cfg_type(environment_factory_type)
-    _add_environment_config_arguments(parser, environment_cfg_type)
+    add_dataclass_cli_args(
+        parser,
+        environment_cfg_type,
+        excluded_fields=_FIELDS_PROVIDED_BY_SHARED_PARSERS,
+    )
 
     add_cli_only_args = getattr(environment_factory_type, "_add_legacy_cli_only_args", None)
     if add_cli_only_args is not None:
@@ -126,12 +81,7 @@ def _environment_cfg_from_cli(
 ) -> ArenaEnvironmentCfg:
     """Create a typed environment config from matching legacy Namespace values."""
     environment_cfg_type = _get_legacy_argparse_cfg_type(environment_factory_type)
-    config_values = {
-        config_field.name: getattr(args_cli, config_field.name)
-        for config_field in fields(environment_cfg_type)
-        if hasattr(args_cli, config_field.name)
-    }
-    return environment_cfg_type(**config_values)
+    return dataclass_from_cli(environment_cfg_type, args_cli)
 
 
 def build_environment_from_cli(

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -190,9 +190,9 @@ def run_zero_action_policy(env: ManagerBasedEnv, num_steps: int) -> None:
     """Run the zero-action policy for a given number of steps."""
     import torch
 
-    from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyArgs
+    from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyCfg
 
-    policy = ZeroActionPolicy(ZeroActionPolicyArgs())
+    policy = ZeroActionPolicy(ZeroActionPolicyCfg())
     obs, _ = env.reset()
     policy.reset()
     for step in range(num_steps):

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
@@ -150,7 +150,7 @@ def run_sim_preview(
     import yaml
 
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
-    from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyArgs
+    from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyCfg
 
     started_at = time.monotonic()
     _preview_log(started_at, "run_sim_preview started")
@@ -171,7 +171,7 @@ def run_sim_preview(
 
     args = _preview_args(num_envs=num_envs, env_spacing=env_spacing)
     builder = ArenaEnvBuilder(arena_env, args)
-    policy = ZeroActionPolicy(ZeroActionPolicyArgs())
+    policy = ZeroActionPolicy(ZeroActionPolicyCfg())
 
     cache_dir = sim_preview_cache_dir()
     stamp = int(time.time() * 1000)

--- a/isaaclab_arena_gr00t/policy/config/gr00t_closedloop_policy_config.py
+++ b/isaaclab_arena_gr00t/policy/config/gr00t_closedloop_policy_config.py
@@ -10,7 +10,8 @@ from isaaclab_arena_gr00t.policy.config.task_mode import TaskMode
 
 
 @dataclass
-class Gr00tClosedloopPolicyConfig:
+class Gr00tClosedloopPolicyCfg:
+    """Configure GR00T closed-loop policy translation and inference."""
 
     language_instruction: str = field(
         default="", metadata={"description": "Instruction given to the policy in natural language."}

--- a/isaaclab_arena_gr00t/policy/gr00t_core.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_core.py
@@ -24,15 +24,16 @@ from __future__ import annotations
 
 import numpy as np
 import torch
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
+from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_g1.g1_whole_body_controller.wbc_policy.policy.policy_constants import (
     NUM_BASE_HEIGHT_CMD,
     NUM_NAVIGATE_CMD,
     NUM_TORSO_ORIENTATION_RPY_CMD,
 )
-from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
+from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyCfg, TaskMode
 from isaaclab_arena_gr00t.utils.image_conversion import resize_frames_with_padding
 from isaaclab_arena_gr00t.utils.io_utils import load_robot_joints_config_from_yaml, to_numpy, to_tensor
 from isaaclab_arena_gr00t.utils.joints_conversion import (
@@ -46,25 +47,17 @@ from isaaclab_arena_gr00t.utils.joints_conversion import (
 
 
 @dataclass
-class Gr00tBasePolicyArgs:
-    """Base arguments for GR00T policies, shared by local and remote.
+class Gr00tBasePolicyCfg(PolicyCfg):
+    """Configure settings shared by local and remote GR00T policies.
 
     Subclasses (e.g. for local vs remote) may add fields such as ``num_envs``.
     """
 
-    policy_config_yaml_path: str = field(
-        metadata={
-            "help": "Path to the Gr00t closedloop policy config YAML file",
-            "required": True,
-        }
-    )
+    policy_config_yaml_path: str
+    """Path to the GR00T closed-loop policy YAML configuration."""
 
-    policy_device: str = field(
-        default="cuda",
-        metadata={
-            "help": "Device to use for policy inference (e.g. 'cuda', 'cpu').",
-        },
-    )
+    policy_device: str = "cuda"
+    """Device used for Arena-side policy operations."""
 
 
 # --------------------------------------------------------------------------- #
@@ -73,7 +66,7 @@ class Gr00tBasePolicyArgs:
 
 
 def load_gr00t_joint_configs(
-    policy_config: Gr00tClosedloopPolicyConfig,
+    policy_config: Gr00tClosedloopPolicyCfg,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     """Load policy, action, and state joint configs from paths in the config.
 
@@ -235,7 +228,7 @@ def build_gr00t_policy_observations(
     rgb_list_np: list[np.ndarray],
     joint_pos_sim_np: np.ndarray,
     task_description: str,
-    policy_config: Gr00tClosedloopPolicyConfig,
+    policy_config: Gr00tClosedloopPolicyCfg,
     robot_state_joints_config: dict[str, Any],
     policy_joints_config: dict[str, Any],
     modality_configs: dict[str, Any],

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -58,7 +58,7 @@ class Gr00tRemoteClosedloopPolicyCfg(Gr00tBasePolicyCfg):
     """Action scheduler used to consume inference chunks."""
 
 
-@register_policy(cfg_type=Gr00tRemoteClosedloopPolicyCfg)
+@register_policy
 class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
     """GR00T closed-loop policy that delegates inference to a remote GR00T server.
 

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -11,7 +11,6 @@ This policy connects to a GR00T policy server (launched via
 
 from __future__ import annotations
 
-import argparse
 import gymnasium as gym
 import torch
 from dataclasses import dataclass
@@ -125,55 +124,6 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
             raise ConnectionError(f"Cannot reach GR00T policy server at {config.remote_host}:{config.remote_port}")
 
         self.task_description: str | None = None
-
-    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
-
-    @staticmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        group = parser.add_argument_group(
-            "Gr00t Remote Closedloop Policy",
-            "Arguments for GR00T remote closed-loop policy evaluation.",
-        )
-        group.add_argument(
-            "--policy_config_yaml_path",
-            type=str,
-            required=True,
-            help="Path to the Gr00t closedloop policy config YAML file",
-        )
-        group.add_argument(
-            "--policy_device",
-            type=str,
-            default="cuda",
-            help="Device for Arena-side tensor operations (default: cuda)",
-        )
-        group.add_argument("--remote_host", type=str, default="localhost", help="GR00T policy server hostname")
-        group.add_argument("--remote_port", type=int, default=5555, help="GR00T policy server port")
-        group.add_argument("--remote_api_token", type=str, default=None, help="API token for the policy server")
-        group.add_argument(
-            "--scheduler",
-            type=str,
-            default="chunk",
-            choices=["chunk", "synced_batch"],
-            help=(
-                "Action scheduler: 'chunk' fetches a new chunk for any env that needs one;"
-                " 'synced_batch' waits until ALL envs need a new chunk and then issues a single"
-                " full-batch inference call (envs that finish early hold their current robot state)."
-            ),
-        )
-        return parser
-
-    @staticmethod
-    def from_args(args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicy:
-        config = Gr00tRemoteClosedloopPolicyCfg(
-            policy_config_yaml_path=args.policy_config_yaml_path,
-            policy_device=args.policy_device,
-            num_envs=args.num_envs,
-            remote_host=args.remote_host,
-            remote_port=args.remote_port,
-            remote_api_token=getattr(args, "remote_api_token", None),
-            scheduler=getattr(args, "scheduler", "chunk"),
-        )
-        return Gr00tRemoteClosedloopPolicy(config)
 
     # ---------------------- Policy interface -------------------
 

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -19,6 +19,7 @@ from typing import Any, Literal
 
 from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
 
+from isaaclab_arena.assets.register import register_policy
 from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, ActionScheduler, SyncedBatchActionScheduler
 from isaaclab_arena.policy.policy_base import PolicyBase
 from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyCfg, TaskMode
@@ -58,7 +59,7 @@ class Gr00tRemoteClosedloopPolicyCfg(Gr00tBasePolicyCfg):
     """Action scheduler used to consume inference chunks."""
 
 
-# TODO(xinjieyao, 2026-04-27): add policy registry
+@register_policy(cfg_type=Gr00tRemoteClosedloopPolicyCfg)
 class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
     """GR00T closed-loop policy that delegates inference to a remote GR00T server.
 
@@ -67,7 +68,6 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
     """
 
     name = "gr00t_remote_closedloop"
-    config_class = Gr00tRemoteClosedloopPolicyCfg
 
     def __init__(self, config: Gr00tRemoteClosedloopPolicyCfg):
         super().__init__(config)
@@ -126,7 +126,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
 
         self.task_description: str | None = None
 
-    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
+    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
 
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:

--- a/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/policy/gr00t_remote_closedloop_policy.py
@@ -14,16 +14,16 @@ from __future__ import annotations
 import argparse
 import gymnasium as gym
 import torch
-from dataclasses import dataclass, field
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from gr00t.policy.server_client import PolicyClient as Gr00tPolicyClient
 
 from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler, ActionScheduler, SyncedBatchActionScheduler
 from isaaclab_arena.policy.policy_base import PolicyBase
-from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyConfig, TaskMode
+from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyCfg, TaskMode
 from isaaclab_arena_gr00t.policy.gr00t_core import (
-    Gr00tBasePolicyArgs,
+    Gr00tBasePolicyCfg,
     build_gr00t_action_tensor,
     build_gr00t_policy_observations,
     compute_action_dim,
@@ -33,36 +33,33 @@ from isaaclab_arena_gr00t.policy.gr00t_core import (
 from isaaclab_arena_gr00t.utils.io_utils import create_config_from_yaml, load_gr00t_modality_config_from_file
 
 
-# TODO(xinjieyao, 2026-04-27): consider adding RemotePolicyArgs to inherit from BasePolicyArgs
-# and then having Gr00tRemoteClosedloopPolicyArgs inherit from RemotePolicyArgs
+# TODO(xinjieyao, 2026-04-27): Consider adding RemotePolicyCfg and deriving this config from it.
 @dataclass
-class Gr00tRemoteClosedloopPolicyArgs(Gr00tBasePolicyArgs):
+class Gr00tRemoteClosedloopPolicyCfg(Gr00tBasePolicyCfg):
     """Configuration for Gr00tRemoteClosedloopPolicy.
 
-    Inherits policy_config_yaml_path and policy_device from Gr00tBasePolicyArgs,
+    Inherits policy_config_yaml_path and policy_device from Gr00tBasePolicyCfg,
     and adds remote server connection parameters and num_envs.
     """
 
-    num_envs: int = field(default=1, metadata={"help": "Number of environments to simulate"})
-    remote_host: str = field(default="localhost", metadata={"help": "GR00T policy server hostname"})
-    remote_port: int = field(default=5555, metadata={"help": "GR00T policy server port"})
-    remote_api_token: str | None = field(default=None, metadata={"help": "API token for the policy server"})
+    num_envs: int = 1
+    """Number of parallel environments served by the policy."""
 
-    @classmethod
-    def from_cli_args(cls, args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicyArgs:
-        """Create configuration from parsed CLI arguments."""
-        return cls(
-            policy_config_yaml_path=args.policy_config_yaml_path,
-            policy_device=args.policy_device,
-            num_envs=args.num_envs,
-            remote_host=args.remote_host,
-            remote_port=args.remote_port,
-            remote_api_token=getattr(args, "remote_api_token", None),
-        )
+    remote_host: str = "localhost"
+    """GR00T policy server hostname."""
+
+    remote_port: int = 5555
+    """GR00T policy server port."""
+
+    remote_api_token: str | None = None
+    """Optional policy-server API token."""
+
+    scheduler: Literal["chunk", "synced_batch"] = "chunk"
+    """Action scheduler used to consume inference chunks."""
 
 
 # TODO(xinjieyao, 2026-04-27): add policy registry
-class Gr00tRemoteClosedloopPolicy(PolicyBase):
+class Gr00tRemoteClosedloopPolicy(PolicyBase[Gr00tRemoteClosedloopPolicyCfg]):
     """GR00T closed-loop policy that delegates inference to a remote GR00T server.
 
     Uses GR00T's native ``PolicyClient`` (from ``gr00t.policy.server_client``)
@@ -70,19 +67,22 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
     """
 
     name = "gr00t_remote_closedloop"
-    config_class = Gr00tRemoteClosedloopPolicyArgs
+    config_class = Gr00tRemoteClosedloopPolicyCfg
 
-    def __init__(
-        self,
-        config: Gr00tRemoteClosedloopPolicyArgs,
-        action_scheduler_cls: type[ActionScheduler] = ActionChunkScheduler,
-    ):
+    def __init__(self, config: Gr00tRemoteClosedloopPolicyCfg):
         super().__init__(config)
+
+        action_scheduler_cls: type[ActionScheduler]
+        if config.scheduler == "synced_batch":
+            action_scheduler_cls = SyncedBatchActionScheduler
+        else:
+            assert config.scheduler == "chunk", f"Unknown action scheduler: {config.scheduler}"
+            action_scheduler_cls = ActionChunkScheduler
 
         # Policy config (for obs/action translation — no model loading)
         # TODO(xinjieyao, 2026-04-27): to be refactored
-        self.policy_config: Gr00tClosedloopPolicyConfig = create_config_from_yaml(
-            config.policy_config_yaml_path, Gr00tClosedloopPolicyConfig
+        self.policy_config: Gr00tClosedloopPolicyCfg = create_config_from_yaml(
+            config.policy_config_yaml_path, Gr00tClosedloopPolicyCfg
         )
         self.num_envs = config.num_envs
         self.device = config.policy_device
@@ -126,7 +126,7 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
 
         self.task_description: str | None = None
 
-    # ---------------------- CLI helpers -------------------
+    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
 
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -164,13 +164,16 @@ class Gr00tRemoteClosedloopPolicy(PolicyBase):
 
     @staticmethod
     def from_args(args: argparse.Namespace) -> Gr00tRemoteClosedloopPolicy:
-        config = Gr00tRemoteClosedloopPolicyArgs.from_cli_args(args)
-        scheduler_cls: type[ActionScheduler] = (
-            SyncedBatchActionScheduler
-            if getattr(args, "scheduler", "chunk") == "synced_batch"
-            else ActionChunkScheduler
+        config = Gr00tRemoteClosedloopPolicyCfg(
+            policy_config_yaml_path=args.policy_config_yaml_path,
+            policy_device=args.policy_device,
+            num_envs=args.num_envs,
+            remote_host=args.remote_host,
+            remote_port=args.remote_port,
+            remote_api_token=getattr(args, "remote_api_token", None),
+            scheduler=getattr(args, "scheduler", "chunk"),
         )
-        return Gr00tRemoteClosedloopPolicy(config, action_scheduler_cls=scheduler_cls)
+        return Gr00tRemoteClosedloopPolicy(config)
 
     # ---------------------- Policy interface -------------------
 

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -24,10 +24,12 @@ from typing import Any
 
 import pytest
 
-pytestmark = pytest.mark.gr00t_policy
-
-
+from isaaclab_arena.assets.registries import PolicyRegistry
+from isaaclab_arena.policy import action_scheduling
+from isaaclab_arena_gr00t.policy import gr00t_remote_closedloop_policy as gr00t_policy
 from isaaclab_arena_gr00t.tests.utils.constants import TestConstants as Gr00tTestConstants
+
+pytestmark = pytest.mark.gr00t_policy
 
 NUM_ENVS = 2
 ORIGINAL_HEIGHT = 480
@@ -109,8 +111,6 @@ class _FakePolicyClient:
 def fake_client_factory(monkeypatch):
     """Patch ``Gr00tPolicyClient`` in the policy module's namespace and return
     a factory that gives access to the most recently constructed fake."""
-    from isaaclab_arena_gr00t.policy import gr00t_remote_closedloop_policy as mod
-
     created: list[_FakePolicyClient] = []
 
     def factory(ping_ok: bool = True):
@@ -119,19 +119,14 @@ def fake_client_factory(monkeypatch):
             created.append(client)
             return client
 
-        monkeypatch.setattr(mod, "Gr00tPolicyClient", _ctor)
+        monkeypatch.setattr(gr00t_policy, "Gr00tPolicyClient", _ctor)
         return created
 
     return factory
 
 
 def _build_policy(policy_config_yaml: str, scheduler: str = "chunk"):
-    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
-        Gr00tRemoteClosedloopPolicy,
-        Gr00tRemoteClosedloopPolicyCfg,
-    )
-
-    cfg = Gr00tRemoteClosedloopPolicyCfg(
+    cfg = gr00t_policy.Gr00tRemoteClosedloopPolicyCfg(
         policy_config_yaml_path=policy_config_yaml,
         policy_device="cpu",  # keep the test portable; remote policy does no GPU compute
         num_envs=NUM_ENVS,
@@ -140,7 +135,7 @@ def _build_policy(policy_config_yaml: str, scheduler: str = "chunk"):
         remote_api_token=None,
         scheduler=scheduler,
     )
-    return Gr00tRemoteClosedloopPolicy(cfg)
+    return gr00t_policy.Gr00tRemoteClosedloopPolicy(cfg)
 
 
 # ------------------------------- tests ------------------------------- #
@@ -214,26 +209,26 @@ def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_cli
         _build_policy(policy_config_yaml)
 
 
-def test_from_dict_builds_typed_config_and_scheduler(policy_config_yaml, fake_client_factory):
-    """The eval-runner dictionary path retains scheduler selection in the config."""
-    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
-    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
-        Gr00tRemoteClosedloopPolicy,
-        Gr00tRemoteClosedloopPolicyCfg,
+def test_registration_builds_typed_config_and_scheduler(policy_config_yaml, fake_client_factory):
+    """The registered typed config retains scheduler selection."""
+    fake_client_factory(ping_ok=True)
+    assert (
+        PolicyRegistry().get_policy_cfg_type(gr00t_policy.Gr00tRemoteClosedloopPolicy)
+        is gr00t_policy.Gr00tRemoteClosedloopPolicyCfg
+    )
+    policy = gr00t_policy.Gr00tRemoteClosedloopPolicy(
+        gr00t_policy.Gr00tRemoteClosedloopPolicyCfg(
+            policy_config_yaml_path=policy_config_yaml,
+            policy_device="cpu",
+            num_envs=NUM_ENVS,
+            remote_host="unused",
+            remote_port=0,
+            scheduler="synced_batch",
+        )
     )
 
-    fake_client_factory(ping_ok=True)
-    policy = Gr00tRemoteClosedloopPolicy.from_dict({
-        "policy_config_yaml_path": policy_config_yaml,
-        "policy_device": "cpu",
-        "num_envs": NUM_ENVS,
-        "remote_host": "unused",
-        "remote_port": 0,
-        "scheduler": "synced_batch",
-    })
-
-    assert isinstance(policy.config, Gr00tRemoteClosedloopPolicyCfg)
-    assert isinstance(policy._chunking_state, SyncedBatchActionScheduler)
+    assert isinstance(policy.config, gr00t_policy.Gr00tRemoteClosedloopPolicyCfg)
+    assert isinstance(policy._chunking_state, action_scheduling.SyncedBatchActionScheduler)
 
 
 # ---------------- scheduler-switch tests ---------------- #
@@ -245,8 +240,6 @@ def test_get_action_returns_correct_shape_for_each_scheduler(
 ):
     """Both ActionChunkScheduler and SyncedBatchActionScheduler should drive the policy
     end-to-end and produce one (num_envs, action_dim) action per get_action call."""
-    from isaaclab_arena.policy import action_scheduling
-
     scheduler_cls = getattr(action_scheduling, scheduler_cls_name)
     scheduler = "synced_batch" if scheduler_cls_name == "SyncedBatchActionScheduler" else "chunk"
 

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy.py
@@ -125,26 +125,22 @@ def fake_client_factory(monkeypatch):
     return factory
 
 
-def _build_policy(policy_config_yaml: str, action_scheduler_cls=None):
+def _build_policy(policy_config_yaml: str, scheduler: str = "chunk"):
     from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
         Gr00tRemoteClosedloopPolicy,
-        Gr00tRemoteClosedloopPolicyArgs,
+        Gr00tRemoteClosedloopPolicyCfg,
     )
 
-    if action_scheduler_cls is None:
-        from isaaclab_arena.policy.action_scheduling import ActionChunkScheduler
-
-        action_scheduler_cls = ActionChunkScheduler
-
-    args = Gr00tRemoteClosedloopPolicyArgs(
+    cfg = Gr00tRemoteClosedloopPolicyCfg(
         policy_config_yaml_path=policy_config_yaml,
         policy_device="cpu",  # keep the test portable; remote policy does no GPU compute
         num_envs=NUM_ENVS,
         remote_host="unused",
         remote_port=0,
         remote_api_token=None,
+        scheduler=scheduler,
     )
-    return Gr00tRemoteClosedloopPolicy(args, action_scheduler_cls=action_scheduler_cls)
+    return Gr00tRemoteClosedloopPolicy(cfg)
 
 
 # ------------------------------- tests ------------------------------- #
@@ -218,6 +214,28 @@ def test_construction_fails_when_server_unreachable(policy_config_yaml, fake_cli
         _build_policy(policy_config_yaml)
 
 
+def test_from_dict_builds_typed_config_and_scheduler(policy_config_yaml, fake_client_factory):
+    """The eval-runner dictionary path retains scheduler selection in the config."""
+    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
+    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import (
+        Gr00tRemoteClosedloopPolicy,
+        Gr00tRemoteClosedloopPolicyCfg,
+    )
+
+    fake_client_factory(ping_ok=True)
+    policy = Gr00tRemoteClosedloopPolicy.from_dict({
+        "policy_config_yaml_path": policy_config_yaml,
+        "policy_device": "cpu",
+        "num_envs": NUM_ENVS,
+        "remote_host": "unused",
+        "remote_port": 0,
+        "scheduler": "synced_batch",
+    })
+
+    assert isinstance(policy.config, Gr00tRemoteClosedloopPolicyCfg)
+    assert isinstance(policy._chunking_state, SyncedBatchActionScheduler)
+
+
 # ---------------- scheduler-switch tests ---------------- #
 
 
@@ -230,9 +248,10 @@ def test_get_action_returns_correct_shape_for_each_scheduler(
     from isaaclab_arena.policy import action_scheduling
 
     scheduler_cls = getattr(action_scheduling, scheduler_cls_name)
+    scheduler = "synced_batch" if scheduler_cls_name == "SyncedBatchActionScheduler" else "chunk"
 
     fake_client_factory(ping_ok=True)
-    policy = _build_policy(policy_config_yaml, action_scheduler_cls=scheduler_cls)
+    policy = _build_policy(policy_config_yaml, scheduler=scheduler)
     assert isinstance(policy._chunking_state, scheduler_cls)
     policy.set_task_description("pick up the brown box")
 
@@ -248,10 +267,8 @@ def test_synced_batch_holds_joint_position_for_env_after_partial_reset(
 ):
     """After resetting a single env, SyncedBatchActionScheduler should hold that env on
     the joint-position-derived hold_action while the others continue stepping their chunk."""
-    from isaaclab_arena.policy.action_scheduling import SyncedBatchActionScheduler
-
     clients = fake_client_factory(ping_ok=True)
-    policy = _build_policy(policy_config_yaml, action_scheduler_cls=SyncedBatchActionScheduler)
+    policy = _build_policy(policy_config_yaml, scheduler="synced_batch")
     policy.set_task_description("pick up the brown box")
 
     # Step 1: every env needs a chunk → exactly one fetch.

--- a/isaaclab_arena_openpi/policy/pi0_remote_config.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_config.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
+from typing import Literal
+
+from isaaclab_arena.policy.policy_base import PolicyCfg
 
 DEFAULT_VARIANT = "pi05"
 
@@ -15,8 +18,11 @@ MAX_RECONNECT_ATTEMPTS = 3
 # (--policy_config_yaml_path). Decide on one mechanism (likely Hydra) when the
 # planned RemotePolicy base class lands; the config-loading shape belongs there.
 @dataclass
-class Pi0RemotePolicyArgs:
+class Pi0RemotePolicyCfg(PolicyCfg):
     """Connection + runtime config for ``Pi0RemotePolicy``."""
+
+    openpi_embodiment_adapter: Literal["droid"] = "droid"
+    """Adapter used to translate Arena observations and policy actions."""
 
     policy_variant: str = DEFAULT_VARIANT
     policy_device: str = "cuda"

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -48,7 +48,7 @@ class Pi0EmbodimentAdapter(ABC):
         """Build the wire-format request payload openpi server expects."""
 
 
-@register_policy(cfg_type=Pi0RemotePolicyCfg)
+@register_policy
 class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
     """openpi remote closed-loop policy, parameterized by an embodiment adapter.
 

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import argparse
 import gymnasium as gym
 import numpy as np
 import torch
@@ -17,7 +16,7 @@ from openpi_client import websocket_client_policy
 
 from isaaclab_arena.assets.register import register_policy
 from isaaclab_arena.policy.policy_base import PolicyBase
-from isaaclab_arena_openpi.policy.pi0_remote_config import DEFAULT_VARIANT, MAX_RECONNECT_ATTEMPTS, Pi0RemotePolicyCfg
+from isaaclab_arena_openpi.policy.pi0_remote_config import MAX_RECONNECT_ATTEMPTS, Pi0RemotePolicyCfg
 from isaaclab_arena_openpi.policy.websocket_client import WebsocketClientPolicy
 
 
@@ -100,65 +99,6 @@ class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
         self._cached_action_chunks: list[np.ndarray | None] | None = None
         self._next_chunk_steps: list[int] | None = None
         self.task_description: str | None = None
-
-    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
-    @staticmethod
-    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        group = parser.add_argument_group(
-            "Pi0 Remote Policy",
-            "Arguments for the openpi (pi0 / pi05) remote client.",
-        )
-        group.add_argument(
-            "--openpi_embodiment_adapter",
-            type=str,
-            default="droid",
-            choices=["droid"],
-            help="Openpi-side embodiment adapter for obs / action wire format (default: droid).",
-        )
-        group.add_argument(
-            "--policy_variant",
-            type=str,
-            default=DEFAULT_VARIANT,
-            help=(
-                f"openpi checkpoint variant (default: {DEFAULT_VARIANT})."
-                " Valid values depend on the chosen --openpi_embodiment_adapter."
-            ),
-        )
-        group.add_argument(
-            "--policy_device",
-            type=str,
-            default="cuda",
-            help="Torch device for action tensors (default: cuda).",
-        )
-        group.add_argument("--remote_host", type=str, default="localhost", help="openpi server host.")
-        group.add_argument("--remote_port", type=int, default=8000, help="openpi server port.")
-        group.add_argument(
-            "--ping_interval",
-            type=float,
-            default=20.0,
-            help="Seconds between websocket keepalive pings.",
-        )
-        group.add_argument(
-            "--ping_timeout",
-            type=float,
-            default=20.0,
-            help="Seconds to wait for a keepalive pong before dropping the connection.",
-        )
-        return parser
-
-    @staticmethod
-    def from_args(args: argparse.Namespace) -> Pi0RemotePolicy:
-        return Pi0RemotePolicy(
-            Pi0RemotePolicyCfg(
-                openpi_embodiment_adapter=args.openpi_embodiment_adapter,
-                policy_variant=args.policy_variant,
-                policy_device=args.policy_device,
-                remote_host=args.remote_host,
-                remote_port=args.remote_port,
-                ping_interval=args.ping_interval,
-                ping_timeout=args.ping_timeout,
-            )
-        )
 
     def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
         assert self.task_description, (

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -15,6 +15,7 @@ from typing import Any
 import websockets.exceptions
 from openpi_client import websocket_client_policy
 
+from isaaclab_arena.assets.register import register_policy
 from isaaclab_arena.policy.policy_base import PolicyBase
 from isaaclab_arena_openpi.policy.pi0_remote_config import DEFAULT_VARIANT, MAX_RECONNECT_ATTEMPTS, Pi0RemotePolicyCfg
 from isaaclab_arena_openpi.policy.websocket_client import WebsocketClientPolicy
@@ -48,6 +49,7 @@ class Pi0EmbodimentAdapter(ABC):
         """Build the wire-format request payload openpi server expects."""
 
 
+@register_policy(cfg_type=Pi0RemotePolicyCfg)
 class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
     """openpi remote closed-loop policy, parameterized by an embodiment adapter.
 
@@ -63,7 +65,6 @@ class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
     # TODO(cvolk, 2026-05-18): Add a RemotePolicy base class.
 
     name = "pi0_remote"
-    config_class = Pi0RemotePolicyCfg
 
     def __init__(self, config: Pi0RemotePolicyCfg) -> None:
         super().__init__(config)
@@ -100,7 +101,7 @@ class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
         self._next_chunk_steps: list[int] | None = None
         self.task_description: str | None = None
 
-    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
+    # TODO(cvolk, 2026-07-03): Remove this deprecated argparse adapter once the CLI builds typed configs directly.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         group = parser.add_argument_group(

--- a/isaaclab_arena_openpi/policy/pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_policy.py
@@ -16,7 +16,7 @@ import websockets.exceptions
 from openpi_client import websocket_client_policy
 
 from isaaclab_arena.policy.policy_base import PolicyBase
-from isaaclab_arena_openpi.policy.pi0_remote_config import DEFAULT_VARIANT, MAX_RECONNECT_ATTEMPTS, Pi0RemotePolicyArgs
+from isaaclab_arena_openpi.policy.pi0_remote_config import DEFAULT_VARIANT, MAX_RECONNECT_ATTEMPTS, Pi0RemotePolicyCfg
 from isaaclab_arena_openpi.policy.websocket_client import WebsocketClientPolicy
 
 
@@ -48,7 +48,7 @@ class Pi0EmbodimentAdapter(ABC):
         """Build the wire-format request payload openpi server expects."""
 
 
-class Pi0RemotePolicy(PolicyBase):
+class Pi0RemotePolicy(PolicyBase[Pi0RemotePolicyCfg]):
     """openpi remote closed-loop policy, parameterized by an embodiment adapter.
 
     Action handling today is straight chunk replay: the policy fetches one
@@ -63,10 +63,11 @@ class Pi0RemotePolicy(PolicyBase):
     # TODO(cvolk, 2026-05-18): Add a RemotePolicy base class.
 
     name = "pi0_remote"
-    config_class = Pi0RemotePolicyArgs
+    config_class = Pi0RemotePolicyCfg
 
-    def __init__(self, config: Pi0RemotePolicyArgs, openpi_embodiment_adapter: Pi0EmbodimentAdapter) -> None:
+    def __init__(self, config: Pi0RemotePolicyCfg) -> None:
         super().__init__(config)
+        openpi_embodiment_adapter = _resolve_openpi_embodiment_adapter(config.openpi_embodiment_adapter)
         assert config.policy_variant in openpi_embodiment_adapter.open_loop_horizon_by_variant, (
             f"Unknown policy_variant {config.policy_variant!r} for adapter"
             f" {type(openpi_embodiment_adapter).__name__};"
@@ -99,6 +100,7 @@ class Pi0RemotePolicy(PolicyBase):
         self._next_chunk_steps: list[int] | None = None
         self.task_description: str | None = None
 
+    # TODO(cvolk, 2026-07-03): Move this legacy argparse adapter into the policy CLI frontend.
     @staticmethod
     def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         group = parser.add_argument_group(
@@ -145,31 +147,17 @@ class Pi0RemotePolicy(PolicyBase):
 
     @staticmethod
     def from_args(args: argparse.Namespace) -> Pi0RemotePolicy:
-        openpi_embodiment_adapter = _resolve_openpi_embodiment_adapter(args.openpi_embodiment_adapter)
         return Pi0RemotePolicy(
-            Pi0RemotePolicyArgs(
+            Pi0RemotePolicyCfg(
+                openpi_embodiment_adapter=args.openpi_embodiment_adapter,
                 policy_variant=args.policy_variant,
                 policy_device=args.policy_device,
                 remote_host=args.remote_host,
                 remote_port=args.remote_port,
                 ping_interval=args.ping_interval,
                 ping_timeout=args.ping_timeout,
-            ),
-            openpi_embodiment_adapter=openpi_embodiment_adapter,
+            )
         )
-
-    @classmethod
-    def from_dict(cls, config_dict: dict[str, Any]) -> Pi0RemotePolicy:
-        """JSON-jobs-config path used by ``eval_runner``.
-
-        Overrides ``PolicyBase.from_dict`` because our ``__init__`` takes an
-        adapter alongside the config dataclass.
-        # TODO(cvolk, 2026-05-18): add a RemotePolicy base class to unify this and other remote policies.
-        """
-        config_dict = dict(config_dict)
-        adapter_key = config_dict.pop("openpi_embodiment_adapter", "droid")
-        openpi_embodiment_adapter = _resolve_openpi_embodiment_adapter(adapter_key)
-        return cls(Pi0RemotePolicyArgs(**config_dict), openpi_embodiment_adapter=openpi_embodiment_adapter)
 
     def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
         assert self.task_description, (

--- a/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
@@ -12,6 +12,7 @@ import types
 import pytest
 import websockets.exceptions
 
+from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena_openpi.policy.droid_adapter import Pi0DroidAdapter
 from isaaclab_arena_openpi.policy.pi0_remote_config import Pi0RemotePolicyCfg
 from isaaclab_arena_openpi.policy.pi0_remote_policy import Pi0RemotePolicy
@@ -96,16 +97,19 @@ def test_droid_adapter_uses_pi0_wire_keys():
     assert server_request["prompt"] == "pick up the block"
 
 
-def test_from_dict_resolves_adapter(monkeypatch):
-    """eval_runner path: JSON dict -> Pi0RemotePolicy with adapter resolved from the dict."""
+def test_registration_builds_typed_config_and_resolves_adapter(monkeypatch):
+    """The registered typed config retains embodiment-adapter selection."""
     _patch_websocket_client(monkeypatch)
-    policy = Pi0RemotePolicy.from_dict({
-        "policy_variant": "pi05",
-        "policy_device": "cpu",
-        "remote_host": "localhost",
-        "remote_port": 8000,
-        "openpi_embodiment_adapter": "droid",
-    })
+    assert PolicyRegistry().get_policy_cfg_type(Pi0RemotePolicy) is Pi0RemotePolicyCfg
+    policy = Pi0RemotePolicy(
+        Pi0RemotePolicyCfg(
+            policy_variant="pi05",
+            policy_device="cpu",
+            remote_host="localhost",
+            remote_port=8000,
+            openpi_embodiment_adapter="droid",
+        )
+    )
     assert isinstance(policy._openpi_embodiment_adapter, Pi0DroidAdapter)
     assert policy._open_loop_horizon == 15
 

--- a/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
+++ b/isaaclab_arena_openpi/tests/test_pi0_remote_policy.py
@@ -13,7 +13,7 @@ import pytest
 import websockets.exceptions
 
 from isaaclab_arena_openpi.policy.droid_adapter import Pi0DroidAdapter
-from isaaclab_arena_openpi.policy.pi0_remote_config import Pi0RemotePolicyArgs
+from isaaclab_arena_openpi.policy.pi0_remote_config import Pi0RemotePolicyCfg
 from isaaclab_arena_openpi.policy.pi0_remote_policy import Pi0RemotePolicy
 from isaaclab_arena_openpi.policy.websocket_client import WebsocketClientPolicy
 
@@ -68,8 +68,7 @@ def make_policy(monkeypatch):
 
     def _factory(policy_variant: str = "pi05"):
         return Pi0RemotePolicy(
-            Pi0RemotePolicyArgs(policy_variant=policy_variant, policy_device="cpu"),
-            openpi_embodiment_adapter=Pi0DroidAdapter(),
+            Pi0RemotePolicyCfg(policy_variant=policy_variant, policy_device="cpu"),
         )
 
     return _factory
@@ -145,7 +144,7 @@ def test_get_action_parallel_envs_loops_per_env(monkeypatch):
         return {"actions": _synthetic_chunk()}
 
     _patch_websocket_client(monkeypatch, infer_impl=counting_infer)
-    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy = Pi0RemotePolicy(Pi0RemotePolicyCfg(policy_device="cpu"))
     policy.set_task_description("pick up the block")
 
     num_envs = 3
@@ -168,7 +167,7 @@ def test_get_action_parallel_envs_loops_per_env(monkeypatch):
 def test_reset_honors_env_ids(monkeypatch):
     """reset(env_ids) clears only those envs' caches; others keep replaying."""
     _patch_websocket_client(monkeypatch)
-    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy = Pi0RemotePolicy(Pi0RemotePolicyCfg(policy_device="cpu"))
     policy.set_task_description("pick up the block")
     env = _fake_env(num_envs=3)
     obs = _fake_observation(num_envs=3)
@@ -195,7 +194,7 @@ def test_call_server_with_retry_reconnects_on_drop(monkeypatch):
         return successful_response
 
     _patch_websocket_client(monkeypatch, infer_impl=flaky_infer)
-    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy = Pi0RemotePolicy(Pi0RemotePolicyCfg(policy_device="cpu"))
     policy.set_task_description("pick up the block")
     policy._cached_action_chunks = [np.zeros((15, 8), dtype=np.float32)]
     policy._next_chunk_steps = [5]
@@ -213,7 +212,7 @@ def test_call_server_with_retry_gives_up_after_max_attempts(monkeypatch):
         raise websockets.exceptions.ConnectionClosedError(None, None)
 
     _patch_websocket_client(monkeypatch, infer_impl=always_drops)
-    policy = Pi0RemotePolicy(Pi0RemotePolicyArgs(policy_device="cpu"), openpi_embodiment_adapter=Pi0DroidAdapter())
+    policy = Pi0RemotePolicy(Pi0RemotePolicyCfg(policy_device="cpu"))
     policy.set_task_description("pick up the block")
 
     with pytest.raises(websockets.exceptions.ConnectionClosedError):


### PR DESCRIPTION
## Summary
Decouple policy construction from argparse

## Detailed description
- Add a generic `PolicyCfg` contract and limit `PolicyBase` to typed runtime configs.
- Rename first-party policy configurations consistently with the `Cfg` convention.
- Preserve the existing CLI through the shared dataclass-to-argparse compatibility adapter.
- Continue the broader migration from argparse namespaces to strongly typed configurations.