### PR TITLE
Add FaceTo in Relation Solver

### DIFF
--- a/isaaclab_arena/environments/relation_solver_interface.py
+++ b/isaaclab_arena/environments/relation_solver_interface.py
@@ -12,7 +12,8 @@ from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_events import get_rotation_xyzw, solve_and_place_objects
 from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
 from isaaclab_arena.relations.relations import get_anchor_objects
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, yaw_from_quat_xyzw
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.yaw import rotate_quat_by_yaw, yaw_from_quat_xyzw
 
 if TYPE_CHECKING:
     from isaaclab.managers import EventTermCfg

--- a/isaaclab_arena/relations/no_overlap_mesh.py
+++ b/isaaclab_arena/relations/no_overlap_mesh.py
@@ -17,7 +17,8 @@ from isaaclab_arena.relations.mesh_pair_cache import MeshPairCache, MeshPairEntr
 from isaaclab_arena.relations.relation_solver_state import RelationSolverState
 from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
 from isaaclab_arena.relations.warp_sdf_kernels import clamp_sdf_sentinel, multi_mesh_sdf
-from isaaclab_arena.utils.pose import Pose, rotate_points_by_yaw_batch, yaw_from_quat_xyzw
+from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.yaw import rotate_points_by_yaw_batch, yaw_from_quat_xyzw
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -60,7 +60,7 @@ class PlacementCandidate:
     """Per-check validation results for this candidate's layout."""
 
     orientations: dict[ObjectBase, float] = field(default_factory=dict)
-    """Absolute world Z-yaw per oriented object. Empty when unrotated."""
+    """Placement-computed absolute world Z-yaws. Omitted objects retain their marker orientation."""
 
     @property
     def is_valid(self) -> bool:
@@ -125,12 +125,13 @@ class ObjectPlacer:
         )
         results_per_env = [env_results[0] for env_results in ranked_results_per_env]
 
-        for env_idx, result in enumerate(results_per_env):
-            if not result.success:
-                print(
-                    f"  env {env_idx}: no valid layout; using lowest-loss fallback "
-                    f"(failed: {result.validation_results.get_failed_validation_check_names})"
-                )
+        if self.params.verbose:
+            for env_idx, result in enumerate(results_per_env):
+                if not result.success:
+                    print(
+                        f"  env {env_idx}: no valid layout; using lowest-loss fallback "
+                        f"(failed: {result.validation_results.get_failed_validation_check_names})"
+                    )
 
         if self.params.apply_positions_to_objects:
             positions_per_env = [r.positions for r in results_per_env]
@@ -178,31 +179,9 @@ class ObjectPlacer:
                 f"Object '{obj.name}' has no relations. All objects passed to place() must have "
                 "at least one relation (e.g., On(), NextTo(), or IsAnchor())."
             )
-            face_to_relations = [relation for relation in obj.get_relations() if isinstance(relation, FaceTo)]
-            assert len(face_to_relations) <= 1, f"Object '{obj.name}' has more than one FaceTo relation."
-            if face_to_relations:
-                assert not obj.is_anchor, f"Anchor object '{obj.name}' cannot have a FaceTo relation."
-                assert face_to_relations[0].parent is not obj, f"Object '{obj.name}' cannot face itself."
-                assert (
-                    face_to_relations[0].parent in object_set
-                ), f"FaceTo parent '{face_to_relations[0].parent.name}' must participate in placement."
-                assert (
-                    self._get_rotate_around_solution(obj) is None
-                ), f"Object '{obj.name}' cannot combine FaceTo with RotateAroundSolution."
-                subject_randomization = self._get_random_around_solution(obj)
-                if subject_randomization is not None:
-                    assert (
-                        subject_randomization.x_half_m == 0.0
-                        and subject_randomization.y_half_m == 0.0
-                        and subject_randomization.roll_half_rad == 0.0
-                        and subject_randomization.pitch_half_rad == 0.0
-                        and subject_randomization.yaw_half_rad == 0.0
-                    ), f"Object '{obj.name}' cannot randomize XY or rotation while using FaceTo."
-                parent_randomization = self._get_random_around_solution(face_to_relations[0].parent)
-                if parent_randomization is not None:
-                    assert (
-                        parent_randomization.x_half_m == 0.0 and parent_randomization.y_half_m == 0.0
-                    ), f"FaceTo parent '{face_to_relations[0].parent.name}' cannot randomize XY."
+            face_to = self._get_face_to(obj)
+            if face_to is not None:
+                self._validate_face_to_configuration(obj, face_to, object_set)
 
         anchor_objects = get_anchor_objects(objects)
         assert len(anchor_objects) > 0, (
@@ -964,11 +943,21 @@ class ObjectPlacer:
         positions: dict[ObjectBase, tuple[float, float, float]],
         orientations: dict[ObjectBase, float] | None,
     ) -> bool:
-        """Validate that every FaceTo subject has a defined orientation."""
+        """Validate that every FaceTo subject has a defined direction and computed yaw."""
         for obj in positions:
-            if self._get_face_to(obj) is not None and (orientations is None or obj not in orientations):
+            face_to = self._get_face_to(obj)
+            if face_to is None:
+                continue
+            subject_position = torch.tensor([positions[obj]])
+            target_position = torch.tensor([positions[face_to.parent]])
+            _, direction_is_defined = yaw_toward_positions(subject_position, target_position)
+            if not direction_is_defined.item():
                 if self.params.verbose:
-                    print(f"  FaceTo: '{obj.name}' has the same XY position as its target")
+                    print(f"  FaceTo: '{obj.name}' is too close to its target in XY")
+                return False
+            if orientations is None or obj not in orientations:
+                if self.params.verbose:
+                    print(f"  FaceTo: '{obj.name}' has no computed facing yaw")
                 return False
         return True
 
@@ -1020,6 +1009,38 @@ class ObjectPlacer:
                 return rel
         return None
 
+    def _validate_face_to_configuration(
+        self,
+        obj: ObjectBase,
+        face_to: FaceTo,
+        object_set: set[ObjectBase],
+    ) -> None:
+        """Require a movable subject, participating target, and stable facing direction."""
+        face_to_count = sum(isinstance(relation, FaceTo) for relation in obj.get_relations())
+        assert face_to_count == 1, f"Object '{obj.name}' has more than one FaceTo relation."
+        assert not obj.is_anchor, f"Anchor object '{obj.name}' cannot have a FaceTo relation."
+        assert face_to.parent is not obj, f"Object '{obj.name}' cannot face itself."
+        assert face_to.parent in object_set, f"FaceTo parent '{face_to.parent.name}' must participate in placement."
+        assert (
+            self._get_rotate_around_solution(obj) is None
+        ), f"Object '{obj.name}' cannot combine FaceTo with RotateAroundSolution."
+
+        subject_randomization = self._get_random_around_solution(obj)
+        if subject_randomization is not None:
+            assert (
+                subject_randomization.x_half_m == 0.0
+                and subject_randomization.y_half_m == 0.0
+                and subject_randomization.roll_half_rad == 0.0
+                and subject_randomization.pitch_half_rad == 0.0
+                and subject_randomization.yaw_half_rad == 0.0
+            ), f"Object '{obj.name}' cannot randomize XY or rotation while using FaceTo."
+
+        parent_randomization = self._get_random_around_solution(face_to.parent)
+        if parent_randomization is not None:
+            assert (
+                parent_randomization.x_half_m == 0.0 and parent_randomization.y_half_m == 0.0
+            ), f"FaceTo parent '{face_to.parent.name}' cannot randomize XY."
+
     @staticmethod
     def _get_rotate_around_solution(obj: ObjectBase) -> RotateAroundSolution | None:
         for rel in obj.get_relations():
@@ -1029,10 +1050,7 @@ class ObjectPlacer:
 
     @staticmethod
     def _get_face_to(obj: ObjectBase) -> FaceTo | None:
-        for relation in obj.get_relations():
-            if isinstance(relation, FaceTo):
-                return relation
-        return None
+        return next((relation for relation in obj.get_relations() if isinstance(relation, FaceTo)), None)
 
     @property
     def last_loss_history(self) -> list[float]:

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -416,6 +416,7 @@ class ObjectPlacer:
 
         Undefined directions leave the subject absent from the dictionary.
         """
+        assert positions_per_candidate, "positions_per_candidate must not be empty"
         assert len(positions_per_candidate) == len(orientations_per_candidate)
         objects = positions_per_candidate[0]
         for obj in objects:

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import torch
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
 from isaaclab_arena.relations.collision_mode import CollisionMode
@@ -23,6 +23,7 @@ from isaaclab_arena.relations.relations import (
     NotNextTo,
     On,
     RandomAroundSolution,
+    RelationBase,
     RotateAroundSolution,
     get_anchor_objects,
 )
@@ -44,6 +45,9 @@ if TYPE_CHECKING:
     import trimesh
 
     from isaaclab_arena.assets.object_base import ObjectBase
+
+
+RelationT = TypeVar("RelationT", bound=RelationBase)
 
 
 @dataclass
@@ -179,9 +183,8 @@ class ObjectPlacer:
                 f"Object '{obj.name}' has no relations. All objects passed to place() must have "
                 "at least one relation (e.g., On(), NextTo(), or IsAnchor())."
             )
-            face_to = self._get_face_to(obj)
-            if face_to is not None:
-                self._validate_face_to_configuration(obj, face_to, object_set)
+            for relation in obj.get_relations():
+                relation.validate_configuration(obj, object_set)
 
         anchor_objects = get_anchor_objects(objects)
         assert len(anchor_objects) > 0, (
@@ -400,7 +403,7 @@ class ObjectPlacer:
                     "Anchors are not repositioned by the placer, so any marker rotation must "
                     "already be baked into the anchor's initial_pose before calling place()."
                 )
-            elif self._get_face_to(obj) is None:
+            elif self._get_relation(obj, FaceTo) is None:
                 orientations[obj] = wrap_angle_to_pi(get_random_rotation(generator) + marker_yaw)
         return orientations
 
@@ -416,7 +419,7 @@ class ObjectPlacer:
         assert len(positions_per_candidate) == len(orientations_per_candidate)
         objects = positions_per_candidate[0]
         for obj in objects:
-            relation = ObjectPlacer._get_face_to(obj)
+            relation = ObjectPlacer._get_relation(obj, FaceTo)
             if relation is None:
                 continue
             subject_positions = torch.tensor([positions[obj] for positions in positions_per_candidate])
@@ -457,7 +460,7 @@ class ObjectPlacer:
         Rejects roll/pitch markers: a Z-rotated box can't enclose them, so they would otherwise
         validate a silently-wrong footprint.
         """
-        marker = ObjectPlacer._get_rotate_around_solution(obj)
+        marker = ObjectPlacer._get_relation(obj, RotateAroundSolution)
         if marker is None:
             return 0.0
         assert marker.roll_rad == 0.0 and marker.pitch_rad == 0.0, (
@@ -945,7 +948,7 @@ class ObjectPlacer:
     ) -> bool:
         """Validate that every FaceTo subject has a defined direction and computed yaw."""
         for obj in positions:
