### PR TITLE
Narrow config registry loading boundaries

### DIFF
--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -275,8 +275,8 @@ class HDRImageRegistry(_GloballyLoadedRegistry):
 class EnvironmentRegistry(Registry):
     """Store factories and configs registered by environment extension packages.
 
-    This registry has no lazy loader. First-party callers populate it through
-    ensure_environments_registered() before lookup.
+    This registry has no lazy loader. The isaaclab_arena_environments package
+    populates it through ensure_environments_registered() before lookup.
     """
 
     def __init__(self):

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -38,29 +38,22 @@ class Registry(metaclass=SingletonMeta):
         assert key is not None, "component name is not set"
         self._components[key] = component
 
+    def _ensure_components_registered(self) -> None:
+        """Import the modules that populate this registry."""
+        if isinstance(self, REGISTRIES):
+            ensure_assets_registered()
+
     def is_registered(self, key: str, ensure_loaded: bool = True) -> bool:
-        """Check whether a component is already registered under ``key``.
+        """Check whether a component is already registered under a key.
 
         Args:
             key: The name to look up.
-            ensure_loaded: Whether to load every component before answering.
-
-                Components register themselves lazily: nothing is in the registry until
-                ``ensure_assets_registered()`` imports all the library modules. So a plain
-                membership check can say "not registered" simply because the libraries
-                haven't been imported yet. With ``ensure_loaded=True`` (the default) we
-                import them first, so the answer reflects everything that exists.
-
-                The ``register_*`` decorators pass ``False``. They run *while* those
-                library modules are being imported, and all they need is to spot a
-                duplicate key. Forcing a full load at that moment would re-enter the
-                import that's already in progress and pull in the task/environment modules
-                — which import Isaac Sim's ``pxr``/USD packages. If that happens during
-                pytest collection (before ``SimulationApp()`` starts) the simulator
-                segfaults, because those packages must be imported only after it starts.
+            ensure_loaded: Whether to import the modules that populate this registry.
+                Registration decorators pass False to avoid re-entering imports that are
+                already in progress.
         """
-        if ensure_loaded and isinstance(self, REGISTRIES):
-            ensure_assets_registered()
+        if ensure_loaded:
+            self._ensure_components_registered()
         return key in self._components
 
     def get_component_by_name(self, key: str) -> Any:
@@ -72,8 +65,7 @@ class Registry(metaclass=SingletonMeta):
         Returns:
             Any: The component.
         """
-        if isinstance(self, REGISTRIES):
-            ensure_assets_registered()
+        self._ensure_components_registered()
         assert key in self._components, f"component {key} not found, please check if requested component is registered"
         return self._components[key]
 
@@ -83,8 +75,7 @@ class Registry(metaclass=SingletonMeta):
         Returns:
             list[str]: The list of keys.
         """
-        if isinstance(self, REGISTRIES):
-            ensure_assets_registered()
+        self._ensure_components_registered()
         return list(self._components.keys())
 
 
@@ -188,6 +179,10 @@ class PolicyRegistry(Registry):
         self._cfg_types: dict[type["PolicyBase"], type["PolicyCfg"]] = {}
         self._policy_types_by_cfg_type: dict[type["PolicyCfg"], type["PolicyBase"]] = {}
 
+    def _ensure_components_registered(self) -> None:
+        """Import only the modules that register Arena's built-in policies."""
+        import isaaclab_arena.policy  # noqa: F401
+
     def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"]) -> None:
         """Register a policy and its typed configuration."""
         assert cfg_type not in self._policy_types_by_cfg_type, f"Policy config {cfg_type.__name__} already registered"
@@ -199,7 +194,7 @@ class PolicyRegistry(Registry):
     # lookup when policy_runner and eval_runner receive PolicyCfg instances directly.
     def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"]:
         """Get the config type used by the temporary policy frontend adapters."""
-        ensure_assets_registered()
+        self._ensure_components_registered()
         assert policy_type in self._cfg_types, f"Policy {policy_type.__name__} must register a PolicyCfg"
         return self._cfg_types[policy_type]
 
@@ -207,7 +202,7 @@ class PolicyRegistry(Registry):
     # to typed run execution and remains after the legacy adapters are removed.
     def get_policy_type_for_cfg(self, cfg: "PolicyCfg") -> type["PolicyBase"]:
         """Get the registered policy that consumes a concrete configuration."""
