### PR TITLE
Remove light from purple_crate object usd

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -723,7 +723,7 @@ class PurpleCrate(LibraryObject):
 
     name = "purple_crate"
     tags = ["object", "container"]
-    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/KLT_Bin/small_KLT.usd"
+    usd_path = f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/object_library/KLT_Bin/small_KLT.usd"
 
 
 @register_asset


### PR DESCRIPTION
## Summary
Switch purple_crate to staging server without light.

## Detailed description
- Production server version has dome light as part of the object usd, so the bottles_crate.yaml RoboLab env loads without a global DomeLight.
- A new version of the purple crate with its dome light removed is saved to the staging server. Update object library to use the staging server version.
- Now the bottles_crate.yaml loads with correct dome light.

Before:
<img width="830" height="575" alt="image" src="https://github.com/user-attachments/assets/07106b02-c22c-4d47-82c5-2279e4d16591" />

After: 
<img width="882" height="554" alt="image" src="https://github.com/user-attachments/assets/933b60f0-7185-43f3-aaf8-82125707b068" />