-            face_to = self._get_face_to(obj)
+            face_to = self._get_relation(obj, FaceTo)
             if face_to is None:
                 continue
             subject_position = torch.tensor([positions[obj]])
@@ -977,7 +980,7 @@ class ObjectPlacer:
             if obj in anchor_objects:
                 continue
 
-            rotate_marker = self._get_rotate_around_solution(obj)
+            rotate_marker = self._get_relation(obj, RotateAroundSolution)
             base_rotation = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
             marker_yaw = yaw_from_quat_xyzw(base_rotation)
 
@@ -988,7 +991,7 @@ class ObjectPlacer:
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
                 rotation_xyzw = rotate_quat_by_yaw(base_rotation, _yaw_delta(0))
-                random_marker = self._get_random_around_solution(obj)
+                random_marker = self._get_relation(obj, RandomAroundSolution)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
                 else:
@@ -1003,54 +1006,9 @@ class ObjectPlacer:
                 ]
                 obj.set_initial_pose(PosePerEnv(poses=poses))
 
-    def _get_random_around_solution(self, obj: ObjectBase) -> RandomAroundSolution | None:
-        for rel in obj.get_relations():
-            if isinstance(rel, RandomAroundSolution):
-                return rel
-        return None
-
-    def _validate_face_to_configuration(
-        self,
-        obj: ObjectBase,
-        face_to: FaceTo,
-        object_set: set[ObjectBase],
-    ) -> None:
-        """Require a movable subject, participating target, and stable facing direction."""
-        face_to_count = sum(isinstance(relation, FaceTo) for relation in obj.get_relations())
-        assert face_to_count == 1, f"Object '{obj.name}' has more than one FaceTo relation."
-        assert not obj.is_anchor, f"Anchor object '{obj.name}' cannot have a FaceTo relation."
-        assert face_to.parent is not obj, f"Object '{obj.name}' cannot face itself."
-        assert face_to.parent in object_set, f"FaceTo parent '{face_to.parent.name}' must participate in placement."
-        assert (
-            self._get_rotate_around_solution(obj) is None
-        ), f"Object '{obj.name}' cannot combine FaceTo with RotateAroundSolution."
-
-        subject_randomization = self._get_random_around_solution(obj)
-        if subject_randomization is not None:
-            assert (
-                subject_randomization.x_half_m == 0.0
-                and subject_randomization.y_half_m == 0.0
-                and subject_randomization.roll_half_rad == 0.0
-                and subject_randomization.pitch_half_rad == 0.0
-                and subject_randomization.yaw_half_rad == 0.0
-            ), f"Object '{obj.name}' cannot randomize XY or rotation while using FaceTo."
-
-        parent_randomization = self._get_random_around_solution(face_to.parent)
-        if parent_randomization is not None:
-            assert (
-                parent_randomization.x_half_m == 0.0 and parent_randomization.y_half_m == 0.0
-            ), f"FaceTo parent '{face_to.parent.name}' cannot randomize XY."
-
     @staticmethod
-    def _get_rotate_around_solution(obj: ObjectBase) -> RotateAroundSolution | None:
-        for rel in obj.get_relations():
-            if isinstance(rel, RotateAroundSolution):
-                return rel
-        return None
-
-    @staticmethod
-    def _get_face_to(obj: ObjectBase) -> FaceTo | None:
-        return next((relation for relation in obj.get_relations() if isinstance(relation, FaceTo)), None)
+    def _get_relation(obj: ObjectBase, relation_type: type[RelationT]) -> RelationT | None:
+        return next((relation for relation in obj.get_relations() if isinstance(relation, relation_type)), None)
 
     @property
     def last_loss_history(self) -> list[float]:

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -30,16 +30,15 @@ from isaaclab_arena.relations.relations import (
 from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
 from isaaclab_arena.relations.warp_sdf_kernels import has_sdf_sentinel, mesh_sdf
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import (
-    Pose,
-    PosePerEnv,
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.random import get_random_rotation
+from isaaclab_arena.utils.yaw import (
     centers_in_target_frame,
     rotate_quat_by_yaw,
     wrap_angle_to_pi,
     yaw_from_quat_xyzw,
     yaw_toward_positions,
 )
-from isaaclab_arena.utils.random import get_random_rotation
 
 if TYPE_CHECKING:
     import trimesh
@@ -184,7 +183,7 @@ class ObjectPlacer:
                 "at least one relation (e.g., On(), NextTo(), or IsAnchor())."
             )
             for relation in obj.get_relations():
-                relation.validate_configuration(obj, object_set)
+                relation.validate_placement_configuration(obj, object_set)
 
         anchor_objects = get_anchor_objects(objects)
         assert len(anchor_objects) > 0, (
@@ -982,16 +981,16 @@ class ObjectPlacer:
                 continue
 
             rotate_marker = self._get_relation(obj, RotateAroundSolution)
-            base_rotation = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
-            marker_yaw = yaw_from_quat_xyzw(base_rotation)
+            marker_rotation = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
+            marker_yaw = yaw_from_quat_xyzw(marker_rotation)
 
             def _yaw_delta(env_idx: int) -> float:
-                """Return the yaw to compose with the base rotation."""
+                """Return the yaw to compose with the RotateAroundSolution marker rotation."""
                 return orientations_per_env[env_idx].get(obj, marker_yaw) - marker_yaw
 
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
-                rotation_xyzw = rotate_quat_by_yaw(base_rotation, _yaw_delta(0))
+                rotation_xyzw = rotate_quat_by_yaw(marker_rotation, _yaw_delta(0))
                 random_marker = self._get_relation(obj, RandomAroundSolution)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
@@ -1001,7 +1000,7 @@ class ObjectPlacer:
                 poses = [
                     Pose(
                         position_xyz=positions_per_env[env_idx][obj],
-                        rotation_xyzw=rotate_quat_by_yaw(base_rotation, _yaw_delta(env_idx)),
+                        rotation_xyzw=rotate_quat_by_yaw(marker_rotation, _yaw_delta(env_idx)),
                     )
                     for env_idx in range(num_envs)
                 ]

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -18,6 +18,7 @@ from isaaclab_arena.relations.placement_validation import PlacementCheck, Placem
 from isaaclab_arena.relations.relation_loss_strategies import SIDE_CONFIGS, next_to_violations, not_next_to_violations
 from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relations import (
+    FaceTo,
     NextTo,
     NotNextTo,
     On,
@@ -35,6 +36,7 @@ from isaaclab_arena.utils.pose import (
     rotate_quat_by_yaw,
     wrap_angle_to_pi,
     yaw_from_quat_xyzw,
+    yaw_toward_positions,
 )
 from isaaclab_arena.utils.random import get_random_rotation
 
@@ -58,7 +60,7 @@ class PlacementCandidate:
     """Per-check validation results for this candidate's layout."""
 
     orientations: dict[ObjectBase, float] = field(default_factory=dict)
-    """Total applied Z-yaw (marker + sampled) per object. Empty when unrotated."""
+    """Absolute world Z-yaw per oriented object. Empty when unrotated."""
 
     @property
     def is_valid(self) -> bool:
@@ -123,15 +125,12 @@ class ObjectPlacer:
         )
         results_per_env = [env_results[0] for env_results in ranked_results_per_env]
 
-        if self.params.verbose:
-            # If no valid layout is found, print the failed checks for the lowest-loss fallback
-            # So we can debug the placement problem and it still produces some layouts for the envs
-            for env_idx, result in enumerate(results_per_env):
-                if not result.success:
-                    print(
-                        f"  env {env_idx}: no valid layout; using lowest-loss fallback "
-                        f"(failed: {result.validation_results.get_failed_validation_check_names})"
-                    )
+        for env_idx, result in enumerate(results_per_env):
+            if not result.success:
+                print(
+                    f"  env {env_idx}: no valid layout; using lowest-loss fallback "
+                    f"(failed: {result.validation_results.get_failed_validation_check_names})"
+                )
 
         if self.params.apply_positions_to_objects:
             positions_per_env = [r.positions for r in results_per_env]
@@ -173,11 +172,37 @@ class ObjectPlacer:
         objects: list[ObjectBase],
     ) -> tuple[set[ObjectBase], torch.Generator | None]:
         """Validate placement inputs and allocate an RNG seeded per candidate later."""
+        object_set = set(objects)
         for obj in objects:
             assert obj.get_relations(), (
                 f"Object '{obj.name}' has no relations. All objects passed to place() must have "
                 "at least one relation (e.g., On(), NextTo(), or IsAnchor())."
             )
+            face_to_relations = [relation for relation in obj.get_relations() if isinstance(relation, FaceTo)]
+            assert len(face_to_relations) <= 1, f"Object '{obj.name}' has more than one FaceTo relation."
+            if face_to_relations:
+                assert not obj.is_anchor, f"Anchor object '{obj.name}' cannot have a FaceTo relation."
+                assert face_to_relations[0].parent is not obj, f"Object '{obj.name}' cannot face itself."
+                assert (
+                    face_to_relations[0].parent in object_set
+                ), f"FaceTo parent '{face_to_relations[0].parent.name}' must participate in placement."
+                assert (
+                    self._get_rotate_around_solution(obj) is None
+                ), f"Object '{obj.name}' cannot combine FaceTo with RotateAroundSolution."
+                subject_randomization = self._get_random_around_solution(obj)
+                if subject_randomization is not None:
+                    assert (
+                        subject_randomization.x_half_m == 0.0
+                        and subject_randomization.y_half_m == 0.0
+                        and subject_randomization.roll_half_rad == 0.0
+                        and subject_randomization.pitch_half_rad == 0.0
+                        and subject_randomization.yaw_half_rad == 0.0
+                    ), f"Object '{obj.name}' cannot randomize XY or rotation while using FaceTo."
+                parent_randomization = self._get_random_around_solution(face_to_relations[0].parent)
+                if parent_randomization is not None:
+                    assert (
+                        parent_randomization.x_half_m == 0.0 and parent_randomization.y_half_m == 0.0
+                    ), f"FaceTo parent '{face_to_relations[0].parent.name}' cannot randomize XY."
 
         anchor_objects = get_anchor_objects(objects)
         assert len(anchor_objects) > 0, (
@@ -218,7 +243,7 @@ class ObjectPlacer:
         assign_variants_for_envs(objects, num_envs, placement_seed=self.params.placement_seed)
         num_candidates = num_envs * candidates_per_env
         env_bboxes = build_per_env_bounding_boxes(objects, num_envs)
-        candidate_bboxes = env_bboxes.get_bounding_boxes_for_solver_candidates(candidates_per_env)
+        unrotated_candidate_bboxes = env_bboxes.get_bounding_boxes_for_solver_candidates(candidates_per_env)
         per_env_bboxes = env_bboxes.get_bounding_boxes_for_all_envs()
 
         initial_positions: list[dict[ObjectBase, tuple[float, float, float]]] = []
@@ -235,11 +260,18 @@ class ObjectPlacer:
                 self._generate_initial_orientations(objects, anchor_objects_set, generator)
             )
 
-        # Bake each candidate's total yaw into a conservative enclosing bbox for overlap checks.
-        candidate_bboxes = self._rotate_candidate_bboxes(objects, candidate_bboxes, orientations_per_candidate)
+        # Bake each candidate's yaw into a conservative enclosing bbox for overlap checks.
+        candidate_bboxes = self._rotate_candidate_bboxes(
+            objects, unrotated_candidate_bboxes, orientations_per_candidate
+        )
 
         all_positions = self._solver.solve(
             objects, initial_positions, env_bboxes=candidate_bboxes, orientations=orientations_per_candidate
+        )
+        self._apply_face_to_orientations(all_positions, orientations_per_candidate)
+        # FaceTo yaw is only known after solving, so rebuild from unrotated boxes before validation.
+        candidate_bboxes = self._rotate_candidate_bboxes(
+            objects, unrotated_candidate_bboxes, orientations_per_candidate
         )
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()
@@ -374,7 +406,7 @@ class ObjectPlacer:
         anchor_objects: set[ObjectBase],
         generator: torch.Generator | None = None,
     ) -> dict[ObjectBase, float]:
-        """Compute the total applied Z-yaw (marker + sampled) for each non-anchor object.
+        """Sample absolute world Z-yaws for non-anchor objects without FaceTo.
 
         Empty dict when random_yaw_init is off.
         """
@@ -389,9 +421,31 @@ class ObjectPlacer:
                     "Anchors are not repositioned by the placer, so any marker rotation must "
                     "already be baked into the anchor's initial_pose before calling place()."
                 )
-            else:
+            elif self._get_face_to(obj) is None:
                 orientations[obj] = wrap_angle_to_pi(get_random_rotation(generator) + marker_yaw)
         return orientations
+
+    @staticmethod
+    def _apply_face_to_orientations(
+        positions_per_candidate: list[dict[ObjectBase, tuple[float, float, float]]],
+        orientations_per_candidate: list[dict[ObjectBase, float]],
+    ) -> None:
+        """Write defined FaceTo yaws into each candidate's orientation dictionary in place.
+
+        Undefined directions leave the subject absent from the dictionary.
+        """
+        assert len(positions_per_candidate) == len(orientations_per_candidate)
+        objects = positions_per_candidate[0]
+        for obj in objects:
+            relation = ObjectPlacer._get_face_to(obj)
+            if relation is None:
+                continue
+            subject_positions = torch.tensor([positions[obj] for positions in positions_per_candidate])
+            target_positions = torch.tensor([positions[relation.parent] for positions in positions_per_candidate])
+            yaws, is_defined = yaw_toward_positions(subject_positions, target_positions)
+            for candidate_idx, (yaw, direction_is_defined) in enumerate(zip(yaws, is_defined, strict=True)):
+                if direction_is_defined:
+                    orientations_per_candidate[candidate_idx][obj] = yaw.item()
 
     @staticmethod
     def _rotate_candidate_bboxes(
@@ -401,7 +455,7 @@ class ObjectPlacer:
     ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
         """Replace each candidate's bbox with the enclosing box of its yaw-rotated object.
 
-        orientations_per_candidate carries total applied yaw (marker + sampled).
+        orientations_per_candidate carries absolute world yaw.
         Returns the input unchanged when no yaw is set, keeping the no-yaw path exact.
         """
         if not any(orientations for orientations in orientations_per_candidate):
@@ -410,11 +464,10 @@ class ObjectPlacer:
         rotated: dict[ObjectBase, AxisAlignedBoundingBox] = {}
         for obj in objects:
             bbox = candidate_bboxes[obj]
-            if any(obj in orientations for orientations in orientations_per_candidate):
-                yaws = [orientations_per_candidate[c].get(obj, 0.0) for c in range(num_candidates)]
-                if any(yaw != 0.0 for yaw in yaws):
-                    yaw_tensor = torch.tensor(yaws, dtype=torch.float32, device=bbox.min_point.device)
-                    bbox = bbox.rotated_around_z(yaw_tensor)
+            yaws = [orientations_per_candidate[c].get(obj, 0.0) for c in range(num_candidates)]
+            if any(yaw != 0.0 for yaw in yaws):
+                yaw_tensor = torch.tensor(yaws, dtype=torch.float32, device=bbox.min_point.device)
+                bbox = bbox.rotated_around_z(yaw_tensor)
             rotated[obj] = bbox
         return rotated
 
@@ -870,7 +923,7 @@ class ObjectPlacer:
         env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
         orientations: dict[ObjectBase, float] | None = None,
     ) -> PlacementValidationResults:
-        """Validate that no two objects overlap in 3D and On / NextTo / NotNextTo relations are satisfied.
+        """Validate overlap and all supported placement relations.
 
         Args:
             positions: Dictionary mapping objects to their solved (x, y, z) positions.
@@ -887,6 +940,7 @@ class ObjectPlacer:
         on_relation = self._validate_on_relations(positions, env_bboxes)
         next_to = self._validate_next_to_relations(positions, env_bboxes)
         not_next_to = self._validate_not_next_to_relations(positions, env_bboxes)
+        face_to = self._validate_face_to_relations(positions, orientations)
 
         return PlacementValidationResults(
             validation_results={
@@ -894,14 +948,29 @@ class ObjectPlacer:
                 PlacementCheck.ON_RELATION: on_relation,
                 PlacementCheck.NEXT_TO: next_to,
                 PlacementCheck.NOT_NEXT_TO: not_next_to,
+                PlacementCheck.FACE_TO: face_to,
             },
             required_checks={
                 PlacementCheck.NO_OVERLAP,
                 PlacementCheck.ON_RELATION,
                 PlacementCheck.NEXT_TO,
                 PlacementCheck.NOT_NEXT_TO,
+                PlacementCheck.FACE_TO,
             },
         )
+
+    def _validate_face_to_relations(
+        self,
+        positions: dict[ObjectBase, tuple[float, float, float]],
+        orientations: dict[ObjectBase, float] | None,
+    ) -> bool:
+        """Validate that every FaceTo subject has a defined orientation."""
+        for obj in positions:
+            if self._get_face_to(obj) is not None and (orientations is None or obj not in orientations):
+                if self.params.verbose:
+                    print(f"  FaceTo: '{obj.name}' has the same XY position as its target")
+                return False
+        return True
 
     def _apply_poses(
         self,
@@ -911,7 +980,7 @@ class ObjectPlacer:
     ) -> None:
         """Apply solved positions and orientations to non-anchor objects.
 
-        orientations_per_env carries total Z-yaw; marker yaw is subtracted to get the sampled delta.
+        orientations_per_env carries absolute world yaw; marker yaw is subtracted before composition.
         """
         num_envs = len(positions_per_env)
         objects = list(positions_per_env[0])
@@ -923,13 +992,13 @@ class ObjectPlacer:
             base_rotation = rotate_marker.get_rotation_xyzw() if rotate_marker else (0.0, 0.0, 0.0, 1.0)
             marker_yaw = yaw_from_quat_xyzw(base_rotation)
 
-            def _sampled_yaw_delta(env_idx: int) -> float:
-                """Total yaw minus marker yaw = solver-sampled delta."""
+            def _yaw_delta(env_idx: int) -> float:
+                """Return the yaw to compose with the base rotation."""
                 return orientations_per_env[env_idx].get(obj, marker_yaw) - marker_yaw
 
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
-                rotation_xyzw = rotate_quat_by_yaw(base_rotation, _sampled_yaw_delta(0))
+                rotation_xyzw = rotate_quat_by_yaw(base_rotation, _yaw_delta(0))
                 random_marker = self._get_random_around_solution(obj)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
@@ -939,7 +1008,7 @@ class ObjectPlacer:
                 poses = [
                     Pose(
                         position_xyz=positions_per_env[env_idx][obj],
-                        rotation_xyzw=rotate_quat_by_yaw(base_rotation, _sampled_yaw_delta(env_idx)),
+                        rotation_xyzw=rotate_quat_by_yaw(base_rotation, _yaw_delta(env_idx)),
                     )
                     for env_idx in range(num_envs)
                 ]
@@ -956,6 +1025,13 @@ class ObjectPlacer:
         for rel in obj.get_relations():
             if isinstance(rel, RotateAroundSolution):
                 return rel
+        return None
+
+    @staticmethod
+    def _get_face_to(obj: ObjectBase) -> FaceTo | None:
+        for relation in obj.get_relations():
+            if isinstance(relation, FaceTo):
+                return relation
         return None
 
     @property

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -12,8 +12,9 @@ from isaaclab.envs import ManagerBasedEnv
 
 from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
 from isaaclab_arena.relations.relations import RotateAroundSolution, get_anchor_objects
-from isaaclab_arena.utils.pose import Pose, rotate_quat_by_yaw, yaw_from_quat_xyzw
+from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.velocity import Velocity
+from isaaclab_arena.utils.yaw import rotate_quat_by_yaw, yaw_from_quat_xyzw
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -131,7 +131,7 @@ def solve_and_place_objects(
         if not result.success:
             print(
                 "Warning: Writing best-loss fallback placement for "
-                f"env {cur_env}; layout failed strict placement validation."
+                f"env {cur_env}; failed checks: {result.validation_results.get_failed_validation_check_names}."
             )
         # only write the non-anchor objects to the sim
         write_layout_to_sim(env, cur_env, result, anchor_objects_set, base_rotations)

--- a/isaaclab_arena/relations/placement_result.py
+++ b/isaaclab_arena/relations/placement_result.py
@@ -30,7 +30,7 @@ class PlacementResult:
     """Number of attempts made."""
 
     orientations: dict[ObjectBase, float] = field(default_factory=dict)
-    """Absolute world Z-yaw (radians) per oriented object. Empty when unrotated."""
+    """Placement-computed absolute world Z-yaws. Omitted objects retain their marker orientation."""
 
     @property
     def success(self) -> bool:

--- a/isaaclab_arena/relations/placement_result.py
+++ b/isaaclab_arena/relations/placement_result.py
@@ -30,7 +30,7 @@ class PlacementResult:
     """Number of attempts made."""
 
     orientations: dict[ObjectBase, float] = field(default_factory=dict)
-    """Total applied Z-yaw (radians) per object (marker + sampled). Empty when unrotated."""
+    """Absolute world Z-yaw (radians) per oriented object. Empty when unrotated."""
 
     @property
     def success(self) -> bool:

--- a/isaaclab_arena/relations/placement_validation.py
+++ b/isaaclab_arena/relations/placement_validation.py
@@ -27,6 +27,9 @@ class PlacementCheck(StrEnum):
     """Build-time check: every ``NotNextTo`` relation holds — child has cleared the keep-out zone
     beside the parent, within the relation's ``tolerance_m``."""
 
+    FACE_TO = "face_to"
+    """Build-time check: every ``FaceTo`` subject has a distinct target XY position."""
+
     PHYSICS_SETTLED = "physics_settled"
     """Run-time check: after stepping physics the movable objects' velocities fall
     below threshold, i.e. the layout is stable and does not drift or topple."""