-        ensure_assets_registered()
+        self._ensure_components_registered()
         cfg_type = type(cfg)
         assert cfg_type in self._policy_types_by_cfg_type, f"Policy config {cfg_type.__name__} is not registered"
         return self._policy_types_by_cfg_type[cfg_type]
@@ -218,7 +213,6 @@ class PolicyRegistry(Registry):
         Args:
             name (str): The name of the policy.
         """
-        ensure_assets_registered()
         return self.get_component_by_name(name)
 
 
@@ -294,7 +288,6 @@ class EnvironmentRegistry(Registry):
         factory_type: type["ArenaEnvironmentFactory"],
     ) -> type["ArenaEnvironmentCfg"]:
         """Get the config type needed to translate a legacy named environment."""
-        ensure_assets_registered()
         assert (
             factory_type in self._cfg_types_by_factory_type
         ), f"Environment {factory_type.__name__} must register a config"
@@ -304,7 +297,6 @@ class EnvironmentRegistry(Registry):
     # to typed run execution and remains after the legacy adapters are removed.
     def get_factory_type_for_cfg(self, cfg: "ArenaEnvironmentCfg") -> type["ArenaEnvironmentFactory"]:
         """Resolve the registered factory used to execute a typed environment config."""
-        ensure_assets_registered()
         cfg_type = type(cfg)
         assert cfg_type in self._factory_types_by_cfg_type, f"Environment config {cfg_type.__name__} is not registered"
         return self._factory_types_by_cfg_type[cfg_type]
@@ -342,13 +334,12 @@ class TaskRegistry(Registry):
         return self.get_component_by_name(name)
 
 
-# Registries populated lazily by ensure_assets_registered(). EnvironmentRegistry is
-# excluded: triggering the cascade during env registration causes an env<->tasks cycle.
+# Registries populated by the broad asset loader. PolicyRegistry and
+# EnvironmentRegistry use their own narrower registration boundaries.
 REGISTRIES = (
     AssetRegistry,
     DeviceRegistry,
     RetargeterRegistry,
-    PolicyRegistry,
     HDRImageRegistry,
     ObjectRelationLibraryRegistry,
     TaskRegistry,

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -188,6 +188,9 @@ class PolicyRegistry(Registry):
 
     def _ensure_components_registered(self) -> None:
         """Import only the modules that register Arena's built-in policies."""
+        # Built-in names such as zero_action, replay, and rsl_rl must work without
+        # callers importing each policy module first. Importing the policy package
+        # registers them without loading unrelated assets, tasks, embodiments, or pxr.
         import isaaclab_arena.policy  # noqa: F401
 
     def register_policy(self, policy_type: type["PolicyBase"], cfg_type: type["PolicyCfg"]) -> None:
@@ -266,6 +269,9 @@ class HDRImageRegistry(_GloballyLoadedRegistry):
         return random.choice(hdrs)
 
 
+# Environment factories come from extension packages, not the shared asset
+# registration pass. Those packages explicitly populate this registry before
+# lookup; first-party callers do so through ensure_environments_registered().
 class EnvironmentRegistry(Registry):
     """Registry for Arena environment factories and their configs."""
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -78,6 +78,10 @@ class Registry(metaclass=SingletonMeta):
         return list(self._components.keys())
 
 
+# TODO(cvolk, 2026-07-08): [typed-config-migration] Separate lightweight
+# component discovery from simulator-dependent registration for these domains.
+# The shared loader imports pxr, so assets (including embodiments), devices,
+# retargeters, HDRs, relations, and tasks cannot be discovered before SimulationApp starts.
 class _GloballyLoadedRegistry(Registry):
     """Load components through the shared asset registration pass."""
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -272,11 +272,12 @@ class HDRImageRegistry(_GloballyLoadedRegistry):
         return random.choice(hdrs)
 
 
-# Environment factories come from extension packages, not the shared asset
-# registration pass. Those packages explicitly populate this registry before
-# lookup; first-party callers do so through ensure_environments_registered().
 class EnvironmentRegistry(Registry):
-    """Registry for Arena environment factories and their configs."""
+    """Store factories and configs registered by environment extension packages.
+
+    This registry has no lazy loader. First-party callers populate it through
+    ensure_environments_registered() before lookup.
+    """
 
     def __init__(self):
         super().__init__()

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -39,7 +39,10 @@ class Registry(metaclass=SingletonMeta):
         self._components[key] = component
 
     def _ensure_components_registered(self) -> None:
