### PR TITLE
Add G1 Factory environments

### DIFF
--- a/isaaclab_arena_environments/G1_Factory/LMBoxLift.py
+++ b/isaaclab_arena_environments/G1_Factory/LMBoxLift.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMBoxLift(ExampleEnvironmentBase):
+
+    name: str = "LMBoxLift"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .g1_locomanip_lift_task import G1LocomanipLiftTask
+        from .pose_utils import pose_range_from_quat
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+
+        TABLE_X = 2.0
+        TABLE_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        if args_cli.table and args_cli.table.lower() != "none":
+            table = self.asset_registry.get_asset_by_name(args_cli.table)()
+            table.set_initial_pose(
+                pose_range_from_quat(
+                    position_xyz_min=(TABLE_X - 0.16, TABLE_Y - 0.16, -0.8),
+                    position_xyz_max=(TABLE_X + 0.16, TABLE_Y + 0.16, -0.8),
+                    rotation_xyzw=(0.0, 0.0, -1, 0.0),
+                    yaw_jitter=0.16,
+                )
+            )
+            assets.append(table)
+
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        set_relative_initial_pose(
+            obj=object,
+            reference=table,
+            offset_range={"x": (-0.33, -0.17), "y": (-0.16, 0.16), "z": (0.80145, 0.80145)},
+            rotation_xyzw=(0.0, 0.0, 0.70711, 0.70711),
+            yaw_jitter=0.16,
+        )
+        assets.append(object)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipLiftTask(object, lift_height=args_cli.lift_height, gripper_far_threshold=0.2),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_cardbox", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument(
+            "--table", type=str, default="locomanip_white_table", help="Table asset (use 'none' or '' to disable)"
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=0.18, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMBoxLiftFloor.py
+++ b/isaaclab_arena_environments/G1_Factory/LMBoxLiftFloor.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMBoxLiftFloor(ExampleEnvironmentBase):
+
+    name: str = "LMBoxLiftFloor"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .g1_locomanip_lift_task import G1LocomanipLiftTask
+        from .pose_utils import pose_range_from_quat
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+
+        BOX_X = 2
+        BOX_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        assets.append(object)
+
+        # Optional table (use --table none or --table "" to disable)
+        if args_cli.table and args_cli.table.lower() != "none":
+            table = self.asset_registry.get_asset_by_name(args_cli.table)()
+            assets.append(table)
+
+        object.scale = (1.0, 1.0, 1.0)
+        object.object_cfg = object._init_object_cfg()
+        object.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(BOX_X - 0.16, BOX_Y - 0.16, -0.8),
+                position_xyz_max=(BOX_X + 0.16, BOX_Y + 0.16, -0.8),
+                rotation_xyzw=(0.0, 0.0, 0.0, 1.0),
+                yaw_jitter=0.16,
+            )
+        )
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipLiftTask(
+                object,
+                lift_height=args_cli.lift_height,
+                upright_threshold=0.9,
+                upright_z_axis_up=True,
+                gripper_far_threshold=0.6,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_longbox", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument("--table", type=str, default="none", help="Table asset (use 'none' or '' to disable)")
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=-0.5, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMBoxTableToShelfPnP.py
+++ b/isaaclab_arena_environments/G1_Factory/LMBoxTableToShelfPnP.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMBoxTableToShelfPnP(ExampleEnvironmentBase):
+
+    name: str = "LMBoxTableToShelfPnP"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .g1_locomanip_pnp_task import G1LocomanipPnPTask
+        from .pose_utils import pose_range_from_quat
+
+        assets = []
+
+        TABLE_X = 1.4
+        TABLE_Y = 0
+        SHELF_X = 0.3
+        SHELF_Y = -1.1
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        table = self.asset_registry.get_asset_by_name("locomanip_white_table")()
+        table.name = "office_table"
+        table.prim_path = "{ENV_REGEX_NS}/office_table"
+        table.scale = (0.8, 1.0, 0.95)
+        table.object_cfg = table._init_object_cfg()
+        table.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TABLE_X - 0.1, TABLE_Y - 0.1, -0.8),
+                position_xyz_max=(TABLE_X + 0.1, TABLE_Y + 0.1, -0.8),
+                rotation_xyzw=(0, 0, -1, 0),
+                yaw_jitter=0.02,
+            )
+        )
+        assets.append(table)
+
+        object = self.asset_registry.get_asset_by_name("locomanip_cardbox")()
+        set_relative_initial_pose(
+            obj=object,
+            reference=table,
+            offset_range={"x": (-0.341, 0.159), "y": (-0.278, 0.322), "z": (0.762, 0.762)},
+            rotation_xyzw=(0, 0, 0, 1),
+            yaw_jitter=0.36,
+        )
+        assets.append(object)
+
+        industrial_shelf = self.asset_registry.get_asset_by_name("locomanip_industrial_shelf")()
+        industrial_shelf.name = "industrial_shelf"
+        industrial_shelf.prim_path = "{ENV_REGEX_NS}/industrial_shelf"
+        industrial_shelf.scale = (1.0, 1.0, 0.9)
+        industrial_shelf.object_cfg = industrial_shelf._init_object_cfg()
+        industrial_shelf.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(SHELF_X - 0.18, SHELF_Y - 0.18, -0.8),
+                position_xyz_max=(SHELF_X + 0.18, SHELF_Y + 0.18, -0.8),
+                rotation_xyzw=(0, 0, 0.70711, 0.70711),
+                yaw_jitter=0.36,
+            )
+        )
+        assets.append(industrial_shelf)
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipPnPTask(
+                object,
+                industrial_shelf,
+                max_x_separation=0.16,
+                max_y_separation=0.14,
+                max_z_separation=0.9227,
+                require_static=True,
+                gripper_far_threshold=0.1,
+                require_contact=True,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="brown_box", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")

--- a/isaaclab_arena_environments/G1_Factory/LMDrillLift.py
+++ b/isaaclab_arena_environments/G1_Factory/LMDrillLift.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMDrillLift(ExampleEnvironmentBase):
+
+    name: str = "LMDrillLift"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .g1_locomanip_lift_task import G1LocomanipLiftTask
+        from .pose_utils import pose_range_from_quat
+
+        assets = []
+
+        TABLE_X = 2
+        TABLE_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        if args_cli.table and args_cli.table.lower() != "none":
+            table = self.asset_registry.get_asset_by_name(args_cli.table)()
+            table.set_initial_pose(
+                pose_range_from_quat(
+                    position_xyz_min=(TABLE_X - 0.16, TABLE_Y - 0.16, -0.8),
+                    position_xyz_max=(TABLE_X + 0.16, TABLE_Y + 0.16, -0.8),
+                    rotation_xyzw=(0.0, 0, 1, 0),
+                    yaw_jitter=0.16,
+                )
+            )
+            assets.append(table)
+
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        set_relative_initial_pose(
+            obj=object,
+            reference=table,
+            offset_range={"x": (-0.42, -0.10), "y": (-0.40, 0.40), "z": (0.80145, 0.80145)},
+            rotation_xyzw=(0.0, 0.0, -0.70711, 0.70711),
+            yaw_jitter=0.4,
+        )
+        assets.append(object)
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipLiftTask(
+                object,
+                lift_height=args_cli.lift_height,
+                require_grasped=True,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_power_drill", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument(
+            "--table", type=str, default="locomanip_white_table", help="Table asset (use 'none' or '' to disable)"
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=0.16, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMDrillLiftObs.py
+++ b/isaaclab_arena_environments/G1_Factory/LMDrillLiftObs.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMDrillLiftObs(ExampleEnvironmentBase):
+
+    name: str = "LMDrillLiftObs"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .g1_locomanip_lift_task import G1LocomanipLiftTask
+        from .pose_utils import pose_range_from_quat
+
+        assets = []
+
+        TABLE_X = 2.3
+        TABLE_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        industrial_shelf = self.asset_registry.get_asset_by_name("locomanip_industrial_shelf")()
+        industrial_shelf.name = "industrial_shelf"
+        industrial_shelf.prim_path = "{ENV_REGEX_NS}/industrial_shelf"
+        industrial_shelf.scale = (1.0, 1.0, 0.9)
+        industrial_shelf.object_cfg = industrial_shelf._init_object_cfg()
+        industrial_shelf.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TABLE_X * 0.35 - 0.12, TABLE_Y - 0.6, -0.8),
+                position_xyz_max=(TABLE_X * 0.35 + 0.12, TABLE_Y + 0.6, -0.8),
+                rotation_xyzw=(0, 0, 0, 1),
+                yaw_jitter=0.12,
+            )
+        )
+        assets.append(industrial_shelf)
+
+        if args_cli.table and args_cli.table.lower() != "none":
+            table = self.asset_registry.get_asset_by_name(args_cli.table)()
+            table.set_initial_pose(
+                pose_range_from_quat(
+                    position_xyz_min=(TABLE_X - 0.12, TABLE_Y - 0.12, -0.8),
+                    position_xyz_max=(TABLE_X + 0.12, TABLE_Y + 0.12, -0.8),
+                    rotation_xyzw=(0.0, 0, 1, 0),
+                    yaw_jitter=0.12,
+                )
+            )
+            assets.append(table)
+
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        set_relative_initial_pose(
+            obj=object,
+            reference=table,
+            offset_range={"x": (-0.38, -0.14), "y": (0.28, 0.67), "z": (0.80145, 0.80145)},
+            rotation_xyzw=(0.0, 0.0, -0.70711, 0.70711),
+            yaw_jitter=0.3,
+        )
+        assets.append(object)
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipLiftTask(
+                object,
+                lift_height=args_cli.lift_height,
+                require_grasped=True,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_power_drill", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument(
+            "--table", type=str, default="locomanip_white_table", help="Table asset (use 'none' or '' to disable)"
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=0.16, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMDrillPnP.py
+++ b/isaaclab_arena_environments/G1_Factory/LMDrillPnP.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMDrillPnP(ExampleEnvironmentBase):
+
+    name: str = "LMDrillPnP"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .g1_locomanip_pnp_task import G1LocomanipPnPTask
+        from .pose_utils import pose_range_from_quat
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+
+        TABLE_X = 1.2
+        TABLE_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        table_right = self.asset_registry.get_asset_by_name(args_cli.table_right)()
+        table_right.name = "table_right"
+        table_right.prim_path = "{ENV_REGEX_NS}/table_right"
+        table_right.scale = (0.8, 1.0, 1.0)
+        table_right.object_cfg = table_right._init_object_cfg()
+        table_right.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TABLE_X - 0.12, TABLE_Y - 0.12, -0.8),
+                position_xyz_max=(TABLE_X + 0.12, TABLE_Y + 0.12, -0.8),
+                rotation_xyzw=(0.0, 0.0, 1.0, 0.0),
+                yaw_jitter=0.12,
+            )
+        )
+        assets.append(table_right)
+
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        set_relative_initial_pose(
+            obj=object,
+            reference=table_right,
+            offset_range={"x": (-0.32, -0.14), "y": (-0.30, 0.30), "z": (0.8, 0.8)},
+            rotation_xyzw=(0.0, 0.0, -0.70711, 0.70711),
+            yaw_jitter=0.3,
+        )
+        assets.append(object)
+
+        table_left = self.asset_registry.get_asset_by_name(args_cli.table_left)()
+        table_left.name = "table_left"
+        table_left.prim_path = "{ENV_REGEX_NS}/table_left"
+        table_left.scale = (0.8, 1.0, 1.0)
+        table_left.object_cfg = table_left._init_object_cfg()
+        table_left.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TABLE_Y - 0.12, TABLE_X - 0.12, -0.8),
+                position_xyz_max=(TABLE_Y + 0.12, TABLE_X + 0.12, -0.8),
+                rotation_xyzw=(0, 0, -0.70711, 0.70711),
+                yaw_jitter=0.12,
+            )
+        )
+        assets.append(table_left)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipPnPTask(
+                object,
+                table_left,
+                max_x_separation=0.3,
+                max_y_separation=0.27,
+                max_z_separation=0.81,
+                gripper_far_threshold=0.1,
+                upright_threshold=0.8,
+                upright_z_axis_up=True,
+                require_static=True,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_power_drill", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument("--table_right", type=str, default="locomanip_white_table", help="Table asset")
+        parser.add_argument("--table_left", type=str, default="locomanip_white_table", help="Table asset")
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=0.15, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMPickDrillFromHolder.py
+++ b/isaaclab_arena_environments/G1_Factory/LMPickDrillFromHolder.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMPickDrillFromHolder(ExampleEnvironmentBase):
+
+    name: str = "LMPickDrillFromHolder"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab.managers import EventTermCfg, SceneEntityCfg
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_object_pose_random_choice, set_relative_initial_pose
+        from .g1_locomanip_lift_task import G1LocomanipLiftTask
+        from .pose_utils import pose_range_from_quat
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+        INDUSTRIAL_SHELF_X = 2
+        INDUSTRIAL_SHELF_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        industrial_shelf = self.asset_registry.get_asset_by_name("locomanip_industrial_shelf")()
+        industrial_shelf.scale = (1.0, 1.0, 0.8)
+        industrial_shelf.object_cfg = industrial_shelf._init_object_cfg()
+        industrial_shelf.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(INDUSTRIAL_SHELF_X - 0.12, INDUSTRIAL_SHELF_Y - 0.12, -0.79),
+                position_xyz_max=(INDUSTRIAL_SHELF_X + 0.12, INDUSTRIAL_SHELF_Y + 0.12, -0.79),
+                rotation_xyzw=(0.0, 0.0, 0.70711, 0.70711),
+                yaw_jitter=0.12,
+            )
+        )
+        assets.append(industrial_shelf)
+
+        industrial_shelf_holder = self.asset_registry.get_asset_by_name("locomanip_powerdrill_holder")()
+        set_relative_initial_pose(
+            obj=industrial_shelf_holder,
+            reference=industrial_shelf,
+            offset_range={"x": (-0.769, -0.769), "y": (-0.12, 0.12), "z": (0.75, 0.75)},
+            rotation_xyzw=(0.0, 0.0, 0.70711, 0.70711),
+            yaw_jitter=0.0,
+        )
+        assets.append(industrial_shelf_holder)
+
+        # Drill: picks randomly from 4 holder slots, positioned relative to the shelf
+        # Pose positions are offsets from the shelf's current position
+        drill_rotation = (0.0, 0.0, -0.70711, 0.70711)
+        drill_slot_poses = [
+            Pose(position_xyz=(-0.07, 0.165, -0.16), rotation_xyzw=drill_rotation),
+            Pose(position_xyz=(-0.07, 0.055, -0.16), rotation_xyzw=drill_rotation),
+            Pose(position_xyz=(-0.07, -0.055, -0.16), rotation_xyzw=drill_rotation),
+            Pose(position_xyz=(-0.07, -0.165, -0.16), rotation_xyzw=drill_rotation),
+        ]
+        object = self.asset_registry.get_asset_by_name(args_cli.object)()
+        object.set_initial_pose(drill_slot_poses[0])
+        object.event_cfg = EventTermCfg(
+            func=set_object_pose_random_choice,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(object.name),
+                "reference_cfg": SceneEntityCfg(industrial_shelf_holder.name),
+                "pose_choices": drill_slot_poses,
+            },
+        )
+        assets.append(object)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipLiftTask(
+                object,
+                lift_height=args_cli.lift_height,
+                require_grasped=True,
+                not_in_contact_with=industrial_shelf_holder,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="locomanip_power_drill_holder_task", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument(
+            "--table", type=str, default="locomanip_white_table", help="Table asset (use 'none' or '' to disable)"
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument(
+            "--lift_height", type=float, default=0.13, help="Height to lift object for success (meters)"
+        )

--- a/isaaclab_arena_environments/G1_Factory/LMPushButton.py
+++ b/isaaclab_arena_environments/G1_Factory/LMPushButton.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMPushButton(ExampleEnvironmentBase):
+
+    name: str = "LMPushButton"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .events import set_relative_initial_pose
+        from .pose_utils import pose_range_from_quat
+        from .press_button_task import G1FactoryPressButtonTask
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+        CONTROL_BOX_X = 2
+        CONTROL_BOX_Y = 1
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        assets.append(background)
+
+        control_box = self.asset_registry.get_asset_by_name("control_box")()
+        control_box.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(CONTROL_BOX_X - 1, CONTROL_BOX_Y - 1.2, -0.79),
+                position_xyz_max=(CONTROL_BOX_X - 0.2, CONTROL_BOX_Y - 0.2, -0.79),
+                rotation_xyzw=(0.0, 0.0, 0.70711, 0.70711),
+                yaw_jitter=0.0,
+            )
+        )
+        assets.append(control_box)
+
+        button = self.asset_registry.get_asset_by_name("button")()
+        set_relative_initial_pose(
+            obj=button,
+            reference=control_box,
+            offset_range={"x": (-0.3, -0.3), "y": (-0.48, -0.38), "z": (0.8, 0.8)},
+            rotation_xyzw=(0.0, -0.70711, 0.0, 0.70711),
+            yaw_jitter=0.0,
+        )
+        assets.append(button)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1FactoryPressButtonTask(
+                button,
+                reset_pressedness=0.8,
+                gripper_far_threshold=0.2,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--background", type=str, default="factory_room", help="Background scene")
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")

--- a/isaaclab_arena_environments/G1_Factory/LMPushShelfForward.py
+++ b/isaaclab_arena_environments/G1_Factory/LMPushShelfForward.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+from isaaclab_arena_environments.example_environment_base import ExampleEnvironmentBase
+
+
+class LMPushShelfForward(ExampleEnvironmentBase):
+
+    name: str = "LMPushShelfForward"
+
+    def get_env(self, args_cli: argparse.Namespace):
+        import math
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.utils.pose import Pose
+
+        from .g1_locomanip_pnp_task import G1LocomanipPnPTask
+        from .pose_utils import pose_range_from_quat
+
+        embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, -0.015), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        assets = []
+        TARGET_X = 1.5
+        TARGET_Y = 0.0
+
+        background = self.asset_registry.get_asset_by_name(args_cli.background)()
+        background.set_initial_pose(Pose(position_xyz=(7.0, 7.2, -0.785), rotation_xyzw=(0.0, 0.0, 0.70711, 0.70711)))
+        assets.append(background)
+
+        object = self.asset_registry.get_asset_by_name("locomanip_mobile_cart")()
+        object.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TARGET_X - 0.3, TARGET_Y - 0.3, -0.8),
+                position_xyz_max=(TARGET_X + 0.3, TARGET_Y + 0.3, -0.8),
+                rotation_xyzw=(0.0, 0.0, -0.70711, 0.70711),
+                yaw_jitter=0.06,
+            )
+        )
+        assets.append(object)
+
+        target_zone = self.asset_registry.get_asset_by_name("locomanip_target_zone")()
+        target_zone.set_initial_pose(
+            pose_range_from_quat(
+                position_xyz_min=(TARGET_X * 2.87 - 0.1, TARGET_Y - 0.1, -0.8),
+                position_xyz_max=(TARGET_X * 2.87 + 0.1, TARGET_Y + 0.1, -0.8),
+                rotation_xyzw=(0, 0, 0, 1),
+                yaw_jitter=0.02,
+            )
+        )
+        assets.append(target_zone)
+
+        if args_cli.teleop_device is not None:
+            teleop_device = self.device_registry.get_device_by_name(args_cli.teleop_device)()
+        else:
+            teleop_device = None
+
+        scene = Scene(assets=assets)
+
+        isaaclab_arena_environment = IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=G1LocomanipPnPTask(
+                object,
+                target_zone,
+                drop_height=None,
+                max_x_separation=0.3,
+                max_y_separation=0.3,
+                max_z_separation=0.01,
+                upright_threshold=0.9,
+                upright_z_axis_up=True,
+                gripper_near_threshold=1.1,
+                require_static=True,
+            ),
+            teleop_device=teleop_device,
+        )
+
+        isaaclab_arena_environment.task.robot_pose_range = {
+            "x": (-0.05, 0.05),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-math.pi / 18, math.pi / 18),
+        }
+
+        return isaaclab_arena_environment
+
+    @staticmethod
+    def add_cli_args(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--object", type=str, default="brown_box", help="Object to lift")
+        parser.add_argument(
+            "--background",
+            type=str,
+            default="factory_room",
+            help="Background scene (factory_room, ground_plane, kitchen, etc.)",
+        )
+        parser.add_argument(
+            "--table", type=str, default="white_table", help="Table asset (use 'none' or '' to disable)"
+        )
+        parser.add_argument("--teleop_device", type=str, default=None)
+        parser.add_argument("--embodiment", type=str, default="g1_wbc_pink")
+        parser.add_argument("--lift_height", type=float, default=0.2, help="Height to lift object for success (meters)")

--- a/isaaclab_arena_environments/G1_Factory/README.md
+++ b/isaaclab_arena_environments/G1_Factory/README.md
@@ -1,0 +1,79 @@
+# G1 Factory environments
+
+This package contains the G1 Factory task port. The task and robot-specific code is intentionally colocated under
+`isaaclab_arena_environments/G1_Factory/` so the port builds on top of Arena main without modifying shared Arena task or
+policy code.
+
+## What is included
+
+- G1 Factory task definitions for box lift, drill lift, drill pick-and-place, drill-from-holder, push-button, and
+  push-shelf-forward tasks.
+- Per-task GR00T closed-loop policy translation configs in `policy_configs/benchmark/`.
+- A run path for Arena main's current `Gr00tRemoteClosedloopPolicy`, which talks to a GR00T policy server.
+
+The zero-action policy is useful only as an environment/action-space smoke test. It does not represent a valid G1
+Factory controller, and the robot can twitch or settle poorly because the zero vector is not a meaningful PINK/WBC
+command.
+
+## GR00T checkpoint mapping
+
+Arena main's GR00T remote policy config handles observation/action translation. The model checkpoint is loaded by the
+GR00T server process, so checkpoint paths are documented here instead of added as unsupported policy YAML fields.
+
+| Environment | Policy config | Legacy checkpoint |
+| --- | --- | --- |
+| `LMBoxLift` | `policy_configs/benchmark/LMBoxLift_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftD1_100_gn1_5_output/checkpoint-20000` |
+| `LMBoxLiftFloor` | `policy_configs/benchmark/LMBoxLiftFloor_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftFloorD1_100_gn1_5_output/checkpoint-20000` |
+| `LMBoxTableToShelfPnP` | `policy_configs/benchmark/LMBoxTableToShelfPnP_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxTableToShelfPnPD1_100_gn1_5_output/checkpoint-20000` |
+| `LMDrillLift` | `policy_configs/benchmark/LMDrillLift_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000` |
+| `LMDrillLiftObs` | `policy_configs/benchmark/LMDrillLiftObs_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/g1_benchmark_LMDrillLiftObs-0629_processed100_gn1_5_output_6_29/checkpoint-20000` |
+| `LMDrillPnP` | `policy_configs/benchmark/LMDrillPnP_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillPnPD1_100_gn1_5_output/checkpoint-20000` |
+| `LMPickDrillFromHolder` | `policy_configs/benchmark/LMPickDrillFromHolder_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/g1_benchmark_LMPickDrillFromHolder-0610_processed100_gn1_5_output_6_10/checkpoint-20000` |
+| `LMPushButton` | `policy_configs/benchmark/LMPushButton_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMPushButtonD1_100_gn1_5_output/checkpoint-20000` |
+| `LMPushShelfForward` | `policy_configs/benchmark/LMPushShelfForward_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMPushShelfForwardD1_100_gn1_5_output/checkpoint-20000` |
+
+## Run a real GR00T policy
+
+Start the GR00T policy server from an environment that has GR00T installed and can access the checkpoint. Replace
+`<checkpoint>` with the task checkpoint from the table above.
+
+```bash
+python gr00t/eval/run_gr00t_server.py \
+  --model_path <checkpoint> \
+  --embodiment_tag NEW_EMBODIMENT \
+  --host 0.0.0.0 \
+  --port 5555
+```
+
+Then run the Arena client from this repository. This example uses `LMDrillLift`.
+
+```bash
+PYTHONPATH=/workspaces/isaaclab_arena:${PYTHONPATH:-} \
+submodules/IsaacLab/isaaclab.sh -p \
+  isaaclab_arena/evaluation/policy_runner.py \
+  --policy_type isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy \
+  --policy_config_yaml_path isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLift_gr00t_closedloop.yaml \
+  --remote_host 127.0.0.1 \
+  --remote_port 5555 \
+  --num_steps 800 \
+  --viz kit \
+  --enable_cameras \
+  --external_environment_class_path isaaclab_arena_environments.G1_Factory.LMDrillLift:LMDrillLift \
+  LMDrillLift
+```
+
+For a headless environment smoke test without the learned policy, run:
+
+```bash
+PYTHONPATH=/workspaces/isaaclab_arena:${PYTHONPATH:-} \
+submodules/IsaacLab/isaaclab.sh -p \
+  isaaclab_arena/evaluation/policy_runner.py \
+  --policy_type zero_action \
+  --num_steps 20 \
+  --viz none \
+  --external_environment_class_path isaaclab_arena_environments.G1_Factory.LMDrillLift:LMDrillLift \
+  LMDrillLift
+```
+
+Real-policy validation requires an external GR00T server and checkpoint access, so the repository tests validate the
+Arena-side config schema but do not start the server.

--- a/isaaclab_arena_environments/G1_Factory/README.md
+++ b/isaaclab_arena_environments/G1_Factory/README.md
@@ -34,21 +34,41 @@ GR00T server process, so checkpoint paths are documented here instead of added a
 
 ## Run a real GR00T policy
 
-Start the GR00T policy server from an environment that has GR00T installed and can access the checkpoint. Replace
-`<checkpoint>` with the task checkpoint from the table above.
+The policy config passed to Arena is not the model checkpoint. It only configures Arena-side observation/action
+translation for `Gr00tRemoteClosedloopPolicy`. To use a G1 Factory checkpoint, start the GR00T server with that
+checkpoint, then run the Arena client against that server.
+
+Populate the pinned GR00T submodule first:
 
 ```bash
-python gr00t/eval/run_gr00t_server.py \
-  --model_path <checkpoint> \
-  --embodiment_tag NEW_EMBODIMENT \
-  --host 0.0.0.0 \
+git submodule update --init submodules/Isaac-GR00T
+```
+
+If SSH access to GitHub submodules is not configured in your environment, use an HTTPS rewrite for the submodule
+checkout:
+
+```bash
+git -c url.https://github.com/.insteadOf=git@github.com: submodule update --init submodules/Isaac-GR00T
+```
+
+In terminal 1, start the GR00T policy server from an environment that can access the checkpoint. This `LMDrillLift`
+example uses the legacy G1 Factory checkpoint from the table above.
+
+```bash
+cd submodules/Isaac-GR00T
+uv run python gr00t/eval/run_gr00t_server.py \
+  --model-path /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000 \
+  --embodiment-tag NEW_EMBODIMENT \
+  --device cuda \
+  --host 127.0.0.1 \
   --port 5555
 ```
 
-Then run the Arena client from this repository. This example uses `LMDrillLift`.
+In terminal 2, run the Arena client from the Arena repository root. Include `submodules/Isaac-GR00T` on `PYTHONPATH`;
+the client imports GR00T's `PolicyClient` even though inference runs in the server process.
 
 ```bash
-PYTHONPATH=/workspaces/isaaclab_arena:${PYTHONPATH:-} \
+PYTHONPATH="$(pwd):$(pwd)/submodules/Isaac-GR00T:${PYTHONPATH:-}" \
 submodules/IsaacLab/isaaclab.sh -p \
   isaaclab_arena/evaluation/policy_runner.py \
   --policy_type isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy \

--- a/isaaclab_arena_environments/G1_Factory/README.md
+++ b/isaaclab_arena_environments/G1_Factory/README.md
@@ -20,7 +20,7 @@ command.
 Arena main's GR00T remote policy config handles observation/action translation. The model checkpoint is loaded by the
 GR00T server process, so checkpoint paths are documented here instead of added as unsupported policy YAML fields.
 
-| Environment | Policy config | Legacy checkpoint |
+| Environment | Policy config | Legacy checkpoint reference |
 | --- | --- | --- |
 | `LMBoxLift` | `policy_configs/benchmark/LMBoxLift_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftD1_100_gn1_5_output/checkpoint-20000` |
 | `LMBoxLiftFloor` | `policy_configs/benchmark/LMBoxLiftFloor_gr00t_closedloop.yaml` | `/mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftFloorD1_100_gn1_5_output/checkpoint-20000` |
@@ -51,13 +51,20 @@ checkout:
 git -c url.https://github.com/.insteadOf=git@github.com: submodule update --init submodules/Isaac-GR00T
 ```
 
+The checkpoint references above are the paths used by the legacy G1 Factory repo on its original training/evaluation
+machine. Cloning `arena_data` provides task assets, not these model checkpoints. Before starting the server, make sure
+the checkpoint has been downloaded or mounted on the machine/container running GR00T.
+
 In terminal 1, start the GR00T policy server from an environment that can access the checkpoint. This `LMDrillLift`
-example uses the legacy G1 Factory checkpoint from the table above.
+example uses the legacy G1 Factory checkpoint from the table above after you map it to a local path.
 
 ```bash
 cd submodules/Isaac-GR00T
+export G1_FACTORY_CHECKPOINT=/path/to/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000
+test -d "${G1_FACTORY_CHECKPOINT}"
+
 uv run python gr00t/eval/run_gr00t_server.py \
-  --model-path /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000 \
+  --model-path "${G1_FACTORY_CHECKPOINT}" \
   --embodiment-tag NEW_EMBODIMENT \
   --device cuda \
   --host 127.0.0.1 \

--- a/isaaclab_arena_environments/G1_Factory/__init__.py
+++ b/isaaclab_arena_environments/G1_Factory/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""G1 Factory environments and local compatibility registrations.
+
+This package intentionally keeps Factory-specific assets, tasks, reset events,
+and termination predicates out of Arena core while still reusing Arena main's
+environment builder, registries, embodiment, and runner stack.
+"""
+
+# Importing this package registers the local Factory assets with Arena's
+# AssetRegistry before any Factory environment attempts to resolve them.
+from . import assets as _assets  # noqa: F401

--- a/isaaclab_arena_environments/G1_Factory/assets.py
+++ b/isaaclab_arena_environments/G1_Factory/assets.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any
+
+import isaaclab.sim as sim_utils
+
+from isaaclab_arena.affordances.pressable import Pressable
+from isaaclab_arena.assets.background import Background
+from isaaclab_arena.assets.object import Object
+from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.utils.pose import Pose
+
+
+class FactoryObject(Object):
+    """Base class for G1 Factory-local USD objects."""
+
+    name: str
+    tags: list[str]
+    usd_path: str | None = None
+    object_type: ObjectType = ObjectType.RIGID
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+    spawn_cfg_addon: dict[str, Any] = {}
+    asset_cfg_addon: dict[str, Any] = {}
+
+    def __init__(
+        self,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | None = None,
+        scale: tuple[float, float, float] | None = None,
+        **kwargs,
+    ):
+        name = instance_name if instance_name is not None else self.name
+        scale = scale if scale is not None else self.scale
+        super().__init__(
+            name=name,
+            prim_path=prim_path,
+            tags=self.tags,
+            usd_path=self.usd_path,
+            object_type=self.object_type,
+            scale=scale,
+            initial_pose=initial_pose,
+            spawn_cfg_addon=self.spawn_cfg_addon,
+            asset_cfg_addon=self.asset_cfg_addon,
+            **kwargs,
+        )
+
+
+class FactoryBackgroundBase(Background):
+    """Base class for G1 Factory-local backgrounds."""
+
+    name: str
+    tags: list[str]
+    usd_path: str
+    initial_pose: Pose | None = None
+    object_min_z: float
+    scale: tuple[float, float, float] = (1.0, 1.0, 1.0)
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            name=self.name,
+            tags=self.tags,
+            usd_path=self.usd_path,
+            initial_pose=self.initial_pose,
+            object_min_z=self.object_min_z,
+            scale=self.scale,
+            **kwargs,
+        )
+
+
+@register_asset
+class FactoryBackground(FactoryBackgroundBase):
+    name = "factory_room"
+    tags = ["background"]
+    usd_path = "/datasets/assets/room/room.usd"
+    initial_pose = Pose(position_xyz=(7, 0, -0.785))
+    object_min_z = -0.2
+    scale = (300.0, 300.0, 100.0)
+
+
+@register_asset
+class LocomanipWhiteTable(FactoryObject):
+    name = "locomanip_white_table"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_factory_ergo_table_01/factory_ergo_table_01.usd"
+    default_prim_path = "{ENV_REGEX_NS}/table"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipPowerDrill(FactoryObject):
+    name = "locomanip_power_drill"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_sm_powerdrill_b01/sm_powerdrill_b01.usd"
+    default_prim_path = "{ENV_REGEX_NS}/power_drill"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipPowerDrillHolderTask(FactoryObject):
+    name = "locomanip_power_drill_holder_task"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_sm_powerdrill_b01_holdertask/sm_powerdrill_b01.usd"
+    default_prim_path = "{ENV_REGEX_NS}/power_drill"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipIndustrialShelf(FactoryObject):
+    name = "locomanip_industrial_shelf"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_openindustrialsteelshelving_a12/openindustrialsteelshelving_a12.usd"
+    default_prim_path = "{ENV_REGEX_NS}/industrial_shelf"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipCardbox(FactoryObject):
+    name = "locomanip_cardbox"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_cardbox_a1_01/cardbox_a1_01.usd"
+    default_prim_path = "{ENV_REGEX_NS}/locomanip_cardbox"
+    scale = (0.8, 0.8, 0.8)
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipLongbox(FactoryObject):
+    name = "locomanip_longbox"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_longbox_a08/longbox_a08.usd"
+    default_prim_path = "{ENV_REGEX_NS}/locomanip_longbox"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipPowerdrillHolder(FactoryObject):
+    name = "locomanip_powerdrill_holder"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_powerdrill_holder/powerdrill_holder.usd"
+    default_prim_path = "{ENV_REGEX_NS}/locomanip_powerdrill_holder"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipMobileCart(FactoryObject):
+    name = "locomanip_mobile_cart"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_sm_mobileshelvingcart_a01/sm_mobileshelvingcart_a01.usd"
+    default_prim_path = "{ENV_REGEX_NS}/locomanip_mobile_cart"
+    object_type: ObjectType = ObjectType.ARTICULATION
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(1.0, 0, 0, 0.0))
+    spawn_cfg_addon = {
+        "articulation_props": sim_utils.ArticulationRootPropertiesCfg(fix_root_link=False),
+    }
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class LocomanipTargetZone(FactoryObject):
+    name = "locomanip_target_zone"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets/Collected_target_zone/target_zone.usd"
+    default_prim_path = "{ENV_REGEX_NS}/locomanip_target_zone"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)
+
+
+@register_asset
+class Button(FactoryObject, Pressable):
+    name = "button"
+    tags = ["object", "pressable"]
+    usd_path = "/datasets/assets/locomanip_assets_collected_usd/Collected_control_box/button.usd"
+    default_prim_path = "{ENV_REGEX_NS}/button"
+    object_type: ObjectType = ObjectType.ARTICULATION
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(1, 0, 0, 0.0))
+    pressable_joint_name = "button_joint"
+    pressedness_threshold = 0.5
+
+    def __init__(
+        self,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            instance_name=instance_name,
+            prim_path=prim_path,
+            initial_pose=initial_pose or self.default_initial_pose,
+            pressable_joint_name=self.pressable_joint_name,
+            pressedness_threshold=self.pressedness_threshold,
+            **kwargs,
+        )
+
+
+@register_asset
+class ControlBox(FactoryObject):
+    name = "control_box"
+    tags = ["object"]
+    usd_path = "/datasets/assets/locomanip_assets_collected_usd/Collected_control_box/control_box.usd"
+    default_prim_path = "{ENV_REGEX_NS}/control_box"
+    default_initial_pose = Pose(position_xyz=(0.9, 0, -0.79), rotation_xyzw=(0.70711, 0, 0, 0.70711))
+
+    def __init__(self, prim_path: str | None = None, initial_pose: Pose | None = None, **kwargs):
+        super().__init__(prim_path=prim_path, initial_pose=initial_pose or self.default_initial_pose, **kwargs)

--- a/isaaclab_arena_environments/G1_Factory/events.py
+++ b/isaaclab_arena_environments/G1_Factory/events.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import random
+import torch
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+import warp as wp
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
+
+from isaaclab_arena.utils.pose import Pose
+
+from .pose_utils import pose_range_from_quat
+
+
+def reset_all_distractors_uniform(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    distractor_names: list[str],
+    pose_range: dict[str, tuple[float, float]] | None = None,
+) -> None:
+    """Reset each listed distractor asset with random pose offset."""
+    if pose_range is None:
+        pose_range = {
+            "x": (-0.02, 0.02),
+            "y": (-0.05, 0.05),
+            "z": (0.0, 0.0),
+            "roll": (0.0, 0.0),
+            "pitch": (0.0, 0.0),
+            "yaw": (-np.pi / 6, np.pi / 6),
+        }
+    for name in distractor_names:
+        if name not in env.scene.keys():
+            continue
+        mdp_isaac_lab.reset_root_state_uniform(
+            env,
+            env_ids,
+            pose_range=pose_range,
+            velocity_range={},
+            asset_cfg=SceneEntityCfg(name),
+        )
+
+
+def set_object_pose_random_choice(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_choices: list[Pose],
+    reference_cfg: SceneEntityCfg | None = None,
+) -> None:
+    """Reset an object to one of several discrete poses chosen per environment."""
+    if env_ids is None:
+        return
+    asset = env.scene[asset_cfg.name]
+
+    ref_offset = None
+    if reference_cfg is not None:
+        reference = env.scene[reference_cfg.name]
+        if hasattr(reference, "data") and hasattr(reference.data, "root_pos_w"):
+            root_pos_w = reference.data.root_pos_w
+            if not isinstance(root_pos_w, torch.Tensor):
+                root_pos_w = wp.to_torch(root_pos_w)
+            ref_offset = root_pos_w - env.scene.env_origins
+        else:
+            raw = reference.get_world_poses()[0]
+            ref_pos_w = (
+                (raw.detach().clone() if isinstance(raw, torch.Tensor) else torch.tensor(raw, device=env.device))
+                .reshape(-1, 3)
+                .to(env.device)
+            )
+            ref_offset = ref_pos_w - env.scene.env_origins
+
+    assert env_ids.ndim == 1
+    for cur_env in env_ids.tolist():
+        pose = random.choice(pose_choices)
+        pose_t_xyz_q_xyzw = pose.to_tensor(device=env.device)
+        if ref_offset is not None:
+            pose_t_xyz_q_xyzw[:3] += ref_offset[cur_env]
+        pose_t_xyz_q_xyzw[:3] += env.scene.env_origins[cur_env, :].squeeze()
+        cur_ids = torch.tensor([cur_env], device=env.device)
+        if hasattr(asset, "write_root_pose_to_sim"):
+            asset.write_root_pose_to_sim(pose_t_xyz_q_xyzw.unsqueeze(0), env_ids=cur_ids)
+            asset.write_root_velocity_to_sim(torch.zeros(1, 6, device=env.device), env_ids=cur_ids)
+        else:
+            asset.set_world_poses(
+                positions=pose_t_xyz_q_xyzw[:3].unsqueeze(0),
+                orientations=pose_t_xyz_q_xyzw[3:].unsqueeze(0),
+                indices=cur_ids,
+            )
+
+
+def set_relative_initial_pose(
+    obj,
+    reference,
+    offset_range: dict[str, tuple[float, float]],
+    rotation_xyzw: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0),
+    yaw_jitter: float | tuple[float, float] = 0.0,
+    roll_jitter: float | tuple[float, float] = 0.0,
+    pitch_jitter: float | tuple[float, float] = 0.0,
+) -> None:
+    """Configure an object to reset relative to a reference object's current pose."""
+    from isaaclab.utils.math import euler_xyz_from_quat
+
+    ref_pose = reference._get_initial_pose_as_pose()
+    ref_pos = (0.0, 0.0, 0.0) if ref_pose is None else ref_pose.position_xyz
+
+    ox = offset_range.get("x", (0.0, 0.0))
+    oy = offset_range.get("y", (0.0, 0.0))
+    oz = offset_range.get("z", (0.0, 0.0))
+
+    obj.set_initial_pose(
+        pose_range_from_quat(
+            position_xyz_min=(ref_pos[0] + ox[0], ref_pos[1] + oy[0], ref_pos[2] + oz[0]),
+            position_xyz_max=(ref_pos[0] + ox[1], ref_pos[1] + oy[1], ref_pos[2] + oz[1]),
+            rotation_xyzw=rotation_xyzw,
+            yaw_jitter=yaw_jitter,
+            roll_jitter=roll_jitter,
+            pitch_jitter=pitch_jitter,
+        )
+    )
+
+    q = torch.tensor(rotation_xyzw).unsqueeze(0)
+    roll, pitch, yaw = (v.item() for v in euler_xyz_from_quat(q))
+
+    def _jitter_range(center: float, jitter: float | tuple[float, float]) -> tuple[float, float]:
+        if isinstance(jitter, (list, tuple)):
+            return (center + jitter[0], center + jitter[1])
+        return (center - jitter, center + jitter)
+
+    obj.event_cfg = EventTermCfg(
+        func=reset_object_relative_to,
+        mode="reset",
+        params={
+            "asset_cfg": SceneEntityCfg(obj.name),
+            "reference_cfg": SceneEntityCfg(reference.name),
+            "offset_range": {
+                "x": ox,
+                "y": oy,
+                "z": oz,
+                "roll": _jitter_range(roll, roll_jitter),
+                "pitch": _jitter_range(pitch, pitch_jitter),
+                "yaw": _jitter_range(yaw, yaw_jitter),
+            },
+        },
+    )
+
+
+def reset_object_relative_to(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    reference_cfg: SceneEntityCfg,
+    offset_range: dict[str, tuple[float, float]],
+) -> None:
+    """Reset an object's position relative to another object's current position."""
+    if env_ids is None:
+        return
+    asset = env.scene[asset_cfg.name]
+    reference = env.scene[reference_cfg.name]
+
+    if hasattr(reference, "data") and hasattr(reference.data, "root_pos_w"):
+        root_pos_w = reference.data.root_pos_w
+        if not isinstance(root_pos_w, torch.Tensor):
+            root_pos_w = torch.as_tensor(root_pos_w, device=env.device)
+        ref_pos = root_pos_w[env_ids] - env.scene.env_origins[env_ids]
+    else:
+        raw = reference.get_world_poses()[0]
+        ref_pos_w = (
+            (raw.detach().clone() if isinstance(raw, torch.Tensor) else torch.tensor(raw, device=env.device))
+            .reshape(-1, 3)
+            .to(env.device)
+        )
+        ref_pos = (ref_pos_w - env.scene.env_origins)[env_ids]
+
+    num_envs = len(env_ids)
+    x_off = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("x", (0.0, 0.0)))
+    y_off = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("y", (0.0, 0.0)))
+    z_off = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("z", (0.0, 0.0)))
+    roll = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("roll", (0.0, 0.0)))
+    pitch = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("pitch", (0.0, 0.0)))
+    yaw = torch.empty(num_envs, device=env.device).uniform_(*offset_range.get("yaw", (0.0, 0.0)))
+
+    from isaaclab.utils.math import quat_from_euler_xyz
+
+    pos = ref_pos + torch.stack([x_off, y_off, z_off], dim=-1)
+    pos += env.scene.env_origins[env_ids]
+    quat = quat_from_euler_xyz(roll, pitch, yaw)
+
+    if hasattr(asset, "write_root_pose_to_sim"):
+        asset.write_root_pose_to_sim(torch.cat([pos, quat], dim=-1), env_ids=env_ids)
+        asset.write_root_velocity_to_sim(torch.zeros(num_envs, 6, device=env.device), env_ids=env_ids)
+    else:
+        asset.set_world_poses(positions=pos, orientations=quat, indices=env_ids)

--- a/isaaclab_arena_environments/G1_Factory/g1_locomanip_lift_task.py
+++ b/isaaclab_arena_environments/G1_Factory/g1_locomanip_lift_task.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from dataclasses import MISSING
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import EventTermCfg, SceneEntityCfg, TerminationTermCfg
+from isaaclab.utils import configclass
+
+from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.terms.events import set_object_pose
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+from isaaclab_arena.utils.configclass import make_configclass
+from isaaclab_arena.utils.pose import PoseRange
+
+from .terminations import is_grasped, is_gripper_far, is_in_contact, is_static, is_upright, object_lifted
+
+# Default pose range is no randomization
+_DEFAULT_POSE_RANGE = {
+    "x": (-0.0, 0.0),
+    "y": (-0.0, 0.0),
+    "z": (0.0, 0.0),
+    "roll": (0.0, 0.0),
+    "pitch": (0.0, 0.0),
+    "yaw": (0.0, 0.0),
+}
+
+
+class G1LocomanipLiftTask(TaskBase):
+    def __init__(
+        self,
+        object: Asset,
+        lift_height: float = 0.15,
+        drop_height: float | None = None,
+        episode_length_s: float | None = None,
+        pose_range: dict[str, tuple[float, float]] | None = None,
+        task_description: str | None = None,
+        robot_pose_range: dict[str, tuple[float, float]] | None = None,
+        require_static: bool = False,
+        contact_sensor_name: str | None = None,
+        contact_force_threshold: float = 1.0,
+        upright_threshold: float | None = None,
+        upright_z_axis_up: bool = False,
+        gripper_far_threshold: float | None = None,
+        require_grasped: bool = False,
+        not_in_contact_with: Asset | None = None,
+    ):
+        super().__init__(episode_length_s=episode_length_s)
+        self.object = object
+        self.lift_height = lift_height
+        self.drop_height = drop_height
+        self.pose_range = pose_range if pose_range is not None else _DEFAULT_POSE_RANGE
+        self.task_description = task_description
+        self.robot_pose_range = robot_pose_range
+        self.require_static = require_static
+        self.contact_sensor_name = contact_sensor_name
+        self.contact_force_threshold = contact_force_threshold
+        self.upright_threshold = upright_threshold
+        self.upright_z_axis_up = upright_z_axis_up
+        self.gripper_far_threshold = gripper_far_threshold
+        self.require_grasped = require_grasped
+        self.not_in_contact_with = not_in_contact_with
+
+        self._contact_sensor_name: str | None = None
+        self._contact_sensor_cfg = None
+        if (
+            not_in_contact_with is not None
+            and isinstance(object, ObjectBase)
+            and isinstance(not_in_contact_with, ObjectBase)
+        ):
+            self._contact_sensor_name = f"contact_sensor_{object.name}"
+            self._contact_sensor_cfg = object.get_contact_sensor_cfg(contact_against_object=not_in_contact_with)
+
+    def get_scene_cfg(self):
+        if self._contact_sensor_cfg is not None:
+            SceneCfg = make_configclass(
+                "SceneCfg",
+                [(self._contact_sensor_name, type(self._contact_sensor_cfg), self._contact_sensor_cfg)],
+            )
+            return SceneCfg()
+        return None
+
+    def get_termination_cfg(self):
+        return TerminationsCfg(
+            object=self.object,
+            lift_height=self.lift_height,
+            drop_height=self.drop_height,
+            require_static=self.require_static,
+            contact_sensor_name=self.contact_sensor_name,
+            contact_force_threshold=self.contact_force_threshold,
+            upright_threshold=self.upright_threshold,
+            upright_z_axis_up=self.upright_z_axis_up,
+            gripper_far_threshold=self.gripper_far_threshold,
+            require_grasped=self.require_grasped,
+            not_in_contact_sensor_name=self._contact_sensor_name,
+        )
+
+    def get_events_cfg(self):
+        return EventCfg(object=self.object, pose_range=self.pose_range, robot_pose_range=self.robot_pose_range)
+
+    def get_prompt(self):
+        raise NotImplementedError("Function not implemented yet.")
+
+    def get_mimic_env_cfg(self, embodiment_name: str):
+        raise NotImplementedError("Function not implemented yet.")
+
+    def get_metrics(self):
+        return [SuccessRateMetric()]
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.object,
+            offset=np.array([-1.3, 1.7, 1.5]),
+        )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out: TerminationTermCfg = MISSING
+    object_dropping: TerminationTermCfg | None = None
+    success: TerminationTermCfg = MISSING
+
+    def __init__(
+        self,
+        object: Asset,
+        lift_height: float = 0.15,
+        drop_height: float | None = -0.05,
+        require_static: bool = False,
+        contact_sensor_name: str | None = None,
+        contact_force_threshold: float = 1.0,
+        upright_threshold: float | None = None,
+        upright_z_axis_up: bool = False,
+        gripper_far_threshold: float | None = None,
+        require_grasped: bool = False,
+        not_in_contact_sensor_name: str | None = None,
+    ):
+        self.time_out = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+        self.object_dropping = None
+        self.success = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+
+        is_physics = isinstance(object, ObjectBase) and object.object_type in (
+            ObjectType.RIGID,
+            ObjectType.ARTICULATION,
+        )
+        if not is_physics:
+            return
+
+        if drop_height is not None:
+            self.object_dropping = TerminationTermCfg(
+                func=mdp_isaac_lab.root_height_below_minimum,
+                params={"minimum_height": drop_height, "asset_cfg": SceneEntityCfg(object.name)},
+            )
+
+        # Collect optional success criteria (each individually toggleable)
+        extra_checks: list[tuple[callable, dict]] = []
+        if require_static:
+            extra_checks.append((
+                is_static,
+                {
+                    "asset_cfg": SceneEntityCfg(object.name),
+                },
+            ))
+        if upright_threshold is not None:
+            extra_checks.append((
+                is_upright,
+                {
+                    "asset_cfg": SceneEntityCfg(object.name),
+                    "threshold": upright_threshold,
+                    "z_axis_up": upright_z_axis_up,
+                },
+            ))
+
+        # For lift tasks, gripper_far_threshold is NEGATED: success requires
+        # the gripper to be NEAR the object (robot is still holding it).
+        # Maps to MuJoCo NotCriteria(IsGripperFar(obj)).
+        if gripper_far_threshold is not None:
+            _th = gripper_far_threshold
+
+            def _gripper_near(env):
+                return ~is_gripper_far(
+                    env,
+                    object_cfg=SceneEntityCfg(object.name),
+                    threshold=_th,
+                )
+
+            extra_checks.append((_gripper_near, {}))
+
+        # Grasped: at least one finger is close to the object.
+        # Maps to MuJoCo IsGrasped(obj).
+        if require_grasped:
+            extra_checks.append((
+                is_grasped,
+                {
+                    "object_cfg": SceneEntityCfg(object.name),
+                },
+            ))
+
+        if not_in_contact_sensor_name is not None:
+            _sensor_name = not_in_contact_sensor_name
+
+            def _not_in_contact(env):
+                return ~is_in_contact(
+                    env,
+                    contact_sensor_cfg=SceneEntityCfg(_sensor_name),
+                )
+
+            extra_checks.append((_not_in_contact, {}))
+
+        base_params = {"minimum_height": lift_height, "asset_cfg": SceneEntityCfg(object.name)}
+
+        if extra_checks:
+            _base_params = base_params
+            _checks = extra_checks
+
+            def _success(env):
+                result = object_lifted(env, **_base_params)
+                for check_fn, check_kw in _checks:
+                    result = result & check_fn(env, **check_kw)
+                return result
+
+            self.success = TerminationTermCfg(func=_success, params={})
+        else:
+            self.success = TerminationTermCfg(func=object_lifted, params=base_params)
+
+
+@configclass
+class EventCfg:
+    """Events for the MDP."""
+
+    reset_all: EventTermCfg = MISSING
+    reset_object_position: EventTermCfg | None = None
+    reset_robot_pose: EventTermCfg | None = None
+
+    def __init__(
+        self,
+        object: Asset,
+        pose_range: dict[str, tuple[float, float]] | None = None,
+        robot_pose_range: dict[str, tuple[float, float]] | None = None,
+    ):
+        if pose_range is None:
+            pose_range = _DEFAULT_POSE_RANGE
+        if robot_pose_range is None:
+            robot_pose_range = _DEFAULT_POSE_RANGE
+
+        self.reset_all = EventTermCfg(func=mdp_isaac_lab.reset_scene_to_default, mode="reset")
+        self.reset_object_position = None
+        self.reset_robot_pose = None
+
+        is_physics_object = isinstance(object, ObjectBase) and object.object_type in (
+            ObjectType.RIGID,
+            ObjectType.ARTICULATION,
+        )
+        # Skip if the object already has its own randomization:
+        #   - PoseRange initial pose (randomizes via randomize_object_pose)
+        #   - Manually-set event_cfg with a custom function (e.g. set_object_pose_random_choice)
+        # Only add task randomization when the object has no event or only the
+        # auto-generated fixed-pose reset (set_object_pose).
+        has_own_randomization = isinstance(object, ObjectBase) and (
+            isinstance(object.get_initial_pose(), PoseRange)
+            or (object.event_cfg is not None and object.event_cfg.func is not set_object_pose)
+        )
+        if is_physics_object and not has_own_randomization:
+            self.reset_object_position = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg(object.name),
+                },
+            )
+
+        if robot_pose_range is not None:
+            self.reset_robot_pose = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": robot_pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg("robot"),
+                },
+            )

--- a/isaaclab_arena_environments/G1_Factory/g1_locomanip_pnp_task.py
+++ b/isaaclab_arena_environments/G1_Factory/g1_locomanip_pnp_task.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+from dataclasses import MISSING
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import EventTermCfg, SceneEntityCfg, TerminationTermCfg
+from isaaclab.utils import configclass
+
+from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.tasks.terminations import objects_in_proximity
+from isaaclab_arena.terms.events import set_object_pose
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+from isaaclab_arena.utils.configclass import make_configclass
+from isaaclab_arena.utils.pose import Pose, PoseRange
+
+from .events import reset_all_distractors_uniform
+from .terminations import is_gripper_far, is_in_contact, is_static, is_upright, object_near_fixed_position
+
+# Default pose range is no randomization
+_DEFAULT_POSE_RANGE = {
+    "x": (-0.0, 0.0),
+    "y": (-0.0, 0.0),
+    "z": (0.0, 0.0),
+    "roll": (0.0, 0.0),
+    "pitch": (0.0, 0.0),
+    "yaw": (0.0, 0.0),
+}
+
+
+def _is_physics_object(obj: Asset) -> bool:
+    return isinstance(obj, ObjectBase) and obj.object_type in (ObjectType.RIGID, ObjectType.ARTICULATION)
+
+
+class G1LocomanipPnPTask(TaskBase):
+    def __init__(
+        self,
+        object: Asset,
+        destination: Asset,
+        # lift_height: float = 0.15,
+        drop_height: float | None = -0.6,
+        episode_length_s: float | None = None,
+        task_description: str | None = None,
+        max_x_separation: float = 0.1,
+        max_y_separation: float = 0.1,
+        max_z_separation: float = 0.859,
+        tool: Asset | None = None,
+        tool_max_separation: float = 0.1,
+        distractors: list | None = None,
+        require_static: bool = False,
+        require_contact: bool = False,
+        upright_threshold: float | None = None,
+        upright_z_axis_up: bool = False,
+        gripper_far_threshold: float | None = None,
+        gripper_near_threshold: float | None = None,
+    ):
+        super().__init__(episode_length_s=episode_length_s)
+        self.object = object
+        self.destination = destination
+        # self.lift_height = lift_height
+        self.drop_height = drop_height
+        self.max_x_separation = max_x_separation
+        self.max_y_separation = max_y_separation
+        self.max_z_separation = max_z_separation
+        self.tool = tool
+        self.tool_max_separation = tool_max_separation
+        self.distractors = distractors if distractors is not None else []
+        self.require_static = require_static
+        self.require_contact = require_contact
+        self.upright_threshold = upright_threshold
+        self.upright_z_axis_up = upright_z_axis_up
+        self.gripper_far_threshold = gripper_far_threshold
+        self.gripper_near_threshold = gripper_near_threshold
+        self._contact_sensor_name: str | None = None
+        self._contact_sensor_cfg = None
+        if require_contact and _is_physics_object(object) and isinstance(destination, ObjectBase):
+            self._contact_sensor_name = f"contact_sensor_{object.name}"
+            self._contact_sensor_cfg = object.get_contact_sensor_cfg(contact_against_object=destination)
+        self.task_description = (
+            f"Pick up the {object.name}, and place it on the {destination.name}"
+            if task_description is None
+            else task_description
+        )
+
+    def get_scene_cfg(self):
+        if self._contact_sensor_cfg is not None:
+            SceneCfg = make_configclass(
+                "SceneCfg",
+                [(self._contact_sensor_name, type(self._contact_sensor_cfg), self._contact_sensor_cfg)],
+            )
+            return SceneCfg()
+        return None
+
+    def get_termination_cfg(self):
+        return TerminationsCfg(
+            object=self.object,
+            destination=self.destination,
+            drop_height=self.drop_height,
+            max_x_separation=self.max_x_separation,
+            max_y_separation=self.max_y_separation,
+            max_z_separation=self.max_z_separation,
+            tool=self.tool,
+            tool_max_separation=self.tool_max_separation,
+            require_static=self.require_static,
+            contact_sensor_name=self._contact_sensor_name,
+            upright_threshold=self.upright_threshold,
+            upright_z_axis_up=self.upright_z_axis_up,
+            gripper_far_threshold=self.gripper_far_threshold,
+            gripper_near_threshold=self.gripper_near_threshold,
+        )
+
+    def get_events_cfg(self):
+        return EventCfg(object=self.object, tool=self.tool, distractors=self.distractors)
+
+    def get_prompt(self):
+        raise NotImplementedError("Function not implemented yet.")
+
+    def get_mimic_env_cfg(self, embodiment_name: str):
+        raise NotImplementedError("Function not implemented yet.")
+
+    def get_metrics(self):
+        return [SuccessRateMetric()]
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.object,
+            offset=np.array([-1.3, 1.7, 1.5]),
+        )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out: TerminationTermCfg = MISSING
+    object_dropping: TerminationTermCfg | None = None
+    tool_dropping: TerminationTermCfg | None = None
+    success: TerminationTermCfg = MISSING
+
+    def __init__(
+        self,
+        object: Asset,
+        destination: Asset,
+        drop_height: float | None = -0.05,
+        max_x_separation: float = 0.1,
+        max_y_separation: float = 0.1,
+        max_z_separation: float = 0.859,
+        tool: Asset | None = None,
+        tool_max_separation: float = 0.1,
+        require_static: bool = False,
+        contact_sensor_name: str | None = None,
+        upright_threshold: float | None = None,
+        upright_z_axis_up: bool = False,
+        gripper_far_threshold: float | None = None,
+        gripper_near_threshold: float | None = None,
+    ):
+        self.object = object
+        self.destination = destination
+        self.time_out = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+        self.object_dropping = None
+        self.tool_dropping = None
+        self.gripper_near_threshold = gripper_near_threshold
+        if drop_height is not None:
+            if _is_physics_object(object):
+                self.object_dropping = TerminationTermCfg(
+                    func=mdp_isaac_lab.root_height_below_minimum,
+                    params={"minimum_height": drop_height, "asset_cfg": SceneEntityCfg(object.name)},
+                )
+            if tool is not None and _is_physics_object(tool):
+                self.tool_dropping = TerminationTermCfg(
+                    func=mdp_isaac_lab.root_height_below_minimum,
+                    params={"minimum_height": drop_height, "asset_cfg": SceneEntityCfg(tool.name)},
+                )
+
+        # Collect optional success criteria (each individually toggleable)
+        extra_checks: list[tuple[callable, dict]] = []
+        if _is_physics_object(object):
+            if require_static:
+                extra_checks.append((
+                    is_static,
+                    {
+                        "asset_cfg": SceneEntityCfg(object.name),
+                    },
+                ))
+            if upright_threshold is not None:
+                extra_checks.append((
+                    is_upright,
+                    {
+                        "asset_cfg": SceneEntityCfg(object.name),
+                        "threshold": upright_threshold,
+                        "z_axis_up": upright_z_axis_up,
+                    },
+                ))
+        if contact_sensor_name is not None:
+            extra_checks.append((
+                is_in_contact,
+                {
+                    "contact_sensor_cfg": SceneEntityCfg(contact_sensor_name),
+                },
+            ))
+
+        # Gripper far: is_gripper_far — all fingers must be far from object
+        # Maps to MuJoCo IsGripperFar(obj, threshold)
+        if gripper_far_threshold is not None:
+            extra_checks.append((
+                is_gripper_far,
+                {
+                    "object_cfg": SceneEntityCfg(object.name),
+                    "threshold": gripper_far_threshold,
+                },
+            ))
+
+        # Gripper near: ~is_gripper_far — at least one finger must be close
+        if gripper_near_threshold is not None:
+            _near_th = gripper_near_threshold
+
+            def _gripper_near(env):
+                return ~is_gripper_far(
+                    env,
+                    object_cfg=SceneEntityCfg(object.name),
+                    threshold=_near_th,
+                )
+
+            extra_checks.append((_gripper_near, {}))
+
+        # Determine base success function and params
+        base_fn = None
+        base_params: dict = {}
+
+        if _is_physics_object(object) and _is_physics_object(destination):
+            base_fn = objects_in_proximity
+            base_params = {
+                "object_cfg": SceneEntityCfg(self.object.name),
+                "target_object_cfg": SceneEntityCfg(self.destination.name),
+                "max_x_separation": max_x_separation,
+                "max_y_separation": max_y_separation,
+                "max_z_separation": max_z_separation,
+            }
+            if tool is not None:
+                base_params["tool_cfg"] = SceneEntityCfg(tool.name)
+                base_params["tool_max_x_separation"] = tool_max_separation
+                base_params["tool_max_y_separation"] = tool_max_separation
+                base_params["tool_max_z_separation"] = tool_max_separation
+        elif _is_physics_object(object) and isinstance(destination, ObjectBase):
+            dest_initial = destination.get_initial_pose()
+            dest_pose = dest_initial.get_midpoint() if isinstance(dest_initial, PoseRange) else dest_initial
+            if isinstance(dest_pose, Pose):
+                base_fn = object_near_fixed_position
+                base_params = {
+                    "object_cfg": SceneEntityCfg(self.object.name),
+                    "target_position": dest_pose.position_xyz,
+                    "max_x_separation": max_x_separation,
+                    "max_y_separation": max_y_separation,
+                    "max_z_separation": max_z_separation,
+                }
+
+        # Build the success TerminationTermCfg, ANDing extra checks into it
+        if base_fn is not None and extra_checks:
+            _base_fn = base_fn
+            _base_params = base_params
+            _checks = extra_checks
+
+            def _success(env):
+                result = _base_fn(env, **_base_params)
+                for check_fn, check_kw in _checks:
+                    result = result & check_fn(env, **check_kw)
+                return result
+
+            self.success = TerminationTermCfg(func=_success, params={})
+        elif base_fn is not None:
+            self.success = TerminationTermCfg(func=base_fn, params=base_params)
+        else:
+            self.success = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+
+
+@configclass
+class EventCfg:
+    """Events for the MDP."""
+
+    reset_all: EventTermCfg = MISSING
+    reset_object_position: EventTermCfg | None = None
+    reset_tool_position: EventTermCfg | None = None
+    reset_distractors_position: EventTermCfg | None = None
+    reset_robot_pose: EventTermCfg | None = None
+
+    def __init__(
+        self,
+        object: Asset,
+        tool: Asset,
+        distractors: list | None = None,
+        pose_range: dict[str, tuple[float, float]] | None = None,
+        robot_pose_range: dict[str, tuple[float, float]] | None = None,
+    ):
+        self.reset_all = EventTermCfg(func=mdp_isaac_lab.reset_scene_to_default, mode="reset")
+        self.reset_object_position = None
+        self.reset_tool_position = None
+        self.reset_distractors_position = None
+        self.reset_robot_pose = None
+        if pose_range is None:
+            pose_range = _DEFAULT_POSE_RANGE
+        if robot_pose_range is None:
+            robot_pose_range = _DEFAULT_POSE_RANGE
+
+        has_own_randomization = isinstance(object, ObjectBase) and (
+            isinstance(object.get_initial_pose(), PoseRange)
+            or (object.event_cfg is not None and object.event_cfg.func is not set_object_pose)
+        )
+        if _is_physics_object(object) and not has_own_randomization:
+            self.reset_object_position = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg(object.name),
+                },
+            )
+
+        if tool is not None and _is_physics_object(tool):
+            self.reset_tool_position = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg(tool.name),
+                },
+            )
+
+        if distractors is not None and len(distractors) > 0:
+            distractor_names = [d.name for d in distractors]
+            self.reset_distractors_position = EventTermCfg(
+                func=reset_all_distractors_uniform,
+                mode="reset",
+                params={
+                    "distractor_names": distractor_names,
+                    "pose_range": pose_range,
+                },
+            )
+
+        if robot_pose_range is not None:
+            self.reset_robot_pose = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": robot_pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg("robot"),
+                },
+            )

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxLiftFloor_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxLiftFloor_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftFloorD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Walk to the box, pick it up from the floor"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxLift_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxLift_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxLiftD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Walk to table and pick up the box"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxTableToShelfPnP_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMBoxTableToShelfPnP_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMBoxTableToShelfPnPD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Move box from table to shelf"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLiftObs_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLiftObs_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/g1_benchmark_LMDrillLiftObs-0629_processed100_gn1_5_output_6_29/checkpoint-20000
+language_instruction: "Pick up the drill with a shelf obstacle"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLift_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLift_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Walk to the table and pick up the power drill"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillPnP_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillPnP_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMDrillPnPD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Move power drill from one table to another"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPickDrillFromHolder_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPickDrillFromHolder_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/g1_benchmark_LMPickDrillFromHolder-0610_processed100_gn1_5_output_6_10/checkpoint-20000
+language_instruction: "Pick up the drill from holder"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPushButton_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPushButton_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMPushButtonD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Walk to the console and press red button"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPushShelfForward_gr00t_closedloop.yaml
+++ b/isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMPushShelfForward_gr00t_closedloop.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Matching GR00T server checkpoint:
+# /mnt/data/isaaclab_arena/ckpts/D1-100/g1_benchmark_LMPushShelfForwardD1_100_gn1_5_output/checkpoint-20000
+language_instruction: "Push high wheeled shelf to marked area"
+action_horizon: 16
+embodiment_tag: NEW_EMBODIMENT
+video_backend: decord
+modality_config_path: isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py
+
+policy_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml
+action_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+state_joints_config_path: isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml
+
+action_chunk_length: 16
+pov_cam_name_sim: "robot_head_cam_rgb"
+original_image_size: [480, 640, 3]
+target_image_size: [480, 640, 3]
+task_mode_name: g1_locomanipulation

--- a/isaaclab_arena_environments/G1_Factory/pose_utils.py
+++ b/isaaclab_arena_environments/G1_Factory/pose_utils.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.utils.math import euler_xyz_from_quat
+
+from isaaclab_arena.utils.pose import PoseRange
+
+
+def pose_range_from_quat(
+    position_xyz_min: tuple[float, float, float],
+    position_xyz_max: tuple[float, float, float],
+    rotation_xyzw: tuple[float, float, float, float],
+    yaw_jitter: float | tuple[float, float] = 0.0,
+    roll_jitter: float | tuple[float, float] = 0.0,
+    pitch_jitter: float | tuple[float, float] = 0.0,
+) -> PoseRange:
+    """Factory-local equivalent of the old ``PoseRange.from_quat`` helper."""
+    q = torch.tensor(rotation_xyzw).unsqueeze(0)
+    roll, pitch, yaw = euler_xyz_from_quat(q)
+    r, p, y = roll.item(), pitch.item(), yaw.item()
+
+    def _offset(center: float, jitter: float | tuple[float, float]) -> tuple[float, float]:
+        if isinstance(jitter, (list, tuple)):
+            return (center + jitter[0], center + jitter[1])
+        return (center - jitter, center + jitter)
+
+    roll_min, roll_max = _offset(r, roll_jitter)
+    pitch_min, pitch_max = _offset(p, pitch_jitter)
+    yaw_min, yaw_max = _offset(y, yaw_jitter)
+
+    return PoseRange(
+        position_xyz_min=position_xyz_min,
+        position_xyz_max=position_xyz_max,
+        rpy_min=(roll_min, pitch_min, yaw_min),
+        rpy_max=(roll_max, pitch_max, yaw_max),
+    )

--- a/isaaclab_arena_environments/G1_Factory/press_button_task.py
+++ b/isaaclab_arena_environments/G1_Factory/press_button_task.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+from dataclasses import MISSING
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import EventTermCfg, SceneEntityCfg, TerminationTermCfg
+from isaaclab.utils import configclass
+
+from isaaclab_arena.affordances.pressable import Pressable
+from isaaclab_arena.embodiments.common.arm_mode import ArmMode
+from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+
+from .terminations import is_gripper_far
+
+
+class G1FactoryPressButtonTask(TaskBase):
+    """Factory-compatible button task preserving old gripper-near success semantics."""
+
+    def __init__(
+        self,
+        pressable_object: Pressable,
+        pressedness_threshold: float | None = None,
+        reset_pressedness: float | None = None,
+        episode_length_s: float | None = None,
+        task_description: str | None = None,
+        robot_pose_range: dict[str, tuple[float, float]] | None = None,
+        gripper_far_threshold: float | None = None,
+    ):
+        super().__init__(episode_length_s=episode_length_s)
+        assert isinstance(pressable_object, Pressable), "Pressable object must be an instance of Pressable"
+        self.pressable_object = pressable_object
+        self.pressedness_threshold = pressedness_threshold
+        self.reset_pressedness = reset_pressedness
+        self.robot_pose_range = robot_pose_range
+        self.gripper_far_threshold = gripper_far_threshold
+        self.task_description = (
+            f"Press the {pressable_object.name} button" if task_description is None else task_description
+        )
+
+    def get_scene_cfg(self):
+        pass
+
+    def get_termination_cfg(self):
+        press_params = {}
+        if self.pressedness_threshold is not None:
+            press_params["pressedness_threshold"] = self.pressedness_threshold
+
+        if self.gripper_far_threshold is not None:
+            is_pressed = self.pressable_object.is_pressed
+            object_name = self.pressable_object.name
+            threshold = self.gripper_far_threshold
+
+            def success_func(env):
+                pressed = is_pressed(env, **press_params)
+                gripper_near = ~is_gripper_far(
+                    env,
+                    object_cfg=SceneEntityCfg(object_name),
+                    threshold=threshold,
+                )
+                return pressed & gripper_near
+
+            success = TerminationTermCfg(func=success_func, params={})
+        else:
+            success = TerminationTermCfg(func=self.pressable_object.is_pressed, params=press_params)
+        return TerminationsCfg(success=success)
+
+    def get_events_cfg(self):
+        return PressEventCfg(
+            self.pressable_object,
+            reset_pressedness=self.reset_pressedness,
+            robot_pose_range=self.robot_pose_range,
+        )
+
+    def get_mimic_env_cfg(self, arm_mode: ArmMode):
+        raise NotImplementedError("Function not implemented yet.")
+
+    def get_metrics(self) -> list[MetricBase]:
+        return [SuccessRateMetric()]
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.pressable_object,
+            offset=np.array([-1.5, -1.5, 1.5]),
+        )
+
+
+@configclass
+class TerminationsCfg:
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    success: TerminationTermCfg = MISSING
+
+
+@configclass
+class PressEventCfg:
+    reset_button_state: EventTermCfg = MISSING
+    reset_robot_pose: EventTermCfg | None = None
+
+    def __init__(
+        self,
+        pressable_object: Pressable,
+        reset_pressedness: float | None,
+        robot_pose_range: dict[str, tuple[float, float]] | None = None,
+    ):
+        assert isinstance(pressable_object, Pressable), "Object pose must be an instance of Pressable"
+        params = {}
+        if reset_pressedness is not None:
+            params["unpressed_percentage"] = reset_pressedness
+        self.reset_button_state = EventTermCfg(
+            func=pressable_object.unpress,
+            mode="reset",
+            params=params,
+        )
+        self.reset_robot_pose = None
+        if robot_pose_range is not None:
+            self.reset_robot_pose = EventTermCfg(
+                func=mdp_isaac_lab.reset_root_state_uniform,
+                mode="reset",
+                params={
+                    "pose_range": robot_pose_range,
+                    "velocity_range": {},
+                    "asset_cfg": SceneEntityCfg("robot"),
+                },
+            )

--- a/isaaclab_arena_environments/G1_Factory/terminations.py
+++ b/isaaclab_arena_environments/G1_Factory/terminations.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import torch
+
+import warp as wp
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors.contact_sensor.contact_sensor import ContactSensor
+
+
+def _to_torch(data: torch.Tensor) -> torch.Tensor:
+    if isinstance(data, torch.Tensor):
+        return data
+    return wp.to_torch(data)
+
+
+def object_near_fixed_position(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg,
+    target_position: tuple[float, float, float],
+    max_x_separation: float,
+    max_y_separation: float,
+    max_z_separation: float,
+) -> torch.Tensor:
+    object: RigidObject = env.scene[object_cfg.name]
+    object_pos = _to_torch(object.data.root_pos_w) - env.scene.env_origins
+    target_pos = torch.tensor(target_position, device=env.device, dtype=torch.float32).unsqueeze(0)
+    done = torch.abs(object_pos[:, 0] - target_pos[:, 0]) < max_x_separation
+    done &= torch.abs(object_pos[:, 1] - target_pos[:, 1]) < max_y_separation
+    done &= torch.abs(object_pos[:, 2] - target_pos[:, 2]) < max_z_separation
+    return done
+
+
+def object_lifted(
+    env: ManagerBasedRLEnv,
+    minimum_height: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+) -> torch.Tensor:
+    asset: RigidObject = env.scene[asset_cfg.name]
+    return _to_torch(asset.data.root_pos_w)[:, 2] > minimum_height
+
+
+def is_upright(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    threshold: float = 0.01,
+    z_axis_up: bool = False,
+) -> torch.Tensor:
+    asset: RigidObject = env.scene[asset_cfg.name]
+    quat = _to_torch(asset.data.root_quat_w)
+    z_dot_up = 1.0 - 2.0 * (quat[:, 0] ** 2 + quat[:, 1] ** 2)
+    if z_axis_up:
+        return z_dot_up >= threshold
+    return torch.abs(z_dot_up) <= threshold
+
+
+def is_static(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    lin_vel_threshold: float = 0.15,
+    ang_vel_threshold: float = 0.15,
+) -> torch.Tensor:
+    asset: RigidObject = env.scene[asset_cfg.name]
+    lin_vel_norm = torch.norm(_to_torch(asset.data.root_lin_vel_w), dim=-1)
+    ang_vel_norm = torch.norm(_to_torch(asset.data.root_ang_vel_w), dim=-1)
+    return (lin_vel_norm <= lin_vel_threshold) & (ang_vel_norm <= ang_vel_threshold)
+
+
+def is_in_contact(
+    env: ManagerBasedRLEnv,
+    contact_sensor_cfg: SceneEntityCfg = SceneEntityCfg("contact_sensor"),
+    force_threshold: float = 0.95,
+) -> torch.Tensor:
+    sensor: ContactSensor = env.unwrapped.scene[contact_sensor_cfg.name]
+    fm = sensor.data.force_matrix_w
+    if fm is not None:
+        force_norm = torch.norm(_to_torch(fm), dim=-1).reshape(env.unwrapped.num_envs, -1)
+        return force_norm.max(dim=-1).values > force_threshold
+    force_norm = torch.norm(_to_torch(sensor.data.net_forces_w), dim=-1).reshape(env.unwrapped.num_envs, -1)
+    return force_norm.max(dim=-1).values > force_threshold
+
+
+G1_FINGER_BODY_NAMES: list[str] = [
+    "left_hand_index_0_link",
+    "left_hand_index_1_link",
+    "left_hand_middle_0_link",
+    "left_hand_middle_1_link",
+    "left_hand_thumb_0_link",
+    "left_hand_thumb_1_link",
+    "left_hand_thumb_2_link",
+    "right_hand_index_0_link",
+    "right_hand_index_1_link",
+    "right_hand_middle_0_link",
+    "right_hand_middle_1_link",
+    "right_hand_thumb_0_link",
+    "right_hand_thumb_1_link",
+    "right_hand_thumb_2_link",
+]
+
+
+def _gripper_obj_distance(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg,
+    robot_cfg: SceneEntityCfg,
+    ee_body_name: str,
+) -> torch.Tensor:
+    obj: RigidObject = env.scene[object_cfg.name]
+    robot: Articulation = env.scene[robot_cfg.name]
+    ee_body_idx = robot.find_bodies(ee_body_name)[0][0]
+    ee_pos = _to_torch(robot.data.body_pos_w)[:, ee_body_idx, :]
+    obj_pos = _to_torch(obj.data.root_pos_w)
+    return torch.norm(ee_pos - obj_pos, dim=-1)
+
+
+def is_gripper_far(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    ee_body_names: list[str] | str | None = None,
+    threshold: float = 0.4,
+) -> torch.Tensor:
+    if ee_body_names is None:
+        ee_body_names = G1_FINGER_BODY_NAMES
+    elif isinstance(ee_body_names, str):
+        ee_body_names = [ee_body_names]
+    all_far = torch.ones(env.num_envs, dtype=torch.bool, device=env.device)
+    for name in ee_body_names:
+        all_far &= _gripper_obj_distance(env, object_cfg, robot_cfg, name) > threshold
+    return all_far
+
+
+G1_FINGER_JOINT_REGEX = ".*_hand_.*_joint"
+
+
+def _fingers_closed(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    finger_joint_regex: str = G1_FINGER_JOINT_REGEX,
+    min_deviation: float = 0.1,
+    min_fingers_closed: int = 3,
+) -> torch.Tensor:
+    robot: Articulation = env.scene[robot_cfg.name]
+    joint_ids, _ = robot.find_joints(finger_joint_regex)
+    pos = _to_torch(robot.data.joint_pos)[:, joint_ids]
+    default_pos = _to_torch(robot.data.default_joint_pos)[:, joint_ids]
+    closed_count = (torch.abs(pos - default_pos) > min_deviation).sum(dim=-1)
+    return closed_count >= min_fingers_closed
+
+
+def is_grasped(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg = SceneEntityCfg("object"),
+    robot_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    ee_body_names: list[str] | str | None = None,
+    proximity_threshold: float = 0.18,
+    contact_sensor_cfgs: list[SceneEntityCfg] | SceneEntityCfg | None = None,
+    contact_force_threshold: float = 1.0,
+    require_closed_fingers: bool = True,
+    finger_joint_regex: str = G1_FINGER_JOINT_REGEX,
+    min_deviation: float = 0.1,
+    min_fingers_closed: int = 3,
+) -> torch.Tensor:
+    if ee_body_names is None:
+        ee_body_names = G1_FINGER_BODY_NAMES
+    elif isinstance(ee_body_names, str):
+        ee_body_names = [ee_body_names]
+    if isinstance(contact_sensor_cfgs, SceneEntityCfg):
+        contact_sensor_cfgs = [contact_sensor_cfgs] * len(ee_body_names)
+
+    any_grasped = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+    for i, name in enumerate(ee_body_names):
+        gripper_close = _gripper_obj_distance(env, object_cfg, robot_cfg, name) <= proximity_threshold
+        if contact_sensor_cfgs is not None:
+            gripper_close &= is_in_contact(
+                env,
+                contact_sensor_cfg=contact_sensor_cfgs[i],
+                force_threshold=contact_force_threshold,
+            )
+        any_grasped |= gripper_close
+
+    if require_closed_fingers:
+        any_grasped &= _fingers_closed(
+            env,
+            robot_cfg=robot_cfg,
+            finger_joint_regex=finger_joint_regex,
+            min_deviation=min_deviation,
+            min_fingers_closed=min_fingers_closed,
+        )
+    return any_grasped

--- a/isaaclab_arena_environments/G1_Factory/tests/test_policy_configs.py
+++ b/isaaclab_arena_environments/G1_Factory/tests/test_policy_configs.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import yaml
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena_gr00t.policy.config.gr00t_closedloop_policy_config import Gr00tClosedloopPolicyCfg
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_DIR = REPO_ROOT / "isaaclab_arena_environments" / "G1_Factory" / "policy_configs" / "benchmark"
+
+EXPECTED_CONFIGS = {
+    "LMBoxLift": "Walk to table and pick up the box",
+    "LMBoxLiftFloor": "Walk to the box, pick it up from the floor",
+    "LMBoxTableToShelfPnP": "Move box from table to shelf",
+    "LMDrillLift": "Walk to the table and pick up the power drill",
+    "LMDrillLiftObs": "Pick up the drill with a shelf obstacle",
+    "LMDrillPnP": "Move power drill from one table to another",
+    "LMPickDrillFromHolder": "Pick up the drill from holder",
+    "LMPushButton": "Walk to the console and press red button",
+    "LMPushShelfForward": "Push high wheeled shelf to marked area",
+}
+
+
+def _load_policy_config(env_name: str) -> Gr00tClosedloopPolicyCfg:
+    config_path = CONFIG_DIR / f"{env_name}_gr00t_closedloop.yaml"
+    with config_path.open(encoding="utf-8") as config_file:
+        config_data = yaml.safe_load(config_file)
+
+    valid_fields = {field.name for field in fields(Gr00tClosedloopPolicyCfg)}
+    unknown_fields = sorted(set(config_data) - valid_fields)
+    assert unknown_fields == [], f"{config_path} contains fields not supported by Gr00tClosedloopPolicyCfg"
+
+    return Gr00tClosedloopPolicyCfg(**config_data)
+
+
+def test_expected_policy_configs_exist():
+    expected_files = {f"{env_name}_gr00t_closedloop.yaml" for env_name in EXPECTED_CONFIGS}
+    actual_files = {path.name for path in CONFIG_DIR.glob("*_gr00t_closedloop.yaml")}
+
+    assert actual_files == expected_files
+
+
+@pytest.mark.parametrize("env_name", sorted(EXPECTED_CONFIGS))
+def test_policy_config_loads_against_current_gr00t_schema(env_name: str, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.chdir(REPO_ROOT)
+
+    policy_config = _load_policy_config(env_name)
+
+    assert policy_config.language_instruction == EXPECTED_CONFIGS[env_name]
+    assert policy_config.action_horizon == 16
+    assert policy_config.action_chunk_length == 16
+    assert policy_config.embodiment_tag == "NEW_EMBODIMENT"
+    assert policy_config.task_mode_name == "g1_locomanipulation"
+    assert policy_config.pov_cam_name_sim == ["robot_head_cam_rgb"]
+    assert tuple(policy_config.original_image_size) == (480, 640, 3)
+    assert tuple(policy_config.target_image_size) == (480, 640, 3)
+    assert policy_config.modality_config_path == "isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py"
+    assert (
+        str(policy_config.policy_joints_config_path)
+        == "isaaclab_arena_gr00t/embodiments/g1/gr00t_43dof_joint_space.yaml"
+    )
+    assert str(policy_config.action_joints_config_path) == "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"
+    assert str(policy_config.state_joints_config_path) == "isaaclab_arena_gr00t/embodiments/g1/43dof_joint_space.yaml"


### PR DESCRIPTION
## Summary

Ports the G1 Factory environment set onto current IsaacLab-Arena `main`, keeping G1-specific task/robot code isolated under:

```text
isaaclab_arena_environments/G1_Factory/
```

Includes:

- 9 G1 Factory environment entrypoints: `LMDrillLift`, `LMDrillPnP`, `LMPushButton`, `LMBoxLift`, `LMBoxLiftFloor`, `LMBoxTableToShelfPnP`, `LMDrillLiftObs`, `LMPickDrillFromHolder`, `LMPushShelfForward`
- G1-local assets/events/terminations/task wrappers/pose utilities
- Per-task GR00T closed-loop Arena-side translation configs under `policy_configs/benchmark/`
- G1 Factory README with checkpoint references and run commands
- Schema tests that load all G1 GR00T configs against current `Gr00tClosedloopPolicyCfg`

## Design notes

The port targets feature parity while reusing Arena `main` and avoiding shared Arena core changes. G1-specific behavior is contained under `isaaclab_arena_environments/G1_Factory/`.

The legacy G1 policy YAMLs included `model_path`. Arena main's `Gr00tRemoteClosedloopPolicy` now uses YAML only for Arena-side observation/action translation. The checkpoint is loaded by the external GR00T server, so this PR documents checkpoint references in the G1 Factory README instead of adding unsupported YAML keys.

Important preserved legacy policy values:

- `action_horizon: 16`
- `action_chunk_length: 16`
- `pov_cam_name_sim: robot_head_cam_rgb`
- `task_mode_name: g1_locomanipulation`
- G1 GR00T modality/joint config paths
- legacy task language instructions

The only intentional schema normalization is `embodiment_tag: NEW_EMBODIMENT`.

## Validation performed

- `pre-commit run --files` on changed README/test/YAML files: passed
- G1 config tests in Docker/Isaac Sim Python: `10 passed`
- All 9 G1 Factory GR00T configs load through Arena's runtime `create_config_from_yaml(..., Gr00tClosedloopPolicyCfg)` path
- GR00T client import path validated with `submodules/Isaac-GR00T` on `PYTHONPATH`
- `LMDrillLift` zero-action smoke:
  - headless, no cameras: completed 2 rollout steps
  - headless, `--enable_cameras`: completed 1 rollout step and confirmed `camera_obs.robot_head_cam_rgb` shape `(480, 640, 3)`

The `zero_action` policy is only an environment/action-space smoke test. It is not expected to produce stable learned G1 Factory behavior.

## Example: zero-action smoke test

```bash
PYTHONPATH=/workspaces/isaaclab_arena:${PYTHONPATH:-} \
submodules/IsaacLab/isaaclab.sh -p \
  isaaclab_arena/evaluation/policy_runner.py \
  --policy_type zero_action \
  --num_steps 20 \
  --viz none \
  --external_environment_class_path isaaclab_arena_environments.G1_Factory.LMDrillLift:LMDrillLift \
  LMDrillLift
```

## Example: G1 Factory GR00T checkpoint run path

Initialize the GR00T submodule first:

```bash
git -c url.https://github.com/.insteadOf=git@github.com: submodule update --init submodules/Isaac-GR00T
```

Start the GR00T server with a locally available G1 Factory checkpoint. The legacy checkpoint references are listed in `isaaclab_arena_environments/G1_Factory/README.md`; cloning `arena_data` provides assets, not these model checkpoints.

```bash
cd submodules/Isaac-GR00T
export G1_FACTORY_CHECKPOINT=/path/to/g1_benchmark_LMDrillLiftD1_100_gn1_5_output/checkpoint-20000
test -d "${G1_FACTORY_CHECKPOINT}"

uv run python gr00t/eval/run_gr00t_server.py \
  --model-path "${G1_FACTORY_CHECKPOINT}" \
  --embodiment-tag NEW_EMBODIMENT \
  --device cuda \
  --host 127.0.0.1 \
  --port 5555
```

From the Arena repository root in a second terminal, run the Arena client:

```bash
PYTHONPATH="$(pwd):$(pwd)/submodules/Isaac-GR00T:${PYTHONPATH:-}" \
submodules/IsaacLab/isaaclab.sh -p \
  isaaclab_arena/evaluation/policy_runner.py \
  --policy_type isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy \
  --policy_config_yaml_path isaaclab_arena_environments/G1_Factory/policy_configs/benchmark/LMDrillLift_gr00t_closedloop.yaml \
  --remote_host 127.0.0.1 \
  --remote_port 5555 \
  --num_steps 800 \
  --viz kit \
  --enable_cameras \
  --external_environment_class_path isaaclab_arena_environments.G1_Factory.LMDrillLift:LMDrillLift \
  LMDrillLift
```

Real-policy validation requires the external GR00T server and a locally available G1 Factory checkpoint, so this PR validates the Arena-side schema, scene construction, action-space path, camera observation path, and GR00T client import path.