@@ -63,7 +66,7 @@ class PlacementValidationResults:
     @property
     def get_failed_validation_check_names(self) -> list[str]:
         """Get the failed validation check names."""
-        return [check for check in self.validation_results.keys() if not self.validation_results[check]]
+        return [str(check) for check, passed in self.validation_results.items() if not passed]
 
     def report(self) -> str:
         """One-line report check items and their results."""

--- a/isaaclab_arena/relations/placement_validation.py
+++ b/isaaclab_arena/relations/placement_validation.py
@@ -28,7 +28,7 @@ class PlacementCheck(StrEnum):
     beside the parent, within the relation's ``tolerance_m``."""
 
     FACE_TO = "face_to"
-    """Build-time check: every ``FaceTo`` subject has a distinct target XY position."""
+    """Build-time check: every ``FaceTo`` subject has a defined target direction and facing yaw."""
 
     PHYSICS_SETTLED = "physics_settled"
     """Run-time check: after stepping physics the movable objects' velocities fall

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -39,7 +39,8 @@ class RelationBase:
     in its relations list.
     """
 
-    pass
+    def validate_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
+        """Validate this relation for its subject and participating objects."""
 
 
 class UnaryRelation(RelationBase):
@@ -94,6 +95,33 @@ class FaceTo(RelationBase):
     def is_unary() -> bool:
         """Return whether the relation constrains a single object."""
         return False
+
+    def validate_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
+        """Validate the facing relation for its subject and target."""
+        face_to_count = sum(isinstance(relation, FaceTo) for relation in subject.get_relations())
+        assert face_to_count == 1, f"Object '{subject.name}' has more than one FaceTo relation."
+        assert not subject.is_anchor, f"Anchor object '{subject.name}' cannot have a FaceTo relation."
+        assert self.parent is not subject, f"Object '{subject.name}' cannot face itself."
+        assert self.parent in objects, f"FaceTo parent '{self.parent.name}' must participate in placement."
+        assert not any(
+            isinstance(relation, RotateAroundSolution) for relation in subject.get_relations()
+        ), f"Object '{subject.name}' cannot combine FaceTo with RotateAroundSolution."
+
+        subject_randomization = next(
+            (relation for relation in subject.get_relations() if isinstance(relation, RandomAroundSolution)), None
+        )
+        if subject_randomization is not None:
+            assert (
+                subject_randomization.x_half_m == 0.0 and subject_randomization.y_half_m == 0.0
+            ), f"Object '{subject.name}' cannot randomize XY while using FaceTo."
+
+        parent_randomization = next(
+            (relation for relation in self.parent.get_relations() if isinstance(relation, RandomAroundSolution)), None
+        )
+        if parent_randomization is not None:
+            assert (
+                parent_randomization.x_half_m == 0.0 and parent_randomization.y_half_m == 0.0
+            ), f"FaceTo parent '{self.parent.name}' cannot randomize XY."
 
 
 @register_object_relation

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -75,10 +75,10 @@ class Relation(RelationBase):
 
 @register_object_relation
 class FaceTo(RelationBase):
-    """Orients an object's local +X axis toward another object's world XY position.
+    """Relates an object's local +X heading to a target object's world-XY direction.
 
-    This post-solve relation sets a Z-axis yaw and is not a position constraint.
-    The subject's XY position must differ from its target's.
+    This orientation relation does not constrain either object's position. The
+    subject's XY position must differ from the target's.
     """
 
     name = "face_to"
@@ -86,7 +86,7 @@ class FaceTo(RelationBase):
     def __init__(self, parent: ObjectBase):
         """
         Args:
-            parent: Object to face.
+            parent: Target object that defines the facing direction.
         """
         self.parent = parent
 

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -39,8 +39,8 @@ class RelationBase:
     in its relations list.
     """
 
-    def validate_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
-        """Validate this relation for its subject and participating objects."""
+    def validate_placement_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
+        """Validate this relation for placement among the participating objects."""
 
 
 class UnaryRelation(RelationBase):
@@ -96,7 +96,7 @@ class FaceTo(RelationBase):
         """Return whether the relation constrains a single object."""
         return False
 
-    def validate_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
+    def validate_placement_configuration(self, subject: ObjectBase, objects: set[ObjectBase]) -> None:
         """Validate the facing relation for its subject and target."""
         face_to_count = sum(isinstance(relation, FaceTo) for relation in subject.get_relations())
         assert face_to_count == 1, f"Object '{subject.name}' has more than one FaceTo relation."

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -74,6 +74,29 @@ class Relation(RelationBase):
 
 
 @register_object_relation