-        """Ensure lazily registered components are available for lookup."""
+        """Provide a hook for registries that load components lazily.
+
+        Registries populated explicitly inherit this no-op implementation.
+        """
         pass
 
     def is_registered(self, key: str, ensure_loaded: bool = True) -> bool:

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -39,9 +39,8 @@ class Registry(metaclass=SingletonMeta):
         self._components[key] = component
 
     def _ensure_components_registered(self) -> None:
-        """Import the modules that populate this registry."""
-        if isinstance(self, REGISTRIES):
-            ensure_assets_registered()
+        """Ensure lazily registered components are available for lookup."""
+        pass
 
     def is_registered(self, key: str, ensure_loaded: bool = True) -> bool:
         """Check whether a component is already registered under a key.
@@ -79,7 +78,15 @@ class Registry(metaclass=SingletonMeta):
         return list(self._components.keys())
 
 
-class AssetRegistry(Registry):
+class _GloballyLoadedRegistry(Registry):
+    """Load components through the shared asset registration pass."""
+
+    def _ensure_components_registered(self) -> None:
+        """Import all modules covered by the shared asset registration pass."""
+        ensure_assets_registered()
+
+
+class AssetRegistry(_GloballyLoadedRegistry):
 
     def __init__(self):
         super().__init__()
@@ -135,7 +142,7 @@ class AssetRegistry(Registry):
         return random.choice(assets)
 
 
-class DeviceRegistry(Registry):
+class DeviceRegistry(_GloballyLoadedRegistry):
 
     def __init__(self):
         super().__init__()
@@ -160,7 +167,7 @@ class DeviceRegistry(Registry):
         return device.get_device_cfg(pipeline_builder=pipeline_builder, embodiment=embodiment)
 
 
-class RetargeterRegistry(Registry):
+class RetargeterRegistry(_GloballyLoadedRegistry):
     def __init__(self):
         super().__init__()
 
@@ -216,7 +223,7 @@ class PolicyRegistry(Registry):
         return self.get_component_by_name(name)
 
 
-class HDRImageRegistry(Registry):
+class HDRImageRegistry(_GloballyLoadedRegistry):
     """Registry for HDR/EXR environment map textures."""
 
     def __init__(self):
@@ -302,7 +309,7 @@ class EnvironmentRegistry(Registry):
         return self._factory_types_by_cfg_type[cfg_type]
 
 
-class ObjectRelationLibraryRegistry(Registry):
+class ObjectRelationLibraryRegistry(_GloballyLoadedRegistry):
     """Registry for object relation classes."""
 
     def __init__(self):
@@ -318,7 +325,7 @@ class ObjectRelationLibraryRegistry(Registry):
         return self.get_component_by_name(name)
 
 
-class TaskRegistry(Registry):
+class TaskRegistry(_GloballyLoadedRegistry):
     """Registry for TaskBase subclasses."""
 
     def __init__(self):
@@ -332,18 +339,6 @@ class TaskRegistry(Registry):
         """
         ensure_assets_registered()
         return self.get_component_by_name(name)
-
-
-# Registries populated by the broad asset loader. PolicyRegistry and
-# EnvironmentRegistry use their own narrower registration boundaries.
-REGISTRIES = (
-    AssetRegistry,
-    DeviceRegistry,
-    RetargeterRegistry,
-    HDRImageRegistry,
-    ObjectRelationLibraryRegistry,
-    TaskRegistry,
-)
 
 
 # Lazy registration to avoid circular imports

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -78,10 +78,10 @@ class Registry(metaclass=SingletonMeta):
         return list(self._components.keys())
 
 
-# TODO(cvolk, 2026-07-08): [typed-config-migration] Separate lightweight
-# component discovery from simulator-dependent registration for these domains.
-# The shared loader imports pxr, so assets (including embodiments), devices,
-# retargeters, HDRs, relations, and tasks cannot be discovered before SimulationApp starts.
+# TODO(cvolk, 2026-07-08): Let these registries list their components before
+# SimulationApp starts. Their shared loader currently imports pxr, so assets
+# (including embodiments), devices, retargeters, HDRs, relations, and tasks can
+# only be discovered after the simulator has started.
 class _GloballyLoadedRegistry(Registry):
     """Load components through the shared asset registration pass."""
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -39,10 +39,7 @@ class Registry(metaclass=SingletonMeta):
         self._components[key] = component
 
     def _ensure_components_registered(self) -> None:
-        """Provide a hook for registries that load components lazily.
-
-        Registries populated explicitly inherit this no-op implementation.
-        """
+        """Let registry subclasses load components before lookup."""
         pass
 
     def is_registered(self, key: str, ensure_loaded: bool = True) -> bool:

--- a/isaaclab_arena/tests/test_environment_cfgs.py
+++ b/isaaclab_arena/tests/test_environment_cfgs.py
@@ -15,6 +15,7 @@ from dataclasses import fields, is_dataclass
 
 import pytest
 
+import isaaclab_arena.assets.registries as registries
 from isaaclab_arena.assets.registries import EnvironmentRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
 from isaaclab_arena_environments.cli import (
@@ -62,6 +63,25 @@ def test_core_environment_factory_does_not_expose_argparse_methods():
     """Keep CLI compatibility outside the core factory contract."""
     assert not hasattr(ArenaEnvironmentFactory, "add_cli_args")
     assert not hasattr(ArenaEnvironmentFactory, "get_env")
+
+
+def test_environment_config_lookups_do_not_load_unrelated_assets(monkeypatch):
+    """Keep registered config lookups independent from global asset registration."""
+
+    def fail_if_assets_are_loaded():
+        pytest.fail("EnvironmentRegistry config lookups must not trigger global asset registration")
+
+    monkeypatch.setattr(registries, "ensure_assets_registered", fail_if_assets_are_loaded)
+
+    environment_registry = EnvironmentRegistry()
+    assert (
+        environment_registry.get_environment_cfg_type(PickAndPlaceMapleTableEnvironment)
+        is PickAndPlaceMapleTableEnvironmentCfg
+    )
+    assert (
+        environment_registry.get_factory_type_for_cfg(PickAndPlaceMapleTableEnvironmentCfg())
+        is PickAndPlaceMapleTableEnvironment
+    )
 
 
 def test_every_registered_cli_adapter_uses_its_typed_cfg_defaults():

--- a/isaaclab_arena/tests/test_policy_cfgs.py
+++ b/isaaclab_arena/tests/test_policy_cfgs.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 import pytest
 
 import isaaclab_arena.assets.register as policy_registration
+import isaaclab_arena.assets.registries as registries
 from isaaclab_arena.assets.registries import PolicyRegistry
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.evaluation.policy_runner_cli import add_policy_cli_args, build_policy_from_cli, policy_cfg_from_cli
@@ -36,6 +37,20 @@ def test_core_policies_register_typed_configs(policy_type, cfg_type):
     """Check that each core policy is registered with its concrete config."""
     assert PolicyRegistry().get_policy_cfg_type(policy_type) is cfg_type
     assert issubclass(cfg_type, PolicyCfg)
+
+
+def test_policy_registry_does_not_load_unrelated_assets(monkeypatch):
+    """Keep policy lookups independent from global asset registration."""
+
+    def fail_if_assets_are_loaded():
+        pytest.fail("PolicyRegistry must not trigger global asset registration")
+
+    monkeypatch.setattr(registries, "ensure_assets_registered", fail_if_assets_are_loaded)
+
+    policy_registry = PolicyRegistry()
+    assert "zero_action" in policy_registry.get_all_keys()
+    assert policy_registry.get_policy_cfg_type(ZeroActionPolicy) is ZeroActionPolicyCfg
+    assert policy_registry.get_policy_type_for_cfg(ZeroActionPolicyCfg()) is ZeroActionPolicy
 
 
 def test_policy_registration_resolves_policy_from_concrete_config():


### PR DESCRIPTION
## Summary
Separate registry loading by ownership

## Detailed description
- Registry lookups previously used one REGISTRIES list to call ensure_assets_registered(). Asking PolicyRegistry for config types therefore also imported unrelated assets, tasks, embodiments, and pxr before SimulationApp started.
- Replace that central list with a loading hook owned by each registry. Asset, device, retargeter, HDR, relation, and task registries keep the existing shared asset-registration behavior.
- PolicyRegistry imports only the built-in policies, so zero_action, replay, and rsl_rl still work without manual imports. EnvironmentRegistry does no lazy loading because extension packages explicitly register their environment factories.
- Typed Experiment composition can now discover policy and environment config types before simulation starts. Regression tests cover both narrowed lookup paths.
- Other components, such as tasks and embodiments, still cannot be discovered before SimulationApp because their shared loader imports pxr. A TODO records that follow-up.