### PR TITLE
Run typed YAML experiments from eval_runner.py

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import json
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
-
-if TYPE_CHECKING:
-    from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-    from isaaclab_arena.policy.policy_base import PolicyCfg
+from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
+from isaaclab_arena.hydra.arena_experiment import load_arena_experiment_from_yaml
+from isaaclab_arena.policy.policy_base import PolicyCfg
+from isaaclab_arena_environments.cli import ensure_environments_registered
 
 
 def load_arena_experiment_from_config_file(
@@ -45,30 +46,31 @@ def load_arena_experiment_from_config_file(
     assert suffix in {".json", ".yaml", ".yml"}, f"Experiment config must use .json, .yaml, or .yml, got '{path}'"
 
     if suffix == ".json":
-        from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-
         assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
         with path.open(encoding="utf-8") as experiment_config_file:
             legacy_experiment_config = json.load(experiment_config_file)
-        experiment = run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
-    else:
-        from isaaclab_arena.hydra.arena_experiment import load_arena_experiment_from_yaml
+        return run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
 
-        experiment = load_arena_experiment_from_yaml(
-            path,
-            environment_cfg_types=_registered_environment_cfg_types(),
-            policy_cfg_types=_registered_policy_cfg_types(),
-            overrides=overrides,
+    yaml_experiment = load_arena_experiment_from_yaml(
+        path,
+        environment_cfg_types=_registered_environment_cfg_types(),
+        policy_cfg_types=_registered_policy_cfg_types(),
+        overrides=overrides,
+    )
+
+    experiment_with_process_device: ArenaExperiment = []
+    for run_config in yaml_experiment:
+        environment_builder_with_process_device = replace(run_config.environment_builder, device=device)
+        run_config_with_process_device = replace(
+            run_config,
+            environment_builder=environment_builder_with_process_device,
         )
-
-    return [replace(run, environment_builder=replace(run.environment_builder, device=device)) for run in experiment]
+        experiment_with_process_device.append(run_config_with_process_device)
+    return experiment_with_process_device
 
 
 def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
     """Return registered environment selector names and their config types."""
-    from isaaclab_arena.assets.registries import EnvironmentRegistry
-    from isaaclab_arena_environments.cli import ensure_environments_registered
-
     ensure_environments_registered()
     registry = EnvironmentRegistry()
     return {
@@ -79,8 +81,6 @@ def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
 
 def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
     """Return registered policy selector names and their config types."""
-    from isaaclab_arena.assets.registries import PolicyRegistry
-
     registry = PolicyRegistry()
     return {
         name: registry.get_policy_cfg_type(registry.get_component_by_name(name)) for name in registry.get_all_keys()

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -15,7 +15,7 @@ from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
 from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-from isaaclab_arena.hydra.arena_experiment import load_arena_experiment_from_yaml
+from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
 

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load Arena Experiments from JSON or YAML configuration files."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
+    from isaaclab_arena.policy.policy_base import PolicyCfg
+
+
+def load_arena_experiment_from_config_file(
+    experiment_config_path: str | Path,
+    *,
+    device: str,
+    overrides: list[str] | None = None,
+) -> ArenaExperiment:
+    """Load a JSON or YAML Arena Experiment and apply its process device.
+
+    Call this only after SimulationApp starts because resolving the complete
+    configuration registries loads Isaac Sim modules.
+
+    Args:
+        experiment_config_path: Path to a legacy JSON or typed YAML Experiment.
+        device: Process-wide simulation device applied to every Run.
+        overrides: Hydra overrides applied to typed YAML Experiments.
+
+    Returns:
+        The ordered typed Runs that make up the Experiment.
+    """
+    path = Path(experiment_config_path)
+    assert path.is_file(), f"Experiment config does not exist: '{path}'"
+
+    suffix = path.suffix.lower()
+    assert suffix in {".json", ".yaml", ".yml"}, f"Experiment config must use .json, .yaml, or .yml, got '{path}'"
+
+    if suffix == ".json":
+        from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
+
+        assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
+        with path.open(encoding="utf-8") as experiment_config_file:
+            legacy_experiment_config = json.load(experiment_config_file)
+        experiment = run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
+    else:
+        from isaaclab_arena.hydra.arena_experiment import load_arena_experiment_from_yaml
+
+        experiment = load_arena_experiment_from_yaml(
+            path,
+            environment_cfg_types=_registered_environment_cfg_types(),
+            policy_cfg_types=_registered_policy_cfg_types(),
+            overrides=overrides,
+        )
+
+    return [replace(run, environment_builder=replace(run.environment_builder, device=device)) for run in experiment]
+
+
+def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
+    """Return registered environment selector names and their config types."""
+    from isaaclab_arena.assets.registries import EnvironmentRegistry
+    from isaaclab_arena_environments.cli import ensure_environments_registered
+
+    ensure_environments_registered()
+    registry = EnvironmentRegistry()
+    return {
+        name: registry.get_environment_cfg_type(registry.get_component_by_name(name))
+        for name in registry.get_all_keys()
+    }
+
+
+def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
+    """Return registered policy selector names and their config types."""
+    from isaaclab_arena.assets.registries import PolicyRegistry
+
+    registry = PolicyRegistry()
+    return {
+        name: registry.get_policy_cfg_type(registry.get_component_by_name(name)) for name in registry.get_all_keys()
+    }

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -20,6 +20,18 @@ from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
 
 
+def validate_experiment_config_path(experiment_config: str | Path) -> Path:
+    """Return an existing Experiment configuration path with a supported suffix."""
+    experiment_config_path = Path(experiment_config)
+    assert experiment_config_path.is_file(), f"Experiment config does not exist: '{experiment_config_path}'"
+    assert experiment_config_path.suffix.lower() in {
+        ".json",
+        ".yaml",
+        ".yml",
+    }, f"Experiment config must use .json, .yaml, or .yml, got '{experiment_config_path}'"
+    return experiment_config_path
+
+
 def load_arena_experiment_from_config_file(
     experiment_config_path: str | Path,
     *,
@@ -39,13 +51,9 @@ def load_arena_experiment_from_config_file(
     Returns:
         The ordered typed Runs that make up the Experiment.
     """
-    path = Path(experiment_config_path)
-    assert path.is_file(), f"Experiment config does not exist: '{path}'"
+    path = validate_experiment_config_path(experiment_config_path)
 
-    suffix = path.suffix.lower()
-    assert suffix in {".json", ".yaml", ".yml"}, f"Experiment config must use .json, .yaml, or .yml, got '{path}'"
-
-    if suffix == ".json":
+    if path.suffix.lower() == ".json":
         assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
         with path.open(encoding="utf-8") as experiment_config_file:
             legacy_experiment_config = json.load(experiment_config_file)
@@ -58,6 +66,9 @@ def load_arena_experiment_from_config_file(
         overrides=overrides,
     )
 
+    # TODO(cvolk, 2026-07-09): [typed-config-migration] Make device a process-level
+    # evaluation setting shared by AppLauncher and Run execution. Then remove device
+    # from ArenaEnvBuilderCfg and delete this per-Run copy.
     experiment_with_process_device: ArenaExperiment = []
     for run_config in yaml_experiment:
         environment_builder_with_process_device = replace(run_config.environment_builder, device=device)

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -40,9 +40,6 @@ def load_arena_experiment_from_config_file(
 ) -> ArenaExperiment:
     """Load a JSON or YAML Arena Experiment and apply its process device.
 
-    Call this only after SimulationApp starts because resolving the complete
-    configuration registries loads Isaac Sim modules.
-
     Args:
         experiment_config_path: Path to a legacy JSON or typed YAML Experiment.
         device: Process-wide simulation device applied to every Run.
@@ -84,15 +81,18 @@ def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
     """Return registered environment selector names and their config types."""
     ensure_environments_registered()
     registry = EnvironmentRegistry()
-    return {
-        name: registry.get_environment_cfg_type(registry.get_component_by_name(name))
-        for name in registry.get_all_keys()
-    }
+    environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]] = {}
+    for name in registry.get_all_keys():
+        environment_factory_type = registry.get_component_by_name(name)
+        environment_cfg_types[name] = registry.get_environment_cfg_type(environment_factory_type)
+    return environment_cfg_types
 
 
 def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
     """Return registered policy selector names and their config types."""
     registry = PolicyRegistry()
-    return {
-        name: registry.get_policy_cfg_type(registry.get_component_by_name(name)) for name in registry.get_all_keys()
-    }
+    policy_cfg_types: dict[str, type[PolicyCfg]] = {}
+    for name in registry.get_all_keys():
+        policy_type = registry.get_component_by_name(name)
+        policy_cfg_types[name] = registry.get_policy_cfg_type(policy_type)
+    return policy_cfg_types

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -13,9 +13,10 @@ import tempfile
 from pathlib import Path
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
-from isaaclab_arena.evaluation.arena_run import ArenaRunCfg, build_runs_info_table
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.evaluation.arena_run import build_runs_info_table
 from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
-from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
 from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg, execute_experiment
 from isaaclab_arena.metrics.metrics_logger import MetricsLogger
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -25,9 +26,9 @@ from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 
 # TODO(cvolk): Move experiment-level variation inspection out of this CLI entry point.
 # Run orchestration belongs in evaluation; catalogue formatting belongs in variations.
-def list_variations(run_cfgs: list[ArenaRunCfg]) -> None:
+def list_variations(experiment: ArenaExperiment) -> None:
     """Print the Hydra-configurable variations for each run's environment."""
-    for run_cfg in run_cfgs:
+    for run_cfg in experiment:
         arena_builder = build_arena_builder_from_run_cfg(run_cfg)
         print(f"=== Variations for run '{run_cfg.name}' ===", flush=True)
         print(arena_builder.get_variations_catalogue_as_string(), flush=True)
@@ -47,19 +48,28 @@ def legacy_json_experiment_requires_cameras(experiment_config: dict) -> bool:
     )
 
 
-def _run_chunk(chunk_label: str, chunk_jobs: list[dict]) -> int:
-    """Run ``chunk_jobs`` in a fresh ``eval_runner`` subprocess and return its exit code."""
+def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: bool) -> None:
+    """Check that AppLauncher enabled camera support requested by typed Runs."""
+    camera_run_names = [run_cfg.name for run_cfg in experiment if getattr(run_cfg.environment, "enable_cameras", False)]
+    assert not camera_run_names or enable_cameras, (
+        f"Runs {camera_run_names} enable environment cameras. Pass --enable_cameras so AppLauncher enables "
+        "camera support before the typed Experiment is composed."
+    )
+
+
+def _run_legacy_json_chunk(chunk_label: str, legacy_job_configs: list[dict]) -> int:
+    """Run legacy JSON entries in a fresh eval_runner subprocess."""
     print(f"[eval_runner] {chunk_label}", flush=True)
-    # Serialize this chunk's jobs to a temp config the child loads via --eval_jobs_config.
+    # Serialize this chunk's jobs to a temp config the child loads via --experiment_config.
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-        json.dump({"jobs": chunk_jobs}, tmp)
+        json.dump({"jobs": legacy_job_configs}, tmp)
         chunk_path = Path(tmp.name)
-    # Re-run this invocation in the child, with --eval_jobs_config appended so it wins over
+    # Re-run this invocation in the child, with --experiment_config appended so it wins over
     # the master config (argparse keeps the last value).
     # Strip --serve_evaluation_report: a child that served its report would block on
     # serve_until_ctrl_c forever.
     forwarded_args = [arg for arg in sys.argv if arg != "--serve_evaluation_report"]
-    config_override = ["--eval_jobs_config", str(chunk_path)]
+    config_override = ["--experiment_config", str(chunk_path)]
     child_cmd = [sys.executable, *forwarded_args, *config_override]
     try:
         result = subprocess.run(child_cmd, check=False)
@@ -69,14 +79,13 @@ def _run_chunk(chunk_label: str, chunk_jobs: list[dict]) -> int:
     return result.returncode
 
 
-def _run_in_chunks(args_cli: argparse.Namespace, experiment_config: dict) -> None:
-    """Run each chunk of ``experiment_config['jobs']`` in a fresh subprocess."""
-    jobs = experiment_config["jobs"]
+def _run_legacy_json_in_chunks(args_cli: argparse.Namespace, legacy_experiment_config: dict) -> None:
+    """Run each chunk of a legacy JSON Experiment in a fresh subprocess."""
+    jobs = legacy_experiment_config["jobs"]
     chunk_size = args_cli.chunk_size
-    if chunk_size <= 0:
-        raise ValueError(f"--chunk_size must be positive, got {chunk_size}")
+    assert chunk_size > 0, f"--chunk_size must be positive, got {chunk_size}"
     n_chunks = math.ceil(len(jobs) / chunk_size)
-    print(f"[eval_runner] {len(jobs)} jobs → {n_chunks} chunks of <= {chunk_size}", flush=True)
+    print(f"[eval_runner] {len(jobs)} Runs → {n_chunks} chunks of <= {chunk_size}", flush=True)
 
     if args_cli.serve_evaluation_report:
         print("--serve_evaluation_report is ignored with --chunk_size.", flush=True)
@@ -84,65 +93,109 @@ def _run_in_chunks(args_cli: argparse.Namespace, experiment_config: dict) -> Non
     for chunk_idx in range(n_chunks):
         start = chunk_idx * chunk_size
         end = min(start + chunk_size, len(jobs))
-        chunk_label = f"chunk {chunk_idx + 1}/{n_chunks}: jobs {start}..{end - 1}"
-        returncode = _run_chunk(chunk_label, jobs[start:end])
+        chunk_label = f"chunk {chunk_idx + 1}/{n_chunks}: Runs {start}..{end - 1}"
+        returncode = _run_legacy_json_chunk(chunk_label, jobs[start:end])
         if returncode != 0:
             print(f"[eval_runner] chunk {chunk_idx} failed (exit {returncode}).", flush=True)
             sys.exit(returncode)
 
 
-def main():
+def _parse_eval_runner_args() -> argparse.Namespace:
+    """Parse and validate the eval runner command-line arguments."""
     args_parser = get_isaaclab_arena_cli_parser()
-    args_cli, unknown = args_parser.parse_known_args()
-
-    # Load the experiment before starting simulation so process-wide requirements
-    # can be configured before Isaac Sim starts.
     add_eval_runner_arguments(args_parser)
     args_cli, _ = args_parser.parse_known_args()
     assert not args_cli.distributed, "Distributed evaluation is not supported yet"
+    return args_cli
 
-    assert os.path.exists(
-        args_cli.eval_jobs_config
-    ), f"eval_jobs_config file does not exist: {args_cli.eval_jobs_config}"
 
-    with open(args_cli.eval_jobs_config, encoding="utf-8") as f:
-        experiment_config = json.load(f)
+def _validate_experiment_config_path(experiment_config: str | Path) -> Path:
+    """Return a supported Experiment configuration path that exists."""
+    experiment_config_path = Path(experiment_config)
+    assert experiment_config_path.is_file(), f"Experiment config does not exist: '{experiment_config_path}'"
+    experiment_config_suffix = experiment_config_path.suffix.lower()
+    assert experiment_config_suffix in {
+        ".json",
+        ".yaml",
+        ".yml",
+    }, f"Experiment config must use .json, .yaml, or .yml, got '{experiment_config_path}'"
+    return experiment_config_path
+
+
+def _load_legacy_json_experiment_config(
+    experiment_config_path: Path,
+    experiment_overrides: list[str],
+) -> dict | None:
+    """Load legacy JSON data needed before startup, or return None for YAML.
+
+    Args:
+        experiment_config_path: Validated path to an Experiment configuration.
+        experiment_overrides: Hydra overrides supplied for a typed YAML Experiment.
+
+    Returns:
+        The legacy JSON mapping, or None when the Experiment uses YAML.
+    """
+    if experiment_config_path.suffix.lower() != ".json":
+        return None
+
+    assert not experiment_overrides, "Experiment overrides are supported only for typed YAML Experiments"
+    with experiment_config_path.open(encoding="utf-8") as experiment_config_file:
+        return json.load(experiment_config_file)
+
+
+def main():
+    args_cli = _parse_eval_runner_args()
+    experiment_config_path = _validate_experiment_config_path(args_cli.experiment_config)
+    legacy_experiment_config = _load_legacy_json_experiment_config(
+        experiment_config_path,
+        args_cli.experiment_override,
+    )
+
+    if args_cli.record_camera_video or (
+        legacy_experiment_config is not None and legacy_json_experiment_requires_cameras(legacy_experiment_config)
+    ):
+        args_cli.enable_cameras = True
 
     # Print the variations catalogue for each run's environment and exit.
     if args_cli.list_variations:
         with SimulationAppContext(args_cli):
-            run_cfgs = run_cfgs_from_legacy_eval_config(experiment_config, device=args_cli.device)
-            list_variations(run_cfgs)
+            experiment = load_arena_experiment_from_config_file(
+                experiment_config_path,
+                device=args_cli.device,
+                overrides=args_cli.experiment_override,
+            )
+            _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
+            list_variations(experiment)
         return
 
     # Chunked dispatch (--chunk_size N). Splits this config across subprocesses so each
     # gets a fresh SimulationApp. Required for long sweeps because some host memory leaks
     # each cycle and is only reclaimed when the process exits — in-process teardown can't
     # release it.
-    if args_cli.chunk_size is not None and len(experiment_config["jobs"]) > args_cli.chunk_size:
+    if args_cli.chunk_size is not None:
+        assert legacy_experiment_config is not None, "--chunk_size currently supports only legacy JSON Experiments"
+
         # TODO(cvolk): aggregate per-chunk metrics into one centralized view. Each chunk
         # subprocess currently prints its own MetricsLogger summary and nothing is merged
         # or persisted (save_metrics_to_file() is unused). Follow-up: have each chunk write
         # metrics JSON to a temp file (forward --metrics_file), then merge + print/save here.
-        _run_in_chunks(args_cli, experiment_config)
-        return
-
-    # Check if any run requires cameras and enable them if needed before starting simulation.
-    if args_cli.record_camera_video or legacy_json_experiment_requires_cameras(experiment_config):
-        args_cli.enable_cameras = True
+        if len(legacy_experiment_config["jobs"]) > args_cli.chunk_size:
+            _run_legacy_json_in_chunks(args_cli, legacy_experiment_config)
+            return
 
     with SimulationAppContext(args_cli):
-        run_cfgs = run_cfgs_from_legacy_eval_config(
-            experiment_config,
+        experiment = load_arena_experiment_from_config_file(
+            experiment_config_path,
             device=args_cli.device,
+            overrides=args_cli.experiment_override,
         )
+        _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
         metrics_logger = MetricsLogger()
 
-        print(build_runs_info_table(run_cfgs, []))
+        print(build_runs_info_table(experiment, []))
 
-        # One reverse-dated output directory for the experiment; each legacy job/run
-        # gets a subdirectory within it. Always date it so each invocation produces
-        # its own report directory, recording or not.
+        # One reverse-dated output directory for the Experiment, with one subdirectory
+        # per Run. Always date it so each invocation produces its own report directory.
         # TODO(alexmillane): Currently each chunk produces its own output directory.
         # We should use the same output directory for all chunks in the future.
         experiment_output_dir = Path(timestamped_run_dir(args_cli.output_base_dir))
@@ -152,7 +205,7 @@ def main():
             print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_dir}")
 
         results = execute_experiment(
-            run_cfgs,
+            experiment,
             output_dir=experiment_output_dir,
             record_viewport_video=args_cli.record_viewport_video,
             record_camera_video=args_cli.record_camera_video,
@@ -162,7 +215,7 @@ def main():
             if result.metrics is not None:
                 metrics_logger.append_job_metrics(result.run_name, result.metrics)
 
-        print(build_runs_info_table(run_cfgs, results))
+        print(build_runs_info_table(experiment, results))
         metrics_logger.print_metrics()
 
         # Write HTML report.

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -14,7 +14,10 @@ from pathlib import Path
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
-from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    load_arena_experiment_from_config_file,
+    validate_experiment_config_path,
+)
 from isaaclab_arena.evaluation.arena_run import build_runs_info_table
 from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
 from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg, execute_experiment
@@ -109,19 +112,6 @@ def _parse_eval_runner_args() -> argparse.Namespace:
     return args_cli
 
 
-def _validate_experiment_config_path(experiment_config: str | Path) -> Path:
-    """Return a supported Experiment configuration path that exists."""
-    experiment_config_path = Path(experiment_config)
-    assert experiment_config_path.is_file(), f"Experiment config does not exist: '{experiment_config_path}'"
-    experiment_config_suffix = experiment_config_path.suffix.lower()
-    assert experiment_config_suffix in {
-        ".json",
-        ".yaml",
-        ".yml",
-    }, f"Experiment config must use .json, .yaml, or .yml, got '{experiment_config_path}'"
-    return experiment_config_path
-
-
 def _load_legacy_json_experiment_config(
     experiment_config_path: Path,
     experiment_overrides: list[str],
@@ -145,7 +135,7 @@ def _load_legacy_json_experiment_config(
 
 def main():
     args_cli = _parse_eval_runner_args()
-    experiment_config_path = _validate_experiment_config_path(args_cli.experiment_config)
+    experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
     legacy_experiment_config = _load_legacy_json_experiment_config(
         experiment_config_path,
         args_cli.experiment_override,

--- a/isaaclab_arena/evaluation/eval_runner.py
+++ b/isaaclab_arena/evaluation/eval_runner.py
@@ -3,23 +3,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import argparse
-import json
-import math
 import os
-import subprocess
-import sys
-import tempfile
 from pathlib import Path
 
-from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
 from isaaclab_arena.evaluation.arena_run import build_runs_info_table
-from isaaclab_arena.evaluation.eval_runner_cli import add_eval_runner_arguments
+from isaaclab_arena.evaluation.eval_runner_cli import parse_eval_runner_args
+from isaaclab_arena.evaluation.legacy_eval_runner import (
+    legacy_json_experiment_requires_cameras,
+    load_legacy_json_experiment_config,
+    run_legacy_json_in_chunks,
+)
 from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg, execute_experiment
 from isaaclab_arena.metrics.metrics_logger import MetricsLogger
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -37,20 +35,12 @@ def list_variations(experiment: ArenaExperiment) -> None:
         print(arena_builder.get_variations_catalogue_as_string(), flush=True)
 
 
-def legacy_json_experiment_requires_cameras(experiment_config: dict) -> bool:
-    """Return whether a legacy JSON Experiment requires camera support.
-
-    Args:
-        experiment_config: Legacy Experiment mapping containing entries below jobs.
-
-    Returns:
-        Whether any legacy entry enables environment cameras.
-    """
-    return any(
-        job_config.get("arena_env_args", {}).get("enable_cameras", False) for job_config in experiment_config["jobs"]
-    )
-
-
+# TODO(cvolk, 2026-07-10): [typed-config-migration] Typed YAML is composed only
+# after SimulationApp starts, so eval_runner cannot determine camera requirements
+# in time to configure AppLauncher. Add enable_cameras to ArenaEnvironmentCfg,
+# update each factory to honor it or reject unsupported cameras, and apply YAML
+# values and Hydra overrides before startup. Enable AppLauncher when any Run enables
+# cameras, then remove this getattr and the requirement to also pass --enable_cameras.
 def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: bool) -> None:
     """Check that AppLauncher enabled camera support requested by typed Runs."""
     camera_run_names = [run_cfg.name for run_cfg in experiment if getattr(run_cfg.environment, "enable_cameras", False)]
@@ -60,85 +50,12 @@ def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: 
     )
 
 
-def _run_legacy_json_chunk(chunk_label: str, legacy_job_configs: list[dict]) -> int:
-    """Run legacy JSON entries in a fresh eval_runner subprocess."""
-    print(f"[eval_runner] {chunk_label}", flush=True)
-    # Serialize this chunk's jobs to a temp config the child loads via --experiment_config.
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-        json.dump({"jobs": legacy_job_configs}, tmp)
-        chunk_path = Path(tmp.name)
-    # Re-run this invocation in the child, with --experiment_config appended so it wins over
-    # the master config (argparse keeps the last value).
-    # Strip --serve_evaluation_report: a child that served its report would block on
-    # serve_until_ctrl_c forever.
-    forwarded_args = [arg for arg in sys.argv if arg != "--serve_evaluation_report"]
-    config_override = ["--experiment_config", str(chunk_path)]
-    child_cmd = [sys.executable, *forwarded_args, *config_override]
-    try:
-        result = subprocess.run(child_cmd, check=False)
-    finally:
-        # Remove the temp chunk config now that the child has loaded it.
-        chunk_path.unlink(missing_ok=True)
-    return result.returncode
-
-
-def _run_legacy_json_in_chunks(args_cli: argparse.Namespace, legacy_experiment_config: dict) -> None:
-    """Run each chunk of a legacy JSON Experiment in a fresh subprocess."""
-    jobs = legacy_experiment_config["jobs"]
-    chunk_size = args_cli.chunk_size
-    assert chunk_size > 0, f"--chunk_size must be positive, got {chunk_size}"
-    n_chunks = math.ceil(len(jobs) / chunk_size)
-    print(f"[eval_runner] {len(jobs)} Runs → {n_chunks} chunks of <= {chunk_size}", flush=True)
-
-    if args_cli.serve_evaluation_report:
-        print("--serve_evaluation_report is ignored with --chunk_size.", flush=True)
-
-    for chunk_idx in range(n_chunks):
-        start = chunk_idx * chunk_size
-        end = min(start + chunk_size, len(jobs))
-        chunk_label = f"chunk {chunk_idx + 1}/{n_chunks}: Runs {start}..{end - 1}"
-        returncode = _run_legacy_json_chunk(chunk_label, jobs[start:end])
-        if returncode != 0:
-            print(f"[eval_runner] chunk {chunk_idx} failed (exit {returncode}).", flush=True)
-            sys.exit(returncode)
-
-
-def _parse_eval_runner_args() -> argparse.Namespace:
-    """Parse and validate the eval runner command-line arguments."""
-    args_parser = get_isaaclab_arena_cli_parser()
-    add_eval_runner_arguments(args_parser)
-    args_cli, _ = args_parser.parse_known_args()
-    assert not args_cli.distributed, "Distributed evaluation is not supported yet"
-    return args_cli
-
-
-def _load_legacy_json_experiment_config(
-    experiment_config_path: Path,
-    experiment_overrides: list[str],
-) -> dict | None:
-    """Load legacy JSON data needed before startup, or return None for YAML.
-
-    Args:
-        experiment_config_path: Validated path to an Experiment configuration.
-        experiment_overrides: Hydra overrides supplied for a typed YAML Experiment.
-
-    Returns:
-        The legacy JSON mapping, or None when the Experiment uses YAML.
-    """
-    if experiment_config_path.suffix.lower() != ".json":
-        return None
-
-    assert not experiment_overrides, "Experiment overrides are supported only for typed YAML Experiments"
-    with experiment_config_path.open(encoding="utf-8") as experiment_config_file:
-        return json.load(experiment_config_file)
-
-
 def main():
-    args_cli = _parse_eval_runner_args()
+    args_cli, experiment_overrides = parse_eval_runner_args()
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
-    legacy_experiment_config = _load_legacy_json_experiment_config(
+    legacy_experiment_config = load_legacy_json_experiment_config(
         experiment_config_path,
-        args_cli.experiment_override,
+        experiment_overrides,
     )
 
     if args_cli.record_camera_video or (
@@ -152,7 +69,7 @@ def main():
             experiment = load_arena_experiment_from_config_file(
                 experiment_config_path,
                 device=args_cli.device,
-                overrides=args_cli.experiment_override,
+                overrides=experiment_overrides,
             )
             _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
             list_variations(experiment)
@@ -165,19 +82,15 @@ def main():
     if args_cli.chunk_size is not None:
         assert legacy_experiment_config is not None, "--chunk_size currently supports only legacy JSON Experiments"
 
-        # TODO(cvolk): aggregate per-chunk metrics into one centralized view. Each chunk
-        # subprocess currently prints its own MetricsLogger summary and nothing is merged
-        # or persisted (save_metrics_to_file() is unused). Follow-up: have each chunk write
-        # metrics JSON to a temp file (forward --metrics_file), then merge + print/save here.
         if len(legacy_experiment_config["jobs"]) > args_cli.chunk_size:
-            _run_legacy_json_in_chunks(args_cli, legacy_experiment_config)
+            run_legacy_json_in_chunks(args_cli, legacy_experiment_config)
             return
 
     with SimulationAppContext(args_cli):
         experiment = load_arena_experiment_from_config_file(
             experiment_config_path,
             device=args_cli.device,
-            overrides=args_cli.experiment_override,
+            overrides=experiment_overrides,
         )
         _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
         metrics_logger = MetricsLogger()

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -5,6 +5,9 @@
 
 import argparse
 
+from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
+
 _DEFAULT_EXPERIMENT_CONFIG_PATH = "isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json"
 
 
@@ -18,16 +21,9 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         dest="experiment_config",
         type=str,
         default=_DEFAULT_EXPERIMENT_CONFIG_PATH,
-        help="Path to a typed YAML Experiment or legacy JSON evaluation config.",
-    )
-    parser.add_argument(
-        "--experiment_override",
-        action="append",
-        default=[],
-        metavar="KEY=VALUE",
         help=(
-            "Hydra override for a typed YAML Experiment. Repeat for multiple overrides. "
-            "Also pass --enable_cameras when an override enables environment cameras."
+            "Path to a typed YAML Experiment or legacy JSON evaluation config. "
+            "For YAML, append Hydra KEY=VALUE overrides to the command."
         ),
     )
     parser.add_argument(
@@ -80,3 +76,18 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
             " set only if a long sweep grows in host memory or gets OOM-killed."
         ),
     )
+
+
+def parse_eval_runner_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
+    """Parse eval-runner arguments and return native Hydra override tokens separately.
+
+    Args:
+        argv: Arguments to parse, or None to read the process arguments.
+    """
+    parser = get_isaaclab_arena_cli_parser()
+    add_eval_runner_arguments(parser)
+    parser.allow_abbrev = False
+    args_cli, experiment_overrides = parser.parse_known_args(argv)
+    assert_hydra_overrides(experiment_overrides, parser)
+    assert not args_cli.distributed, "Distributed evaluation is not supported yet"
+    return args_cli, experiment_overrides

--- a/isaaclab_arena/evaluation/eval_runner_cli.py
+++ b/isaaclab_arena/evaluation/eval_runner_cli.py
@@ -5,26 +5,42 @@
 
 import argparse
 
+_DEFAULT_EXPERIMENT_CONFIG_PATH = "isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json"
+
 
 def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
     """Add eval runner specific arguments to the parser."""
+    # TODO(cvolk, 2026-07-09): [typed-config-migration] Remove the --eval_jobs_config alias
+    # when legacy JSON Experiments are retired. Both flags currently populate experiment_config.
     parser.add_argument(
+        "--experiment_config",
         "--eval_jobs_config",
+        dest="experiment_config",
         type=str,
-        default="isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json",
-        help="Path to the eval jobs config file.",
+        default=_DEFAULT_EXPERIMENT_CONFIG_PATH,
+        help="Path to a typed YAML Experiment or legacy JSON evaluation config.",
+    )
+    parser.add_argument(
+        "--experiment_override",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Hydra override for a typed YAML Experiment. Repeat for multiple overrides. "
+            "Also pass --enable_cameras when an override enables environment cameras."
+        ),
     )
     parser.add_argument(
         "--record_viewport_video",
         action="store_true",
         default=False,
-        help="Record viewport videos for each eval job.",
+        help="Record viewport videos for each Run.",
     )
     parser.add_argument(
         "--record_camera_video",
         action="store_true",
         default=False,
-        help="Record one mp4 per (env, camera, episode) from obs['camera_obs'] for each eval job.",
+        help="Record one mp4 per (env, camera, episode) from obs['camera_obs'] for each Run.",
     )
     parser.add_argument(
         "--output_base_dir",
@@ -32,14 +48,14 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default="/eval/output",
         help=(
             "Base directory for evaluation outputs (videos, per-episode results, report); a"
-            " reverse-dated run subdirectory and per-job subdirectory are added."
+            " reverse-dated Experiment subdirectory and per-Run subdirectory are added."
         ),
     )
     parser.add_argument(
         "--serve_evaluation_report",
         action="store_true",
         default=False,
-        help="After all jobs finish, serve the evaluation report over HTTP.",
+        help="After all Runs finish, serve the evaluation report over HTTP.",
     )
     parser.add_argument(
         "--evaluation_report_port",
@@ -51,14 +67,14 @@ def add_eval_runner_arguments(parser: argparse.ArgumentParser) -> None:
         "--continue_on_error",
         action="store_true",
         default=False,
-        help="Continue evaluation with remaining jobs when a job fails instead of stopping immediately.",
+        help="Continue evaluation with remaining Runs when a Run fails instead of stopping immediately.",
     )
     parser.add_argument(
         "--chunk_size",
         type=int,
         default=None,
         help=(
-            "Run jobs in chunks of at most this many, one fresh subprocess per chunk."
+            "Run legacy JSON entries in chunks of at most this many, one fresh subprocess per chunk."
             " Each restart lets the OS reclaim accumulated memory, avoiding OOM on"
             " long sweeps. Default unset — single process. Leave unset for normal runs;"
             " set only if a long sweep grows in host memory or gets OOM-killed."

--- a/isaaclab_arena/evaluation/legacy_eval_runner.py
+++ b/isaaclab_arena/evaluation/legacy_eval_runner.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Legacy JSON preflight and subprocess dispatch for the evaluation runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def load_legacy_json_experiment_config(
+    experiment_config_path: Path,
+    experiment_overrides: list[str],
+) -> dict | None:
+    """Load legacy JSON data needed before startup, or return None for YAML.
+
+    Args:
+        experiment_config_path: Validated path to an Experiment configuration.
+        experiment_overrides: Hydra overrides supplied for a typed YAML Experiment.
+
+    Returns:
+        The legacy JSON mapping, or None when the Experiment uses YAML.
+    """
+    if experiment_config_path.suffix.lower() != ".json":
+        return None
+
+    assert not experiment_overrides, "Experiment overrides are supported only for typed YAML Experiments"
+    with experiment_config_path.open(encoding="utf-8") as experiment_config_file:
+        return json.load(experiment_config_file)
+
+
+def legacy_json_experiment_requires_cameras(experiment_config: dict) -> bool:
+    """Return whether a legacy JSON Experiment requires camera support.
+
+    Args:
+        experiment_config: Legacy Experiment mapping containing entries below jobs.
+
+    Returns:
+        Whether any legacy entry enables environment cameras.
+    """
+    return any(
+        job_config.get("arena_env_args", {}).get("enable_cameras", False) for job_config in experiment_config["jobs"]
+    )
+
+
+def _run_legacy_json_chunk(chunk_label: str, legacy_job_configs: list[dict]) -> int:
+    """Run legacy JSON entries in a fresh eval_runner subprocess."""
+    print(f"[eval_runner] {chunk_label}", flush=True)
+    # Serialize this chunk's jobs to a temp config the child loads via --experiment_config.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        json.dump({"jobs": legacy_job_configs}, tmp)
+        chunk_path = Path(tmp.name)
+    # Re-run this invocation in the child, with --experiment_config appended so it wins over
+    # the master config (argparse keeps the last value).
+    # Strip --serve_evaluation_report: a child that served its report would block on
+    # serve_until_ctrl_c forever.
+    forwarded_args = [arg for arg in sys.argv if arg != "--serve_evaluation_report"]
+    config_override = ["--experiment_config", str(chunk_path)]
+    child_cmd = [sys.executable, *forwarded_args, *config_override]
+    try:
+        result = subprocess.run(child_cmd, check=False)
+    finally:
+        # Remove the temp chunk config now that the child has loaded it.
+        chunk_path.unlink(missing_ok=True)
+    return result.returncode
+
+
+def run_legacy_json_in_chunks(args_cli: argparse.Namespace, legacy_experiment_config: dict) -> None:
+    """Run each chunk of a legacy JSON Experiment in a fresh subprocess."""
+    # TODO(cvolk): Aggregate per-chunk metrics into one centralized view. Each chunk
+    # subprocess currently prints its own MetricsLogger summary and nothing is merged
+    # or persisted (save_metrics_to_file() is unused). Have each chunk write metrics
+    # JSON to a temp file, then merge and print or save them here.
+    jobs = legacy_experiment_config["jobs"]
+    chunk_size = args_cli.chunk_size
+    assert chunk_size > 0, f"--chunk_size must be positive, got {chunk_size}"
+    n_chunks = math.ceil(len(jobs) / chunk_size)
+    print(f"[eval_runner] {len(jobs)} Runs → {n_chunks} chunks of <= {chunk_size}", flush=True)
+
+    if args_cli.serve_evaluation_report:
+        print("--serve_evaluation_report is ignored with --chunk_size.", flush=True)
+
+    for chunk_idx in range(n_chunks):
+        start = chunk_idx * chunk_size
+        end = min(start + chunk_size, len(jobs))
+        chunk_label = f"chunk {chunk_idx + 1}/{n_chunks}: Runs {start}..{end - 1}"
+        returncode = _run_legacy_json_chunk(chunk_label, jobs[start:end])
+        if returncode != 0:
+            print(f"[eval_runner] chunk {chunk_idx} failed (exit {returncode}).", flush=True)
+            sys.exit(returncode)

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import Any
@@ -35,10 +36,6 @@ def _get_new_hydra_context_if_none_exists() -> AbstractContextManager[None]:
     return initialize(version_base=None, config_path=None)
 
 
-# TODO(cvolk, 2026-07-08): [typed-config-migration] Integrate this composer into eval_runner:
-# dispatch --experiment_config YAML files here after AppLauncher starts and JSON files to the
-# legacy adapter; forward YAML-only --experiment_override values and the process device to typed
-# Runs, while keeping JSON camera auto-detection and chunking during the migration.
 def load_arena_experiment_from_yaml(
     yaml_path: str | Path,
     *,
@@ -92,6 +89,14 @@ def load_arena_experiment_from_yaml(
     return experiment
 
 
+def _assert_run_name_is_hydra_compatible(run_name: str) -> None:
+    """Check that a Run name can be used directly in a Hydra override path."""
+    assert re.fullmatch(r"[A-Za-z_][A-Za-z0-9_-]*", run_name), (
+        f"Experiment Run name '{run_name}' must start with a letter or underscore and contain only letters, "
+        "numbers, underscores, or hyphens"
+    )
+
+
 def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, dict[str, Any]]:
     """Read an Arena Experiment YAML file and return its Run values by name.
 
@@ -127,6 +132,7 @@ def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, d
         assert isinstance(run_values, dict)
         run_name = run_values.pop("name", None)
         assert isinstance(run_name, str) and run_name, f"Run at index {index} must define a non-empty string 'name'"
+        _assert_run_name_is_hydra_compatible(run_name)
         assert run_name not in runs, f"Experiment Run name '{run_name}' is duplicated"
         runs[run_name] = run_values
     return runs

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -10,8 +10,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from isaaclab_arena.evaluation import arena_experiment_config_loader
+from isaaclab_arena.evaluation import arena_experiment_config_loader, eval_runner
 from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.evaluation.eval_runner import (
+    _assert_camera_support_enabled,
+    legacy_json_experiment_requires_cameras,
+)
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena_environments.pick_and_place_maple_table_environment import PickAndPlaceMapleTableEnvironmentCfg
@@ -55,8 +59,6 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
 
 
 def test_eval_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):
-    from isaaclab_arena.evaluation import eval_runner
-
     simulation_is_running = False
 
     class _SimulationAppContext:
@@ -92,8 +94,6 @@ def test_eval_runner_loads_typed_experiment_after_simulation_starts(monkeypatch)
 
 
 def test_typed_camera_run_requires_prelaunch_camera_flag():
-    from isaaclab_arena.evaluation.eval_runner import _assert_camera_support_enabled
-
     camera_run = SimpleNamespace(
         name="camera_run",
         environment=SimpleNamespace(enable_cameras=True),
@@ -106,16 +106,12 @@ def test_typed_camera_run_requires_prelaunch_camera_flag():
 
 
 def test_legacy_json_camera_detection_is_preserved():
-    from isaaclab_arena.evaluation.eval_runner import legacy_json_experiment_requires_cameras
-
     legacy_experiment_config = {"jobs": [{"arena_env_args": {}}, {"arena_env_args": {"enable_cameras": True}}]}
 
     assert legacy_json_experiment_requires_cameras(legacy_experiment_config)
 
 
 def test_eval_runner_rejects_yaml_chunking_before_starting_simulation(monkeypatch):
-    from isaaclab_arena.evaluation.eval_runner import main
-
     monkeypatch.setattr(
         "sys.argv",
         [
@@ -128,7 +124,7 @@ def test_eval_runner_rejects_yaml_chunking_before_starting_simulation(monkeypatc
     )
 
     with pytest.raises(AssertionError, match="only legacy JSON Experiments"):
-        main()
+        eval_runner.main()
 
 
 def test_legacy_json_experiment_rejects_hydra_overrides():

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test loading Arena Experiments at the evaluation boundary."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_arena.evaluation import arena_experiment_config_loader
+from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
+from isaaclab_arena.tests.utils.constants import TestConstants
+from isaaclab_arena_environments.pick_and_place_maple_table_environment import PickAndPlaceMapleTableEnvironmentCfg
+
+GETTING_STARTED_JSON_PATH = (
+    Path(TestConstants.arena_environments_dir) / "eval_jobs_configs" / "getting_started_jobs_config.json"
+)
+GETTING_STARTED_YAML_PATH = (
+    Path(TestConstants.arena_environments_dir) / "experiment_configs" / "getting_started_experiment.yaml"
+)
+
+
+def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_environment_cfg_types",
+        lambda: {"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
+    )
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_policy_cfg_types",
+        lambda: {"zero_action": ZeroActionPolicyCfg},
+    )
+
+    experiment = load_arena_experiment_from_config_file(
+        GETTING_STARTED_YAML_PATH,
+        device="cuda:1",
+        overrides=["runs.baseline.environment.light_intensity=750.0"],
+    )
+
+    assert [run.name for run in experiment] == [
+        "baseline",
+        "swap_objects",
+        "change_background_hdr",
+        "parallel_envs",
+    ]
+    assert isinstance(experiment[0].environment, PickAndPlaceMapleTableEnvironmentCfg)
+    assert experiment[0].environment.light_intensity == 750.0
+    assert all(run.policy == ZeroActionPolicyCfg() for run in experiment)
+    assert all(run.environment_builder.device == "cuda:1" for run in experiment)
+
+
+def test_eval_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):
+    from isaaclab_arena.evaluation import eval_runner
+
+    simulation_is_running = False
+
+    class _SimulationAppContext:
+        def __init__(self, _args_cli):
+            pass
+
+        def __enter__(self):
+            nonlocal simulation_is_running
+            simulation_is_running = True
+
+        def __exit__(self, _exception_type, _exception, _traceback):
+            nonlocal simulation_is_running
+            simulation_is_running = False
+
+    def load_experiment_after_startup(*_args, **_kwargs):
+        assert simulation_is_running
+        return []
+
+    monkeypatch.setattr(eval_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(eval_runner, "load_arena_experiment_from_config_file", load_experiment_after_startup)
+    monkeypatch.setattr(eval_runner, "list_variations", lambda _experiment: None)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "eval_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_YAML_PATH),
+            "--list-variations",
+        ],
+    )
+
+    eval_runner.main()
+
+
+def test_typed_camera_run_requires_prelaunch_camera_flag():
+    from isaaclab_arena.evaluation.eval_runner import _assert_camera_support_enabled
+
+    camera_run = SimpleNamespace(
+        name="camera_run",
+        environment=SimpleNamespace(enable_cameras=True),
+    )
+
+    with pytest.raises(AssertionError, match="Pass --enable_cameras"):
+        _assert_camera_support_enabled([camera_run], enable_cameras=False)
+
+    _assert_camera_support_enabled([camera_run], enable_cameras=True)
+
+
+def test_legacy_json_camera_detection_is_preserved():
+    from isaaclab_arena.evaluation.eval_runner import legacy_json_experiment_requires_cameras
+
+    legacy_experiment_config = {"jobs": [{"arena_env_args": {}}, {"arena_env_args": {"enable_cameras": True}}]}
+
+    assert legacy_json_experiment_requires_cameras(legacy_experiment_config)
+
+
+def test_eval_runner_rejects_yaml_chunking_before_starting_simulation(monkeypatch):
+    from isaaclab_arena.evaluation.eval_runner import main
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "eval_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_YAML_PATH),
+            "--chunk_size",
+            "1",
+        ],
+    )
+
+    with pytest.raises(AssertionError, match="only legacy JSON Experiments"):
+        main()
+
+
+def test_legacy_json_experiment_rejects_hydra_overrides():
+    with pytest.raises(AssertionError, match="only for typed YAML"):
+        load_arena_experiment_from_config_file(
+            GETTING_STARTED_JSON_PATH,
+            device="cuda:0",
+            overrides=["runs.baseline.rollout_limit.num_steps=2"],
+        )
+
+
+def test_unknown_experiment_config_file_type_is_rejected(tmp_path):
+    config_path = tmp_path / "experiment.toml"
+    config_path.write_text("", encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="must use .json, .yaml, or .yml"):
+        load_arena_experiment_from_config_file(config_path, device="cuda:0")

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -15,10 +15,8 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
-from isaaclab_arena.evaluation.eval_runner import (
-    _assert_camera_support_enabled,
-    legacy_json_experiment_requires_cameras,
-)
+from isaaclab_arena.evaluation.eval_runner import _assert_camera_support_enabled
+from isaaclab_arena.evaluation.legacy_eval_runner import legacy_json_experiment_requires_cameras
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena_environments.pick_and_place_maple_table_environment import PickAndPlaceMapleTableEnvironmentCfg
@@ -89,7 +87,7 @@ def test_eval_runner_loads_typed_experiment_after_simulation_starts(monkeypatch)
             "eval_runner.py",
             "--experiment_config",
             str(GETTING_STARTED_YAML_PATH),
-            "--list-variations",
+            "--list_variations",
         ],
     )
 
@@ -137,6 +135,21 @@ def test_legacy_json_experiment_rejects_hydra_overrides():
             device="cuda:0",
             overrides=["runs.baseline.rollout_limit.num_steps=2"],
         )
+
+
+def test_eval_runner_rejects_native_hydra_overrides_for_legacy_json(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "eval_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_JSON_PATH),
+            "runs.baseline.rollout_limit.num_steps=2",
+        ],
+    )
+
+    with pytest.raises(AssertionError, match="only for typed YAML"):
+        eval_runner.main()
 
 
 def test_unknown_experiment_config_file_type_is_rejected(tmp_path):

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -11,7 +11,10 @@ from types import SimpleNamespace
 import pytest
 
 from isaaclab_arena.evaluation import arena_experiment_config_loader, eval_runner
-from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    load_arena_experiment_from_config_file,
+    validate_experiment_config_path,
+)
 from isaaclab_arena.evaluation.eval_runner import (
     _assert_camera_support_enabled,
     legacy_json_experiment_requires_cameras,
@@ -141,4 +144,4 @@ def test_unknown_experiment_config_file_type_is_rejected(tmp_path):
     config_path.write_text("", encoding="utf-8")
 
     with pytest.raises(AssertionError, match="must use .json, .yaml, or .yml"):
-        load_arena_experiment_from_config_file(config_path, device="cuda:0")
+        validate_experiment_config_path(config_path)

--- a/isaaclab_arena/tests/test_eval_runner.py
+++ b/isaaclab_arena/tests/test_eval_runner.py
@@ -23,7 +23,12 @@ def write_jobs_config_to_file(jobs: list[dict], tmp_file_path: str):
         json.dump(jobs_config, f, indent=4)
 
 
-def run_eval_runner(jobs_config_path: str, headless: bool = HEADLESS):
+def run_eval_runner(
+    experiment_config_path: str,
+    headless: bool = HEADLESS,
+    config_option: str = "--eval_jobs_config",
+    extra_args: list[str] | None = None,
+):
     """Run the eval_runner as a subprocess with timeout.
 
     --continue_on_error is NOT passed, so the eval_runner re-raises on the
@@ -31,12 +36,15 @@ def run_eval_runner(jobs_config_path: str, headless: bool = HEADLESS):
     raises CalledProcessError, which surfaces as a test failure.
 
     Args:
-        jobs_config_path: Path to the jobs config JSON file.
+        experiment_config_path: Path to the Experiment configuration file.
         headless: Whether to run in headless mode.
+        config_option: CLI option used to pass the Experiment path.
+        extra_args: Additional eval_runner arguments.
     """
     args = [TestConstants.python_path, f"{TestConstants.evaluation_dir}/eval_runner.py"]
-    args.append("--eval_jobs_config")
-    args.append(jobs_config_path)
+    args.append(config_option)
+    args.append(experiment_config_path)
+    args.extend(extra_args or [])
     if headless:
         args.append("--headless")
     else:
@@ -44,6 +52,36 @@ def run_eval_runner(jobs_config_path: str, headless: bool = HEADLESS):
         args.append(DEFAULT_VISUALIZER)
 
     run_subprocess(args)
+
+
+@pytest.mark.with_subprocess
+def test_eval_runner_from_typed_yaml(tmp_path):
+    """Execute a typed YAML Experiment through the neutral eval_runner CLI."""
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text(
+        """
+runs:
+- name: yaml_baseline
+  environment:
+    type: pick_and_place_maple_table
+  policy:
+    type: zero_action
+  rollout_limit:
+    num_steps: 10
+""",
+        encoding="utf-8",
+    )
+
+    run_eval_runner(
+        str(experiment_config_path),
+        config_option="--experiment_config",
+        extra_args=[
+            "--experiment_override",
+            "runs.yaml_baseline.rollout_limit.num_steps=2",
+            "--output_base_dir",
+            str(tmp_path / "output"),
+        ],
+    )
 
 
 @pytest.mark.with_subprocess

--- a/isaaclab_arena/tests/test_eval_runner.py
+++ b/isaaclab_arena/tests/test_eval_runner.py
@@ -33,11 +33,19 @@ def test_eval_runner_parses_native_hydra_overrides():
     ]
 
 
-def test_eval_runner_rejects_unknown_non_hydra_arguments(capsys):
-    with pytest.raises(SystemExit):
-        parse_eval_runner_args(["--headles"])
+@pytest.mark.with_subprocess
+def test_eval_runner_rejects_unknown_non_hydra_arguments():
+    """Reject misspelled CLI flags in a fresh process."""
+    result = subprocess.run(
+        [TestConstants.python_path, f"{TestConstants.evaluation_dir}/eval_runner.py", "--headles"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
 
-    assert "Unrecognized arguments: --headles" in capsys.readouterr().err
+    assert result.returncode != 0
+    assert "Unrecognized arguments: --headles" in result.stderr
 
 
 def write_jobs_config_to_file(jobs: list[dict], tmp_file_path: str):

--- a/isaaclab_arena/tests/test_eval_runner.py
+++ b/isaaclab_arena/tests/test_eval_runner.py
@@ -5,15 +5,39 @@
 
 import json
 import os
+import subprocess
 
 import pytest
 
+from isaaclab_arena.evaluation.eval_runner_cli import parse_eval_runner_args
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function, run_subprocess
 
 HEADLESS = True
 NUM_STEPS = 2
 DEFAULT_VISUALIZER = "kit"
+
+
+def test_eval_runner_parses_native_hydra_overrides():
+    args_cli, experiment_overrides = parse_eval_runner_args([
+        "--experiment_config",
+        "experiment.yaml",
+        "runs.baseline.rollout_limit.num_steps=2",
+        "runs.baseline.environment.enable_cameras=true",
+    ])
+
+    assert args_cli.experiment_config == "experiment.yaml"
+    assert experiment_overrides == [
+        "runs.baseline.rollout_limit.num_steps=2",
+        "runs.baseline.environment.enable_cameras=true",
+    ]
+
+
+def test_eval_runner_rejects_unknown_non_hydra_arguments(capsys):
+    with pytest.raises(SystemExit):
+        parse_eval_runner_args(["--headles"])
+
+    assert "Unrecognized arguments: --headles" in capsys.readouterr().err
 
 
 def write_jobs_config_to_file(jobs: list[dict], tmp_file_path: str):
@@ -28,7 +52,8 @@ def run_eval_runner(
     headless: bool = HEADLESS,
     config_option: str = "--eval_jobs_config",
     extra_args: list[str] | None = None,
-):
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str] | None:
     """Run the eval_runner as a subprocess with timeout.
 
     --continue_on_error is NOT passed, so the eval_runner re-raises on the
@@ -40,6 +65,10 @@ def run_eval_runner(
         headless: Whether to run in headless mode.
         config_option: CLI option used to pass the Experiment path.
         extra_args: Additional eval_runner arguments.
+        capture_output: Whether to capture and return the subprocess output.
+
+    Returns:
+        The completed subprocess when output is captured, otherwise None.
     """
     args = [TestConstants.python_path, f"{TestConstants.evaluation_dir}/eval_runner.py"]
     args.append(config_option)
@@ -51,7 +80,7 @@ def run_eval_runner(
         args.append("--viz")
         args.append(DEFAULT_VISUALIZER)
 
-    run_subprocess(args)
+    return run_subprocess(args, capture_output=capture_output)
 
 
 @pytest.mark.with_subprocess
@@ -72,16 +101,20 @@ runs:
         encoding="utf-8",
     )
 
-    run_eval_runner(
+    result = run_eval_runner(
         str(experiment_config_path),
         config_option="--experiment_config",
         extra_args=[
-            "--experiment_override",
-            "runs.yaml_baseline.rollout_limit.num_steps=2",
             "--output_base_dir",
             str(tmp_path / "output"),
+            "runs.yaml_baseline.rollout_limit.num_steps=2",
         ],
+        capture_output=True,
     )
+    assert result is not None
+    run_row = next(line for line in result.stdout.splitlines() if "yaml_baseline" in line and "pending" in line)
+    run_cells = [cell.strip() for cell in run_row.split("|")[1:-1]]
+    assert run_cells[4] == "2"
 
 
 @pytest.mark.with_subprocess

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -42,10 +42,10 @@ def test_getting_started_experiment_composes_typed_runs():
     runs = _load_experiment(GETTING_STARTED_EXPERIMENT_PATH)
 
     assert [run.name for run in runs] == [
-        "01_baseline",
-        "02_swap_objects",
-        "03_change_background_hdr",
-        "04_parallel_envs",
+        "baseline",
+        "swap_objects",
+        "change_background_hdr",
+        "parallel_envs",
     ]
     assert runs[0].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
@@ -124,7 +124,7 @@ def _test_getting_started_experiment_executes_baseline_run(simulation_app, outpu
 
     result = build_and_run(baseline_run, output_dir=output_dir)
 
-    assert result.run_name == "01_baseline"
+    assert result.run_name == "baseline"
     assert result.status is RunStatus.COMPLETED
     return True
 
@@ -224,6 +224,23 @@ runs:
     )
 
     with pytest.raises(AssertionError, match="must define a non-empty string 'name'"):
+        _load_experiment(config_path)
+
+
+def test_run_name_must_be_hydra_compatible(tmp_path):
+    config_path = _write_experiment(
+        tmp_path,
+        """
+runs:
+  - name: 01_baseline
+    environment:
+      type: pick_and_place_maple_table
+    policy:
+      type: zero_action
+""",
+    )
+
+    with pytest.raises(AssertionError, match="must start with a letter or underscore"):
         _load_experiment(config_path)
 
 

--- a/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
@@ -5,7 +5,7 @@
 
 # Typed YAML equivalent of eval_jobs_configs/getting_started_jobs_config.json.
 runs:
-- name: 01_baseline
+- name: baseline
   environment:
     type: pick_and_place_maple_table
     embodiment: droid_rel_joint_pos
@@ -17,7 +17,7 @@ runs:
   rollout_limit:
     num_steps: 50
 
-- name: 02_swap_objects
+- name: swap_objects
   environment:
     type: pick_and_place_maple_table
     embodiment: droid_rel_joint_pos
@@ -29,7 +29,7 @@ runs:
   rollout_limit:
     num_steps: 50
 
-- name: 03_change_background_hdr
+- name: change_background_hdr
   environment:
     type: pick_and_place_maple_table
     embodiment: droid_rel_joint_pos
@@ -41,7 +41,7 @@ runs:
   rollout_limit:
     num_steps: 50
 
-- name: 04_parallel_envs
+- name: parallel_envs
   environment:
     type: pick_and_place_maple_table
     embodiment: droid_rel_joint_pos


### PR DESCRIPTION
## Summary
Connect typed YAML Experiments to eval_runner while preserving legacy JSON evaluation.

## Detailed description
- Build on #873 by accepting typed YAML arena experiments through the `--experiment_config` option and forwarding Hydra overrides.
- Compose typed Runs only after AppLauncher starts, avoiding pre-start runtime registry and pxr imports without changing registry boundaries.
- Preserve legacy JSON behavior and the `--eval_jobs_config` alias until legacy json files are ported.