+class FaceTo(RelationBase):
+    """Orients an object's local +X axis toward another object's world XY position.
+
+    This post-solve relation sets a Z-axis yaw and is not a position constraint.
+    The subject's XY position must differ from its target's.
+    """
+
+    name = "face_to"
+
+    def __init__(self, parent: ObjectBase):
+        """
+        Args:
+            parent: Object to face.
+        """
+        self.parent = parent
+
+    @staticmethod
+    def is_unary() -> bool:
+        """Return whether the relation constrains a single object."""
+        return False
+
+
+@register_object_relation
 class NextTo(Relation):
     """Represents a 'next to' relationship between objects.
 

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 from isaaclab_arena.assets.dummy_object import DummyObject
 from isaaclab_arena.assets.object_base import ObjectBase
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
-from isaaclab_arena.environments.arena_env_graph_types import SpatialRelationSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import SpatialRelationSpec
 from isaaclab_arena.relations.collision_mode import CollisionMode
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -3,15 +3,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import math
 import torch
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import ValidationError
 
 from isaaclab_arena.assets.dummy_object import DummyObject
-from isaaclab_arena.assets.object_base import ObjectBase
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.environment_spec.arena_env_graph_types import SpatialRelationSpec
 from isaaclab_arena.relations.collision_mode import CollisionMode
@@ -30,6 +32,9 @@ from isaaclab_arena.utils.pose import (
     yaw_from_quat_xyzw,
     yaw_toward_positions,
 )
+
+if TYPE_CHECKING:
+    from isaaclab_arena.assets.object_base import ObjectBase
 
 
 def _box(name: str, half_extents: tuple[float, float, float] = (0.1, 0.1, 0.1)) -> DummyObject:
@@ -103,8 +108,11 @@ def test_yaw_toward_positions_is_translation_invariant_and_batched():
 
 
 def test_yaw_toward_positions_rejects_near_coincident_xy():
+    from isaaclab_arena.utils.pose import MINIMUM_FACING_DIRECTION_XY_M
+
+    epsilon = MINIMUM_FACING_DIRECTION_XY_M
     subjects = torch.zeros((3, 3))
-    targets = torch.tensor([[1e-7, 0.0, 1.0], [1e-6, 0.0, 1.0], [1.1e-6, 0.0, 1.0]])
+    targets = torch.tensor([[epsilon * 0.1, 0.0, 1.0], [epsilon, 0.0, 1.0], [epsilon * 1.1, 0.0, 1.0]])
 
     _, is_defined = yaw_toward_positions(subjects, targets)
 
@@ -220,15 +228,14 @@ def test_face_to_rejects_reset_randomization_that_changes_direction(randomized_o
         ObjectPlacer()._prepare_placement([pair.target, pair.subject])
 
 
-def test_face_to_allows_reset_rotation_around_facing_yaw(monkeypatch):
+def test_face_to_allows_reset_rotation_around_facing_yaw():
     pair = _face_to_pair(target_position=(0.0, 2.0, 0.0))
-    pair.subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
     pair.subject.add_relation(RandomAroundSolution(roll_half_rad=0.1, pitch_half_rad=0.2, yaw_half_rad=0.3))
-    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1))
+    placer = ObjectPlacer()
     positions = {pair.target: (0.0, 2.0, 0.0), pair.subject: (0.0, 0.0, 0.0)}
-    _set_solver_results(monkeypatch, placer, [positions])
 
-    placer.place([pair.target, pair.subject])
+    anchors, _ = placer._prepare_placement([pair.target, pair.subject])
+    placer._apply_poses([positions], anchors, [{pair.subject: math.pi / 2}])
     pose = pair.subject.get_initial_pose()
 
     assert isinstance(pose, PoseRange)
@@ -312,10 +319,10 @@ def test_face_to_registers_as_binary_graph_relation():
     subject = _box("subject")
     target = _box("target")
     spec = SpatialRelationSpec(kind="face_to", subject="camera", reference="object")
-    relation_class = ObjectRelationLibraryRegistry().get_object_relation_by_name(spec.kind)
-    subject.add_relation(relation_class(target, **spec.params))
+    registry = ObjectRelationLibraryRegistry()
+    subject.add_relation(FaceTo(target, **spec.params))
 
-    assert relation_class is FaceTo
+    assert registry.is_registered(spec.kind, ensure_loaded=False)
     (relation,) = subject.get_relations()
     assert relation.parent is target
     with pytest.raises(ValidationError, match="requires relation.reference"):

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -22,7 +22,14 @@ from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.relations.relations import AtPosition, FaceTo, IsAnchor, RandomAroundSolution, RotateAroundSolution
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, wrap_angle_to_pi, yaw_from_quat_xyzw, yaw_toward_positions
+from isaaclab_arena.utils.pose import (
+    Pose,
+    PosePerEnv,
+    PoseRange,
+    wrap_angle_to_pi,
+    yaw_from_quat_xyzw,
+    yaw_toward_positions,
+)
 
 
 def _box(name: str, half_extents: tuple[float, float, float] = (0.1, 0.1, 0.1)) -> DummyObject:
@@ -157,7 +164,7 @@ def test_face_to_rebuilds_rotated_footprint_before_validation():
     assert validation.validation_results[PlacementCheck.NO_OVERLAP] is False
 
 
-def test_face_to_suppresses_random_yaw_and_rejects_rotate_marker():
+def test_face_to_suppresses_initial_random_yaw_and_rejects_rotate_marker():
     pair = _face_to_pair()
     placer = ObjectPlacer(ObjectPlacerParams(random_yaw_init=True))
 
@@ -201,8 +208,7 @@ def test_face_to_rejects_invalid_relation_configuration(invalid_case, message):
 @pytest.mark.parametrize(
     ("randomized_object", "randomization", "message"),
     [
-        ("subject", RandomAroundSolution(x_half_m=0.1), "cannot randomize XY or rotation"),
-        ("subject", RandomAroundSolution(yaw_half_rad=0.1), "cannot randomize XY or rotation"),
+        ("subject", RandomAroundSolution(x_half_m=0.1), "cannot randomize XY"),
         ("target", RandomAroundSolution(y_half_m=0.1), "cannot randomize XY"),
     ],
 )
@@ -212,6 +218,22 @@ def test_face_to_rejects_reset_randomization_that_changes_direction(randomized_o
 
     with pytest.raises(AssertionError, match=message):
         ObjectPlacer()._prepare_placement([pair.target, pair.subject])
+
+
+def test_face_to_allows_reset_rotation_around_facing_yaw(monkeypatch):
+    pair = _face_to_pair(target_position=(0.0, 2.0, 0.0))
+    pair.subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
+    pair.subject.add_relation(RandomAroundSolution(roll_half_rad=0.1, pitch_half_rad=0.2, yaw_half_rad=0.3))
+    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1))
+    positions = {pair.target: (0.0, 2.0, 0.0), pair.subject: (0.0, 0.0, 0.0)}
+    _set_solver_results(monkeypatch, placer, [positions])
+
+    placer.place([pair.target, pair.subject])
+    pose = pair.subject.get_initial_pose()
+
+    assert isinstance(pose, PoseRange)
+    assert pose.rpy_min == pytest.approx((-0.1, -0.2, math.pi / 2 - 0.3))
+    assert pose.rpy_max == pytest.approx((0.1, 0.2, math.pi / 2 + 0.3))
 
 
 def test_relation_solver_ignores_face_to_marker():

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -24,14 +24,8 @@ from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.relations.relations import AtPosition, FaceTo, IsAnchor, RandomAroundSolution, RotateAroundSolution
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import (
-    Pose,
-    PosePerEnv,
-    PoseRange,
-    wrap_angle_to_pi,
-    yaw_from_quat_xyzw,
-    yaw_toward_positions,
-)
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+from isaaclab_arena.utils.yaw import wrap_angle_to_pi, yaw_from_quat_xyzw, yaw_toward_positions
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase
@@ -108,7 +102,7 @@ def test_yaw_toward_positions_is_translation_invariant_and_batched():
 
 
 def test_yaw_toward_positions_rejects_near_coincident_xy():
-    from isaaclab_arena.utils.pose import MINIMUM_FACING_DIRECTION_XY_M
+    from isaaclab_arena.utils.yaw import MINIMUM_FACING_DIRECTION_XY_M
 
     epsilon = MINIMUM_FACING_DIRECTION_XY_M
     subjects = torch.zeros((3, 3))

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -5,11 +5,13 @@
 
 import math
 import torch
+from dataclasses import dataclass
 
 import pytest
 from pydantic import ValidationError
 
 from isaaclab_arena.assets.dummy_object import DummyObject
+from isaaclab_arena.assets.object_base import ObjectBase
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.environments.arena_env_graph_types import SpatialRelationSpec
 from isaaclab_arena.relations.collision_mode import CollisionMode
@@ -31,8 +33,36 @@ def _box(name: str, half_extents: tuple[float, float, float] = (0.1, 0.1, 0.1)) 
     )
 
 
-def _set_solver_results(monkeypatch, placer, layouts, losses=None):
-    def _solve(objects, initial_positions, env_bboxes, orientations):
+@dataclass(frozen=True)
+class _FaceToPair:
+    target: DummyObject
+    subject: DummyObject
+
+
+def _face_to_pair(
+    target_position: tuple[float, float, float] = (1.0, 0.0, 0.0),
+    subject_half_extents: tuple[float, float, float] = (0.1, 0.1, 0.1),
+) -> _FaceToPair:
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=target_position))
+    target.add_relation(IsAnchor())
+    subject = _box("subject", half_extents=subject_half_extents)
+    subject.add_relation(FaceTo(target))
+    return _FaceToPair(target=target, subject=subject)
+
+
+def _set_solver_results(
+    monkeypatch: pytest.MonkeyPatch,
+    placer: ObjectPlacer,
+    layouts: list[dict[ObjectBase, tuple[float, float, float]]],
+    losses: list[float] | None = None,
+) -> None:
+    def _solve(
+        objects: list[ObjectBase],
+        initial_positions: list[dict[ObjectBase, tuple[float, float, float]]],
+        env_bboxes: dict[ObjectBase, AxisAlignedBoundingBox] | None,
+        orientations: list[dict[ObjectBase, float]] | None,
+    ) -> list[dict[ObjectBase, tuple[float, float, float]]]:
         assert len(initial_positions) == len(layouts)
         placer._solver._last_loss_per_env = torch.tensor(losses or [0.0] * len(layouts))
         return layouts
@@ -75,21 +105,17 @@ def test_yaw_toward_positions_rejects_near_coincident_xy():
 
 
 def test_face_to_uses_candidate_positions_for_anchor_and_foreground_targets():
-    anchor = _box("anchor")
-    anchor.set_initial_pose(Pose(position_xyz=(0.0, -2.0, 0.0)))
-    anchor.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(anchor))
+    pair = _face_to_pair(target_position=(0.0, -2.0, 0.0))
     positions = [
-        {subject: (0.0, 0.0, 0.0), anchor: anchor.get_initial_pose().position_xyz},
-        {subject: (2.0, -2.0, 0.0), anchor: (2.0, 0.0, 0.0)},
+        {pair.subject: (0.0, 0.0, 0.0), pair.target: pair.target.get_initial_pose().position_xyz},
+        {pair.subject: (2.0, -2.0, 0.0), pair.target: (2.0, 0.0, 0.0)},
     ]
     orientations = [{}, {}]
 
     ObjectPlacer._apply_face_to_orientations(positions, orientations)
 
-    assert orientations[0][subject] == pytest.approx(-math.pi / 2)
-    assert orientations[1][subject] == pytest.approx(math.pi / 2)
+    assert orientations[0][pair.subject] == pytest.approx(-math.pi / 2)
+    assert orientations[1][pair.subject] == pytest.approx(math.pi / 2)
 
 
 def test_coincident_face_to_fails_candidate_validation():
@@ -103,7 +129,7 @@ def test_coincident_face_to_fails_candidate_validation():
     validation = ObjectPlacer()._validate_placement(
         positions,
         {obj: obj.get_bounding_box() for obj in positions},
-        orientations[0],
+        {subject: 0.0},
     )
 
     assert orientations == [{}]
@@ -132,18 +158,14 @@ def test_face_to_rebuilds_rotated_footprint_before_validation():
 
 
 def test_face_to_suppresses_random_yaw_and_rejects_rotate_marker():
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(target))
+    pair = _face_to_pair()
     placer = ObjectPlacer(ObjectPlacerParams(random_yaw_init=True))
 
-    assert placer._generate_initial_orientations([target, subject], {target}) == {}
+    assert placer._generate_initial_orientations([pair.target, pair.subject], {pair.target}) == {}
 
-    subject.add_relation(RotateAroundSolution(yaw_rad=0.5))
+    pair.subject.add_relation(RotateAroundSolution(yaw_rad=0.5))
     with pytest.raises(AssertionError, match="cannot combine FaceTo"):
-        placer._prepare_placement([target, subject])
+        placer._prepare_placement([pair.target, pair.subject])
 
 
 def test_face_to_rejects_target_outside_placement():
@@ -164,20 +186,16 @@ def test_face_to_rejects_target_outside_placement():
     ],
 )
 def test_face_to_rejects_invalid_relation_configuration(invalid_case, message):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(target))
+    pair = _face_to_pair()
     if invalid_case == "duplicate":
-        subject.add_relation(FaceTo(target))
+        pair.subject.add_relation(FaceTo(pair.target))
     elif invalid_case == "anchor":
-        target.add_relation(FaceTo(subject))
+        pair.target.add_relation(FaceTo(pair.subject))
     else:
-        subject.relations = [FaceTo(subject)]
+        pair.subject.relations = [FaceTo(pair.subject)]
 
     with pytest.raises(AssertionError, match=message):
-        ObjectPlacer()._prepare_placement([target, subject])
+        ObjectPlacer()._prepare_placement([pair.target, pair.subject])
 
 
 @pytest.mark.parametrize(
@@ -189,104 +207,80 @@ def test_face_to_rejects_invalid_relation_configuration(invalid_case, message):
     ],
 )
 def test_face_to_rejects_reset_randomization_that_changes_direction(randomized_object, randomization, message):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(target))
-    {"subject": subject, "target": target}[randomized_object].add_relation(randomization)
+    pair = _face_to_pair()
+    {"subject": pair.subject, "target": pair.target}[randomized_object].add_relation(randomization)
 
     with pytest.raises(AssertionError, match=message):
-        ObjectPlacer()._prepare_placement([target, subject])
+        ObjectPlacer()._prepare_placement([pair.target, pair.subject])
 
 
 def test_relation_solver_ignores_face_to_marker():
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
-    subject.add_relation(FaceTo(target))
-    positions = {target: (1.0, 0.0, 0.0), subject: (0.0, 0.0, 0.0)}
+    pair = _face_to_pair()
+    pair.subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
+    positions = {pair.target: (1.0, 0.0, 0.0), pair.subject: (0.0, 0.0, 0.0)}
 
-    assert all(not isinstance(relation, FaceTo) for relation in subject.get_spatial_relations())
+    assert all(not isinstance(relation, FaceTo) for relation in pair.subject.get_spatial_relations())
 
-    RelationSolver(RelationSolverParams(max_iters=1, verbose=False)).solve([target, subject], [positions])
+    RelationSolver(RelationSolverParams(max_iters=1, verbose=False)).solve([pair.target, pair.subject], [positions])
 
 
 def test_face_to_applies_absolute_world_yaw_with_default_orientation_params():
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(0.0, 2.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
-    subject.add_relation(FaceTo(target))
+    pair = _face_to_pair(target_position=(0.0, 2.0, 0.0))
+    pair.subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
     params = ObjectPlacerParams(
         solver_params=RelationSolverParams(max_iters=200, verbose=False),
         max_placement_attempts=1,
     )
 
-    (result,) = ObjectPlacer(params).place([target, subject])
-    pose = subject.get_initial_pose()
+    (result,) = ObjectPlacer(params).place([pair.target, pair.subject])
+    pose = pair.subject.get_initial_pose()
 
     assert isinstance(pose, Pose)
-    assert result.orientations[subject] == pytest.approx(math.pi / 2)
+    assert result.orientations[pair.subject] == pytest.approx(math.pi / 2)
     assert abs(wrap_angle_to_pi(yaw_from_quat_xyzw(pose.rotation_xyzw) - math.pi / 2)) < 1e-5
 
 
 def test_face_to_applies_independent_multi_env_yaws(monkeypatch):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(10.0, 0.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(target))
+    pair = _face_to_pair(target_position=(10.0, 0.0, 0.0))
     subject_positions = [(0.0, 0.0, 0.0), (10.0, -10.0, 0.0), (20.0, 0.0, 0.0), (10.0, 10.0, 0.0)]
-    layouts = [{target: (10.0, 0.0, 0.0), subject: position} for position in subject_positions]
+    layouts = [{pair.target: (10.0, 0.0, 0.0), pair.subject: position} for position in subject_positions]
     placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1))
     _set_solver_results(monkeypatch, placer, layouts)
 
-    results = placer.place([target, subject], num_envs=4)
-    pose = subject.get_initial_pose()
+    results = placer.place([pair.target, pair.subject], num_envs=4)
+    pose = pair.subject.get_initial_pose()
 
     assert isinstance(pose, PosePerEnv)
     expected = [0.0, math.pi / 2, math.pi, -math.pi / 2]
     for result, env_pose, expected_yaw in zip(results, pose.poses, expected, strict=True):
-        assert abs(wrap_angle_to_pi(result.orientations[subject] - expected_yaw)) < 1e-5
+        assert abs(wrap_angle_to_pi(result.orientations[pair.subject] - expected_yaw)) < 1e-5
         assert abs(wrap_angle_to_pi(yaw_from_quat_xyzw(env_pose.rotation_xyzw) - expected_yaw)) < 1e-5
 
 
 def test_face_to_reranks_candidate_with_rotated_overlap(monkeypatch):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(0.0, 2.0, 0.0)))
-    target.add_relation(IsAnchor())
+    pair = _face_to_pair(target_position=(0.0, 2.0, 0.0), subject_half_extents=(1.0, 0.1, 0.1))
     blocker = _box("blocker")
     blocker.add_relation(AtPosition(x=0.0, y=0.75, z=0.0))
-    subject = _box("subject", half_extents=(1.0, 0.1, 0.1))
-    subject.add_relation(FaceTo(target))
     layouts = [
-        {target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), subject: (0.0, 0.0, 0.0)},
-        {target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), subject: (2.0, 0.0, 0.0)},
+        {pair.target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), pair.subject: (0.0, 0.0, 0.0)},
+        {pair.target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), pair.subject: (2.0, 0.0, 0.0)},
     ]
     placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=2, apply_positions_to_objects=False))
     _set_solver_results(monkeypatch, placer, layouts, losses=[0.0, 1.0])
 
-    (result,) = placer.place([target, blocker, subject])
+    (result,) = placer.place([pair.target, blocker, pair.subject])
 
     assert result.success
-    assert result.positions[subject] == (2.0, 0.0, 0.0)
+    assert result.positions[pair.subject] == (2.0, 0.0, 0.0)
 
 
 def test_face_to_fallback_warning_names_failed_check(monkeypatch, capsys):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 2.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(FaceTo(target))
-    layout = {target: (0.0, 0.0, 2.0), subject: (0.0, 0.0, 0.0)}
-    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1, apply_positions_to_objects=False))
+    pair = _face_to_pair(target_position=(0.0, 0.0, 2.0))
+    layout = {pair.target: (0.0, 0.0, 2.0), pair.subject: (0.0, 0.0, 0.0)}
+    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1, apply_positions_to_objects=False, verbose=True))
     _set_solver_results(monkeypatch, placer, [layout])
 
-    (result,) = placer.place([target, subject])
+    (result,) = placer.place([pair.target, pair.subject])
 
     assert not result.success
     assert "(failed: ['face_to'])" in capsys.readouterr().out
@@ -307,12 +301,8 @@ def test_face_to_registers_as_binary_graph_relation():
 
 
 def test_mesh_validation_receives_final_face_to_yaw(monkeypatch):
-    target = _box("target")
-    target.set_initial_pose(Pose(position_xyz=(0.0, 1.0, 0.0)))
-    target.add_relation(IsAnchor())
-    subject = _box("subject")
-    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
-    subject.add_relation(FaceTo(target))
+    pair = _face_to_pair(target_position=(0.0, 1.0, 0.0))
+    pair.subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
     params = ObjectPlacerParams(
         solver_params=RelationSolverParams(collision_mode=CollisionMode.MESH, max_iters=200, verbose=False),
         max_placement_attempts=1,
@@ -326,7 +316,7 @@ def test_mesh_validation_receives_final_face_to_yaw(monkeypatch):
         return True
 
     monkeypatch.setattr(placer, "_validate_no_overlap_mesh", _capture_orientations)
-    (result,) = placer.place([target, subject])
+    (result,) = placer.place([pair.target, pair.subject])
 
-    assert received[subject] == pytest.approx(math.pi / 2)
-    assert result.orientations[subject] == pytest.approx(math.pi / 2)
+    assert received[pair.subject] == pytest.approx(math.pi / 2)
+    assert result.orientations[pair.subject] == pytest.approx(math.pi / 2)

--- a/isaaclab_arena/tests/test_face_to.py
+++ b/isaaclab_arena/tests/test_face_to.py
@@ -1,0 +1,332 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import torch
+
+import pytest
+from pydantic import ValidationError
+
+from isaaclab_arena.assets.dummy_object import DummyObject
+from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
+from isaaclab_arena.environments.arena_env_graph_types import SpatialRelationSpec
+from isaaclab_arena.relations.collision_mode import CollisionMode
+from isaaclab_arena.relations.object_placer import ObjectPlacer
+from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+from isaaclab_arena.relations.placement_validation import PlacementCheck
+from isaaclab_arena.relations.relation_solver import RelationSolver
+from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+from isaaclab_arena.relations.relations import AtPosition, FaceTo, IsAnchor, RandomAroundSolution, RotateAroundSolution
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, wrap_angle_to_pi, yaw_from_quat_xyzw, yaw_toward_positions
+
+
+def _box(name: str, half_extents: tuple[float, float, float] = (0.1, 0.1, 0.1)) -> DummyObject:
+    hx, hy, hz = half_extents
+    return DummyObject(
+        name=name,
+        bounding_box=AxisAlignedBoundingBox(min_point=(-hx, -hy, -hz), max_point=(hx, hy, hz)),
+    )
+
+
+def _set_solver_results(monkeypatch, placer, layouts, losses=None):
+    def _solve(objects, initial_positions, env_bboxes, orientations):
+        assert len(initial_positions) == len(layouts)
+        placer._solver._last_loss_per_env = torch.tensor(losses or [0.0] * len(layouts))
+        return layouts
+
+    monkeypatch.setattr(placer._solver, "solve", _solve)
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ((1.0, 0.0, 0.0), 0.0),
+        ((0.0, 1.0, 0.0), math.pi / 2),
+        ((-1.0, -1.0, 0.0), -3 * math.pi / 4),
+    ],
+)
+def test_yaw_toward_positions(target, expected):
+    yaws, is_defined = yaw_toward_positions(torch.tensor([[0.0, 0.0, 2.0]]), torch.tensor([target]))
+
+    torch.testing.assert_close(yaws, torch.tensor([expected]))
+    assert is_defined.tolist() == [True]
+
+
+def test_yaw_toward_positions_is_translation_invariant_and_batched():
+    subjects = torch.tensor([[3.0, 4.0, 0.0], [-2.0, 5.0, 1.0]])
+    targets = torch.tensor([[4.0, 5.0, 8.0], [-3.0, 5.0, -2.0]])
+
+    yaws, is_defined = yaw_toward_positions(subjects, targets)
+
+    torch.testing.assert_close(yaws, torch.tensor([math.pi / 4, math.pi]))
+    assert is_defined.tolist() == [True, True]
+
+
+def test_yaw_toward_positions_rejects_near_coincident_xy():
+    subjects = torch.zeros((3, 3))
+    targets = torch.tensor([[1e-7, 0.0, 1.0], [1e-6, 0.0, 1.0], [1.1e-6, 0.0, 1.0]])
+
+    _, is_defined = yaw_toward_positions(subjects, targets)
+
+    assert is_defined.tolist() == [False, False, True]
+
+
+def test_face_to_uses_candidate_positions_for_anchor_and_foreground_targets():
+    anchor = _box("anchor")
+    anchor.set_initial_pose(Pose(position_xyz=(0.0, -2.0, 0.0)))
+    anchor.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(anchor))
+    positions = [
+        {subject: (0.0, 0.0, 0.0), anchor: anchor.get_initial_pose().position_xyz},
+        {subject: (2.0, -2.0, 0.0), anchor: (2.0, 0.0, 0.0)},
+    ]
+    orientations = [{}, {}]
+
+    ObjectPlacer._apply_face_to_orientations(positions, orientations)
+
+    assert orientations[0][subject] == pytest.approx(-math.pi / 2)
+    assert orientations[1][subject] == pytest.approx(math.pi / 2)
+
+
+def test_coincident_face_to_fails_candidate_validation():
+    target = _box("target")
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    positions = {subject: (0.0, 0.0, 0.0), target: (0.0, 0.0, 2.0)}
+    orientations = [{}]
+
+    ObjectPlacer._apply_face_to_orientations([positions], orientations)
+    validation = ObjectPlacer()._validate_placement(
+        positions,
+        {obj: obj.get_bounding_box() for obj in positions},
+        orientations[0],
+    )
+
+    assert orientations == [{}]
+    assert validation.validation_results[PlacementCheck.FACE_TO] is False
+    assert validation.do_all_required_validation_checks_pass() is False
+
+
+def test_face_to_rebuilds_rotated_footprint_before_validation():
+    target = _box("target")
+    blocker = _box("blocker")
+    subject = _box("subject", half_extents=(1.0, 0.1, 0.1))
+    subject.add_relation(FaceTo(target))
+    objects = [subject, target, blocker]
+    positions = {subject: (0.0, 0.0, 0.0), target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0)}
+    unrotated = {obj: obj.get_bounding_box() for obj in objects}
+    orientations = [{}]
+    placer = ObjectPlacer()
+
+    assert placer._validate_placement(positions, unrotated).validation_results[PlacementCheck.NO_OVERLAP]
+    ObjectPlacer._apply_face_to_orientations([positions], orientations)
+    rotated = ObjectPlacer._rotate_candidate_bboxes(objects, unrotated, orientations)
+    validation = placer._validate_placement(positions, rotated, orientations[0])
+
+    assert orientations[0][subject] == pytest.approx(math.pi / 2)
+    assert validation.validation_results[PlacementCheck.NO_OVERLAP] is False
+
+
+def test_face_to_suppresses_random_yaw_and_rejects_rotate_marker():
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    placer = ObjectPlacer(ObjectPlacerParams(random_yaw_init=True))
+
+    assert placer._generate_initial_orientations([target, subject], {target}) == {}
+
+    subject.add_relation(RotateAroundSolution(yaw_rad=0.5))
+    with pytest.raises(AssertionError, match="cannot combine FaceTo"):
+        placer._prepare_placement([target, subject])
+
+
+def test_face_to_rejects_target_outside_placement():
+    target = _box("target")
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+
+    with pytest.raises(AssertionError, match="must participate in placement"):
+        ObjectPlacer()._prepare_placement([subject])
+
+
+@pytest.mark.parametrize(
+    ("invalid_case", "message"),
+    [
+        ("duplicate", "more than one FaceTo"),
+        ("anchor", "Anchor object"),
+        ("self", "cannot face itself"),
+    ],
+)
+def test_face_to_rejects_invalid_relation_configuration(invalid_case, message):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    if invalid_case == "duplicate":
+        subject.add_relation(FaceTo(target))
+    elif invalid_case == "anchor":
+        target.add_relation(FaceTo(subject))
+    else:
+        subject.relations = [FaceTo(subject)]
+
+    with pytest.raises(AssertionError, match=message):
+        ObjectPlacer()._prepare_placement([target, subject])
+
+
+@pytest.mark.parametrize(
+    ("randomized_object", "randomization", "message"),
+    [
+        ("subject", RandomAroundSolution(x_half_m=0.1), "cannot randomize XY or rotation"),
+        ("subject", RandomAroundSolution(yaw_half_rad=0.1), "cannot randomize XY or rotation"),
+        ("target", RandomAroundSolution(y_half_m=0.1), "cannot randomize XY"),
+    ],
+)
+def test_face_to_rejects_reset_randomization_that_changes_direction(randomized_object, randomization, message):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    {"subject": subject, "target": target}[randomized_object].add_relation(randomization)
+
+    with pytest.raises(AssertionError, match=message):
+        ObjectPlacer()._prepare_placement([target, subject])
+
+
+def test_relation_solver_ignores_face_to_marker():
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(1.0, 0.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
+    subject.add_relation(FaceTo(target))
+    positions = {target: (1.0, 0.0, 0.0), subject: (0.0, 0.0, 0.0)}
+
+    assert all(not isinstance(relation, FaceTo) for relation in subject.get_spatial_relations())
+
+    RelationSolver(RelationSolverParams(max_iters=1, verbose=False)).solve([target, subject], [positions])
+
+
+def test_face_to_applies_absolute_world_yaw_with_default_orientation_params():
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(0.0, 2.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
+    subject.add_relation(FaceTo(target))
+    params = ObjectPlacerParams(
+        solver_params=RelationSolverParams(max_iters=200, verbose=False),
+        max_placement_attempts=1,
+    )
+
+    (result,) = ObjectPlacer(params).place([target, subject])
+    pose = subject.get_initial_pose()
+
+    assert isinstance(pose, Pose)
+    assert result.orientations[subject] == pytest.approx(math.pi / 2)
+    assert abs(wrap_angle_to_pi(yaw_from_quat_xyzw(pose.rotation_xyzw) - math.pi / 2)) < 1e-5
+
+
+def test_face_to_applies_independent_multi_env_yaws(monkeypatch):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(10.0, 0.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    subject_positions = [(0.0, 0.0, 0.0), (10.0, -10.0, 0.0), (20.0, 0.0, 0.0), (10.0, 10.0, 0.0)]
+    layouts = [{target: (10.0, 0.0, 0.0), subject: position} for position in subject_positions]
+    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1))
+    _set_solver_results(monkeypatch, placer, layouts)
+
+    results = placer.place([target, subject], num_envs=4)
+    pose = subject.get_initial_pose()
+
+    assert isinstance(pose, PosePerEnv)
+    expected = [0.0, math.pi / 2, math.pi, -math.pi / 2]
+    for result, env_pose, expected_yaw in zip(results, pose.poses, expected, strict=True):
+        assert abs(wrap_angle_to_pi(result.orientations[subject] - expected_yaw)) < 1e-5
+        assert abs(wrap_angle_to_pi(yaw_from_quat_xyzw(env_pose.rotation_xyzw) - expected_yaw)) < 1e-5
+
+
+def test_face_to_reranks_candidate_with_rotated_overlap(monkeypatch):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(0.0, 2.0, 0.0)))
+    target.add_relation(IsAnchor())
+    blocker = _box("blocker")
+    blocker.add_relation(AtPosition(x=0.0, y=0.75, z=0.0))
+    subject = _box("subject", half_extents=(1.0, 0.1, 0.1))
+    subject.add_relation(FaceTo(target))
+    layouts = [
+        {target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), subject: (0.0, 0.0, 0.0)},
+        {target: (0.0, 2.0, 0.0), blocker: (0.0, 0.75, 0.0), subject: (2.0, 0.0, 0.0)},
+    ]
+    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=2, apply_positions_to_objects=False))
+    _set_solver_results(monkeypatch, placer, layouts, losses=[0.0, 1.0])
+
+    (result,) = placer.place([target, blocker, subject])
+
+    assert result.success
+    assert result.positions[subject] == (2.0, 0.0, 0.0)
+
+
+def test_face_to_fallback_warning_names_failed_check(monkeypatch, capsys):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 2.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(FaceTo(target))
+    layout = {target: (0.0, 0.0, 2.0), subject: (0.0, 0.0, 0.0)}
+    placer = ObjectPlacer(ObjectPlacerParams(max_placement_attempts=1, apply_positions_to_objects=False))
+    _set_solver_results(monkeypatch, placer, [layout])
+
+    (result,) = placer.place([target, subject])
+
+    assert not result.success
+    assert "(failed: ['face_to'])" in capsys.readouterr().out
+
+
+def test_face_to_registers_as_binary_graph_relation():
+    subject = _box("subject")
+    target = _box("target")
+    spec = SpatialRelationSpec(kind="face_to", subject="camera", reference="object")
+    relation_class = ObjectRelationLibraryRegistry().get_object_relation_by_name(spec.kind)
+    subject.add_relation(relation_class(target, **spec.params))
+
+    assert relation_class is FaceTo
+    (relation,) = subject.get_relations()
+    assert relation.parent is target
+    with pytest.raises(ValidationError, match="requires relation.reference"):
+        SpatialRelationSpec(kind="face_to", subject="camera")
+
+
+def test_mesh_validation_receives_final_face_to_yaw(monkeypatch):
+    target = _box("target")
+    target.set_initial_pose(Pose(position_xyz=(0.0, 1.0, 0.0)))
+    target.add_relation(IsAnchor())
+    subject = _box("subject")
+    subject.add_relation(AtPosition(x=0.0, y=0.0, z=0.0))
+    subject.add_relation(FaceTo(target))
+    params = ObjectPlacerParams(
+        solver_params=RelationSolverParams(collision_mode=CollisionMode.MESH, max_iters=200, verbose=False),
+        max_placement_attempts=1,
+        apply_positions_to_objects=False,
+    )
+    placer = ObjectPlacer(params)
+    received = {}
+
+    def _capture_orientations(candidate_positions, candidate_orientations):
+        received.update(candidate_orientations)
+        return True
+
+    monkeypatch.setattr(placer, "_validate_no_overlap_mesh", _capture_orientations)
+    (result,) = placer.place([target, subject])
+
+    assert received[subject] == pytest.approx(math.pi / 2)
+    assert result.orientations[subject] == pytest.approx(math.pi / 2)

--- a/isaaclab_arena/tests/test_object_placer_reproducibility.py
+++ b/isaaclab_arena/tests/test_object_placer_reproducibility.py
@@ -18,7 +18,8 @@ from isaaclab_arena.relations.relation_solver import RelationSolver
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, RotateAroundSolution, Side
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, get_random_pose_within_bounding_box
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, rotate_quat_by_yaw, wrap_angle_to_pi
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.yaw import rotate_quat_by_yaw, wrap_angle_to_pi
 
 
 def _create_test_objects():

--- a/isaaclab_arena/tests/test_placement_events.py
+++ b/isaaclab_arena/tests/test_placement_events.py
@@ -348,7 +348,7 @@ def test_solve_and_place_objects_writes_invalid_fallback_layout(capsys):
     assert set(env._assets) == {box1.name, box2.name}
     assert env._assets[box1.name].write_root_pose_to_sim.call_count == 1
     assert env._assets[box2.name].write_root_pose_to_sim.call_count == 1
-    assert "Writing best-loss fallback placement" in captured.out
+    assert "Writing best-loss fallback placement for env 0; failed checks: ['valid']." in captured.out
 
 
 def test_solve_and_place_objects_partial_reset_env_indexed_uses_absolute_env_result():

--- a/isaaclab_arena/tests/test_pose.py
+++ b/isaaclab_arena/tests/test_pose.py
@@ -6,9 +6,8 @@
 import math
 import torch
 
-from isaaclab_arena.utils.pose import (
-    Pose,
-    PosePerEnv,
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+from isaaclab_arena.utils.yaw import (
     rotate_points_by_yaw,
     rotate_points_by_yaw_batch,
     rotate_quat_by_yaw,

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -64,7 +64,7 @@ def yaw_toward_positions(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return Z-yaws from subject positions toward target positions.
 
-    N is the number of position pairs. Directions shorter than 1e-6 m in XY
+    N is the number of position pairs. Directions at most 1e-6 m long in XY
     are undefined.
 
     Args:
@@ -72,8 +72,8 @@ def yaw_toward_positions(
         target_positions: Target world positions with shape (N, 3).
 
     Returns:
-        A tuple ``(yaws, is_defined)`` of shape-(N,) tensors containing the
-        world Z-yaws and valid-direction mask.
+        A tuple ``(yaws, is_defined)`` containing the world Z-yaws and
+        valid-direction mask as two tensors of shape (N,).
     """
     assert subject_positions.shape == target_positions.shape
     assert subject_positions.ndim == 2 and subject_positions.shape[1] == 3

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -58,14 +58,18 @@ def wrap_angle_to_pi(angle_rad: float) -> float:
     return (angle_rad + math.pi) % (2.0 * math.pi) - math.pi
 
 
