### PR TITLE
Move graph-spec modules into environment_spec package

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -21,7 +21,7 @@ from isaaclab_arena.agentic_environment_generation.spec_validation import (
     try_parse_env_graph_spec,
 )
 from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.relations.relations import RelationBase
 
 # TODO(qianl): This is currently Nvidia internal. Switch to public endpoint.

--- a/isaaclab_arena/agentic_environment_generation/spec_io.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_io.py
@@ -12,7 +12,7 @@ import yaml
 from pathlib import Path
 from typing import Any
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 DEFAULT_AGENTIC_OUTPUT_DIR = Path("isaaclab_arena_environments/agent_generated")
 

--- a/isaaclab_arena/agentic_environment_generation/spec_validation.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_validation.py
@@ -13,7 +13,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from isaaclab_arena.assets.registries import TaskRegistry
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 
 def required_task_init_param_names(task_cls: type) -> list[str]:

--- a/isaaclab_arena/environment_spec/__init__.py
+++ b/isaaclab_arena/environment_spec/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.assets.object_reference import ObjectReference
 from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry
-from isaaclab_arena.environments.arena_env_graph_task_conversion_utils import build_task_from_spec
-from isaaclab_arena.environments.arena_env_graph_types import SpatialRelationSpec
+from isaaclab_arena.environment_spec.arena_env_graph_task_conversion_utils import build_task_from_spec
+from isaaclab_arena.environment_spec.arena_env_graph_types import SpatialRelationSpec
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 from isaaclab_arena.scene.scene import Scene
 from isaaclab_arena.utils.pose import Pose
@@ -21,7 +21,7 @@ _DEFAULT_LIGHT_ASSET_NAME = "light"
 _DEFAULT_LIGHT_NODE_ID = "auto_dome_light"
 
 if TYPE_CHECKING:
-    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 
 def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec, enable_cameras: bool = False) -> Any:

--- a/isaaclab_arena/environment_spec/arena_env_graph_spec.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_spec.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from isaaclab_arena.environments.arena_env_graph_types import (
+from isaaclab_arena.environment_spec.arena_env_graph_types import (
     AssetSpec,
     CliOverrideSpec,
     CompositeTaskSpec,
@@ -194,6 +194,6 @@ class ArenaEnvGraphSpec(BaseModel):
         Args:
             enable_cameras: Forwarded to the embodiment so its cameras are spawned.
         """
-        from isaaclab_arena.environments.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
+        from isaaclab_arena.environment_spec.arena_env_graph_conversion_utils import build_arena_env_from_graph_spec
 
         return build_arena_env_from_graph_spec(self, enable_cameras=enable_cameras)

--- a/isaaclab_arena/environment_spec/arena_env_graph_task_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_task_conversion_utils.py
@@ -14,7 +14,7 @@ from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.assets.registries import TaskRegistry
 
 if TYPE_CHECKING:
-    from isaaclab_arena.environments.arena_env_graph_types import CompositeTaskSpec, TaskSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_types import CompositeTaskSpec, TaskSpec
 
 
 # Annotation bases that mark a task __init__ kwarg as a graph-node reference.
@@ -26,7 +26,7 @@ NODE_REF_BASES: tuple[type, ...] = (Asset, AffordanceBase)
 
 def build_task_from_spec(task_spec: CompositeTaskSpec, assets_by_node_id: dict[str, Any]) -> Any:
     """Build the root graph task into a live env-level task instance."""
-    from isaaclab_arena.environments.arena_env_graph_types import TaskCompositionType
+    from isaaclab_arena.environment_spec.arena_env_graph_types import TaskCompositionType
 
     if task_spec.composition is TaskCompositionType.ATOMIC:
         return _build_atomic_task_from_spec(

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pydantic schema for :class:`~isaaclab_arena.environments.arena_env_graph_spec.ArenaEnvGraphSpec`."""
+"""Pydantic schema for :class:`~isaaclab_arena.environment_spec.arena_env_graph_spec.ArenaEnvGraphSpec`."""
 
 from __future__ import annotations
 

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -16,8 +16,8 @@ from pathlib import Path
 
 import pytest
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import (
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import (
     AssetSpec,
     CompositeTaskSpec,
     TaskCompositionType,

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for :class:`~isaaclab_arena.environments.arena_env_graph_spec.ArenaEnvGraphSpec`."""
+"""Unit tests for :class:`~isaaclab_arena.environment_spec.arena_env_graph_spec.ArenaEnvGraphSpec`."""
 
 from pathlib import Path
 
@@ -12,8 +12,8 @@ from pydantic import ValidationError
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry, TaskRegistry
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import CliOverrideSpec, TaskCompositionType
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import CliOverrideSpec, TaskCompositionType
 from isaaclab_arena.relations.relations import AtPosition, IsAnchor, On, PositionLimits
 
 TEST_DATA_DIR = Path(__file__).parent / "test_data"

--- a/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
@@ -13,7 +13,7 @@ import pytest
 
 from isaaclab_arena.affordances.affordance_base import AffordanceBase
 from isaaclab_arena.assets.asset import Asset
-from isaaclab_arena.environments import arena_env_graph_task_conversion_utils as conversion
+from isaaclab_arena.environment_spec import arena_env_graph_task_conversion_utils as conversion
 
 
 # An affordance is only ever mixed into an Asset; Placeable stands in for that contract.
@@ -170,7 +170,7 @@ def test_build_task_from_spec_atomic_returns_single_task(monkeypatch):
     registry = type("R", (), {"get_task_by_name": lambda self, _name: FakeTask})()
     monkeypatch.setattr(conversion, "TaskRegistry", lambda: registry)
 
-    from isaaclab_arena.environments.arena_env_graph_types import CompositeTaskSpec, TaskCompositionType, TaskSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_types import CompositeTaskSpec, TaskCompositionType, TaskSpec
 
     spec = CompositeTaskSpec(
         composition=TaskCompositionType.ATOMIC,
@@ -205,7 +205,7 @@ def test_build_task_from_spec_sequential_wraps_multiple_tasks(monkeypatch):
         FakeSequential,
     )
 
-    from isaaclab_arena.environments.arena_env_graph_types import CompositeTaskSpec, TaskCompositionType, TaskSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_types import CompositeTaskSpec, TaskCompositionType, TaskSpec
 
     spec = CompositeTaskSpec(
         composition=TaskCompositionType.SEQUENTIAL,
@@ -232,7 +232,7 @@ def test_build_atomic_task_from_spec_params_task_description_takes_precedence(mo
     registry = type("R", (), {"get_task_by_name": lambda self, _name: FakeTask})()
     monkeypatch.setattr(conversion, "TaskRegistry", lambda: registry)
 
-    from isaaclab_arena.environments.arena_env_graph_types import TaskSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_types import TaskSpec
 
     spec = TaskSpec(
         kind="PickAndPlaceTask",

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -16,8 +16,8 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
     RelationCatalogue,
     TaskCatalogue,
 )
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import TaskCompositionType
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import TaskCompositionType
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -12,8 +12,8 @@ from typing import TYPE_CHECKING
 from isaaclab_arena.assets.registries import EnvironmentRegistry
 from isaaclab_arena.cli.dataclass_cli import add_dataclass_cli_args, dataclass_from_cli
 from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import CliOverrideSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import CliOverrideSpec
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
 from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
 

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -43,7 +43,7 @@ from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppCont
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedEnv
 
-    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 DEFAULT_PROMPT = "Franka picks up a cube from the maple table and places it into a bowl on the table."
 
@@ -142,7 +142,7 @@ def print_schema() -> None:
     """Print the Pydantic ArenaEnvGraphSpec JSON schema."""
     import json
 
-    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+    from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
     print(json.dumps(ArenaEnvGraphSpec.model_json_schema(), indent=2))
 
@@ -195,8 +195,8 @@ def print_env_graph(spec: ArenaEnvGraphSpec) -> None:
 
 def build_env_from_env_graph_spec(env_graph_spec_path: Path, args_cli: argparse.Namespace) -> ManagerBasedEnv:
     """Build a gymnasium env from an environment graph spec YAML."""
+    from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
-    from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 
     loaded_env_graph_spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_path)
     arena_env = loaded_env_graph_spec.to_arena_env()

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/editor_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/editor_panel.py
@@ -14,7 +14,7 @@ import streamlit as st
 from streamlit_ace import st_ace
 
 from isaaclab_arena.agentic_environment_generation.spec_io import env_graph_spec_path, write_env_graph_spec
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 
 @dataclass

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -21,7 +21,7 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
     build_relation_catalogue,
     build_task_catalogue,
 )
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.editor_panel import (
     SpecParseResult,
     try_save_env_graph_spec,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/dashboard.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/dashboard.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import html as html_lib
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.render.mermaid_graph import render_mermaid_graph
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.render.panels import (
     render_node_cards,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/mermaid_graph.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/mermaid_graph.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 _MERMAID_ID_SAFE = re.compile(r"[^A-Za-z0-9_]")
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/panels.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/render/panels.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 import html as html_lib
 import yaml
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import AssetSpec, SpatialRelationSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import AssetSpec, SpatialRelationSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.render.thumbnails import render_asset_thumbnail
 
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/asset_usd.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/asset_usd.py
@@ -11,8 +11,8 @@ import hashlib
 import sys
 
 from isaaclab_arena.assets.registries import AssetRegistry
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.environments.arena_env_graph_types import AssetSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import AssetSpec
 from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
 
 AabbDimensionsM = tuple[float, float, float]

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
@@ -19,7 +19,7 @@ import yaml
 from pathlib import Path
 from typing import Any, TextIO
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 SIMAPP_SOCKET_ENV = "ARENA_REVIEW_SIMAPP_SOCKET"
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
@@ -18,7 +18,7 @@ import yaml
 from pathlib import Path
 from typing import Any, TextIO
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.boot import launch_simulation_app
 
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
@@ -16,8 +16,8 @@ from typing import Any
 
 from isaaclab.envs.common import ViewerCfg
 
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import (
     collect_garbage_and_clear_cuda_cache,
     teardown_simulation_app,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/thumbnail_capture.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/thumbnail_capture.py
@@ -14,7 +14,7 @@ import omni.usd
 from omni.kit.viewport.utility import frame_viewport_prims, get_active_viewport
 from pxr import Gf, Sdf, UsdGeom, UsdLux
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.asset_usd import (
     AabbDimensionsM,
     resolve_node_aabb_dimensions_m,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
@@ -12,7 +12,7 @@ import json
 
 import streamlit as st
 
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.render.dashboard import render_dashboard_html
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
     SimAppError,

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.spec_io import env_graph_spec_path, write_env_graph_spec
-from isaaclab_arena.environments.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.editor_panel import (
     SpecParseResult,
     try_save_env_graph_spec,


### PR DESCRIPTION
## Summary
Relocate arena_env_graph_* modules into a new environment_spec package.

## Detailed description
- The graph schema (`arena_env_graph_spec`, `arena_env_graph_types`) and its conversion utils are data-only layers that were living alongside runtime env code in `environments/`; this separates them into a dedicated `isaaclab_arena/environment_spec/` package.
- Behavior is unchanged — import paths only.