+MINIMUM_FACING_DIRECTION_XY_M = 1e-6
+"""XY distances at or below this are too short to define a facing direction."""
+
+
 def yaw_toward_positions(
     subject_positions: torch.Tensor,
     target_positions: torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Return Z-yaws from subject positions toward target positions.
 
-    N is the number of position pairs. Directions at most 1e-6 m long in XY
-    are undefined.
+    N is the number of position pairs. Directions at most MINIMUM_FACING_DIRECTION_XY_M
+    long in XY are undefined.
 
     Args:
         subject_positions: Subject world positions with shape (N, 3).
@@ -78,7 +82,7 @@ def yaw_toward_positions(
     assert subject_positions.shape == target_positions.shape
     assert subject_positions.ndim == 2 and subject_positions.shape[1] == 3
     delta_xy = target_positions[:, :2] - subject_positions[:, :2]
-    is_defined = torch.linalg.vector_norm(delta_xy, dim=1) > 1e-6
+    is_defined = torch.linalg.vector_norm(delta_xy, dim=1) > MINIMUM_FACING_DIRECTION_XY_M
     return torch.atan2(delta_xy[:, 1], delta_xy[:, 0]), is_defined
 
 

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -58,6 +58,30 @@ def wrap_angle_to_pi(angle_rad: float) -> float:
     return (angle_rad + math.pi) % (2.0 * math.pi) - math.pi
 
 
+def yaw_toward_positions(
+    subject_positions: torch.Tensor,
+    target_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return Z-yaws from subject positions toward target positions.
+
+    N is the number of position pairs. Directions shorter than 1e-6 m in XY
+    are undefined.
+
+    Args:
+        subject_positions: Subject world positions with shape (N, 3).
+        target_positions: Target world positions with shape (N, 3).
+
+    Returns:
+        A tuple ``(yaws, is_defined)`` of shape-(N,) tensors containing the
+        world Z-yaws and valid-direction mask.
+    """
+    assert subject_positions.shape == target_positions.shape
+    assert subject_positions.ndim == 2 and subject_positions.shape[1] == 3
+    delta_xy = target_positions[:, :2] - subject_positions[:, :2]
+    is_defined = torch.linalg.vector_norm(delta_xy, dim=1) > 1e-6
+    return torch.atan2(delta_xy[:, 1], delta_xy[:, 0]), is_defined
+
+
 def yaw_from_quat_xyzw(quat_xyzw: tuple[float, float, float, float]) -> float:
     """Extract Z-axis yaw (radians) from an (x, y, z, w) quaternion.
 

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import math
 import torch
 from dataclasses import dataclass
 
@@ -51,109 +50,6 @@ class Pose:
 
     def multiply(self, other: "Pose") -> "Pose":
         return compose_poses(self, other)
-
-
-def wrap_angle_to_pi(angle_rad: float) -> float:
-    """Wrap an angle in radians to [-pi, pi)."""
-    return (angle_rad + math.pi) % (2.0 * math.pi) - math.pi
-
-
-MINIMUM_FACING_DIRECTION_XY_M = 1e-6
-"""XY distances at or below this are too short to define a facing direction."""
-
-
-def yaw_toward_positions(
-    subject_positions: torch.Tensor,
-    target_positions: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Return Z-yaws from subject positions toward target positions.
-
-    N is the number of position pairs. Directions at most MINIMUM_FACING_DIRECTION_XY_M
-    long in XY are undefined.
-
-    Args:
-        subject_positions: Subject world positions with shape (N, 3).
-        target_positions: Target world positions with shape (N, 3).
-
-    Returns:
-        A tuple ``(yaws, is_defined)`` containing the world Z-yaws and
-        valid-direction mask as two tensors of shape (N,).
-    """
-    assert subject_positions.shape == target_positions.shape
-    assert subject_positions.ndim == 2 and subject_positions.shape[1] == 3
-    delta_xy = target_positions[:, :2] - subject_positions[:, :2]
-    is_defined = torch.linalg.vector_norm(delta_xy, dim=1) > MINIMUM_FACING_DIRECTION_XY_M
-    return torch.atan2(delta_xy[:, 1], delta_xy[:, 0]), is_defined
-
-
-def yaw_from_quat_xyzw(quat_xyzw: tuple[float, float, float, float]) -> float:
-    """Extract Z-axis yaw (radians) from an (x, y, z, w) quaternion.
-
-    Returns 0.0 if the quaternion has non-trivial roll or pitch (|qx| or |qy| > 1e-6).
-    """
-    qx, qy, qz, qw = quat_xyzw
-    if abs(qx) > 1e-6 or abs(qy) > 1e-6:
-        return 0.0
-    return 2.0 * math.atan2(qz, qw)
-
-
-def rotate_quat_by_yaw(
-    base_xyzw: tuple[float, float, float, float], yaw_rad: float
-) -> tuple[float, float, float, float]:
-    """Rotate base_xyzw (xyzw) by an extra yaw about Z. Returns base unchanged when yaw is 0."""
-    yaw_rad = wrap_angle_to_pi(yaw_rad)  # keep half-angle small for precision; canonicalize 2pi -> 0
-    if yaw_rad == 0.0:
-        return base_xyzw
-    bx, by, bz, bw = base_xyzw
-    sz = math.sin(yaw_rad / 2.0)
-    cz = math.cos(yaw_rad / 2.0)
-    # Hamilton product base ⊗ (0, 0, sz, cz). Both rotations are about Z, so they commute.
-    return (bx * cz + by * sz, -bx * sz + by * cz, bz * cz + bw * sz, -bz * sz + bw * cz)
-
-
-def rotate_points_by_yaw(points: torch.Tensor, yaw: float) -> torch.Tensor:
-    """Rotate (N, 3) points about the Z-axis by a scalar yaw (radians). Z is unchanged."""
-    if yaw == 0.0:
-        return points
-    cos_y = math.cos(yaw)
-    sin_y = math.sin(yaw)
-    x = points[:, 0] * cos_y - points[:, 1] * sin_y
-    y = points[:, 0] * sin_y + points[:, 1] * cos_y
-    return torch.stack([x, y, points[:, 2]], dim=-1)
-
-
-def rotate_points_by_yaw_batch(points: torch.Tensor, yaws: torch.Tensor) -> torch.Tensor:
-    """Rotate (N, 3) points about Z-axis by per-element yaw (N,) radians. Z is unchanged."""
-    cos_y = torch.cos(yaws)
-    sin_y = torch.sin(yaws)
-    x = points[:, 0] * cos_y - points[:, 1] * sin_y
-    y = points[:, 0] * sin_y + points[:, 1] * cos_y
-    return torch.stack([x, y, points[:, 2]], dim=-1)
-
-
-def centers_in_target_frame(
-    centers_local: torch.Tensor,
-    src_yaw: float,
-    tgt_yaw: float,
-    offset: torch.Tensor,
-) -> torch.Tensor:
-    """Transform source sphere centers into the target's local frame (Z-yaw only).
-
-    Computes R(src_yaw - tgt_yaw) * centers_local + R(-tgt_yaw) * offset.
-
-    Args:
-        centers_local: (N, 3) sphere centers in the source's local frame.
-        src_yaw: Source object yaw (radians).
-        tgt_yaw: Target object yaw (radians).
-        offset: (3,) vector from target position to source position (world frame).
-    """
-    net_yaw = src_yaw - tgt_yaw
-    if net_yaw == 0.0 and tgt_yaw == 0.0:
-        return centers_local + offset
-
-    rotated_centers = rotate_points_by_yaw(centers_local, net_yaw)
-    rotated_offset = rotate_points_by_yaw(offset.unsqueeze(0), -tgt_yaw).squeeze(0)
-    return rotated_centers + rotated_offset
 
 
 def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:

--- a/isaaclab_arena/utils/yaw.py
+++ b/isaaclab_arena/utils/yaw.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import torch
+
+
+def wrap_angle_to_pi(angle_rad: float) -> float:
+    """Wrap an angle in radians to [-pi, pi)."""
+    return (angle_rad + math.pi) % (2.0 * math.pi) - math.pi
+
+
+MINIMUM_FACING_DIRECTION_XY_M = 1e-6
+"""XY distances at or below this are too short to define a facing direction."""
+
+
+def yaw_toward_positions(
+    subject_positions: torch.Tensor,
+    target_positions: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return Z-yaws from subject positions toward target positions.
+
+    N is the number of position pairs. Directions at most MINIMUM_FACING_DIRECTION_XY_M
+    long in XY are undefined.
+
+    Args:
+        subject_positions: Subject world positions with shape (N, 3).
+        target_positions: Target world positions with shape (N, 3).
+
+    Returns:
+        A tuple ``(yaws, is_defined)`` containing the world Z-yaws and
+        valid-direction mask as two tensors of shape (N,).
+    """
+    assert subject_positions.shape == target_positions.shape
+    assert subject_positions.ndim == 2 and subject_positions.shape[1] == 3
+    delta_xy = target_positions[:, :2] - subject_positions[:, :2]
+    is_defined = torch.linalg.vector_norm(delta_xy, dim=1) > MINIMUM_FACING_DIRECTION_XY_M
+    return torch.atan2(delta_xy[:, 1], delta_xy[:, 0]), is_defined
+
+
+def yaw_from_quat_xyzw(quat_xyzw: tuple[float, float, float, float]) -> float:
+    """Extract Z-axis yaw (radians) from an (x, y, z, w) quaternion.
+
+    Returns 0.0 if the quaternion has non-trivial roll or pitch (|qx| or |qy| > 1e-6).
+    """
+    qx, qy, qz, qw = quat_xyzw
+    if abs(qx) > 1e-6 or abs(qy) > 1e-6:
+        return 0.0
+    return 2.0 * math.atan2(qz, qw)
+
+
+def rotate_quat_by_yaw(
+    base_xyzw: tuple[float, float, float, float], yaw_rad: float
+) -> tuple[float, float, float, float]:
+    """Rotate base_xyzw (xyzw) by an extra yaw about Z. Returns base unchanged when yaw is 0."""
+    yaw_rad = wrap_angle_to_pi(yaw_rad)  # keep half-angle small for precision; canonicalize 2pi -> 0
+    if yaw_rad == 0.0:
+        return base_xyzw
+    bx, by, bz, bw = base_xyzw
+    sz = math.sin(yaw_rad / 2.0)
+    cz = math.cos(yaw_rad / 2.0)
+    # Hamilton product base ⊗ (0, 0, sz, cz). Both rotations are about Z, so they commute.
+    return (bx * cz + by * sz, -bx * sz + by * cz, bz * cz + bw * sz, -bz * sz + bw * cz)
+
+
+def rotate_points_by_yaw(points: torch.Tensor, yaw: float) -> torch.Tensor:
+    """Rotate (N, 3) points about the Z-axis by a scalar yaw (radians). Z is unchanged."""
+    if yaw == 0.0:
+        return points
+    cos_y = math.cos(yaw)
+    sin_y = math.sin(yaw)
+    x = points[:, 0] * cos_y - points[:, 1] * sin_y
+    y = points[:, 0] * sin_y + points[:, 1] * cos_y
+    return torch.stack([x, y, points[:, 2]], dim=-1)
+
+
+def rotate_points_by_yaw_batch(points: torch.Tensor, yaws: torch.Tensor) -> torch.Tensor:
+    """Rotate (N, 3) points about Z-axis by per-element yaw (N,) radians. Z is unchanged."""
+    cos_y = torch.cos(yaws)
+    sin_y = torch.sin(yaws)
+    x = points[:, 0] * cos_y - points[:, 1] * sin_y
+    y = points[:, 0] * sin_y + points[:, 1] * cos_y
+    return torch.stack([x, y, points[:, 2]], dim=-1)
+
+
+def centers_in_target_frame(
+    centers_local: torch.Tensor,
+    src_yaw: float,
+    tgt_yaw: float,
+    offset: torch.Tensor,
+) -> torch.Tensor:
+    """Transform source sphere centers into the target's local frame (Z-yaw only).
+
+    Computes R(src_yaw - tgt_yaw) * centers_local + R(-tgt_yaw) * offset.
+
+    Args:
+        centers_local: (N, 3) sphere centers in the source's local frame.
+        src_yaw: Source object yaw (radians).
+        tgt_yaw: Target object yaw (radians).
+        offset: (3,) vector from target position to source position (world frame).
+    """
+    net_yaw = src_yaw - tgt_yaw
+    if net_yaw == 0.0 and tgt_yaw == 0.0:
+        return centers_local + offset
+
+    rotated_centers = rotate_points_by_yaw(centers_local, net_yaw)
+    rotated_offset = rotate_points_by_yaw(offset.unsqueeze(0), -tgt_yaw).squeeze(0)
+    return rotated_centers + rotated_offset


### PR DESCRIPTION
## Summary
Add FaceTo object orientation relation

## Detailed description
- Enables objects to face another object after placement.
- Computes world Z-yaw, revalidates rotated bounds, and handles invalid directions.
