### PR TITLE
Unify Arena Experiment execution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,18 @@ _Avoid_: Job batch, Run
 The component that executes one complete Experiment and produces its results.
 _Avoid_: Eval Runner, Arena Experiment Runner, Sequential Batch Runner
 
+**Evaluation Configuration**:
+Process-level settings and optional Hydra overrides for executing one Experiment and producing its results. It references an Experiment but does not define Runs or deployment infrastructure.
+_Avoid_: Experiment, Eval Job Config, OSMO Configuration
+
+**OSMO Configuration**:
+Infrastructure settings for executing an Experiment on OSMO, including scheduling, containers, storage, and supporting services. It does not define Runs or local evaluation defaults.
+_Avoid_: Experiment Configuration, Policy Runner Configuration
+
+**OSMO Workflow**:
+The remote execution unit for one complete Experiment, including the Experiment Runner and any supporting policy services.
+_Avoid_: Job, Run
+
 **Run**:
 A named, independently dispatchable evaluation setup that pairs an environment with a policy and defines its rollout and requested rebuilds. It contains no execution status or metrics.
 _Avoid_: Job, Trial, Experiment, Environment

--- a/docs/adr/0001-separate-experiment-evaluation-and-osmo-configurations.md
+++ b/docs/adr/0001-separate-experiment-evaluation-and-osmo-configurations.md
@@ -1,0 +1,5 @@
+# Separate Experiment, evaluation, and OSMO configurations
+
+An Arena Experiment YAML owns its Runs, an Evaluation Configuration YAML owns the process-level settings and optional Hydra overrides used to execute that Experiment, and an OSMO Configuration YAML owns remote infrastructure. The Experiment Runner consumes the same Experiment and Evaluation Configuration for local execution or OSMO submission. We keep these as independently parsed contracts instead of nesting deployment settings in the Evaluation Configuration or reconstructing evaluation behavior from OSMO command-line flags, so Experiment definitions do not acquire runner or deployment concerns.
+
+For remote execution, the OSMO Workflow derives an in-memory Evaluation Configuration that points at the staged Experiment, writes to OSMO's output directory, disables the local report server, and appends any supporting-service endpoint overrides. The Experiment Runner executes every Run in that workflow while supporting policy services remain separate workflow tasks. Neither source YAML is modified.

--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -1,247 +1,195 @@
 Evaluation Types
-=================
+================
 
-Isaac Lab Arena supports two main ways to run policy evaluation: a single-job
-**policy runner** (single or multi-GPU) and an **Experiment Runner** for
-multiple jobs in one process. This section summarizes when to use each and how
-they work. Each section below links to the relevant concept docs:
-:doc:`Policy Design <index>`,
+The **Experiment Runner** is the typed entry point for policy evaluation:
+
+``isaaclab_arena/evaluation/experiment_runner.py``
+
+The same runner configuration and Arena Experiment YAML select either of two
+execution routes. Pass ``--local`` to execute the Experiment in the current
+Arena container. Omit ``--local`` to submit the complete Experiment as one OSMO
+workflow. A Run is not submitted as an independent workflow: an Experiment with
+many Runs stays one Experiment on both routes.
+
+The older ``policy_runner.py`` interface and the JSON/``argparse.Namespace``
+evaluation path are deprecated compatibility interfaces. They remain useful
+while existing examples migrate, but new evaluation workflows should use typed
+YAML and the Experiment Runner.
+
+For the types used inside an Experiment, see :doc:`Policy Design <index>`,
 :doc:`Environment Design <../concept_overview>`, and
 :doc:`Metrics Design <../task/concept_metrics_design>`.
 
-Both runners support a **server–client** setup, where simulation runs locally
-(client) and policy inference runs in a separate process or machine (server).
-This is the deployment used by ``Gr00tRemoteClosedloopPolicy``: the simulation
-client ships observations to a `GR00T <https://github.com/NVIDIA/Isaac-GR00T>`_
-policy server over the network, receives action chunks, and applies them in the
-sim. The split lets a heavyweight model (e.g. GR00T N1.6) live on a dedicated
-GPU while the simulation client runs on its own GPU, and is orthogonal to the
-runner choice — pass the remote-policy class as ``--policy_type`` and add
-``--remote_host`` / ``--remote_port`` flags. End-to-end commands (including
-how to launch the GR00T server out of the
-``submodules/Isaac-GR00T`` submodule) live in
-:doc:`../../quickstart/first_experiments/running_a_real_policy/index` and the
-example workflows.
+.. _experiment-runner:
+.. _sequential-batch-experiment-runner:
 
-Summary
--------
+Experiment Runner
+-----------------------
+
+The runner keeps three concerns separate:
+
+.. list-table:: Configuration layers
+   :header-rows: 1
+   :widths: 24 42 34
+
+   * - Configuration
+     - Owns
+     - Used by
+   * - Experiment Runner YAML
+     - Experiment path, output, video, failure handling, and report settings
+     - Local and OSMO routes
+   * - Arena Experiment YAML
+     - The ordered Runs and each Run's typed environment, policy, and rollout limit
+     - Local and OSMO routes
+   * - OSMO workflow YAML
+     - Images, compute resources, timeouts, output storage, and policy-server infrastructure
+     - OSMO route only
+
+The scientific Experiment YAML is therefore independent of where it runs. OSMO
+settings do not leak into the Experiment, and local Isaac Sim launcher settings
+do not become part of it.
+
+Runner configuration
+^^^^^^^^^^^^^^^^^^^^
+
+The YAML passed to ``--config`` is parsed as an
+``ExperimentRunnerCfg``. Its required ``experiment_config`` value may be
+absolute or relative to the runner configuration file:
+
+.. code-block:: yaml
+
+   experiment_config: experiment.yaml
+   output_base_dir: ./output
+   record_viewport_video: false
+   record_camera_video: false
+   continue_on_error: false
+   serve_evaluation_report: false
+   evaluation_report_port: 8000
+
+Runner settings describe how to execute and report the Experiment. They do not
+duplicate environment or policy fields from its Runs.
+
+Experiment configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+An Arena Experiment is an ordered ``runs`` collection. Every Run selects a
+registered, typed environment and policy and defines a rollout limit. For
+example:
+
+.. code-block:: yaml
+
+   runs:
+   - name: openpi_maple_table
+     environment:
+       type: pick_and_place_maple_table
+       enable_cameras: true
+       embodiment: droid_abs_joint_pos
+       pick_up_object: rubiks_cube_hot3d_robolab
+       destination_location: bowl_ycb_robolab
+       hdr: home_office_robolab
+     policy:
+       type: pi0_remote
+       policy_variant: pi05
+     rollout_limit:
+       num_episodes: 1
+
+Typed loading rejects unknown fields instead of silently forwarding arbitrary
+command-line values. Policies and environments receive their registered config
+types directly; they do not need to reconstruct their configuration from an
+``argparse.Namespace``.
+
+Run locally
+^^^^^^^^^^^
+
+Use ``--local`` when the current Arena container should own Isaac Sim and
+execute every Run:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml \
+     --local \
+     --enable_cameras
+
+Arguments owned by Isaac Lab's ``AppLauncher``, such as ``--headless``,
+``--device``, and currently ``--enable_cameras``, are accepted only on the local
+route. A local remote-policy Run expects its policy server to be reachable
+already.
+
+Submit to OSMO
+^^^^^^^^^^^^^^
+
+Omitting ``--local`` builds and submits one OSMO workflow for the complete
+Experiment, then finishes after submission:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml
+
+The bundled infrastructure defaults come from
+``osmo/config/arena_experiment_workflow.yaml``. Select another typed OSMO
+configuration without changing the Experiment:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml \
+     --osmo-config path/to/osmo.yaml
+
+The workflow stages the source Experiment YAML and derives the remote runner
+configuration for the container. When the Experiment contains OpenPI Runs, the
+workflow also starts one shared OpenPI server and injects its endpoint into
+those Runs at submission time; the source Experiment YAML remains unchanged.
+
+Hydra overrides
+^^^^^^^^^^^^^^^
+
+Trailing Hydra overrides apply to the Arena Experiment after its YAML values.
+They work on both routes and are appended after overrides stored in the runner
+configuration:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml \
+     --local \
+     --enable_cameras \
+     runs.openpi_maple_table.rollout_limit.num_episodes=10
+
+Use the Run name in the override path. Keep repeatable values in YAML and use
+trailing overrides for deliberate, invocation-specific changes.
+
+Route summary
+^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 30 30 20
+   :widths: 24 34 42
 
-   * - Type
-     - Use case
-     - Entry point
-     - Multi-GPU
-   * - Policy runner
-     - Single job, one env config, one policy
-     - ``policy_runner.py``
-     - Yes (torchrun)
-   * - Experiment Runner
-     - Multiple jobs (env/policy combos) in sequence
-     - ``experiment_runner.py``
-     - No
+   * - Route
+     - Selection
+     - Result
+   * - Local
+     - Add ``--local``
+     - Execute all Runs in the current container
+   * - OSMO
+     - Omit ``--local``
+     - Submit all Runs as one workflow and return after submission
 
-1. Policy runner — single job (single GPU and multi-GPU)
---------------------------------------------------------
+The Experiment Runner does not currently provide the deprecated policy
+runner's ``torchrun``-based distributed mode. Configure OSMO resources in the
+OSMO workflow YAML, or divide work into intentionally separate Experiments.
 
-The **policy runner** (``isaaclab_arena/evaluation/policy_runner.py``) runs one
-evaluation job: one environment configuration and one policy. It is the right
-choice for ad-hoc runs, debugging, or when you want to drive one scenario with
-full control over CLI arguments.
+Legacy compatibility path
+-------------------------
 
-**Design context:** For how policies are defined and integrated with environments,
-see :doc:`Policy Design <index>`.
+Invoking ``experiment_runner.py`` without ``--config`` selects the
+deprecated interface. That path accepts legacy JSON job files, reconstructs
+configuration through ``argparse.Namespace``, and preserves older runner flags
+while callers migrate. ``policy_runner.py`` is deprecated for the same reason.
 
-**Features:**
-
-- Single environment configuration (scene, embodiment, task) and one policy.
-- **Heterogeneous objects:** When the environment supports it, you can pass
-  ``--object_set`` with a space-separated list of object names. Each parallel
-  environment is assigned a different object from the set (e.g. env 0 gets the
-  first object, env 1 the second, etc.). This allows evaluating one policy
-  across multiple object types in a single run without changing the scene or
-  task logic.
-- Run length by **steps** (``--num_steps``) or **episodes** (``--num_episodes``);
-  policies that define a length (e.g. ``policy.has_length()``) can override this.
-- **Single GPU**: one process, one Isaac Sim instance.
-- **Multi-GPU**: use ``torchrun`` with ``--distributed``; one process per GPU,
-  each with its own Isaac Sim instance and device (e.g. ``cuda:0``, ``cuda:1``).
-- Metrics are computed at the end if the environment registers metrics and are logged to the console.
-
-**Single-GPU example**
-
-.. code-block:: bash
-
-   python isaaclab_arena/evaluation/policy_runner.py \
-     --viz kit \
-     --policy_type <policy_type> \
-     --num_steps 2000 \
-     --num_envs 10 \
-     <arena_environment> \
-     --embodiment <embodiment> \
-     --object <object>
-     ...
-
-**Heterogeneous objects example (single or multi-GPU)**
-
-Use ``--object_set`` so each of the ``--num_envs`` parallel environments gets a
-different object from the list. Object-to-environment mapping: with the default
-deterministic assignment, environment :math:`i` gets the object at index
-:math:`i \\mod n` in the list (where :math:`n` = ``len(object_set)``)—so when
-``num_envs`` > ``len(object_set)`` the assignment **cycles** (no truncation or
-error). If the object set is created with ``random_choice=True``, each environment
-gets a randomly chosen object from the set. Some environments may require
-``num_envs == len(object_set)``.
-
-.. code-block:: bash
-
-   python isaaclab_arena/evaluation/policy_runner.py \
-     --viz kit \
-     --policy_type <policy_type> \
-     --num_steps 2000 \
-     --num_envs 4 \
-     --enable_cameras \
-     put_item_in_fridge_and_close_door \
-     --embodiment gr1_joint \
-     --object_set ketchup_bottle_hope_robolab ranch_dressing_hope_robolab bbq_sauce_bottle_hope_robolab mayonnaise_bottle_hope_robolab
-
-**Multi-GPU example**
-
-Use ``torch.distributed.run`` (or ``torchrun``) with ``--nproc_per_node=<num_gpus>``
-and pass ``--distributed`` so each process uses a different GPU (via ``LOCAL_RANK``):
-
-.. code-block:: bash
-
-   python -m torch.distributed.run --nnode=1 --nproc_per_node=<num_gpus> \
-     isaaclab_arena/evaluation/policy_runner.py \
-     --policy_type <policy_type> \
-     --num_steps 2000 \
-     --num_envs 10 \
-     --distributed \
-     --headless \
-     <arena_environment> \
-     ...
-
-**Policy runner CLI (relevant flags)**
-
-- ``--policy_type``: Registered policy name or dotted path to policy class
-  (e.g. ``module.submodule.ClassName``).
-- ``--num_steps``: Total simulation steps (mutually exclusive with
-  ``--num_episodes``).
-- ``--num_episodes``: Total episodes (mutually exclusive with ``--num_steps``).
-- ``--distributed``: Enable distributed mode; use with ``torchrun`` and set
-  device per rank (e.g. ``cuda:{local_rank}``).
-
-The remaining environment arguments come from the Arena environments CLI. For
-registered policies, policy-specific flags are generated from their ``PolicyCfg``.
-
-.. _sequential-batch-experiment-runner:
-
-2. Experiment Runner — batch jobs
---------------------------------------------
-
-The **Experiment Runner** (``isaaclab_arena/evaluation/experiment_runner.py``)
-runs a **batch** of evaluation jobs sequentially in a single process. Each job can have
-a different environment (scene/object/embodiment), policy type, policy config,
-and length (steps or episodes). This is suited for benchmarking many
-configurations (e.g. many objects or tasks) without launching multiple processes
-by hand. Persistence of the simulation application is maintained between jobs.
-
-**Design context:** For how environments are composed and how metrics are
-defined and computed, see :doc:`Environment Design <../concept_overview>`
-and :doc:`Metrics Design <../task/concept_metrics_design>`. Policies used per job
-follow :doc:`Policy Design <index>`.
-
-**Features:**
-
-- One JSON config file (``--eval_jobs_config``) listing all jobs.
-- Jobs run one after another; each job builds its environment, creates the
-  policy from the job config, runs ``rollout_policy``, then tears down the env
-  before the next job.
-- If a job fails, the runner continues with the next job and marks the failed
-  job accordingly.
-- Metrics are aggregated and printed at the end (e.g. via ``MetricsLogger``).
-- **Distributed evaluation is not supported**: the Experiment Runner
-  runs in a single process. For multi-GPU, use multiple policy runner
-  invocations (e.g. with ``torchrun``) or split the batch across machines.
-
-.. todo::
-
-    Experiment with distributed evaluation in the Experiment Runner.
-
-**Jobs config format**
-
-The config file must be a JSON object with a ``"jobs"`` array. Each job is an
-object with:
-
-- ``name``: Unique job name (for logging and metrics).
-- ``arena_env_args``: Environment arguments as a dict (e.g. ``environment``,
-  ``num_envs``, ``object``, ``embodiment``, ``enable_cameras``, etc.). Converted
-  internally to the same CLI-style list the policy runner uses.
-- ``policy_type``: Same as policy runner (registered name or dotted class path).
-- ``policy_config_dict``: Policy configuration (e.g. checkpoint path, model
-  options). Deserialized through the policy's registered config type; the
-  deprecated CLI conversion fallback remains for legacy policies without one.
-- ``num_steps`` or ``num_episodes`` (optional): Simulation length for this job.
-  If both are omitted, the runner uses the policy’s length if defined, or a CLI
-  default (e.g. ``--num_steps``).
-
-**Example config structure**
-
-.. code-block:: json
-
-   {
-     "jobs": [
-       {
-         "name": "gr1_open_microwave_cracker_box",
-         "arena_env_args": {
-           "environment": "gr1_open_microwave",
-           "object": "cracker_box",
-           "embodiment": "gr1_joint",
-           "num_envs": 4
-         },
-         "num_steps": 500,
-         "policy_type": "zero_action",
-         "policy_config_dict": {}
-       },
-       {
-         "name": "gr1_sequential_static_manipulation_put_ranch_dressing_bottle_in_fridge_and_close_door",
-         "arena_env_args": {
-           "enable_cameras": true,
-           "environment": "gr1_sequential_static_manipulation",
-           "object": "ranch_dressing_hope_robolab",
-           "embodiment": "gr1_joint"
-         },
-         "num_steps": 100,
-         "policy_type": "isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy",
-         "policy_config_dict": {
-           "policy_config_yaml_path": "isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml",
-           "policy_device": "cuda:0",
-           "remote_host": "127.0.0.1",
-           "remote_port": 5555
-          }
-       }
-     ]
-   }
-
-**Running the Experiment Runner**
-
-.. code-block:: bash
-
-   python isaaclab_arena/evaluation/experiment_runner.py \
-     --viz kit \
-     --eval_jobs_config path/to/eval_jobs_config.json \
-     --num_steps 1000
-
-If any job needs cameras, set ``enable_cameras: true`` in that job’s
-``arena_env_args``; the Experiment Runner automatically enables camera support if any job requires it.
-
-Choosing an evaluation type
----------------------------
-
-- **One-off run, one setup**: use the **policy runner** (single or multi-GPU);
-  use ``--object_set`` for heterogeneous objects in one run.
-- **Many env/policy combinations in one go**: use the **sequential batch eval
-  runner** with a jobs JSON; use ``--object_set`` for heterogeneous objects in one run.
+Do not use the compatibility path as the basis for new configuration schemas.
+In particular, do not add new ``--eval_jobs_config`` fields or translate typed
+YAML back into CLI argument dictionaries. Define fields on the appropriate
+typed environment, policy, Experiment, runner, or OSMO configuration instead.

--- a/docs/pages/concepts/policy/index.rst
+++ b/docs/pages/concepts/policy/index.rst
@@ -3,10 +3,9 @@ Policy
 
 A policy in Arena is a standard interface between your model and the evaluation
 pipeline. You implement one method — ``get_action(env, obs)`` — and the policy
-plugs into both the single-job runner and the Experiment Runner without any
-changes to either. In bare IsaacLab you would write an ad-hoc inference loop
-for each model; Arena's ``PolicyBase`` gives a consistent contract that all
-runners depend on.
+plugs into the Experiment Runner without an ad-hoc inference loop for each
+model. Arena's ``PolicyBase`` gives every typed policy the same execution
+contract.
 
 .. code-block:: python
 
@@ -72,19 +71,15 @@ Construct the policy by passing its typed configuration directly:
    policy_cfg = MyPolicyCfg(device="cuda:0")
    policy = MyPolicy(policy_cfg)
 
-The typed registration lets the single-job runner generate CLI flags from
-``MyPolicyCfg`` and lets the Experiment Runner convert the current
-``Job.policy_config_dict`` representation into that same type. See
-:doc:`concept_evaluation_types` for details.
-
-Config fields named ``device`` or ``num_envs`` reuse the corresponding shared
-runner flags, so their defaults must match the runner defaults.
+Typed registration lets an Arena Experiment select ``my_policy`` and compose
+its YAML values directly into ``MyPolicyCfg``. See
+:doc:`concept_evaluation_types` for the local and OSMO execution routes.
 
 .. note::
 
-   ``policy_runner.py`` remains an argparse frontend, but policies do not
-   implement argparse methods. The runner generates their flags from the
-   registered config and reconstructs it before creating the policy.
+   ``policy_runner.py`` and JSON job configurations are deprecated
+   compatibility interfaces. New policies should expose typed configuration;
+   do not add policy-specific ``argparse`` methods.
 
 More details
 ------------

--- a/docs/pages/concepts/variations/variations.rst
+++ b/docs/pages/concepts/variations/variations.rst
@@ -119,64 +119,67 @@ where:
 
 Use ``--list-variations`` on any environment to discover the exact paths available.
 
-Configuring variations in an eval jobs config
+Configuring variations in an Arena Experiment
 ---------------------------------------------
 
-When running batches of jobs with ``experiment_runner.py``, variations are configured per job via a
-dedicated ``variations`` field instead of command-line override tokens.  The field is a nested
-dict that mirrors the dotted Hydra paths: each level of nesting corresponds to one segment of
-the ``<asset>.<variation_name>.<cfg_field>`` path.  For example, the nested entry
-``{"light": {"hdr_image": {"enabled": true}}}`` is equivalent to the command-line override
-``light.hdr_image.enabled=true``.
+In typed Experiment YAML, each Run has a ``variations`` mapping. The nested
+keys mirror the dotted Hydra paths: each level corresponds to one segment of
+``<asset>.<variation_name>.<cfg_field>``. For example,
+``light.hdr_image.enabled: true`` is equivalent to the trailing override
+``light.hdr_image.enabled=true`` used by the legacy single-run examples above.
 
-The example config ``isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json``
-enables three variations on a single job:
+This Experiment enables three variations on one Run:
 
-.. code-block:: json
+.. code-block:: yaml
 
-   {
-       "jobs": [
-           {
-               "name": "variations_demo",
-               "arena_env_args": {
-                   "environment": "pick_and_place_maple_table",
-                   "embodiment": "droid_rel_joint_pos",
-                   "pick_up_object": "rubiks_cube_hot3d_robolab",
-                   "destination_location": "bowl_ycb_robolab",
-                   "hdr": "home_office_robolab"
-               },
-               "num_steps": 10,
-               "num_rebuilds": 5,
-               "policy_type": "zero_action",
-               "policy_config_dict": {},
-               "variations": {
-                   "light": {
-                       "hdr_image": { "enabled": true },
-                       "intensity": { "enabled": true }
-                   },
-                   "droid_rel_joint_pos": {
-                       "camera_extrinsics_wrist_camera": { "enabled": true }
-                   }
-               }
-           }
-       ]
-   }
+   runs:
+   - name: variations_demo
+     environment:
+       type: pick_and_place_maple_table
+       enable_cameras: true
+       embodiment: droid_rel_joint_pos
+       pick_up_object: rubiks_cube_hot3d_robolab
+       destination_location: bowl_ycb_robolab
+       hdr: home_office_robolab
+     policy:
+       type: zero_action
+     rollout_limit:
+       num_steps: 10
+     num_rebuilds: 5
+     variations:
+       light:
+         hdr_image:
+           enabled: true
+         intensity:
+           enabled: true
+       droid_rel_joint_pos:
+         camera_extrinsics_wrist_camera:
+           enabled: true
 
-Run it with:
+Point a runner configuration at that Experiment:
 
-.. code-block:: bash
+.. code-block:: yaml
 
-   python isaaclab_arena/evaluation/experiment_runner.py \
-     --headless \
-     --enable_cameras \
-     --eval_jobs_config isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json
+   experiment_config: variations_experiment.yaml
+   output_base_dir: ./output
 
-``--list-variations`` works with ``experiment_runner.py`` too, printing the variations catalogue for
-each job's environment:
+Then execute it locally:
 
 .. code-block:: bash
 
-   python isaaclab_arena/evaluation/experiment_runner.py \
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml \
+     --local \
      --headless \
-     --list-variations \
-     --eval_jobs_config isaaclab_arena_environments/eval_jobs_configs/droid_pnp_variations_config.json
+     --enable_cameras
+
+Use ``--list_variations`` on the local route to print the catalogue for each
+Run's environment and exit before rollout:
+
+.. code-block:: bash
+
+   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+     --config path/to/runner.yaml \
+     --local \
+     --headless \
+     --list_variations

--- a/docs/pages/example_workflows/agentic_env_gen/eval_with_openpi.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/eval_with_openpi.rst
@@ -119,7 +119,7 @@ OpenPI connection options go in ``policy_config_dict``:
        ]
    }
 
-Then run the Experiment Runner:
+Then run the Experiment Runner's deprecated JSON compatibility path:
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -4,7 +4,7 @@ Agentic Environment Generation and Policy Evaluation
 Agentic environment generation creates Arena environments from natural-language
 prompts, then reuses the generated environment graph specs for downstream policy
 evaluation. This workflow shows how agentically composed environments can be
-used by the policy runner, the Experiment Runner and its
+used by the legacy policy runner, the Experiment Runner with the
 variation system, and policy-specific evaluation flows such as GR00T and PI.
 
 Behind the scenes, this workflow uses the ``ArenaEnvGraphSpec`` schema for scene
@@ -125,8 +125,8 @@ with variations through the policy runner:
    variation sweeps, such as changing the background HDR image to probe policy
    sensitivity.
 
-Experiment Runner with Variations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Legacy Experiment Runner Configuration with Variations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Evaluation jobs can also point their environment source at an environment graph
 spec YAML with variations, instead of a registered example-environment name:

--- a/docs/pages/quickstart/first_experiments/exploring_variations.rst
+++ b/docs/pages/quickstart/first_experiments/exploring_variations.rst
@@ -135,15 +135,15 @@ across hundreds of object and scene combinations in a single run.
    :align: center
 
 
-Sequential Batch Evaluation
----------------------------
+Legacy Sequential Batch Evaluation
+----------------------------------
 
 The four experiments above run one variation at a time. In practice, Arena is used to evaluate
 a policy across hundreds of object, scene, and embodiment combinations in a single run. The
-``experiment_runner.py`` script reads a JSON job config that lists any number of jobs — each with its
-own environment arguments, policy, and step count — and runs them sequentially within one Isaac
-Sim process, collecting success metrics for each. ``getting_started_jobs_config.json`` bundles
-the four experiments above into a single config:
+``getting_started_jobs_config.json`` bundles the four experiments above for the
+Experiment Runner's deprecated JSON compatibility path. It lists each
+job's environment arguments, policy, and step count and runs them sequentially
+within one Isaac Sim process:
 
 .. code-block:: bash
 
@@ -156,7 +156,8 @@ the four experiments above into a single config:
    :align: center
 
 At the end of the run you get a per-job summary of success rates. See
-:ref:`sequential-batch-experiment-runner` for full details on the job config format and available options.
+:ref:`sequential-batch-experiment-runner` for the typed YAML replacement
+and its local and OSMO routes.
 
 All of the above used a zero-action policy — the robot stays still and success rates are zero.
 The next page swaps in a real pre-trained model and runs it in closed loop:

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -196,7 +196,8 @@ class PolicyRegistry(Registry):
         self._policy_types_by_cfg_type[cfg_type] = policy_type
 
     # TODO(cvolk, 2026-07-06): [typed-config-migration] Remove this policy-to-config
-    # lookup when policy_runner and experiment_runner receive PolicyCfg instances directly.
+    # lookup when the deprecated Policy Runner and legacy Experiment Runner
+    # interfaces are retired.
     def get_policy_cfg_type(self, policy_type: type["PolicyBase"]) -> type["PolicyCfg"]:
         """Get the config type used by the temporary policy frontend adapters."""
         ensure_assets_registered()

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -11,8 +11,9 @@ from isaaclab_arena.cli.dataclass_cli import dataclass_from_cli
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
 
 
-# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this Namespace-to-config adapter after policy_runner,
-# experiment_runner, and the remaining argparse scripts pass ArenaEnvBuilderCfg directly.
+# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this Namespace-to-config adapter after the deprecated
+# Policy Runner, legacy Experiment Runner interface, and remaining argparse scripts pass
+# ArenaEnvBuilderCfg directly.
 def arena_env_builder_cfg_from_argparse(args_cli: argparse.Namespace) -> ArenaEnvBuilderCfg:
     """Translate parsed CLI arguments into the typed builder configuration.
 
@@ -25,8 +26,9 @@ def arena_env_builder_cfg_from_argparse(args_cli: argparse.Namespace) -> ArenaEn
     return dataclass_from_cli(ArenaEnvBuilderCfg, args_cli)
 
 
-# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this parser pipeline and its add_* helpers after
-# policy_runner, experiment_runner, and the remaining argparse scripts accept typed configs.
+# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this parser pipeline and its add_* helpers after the
+# deprecated Policy Runner, legacy Experiment Runner interface, and remaining argparse scripts accept typed
+# configs.
 def get_isaaclab_arena_cli_parser() -> argparse.ArgumentParser:
     """Get a complete argument parser with both Isaac Lab and IsaacLab Arena arguments."""
     parser = argparse.ArgumentParser(description="IsaacLab Arena CLI parser.")

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -14,9 +14,13 @@ from pathlib import Path
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
 from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
+
+# Import the first-party extension so its typed policy is registered during composition.
+from isaaclab_arena_openpi.policy import pi0_remote_policy  # noqa: F401
 
 
 def validate_experiment_config_path(experiment_config: str | Path) -> Path:
@@ -50,8 +54,6 @@ def load_arena_experiment_from_config_file(
     path = validate_experiment_config_path(experiment_config_path)
 
     if path.suffix.lower() == ".json":
-        from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-
         assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
         with path.open(encoding="utf-8") as experiment_config_file:
             legacy_experiment_config = json.load(experiment_config_file)
@@ -91,12 +93,6 @@ def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
 
 def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
     """Return registered policy selector names and their config types."""
-    # First-party policy extensions register explicitly so typed Experiment loading
-    # stays independent of the deprecated policy_runner import path. This function
-    # is reached after SimulationApp startup by the Experiment Runner.
-    from isaaclab_arena_openpi.policy import ensure_openpi_policy_registered
-
-    ensure_openpi_policy_registered()
     registry = PolicyRegistry()
     policy_cfg_types: dict[str, type[PolicyCfg]] = {}
     for name in registry.get_all_keys():

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
-from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
 from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
@@ -51,6 +50,8 @@ def load_arena_experiment_from_config_file(
     path = validate_experiment_config_path(experiment_config_path)
 
     if path.suffix.lower() == ".json":
+        from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
+
         assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
         with path.open(encoding="utf-8") as experiment_config_file:
             legacy_experiment_config = json.load(experiment_config_file)
@@ -90,6 +91,12 @@ def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
 
 def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
     """Return registered policy selector names and their config types."""
+    # First-party policy extensions register explicitly so typed Experiment loading
+    # stays independent of the deprecated policy_runner import path. This function
+    # is reached after SimulationApp startup by the Experiment Runner.
+    from isaaclab_arena_openpi.policy import ensure_openpi_policy_registered
+
+    ensure_openpi_policy_registered()
     registry = PolicyRegistry()
     policy_cfg_types: dict[str, type[PolicyCfg]] = {}
     for name in registry.get_all_keys():

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -3,32 +3,33 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Run an Arena Experiment locally or submit it to OSMO."""
+
+from __future__ import annotations
+
+import argparse
 import os
+import sys
+from dataclasses import replace
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
-from isaaclab_arena.evaluation.arena_experiment_config_loader import (
-    load_arena_experiment_from_config_file,
-    validate_experiment_config_path,
+from isaaclab_arena.evaluation.experiment_runner_route import (
+    parse_experiment_runner_route,
+    print_experiment_runner_help,
+    should_show_experiment_runner_help,
+    uses_experiment_runner_cfg,
 )
-from isaaclab_arena.evaluation.arena_run import build_runs_info_table
-from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
-from isaaclab_arena.evaluation.legacy_experiment_runner import (
-    legacy_json_experiment_requires_cameras,
-    load_legacy_json_experiment_config,
-    run_legacy_json_in_chunks,
-)
-from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg, execute_experiment
-from isaaclab_arena.metrics.metrics_logger import MetricsLogger
-from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
-from isaaclab_arena.video.video_recording import timestamped_run_dir
-from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
+
+if TYPE_CHECKING:
+    from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+    from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
 
 
-# TODO(cvolk): Move experiment-level variation inspection out of this CLI entry point.
-# Run orchestration belongs in evaluation; catalogue formatting belongs in variations.
 def list_variations(experiment: ArenaExperiment) -> None:
     """Print the Hydra-configurable variations for each run's environment."""
+    from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg
+
     for run_cfg in experiment:
         arena_builder = build_arena_builder_from_run_cfg(run_cfg)
         print(f"=== Variations for run '{run_cfg.name}' ===", flush=True)
@@ -36,7 +37,7 @@ def list_variations(experiment: ArenaExperiment) -> None:
 
 
 # TODO(cvolk, 2026-07-10): [typed-config-migration] Typed YAML is composed only
-# after SimulationApp starts, so experiment_runner cannot determine camera requirements
+# after SimulationApp starts, so the Experiment Runner cannot determine camera requirements
 # in time to configure AppLauncher. Add enable_cameras to ArenaEnvironmentCfg,
 # update each factory to honor it or reject unsupported cameras, and apply YAML
 # values and Hydra overrides before startup. Enable AppLauncher when any Run enables
@@ -50,8 +51,148 @@ def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: 
     )
 
 
-def main():
-    args_cli, experiment_overrides = parse_experiment_runner_args()
+def _get_simulation_app_context_type() -> Any:
+    """Import the local SimulationApp context only after local execution is selected."""
+    from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext as context_type
+
+    return context_type
+
+
+def _get_experiment_loader() -> Any:
+    """Import the typed Experiment loader only after local execution is selected."""
+    from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+        load_arena_experiment_from_config_file as experiment_loader,
+    )
+
+    return experiment_loader
+
+
+def _execute_experiment_and_report(
+    experiment: ArenaExperiment,
+    *,
+    output_base_dir: str,
+    record_viewport_video: bool,
+    record_camera_video: bool,
+    continue_on_error: bool,
+    serve_evaluation_report: bool,
+    evaluation_report_port: int,
+) -> None:
+    """Execute a loaded Experiment and produce its metrics and report."""
+    from isaaclab_arena.evaluation.arena_run import build_runs_info_table
+    from isaaclab_arena.evaluation.run_execution import execute_experiment
+    from isaaclab_arena.metrics.metrics_logger import MetricsLogger
+    from isaaclab_arena.video.video_recording import timestamped_run_dir
+    from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
+
+    metrics_logger = MetricsLogger()
+    print(build_runs_info_table(experiment, []))
+
+    # One reverse-dated output directory for the Experiment, with one subdirectory
+    # per Run. Always date it so each invocation produces its own report directory.
+    experiment_output_dir = Path(timestamped_run_dir(output_base_dir))
+    if record_viewport_video:
+        os.makedirs(experiment_output_dir, exist_ok=True)
+        print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_dir}")
+
+    results = execute_experiment(
+        experiment,
+        output_dir=experiment_output_dir,
+        record_viewport_video=record_viewport_video,
+        record_camera_video=record_camera_video,
+        continue_on_error=continue_on_error,
+    )
+    for result in results:
+        if result.metrics is not None:
+            metrics_logger.append_job_metrics(result.run_name, result.metrics)
+
+    print(build_runs_info_table(experiment, results))
+    metrics_logger.print_metrics()
+
+    report_path = build_report(experiment_output_dir)
+    if serve_evaluation_report:
+        serve_until_ctrl_c(report_path.parent, evaluation_report_port, report_path.name)
+
+
+def _run_experiment_runner_cfg_locally(cfg: ExperimentRunnerCfg, app_launcher_args: argparse.Namespace) -> int:
+    """Execute one Experiment Runner configuration in the current container."""
+    if cfg.record_camera_video:
+        app_launcher_args.enable_cameras = True
+
+    simulation_app_context_type = _get_simulation_app_context_type()
+    experiment_loader = _get_experiment_loader()
+    with simulation_app_context_type(app_launcher_args):
+        experiment = experiment_loader(
+            cfg.experiment_config,
+            device=app_launcher_args.device,
+            overrides=cfg.experiment_overrides,
+        )
+        _assert_camera_support_enabled(experiment, app_launcher_args.enable_cameras)
+        if app_launcher_args.list_variations:
+            list_variations(experiment)
+            return 0
+        _execute_experiment_and_report(
+            experiment,
+            output_base_dir=cfg.output_base_dir,
+            record_viewport_video=cfg.record_viewport_video,
+            record_camera_video=cfg.record_camera_video,
+            continue_on_error=cfg.continue_on_error,
+            serve_evaluation_report=cfg.serve_evaluation_report,
+            evaluation_report_port=cfg.evaluation_report_port,
+        )
+    return 0
+
+
+def _load_experiment_runner_cfg(config_path: str) -> ExperimentRunnerCfg:
+    """Load the typed execution config without importing local runtime modules."""
+    from isaaclab_arena.evaluation.experiment_runner_cfg import load_experiment_runner_cfg
+
+    return load_experiment_runner_cfg(config_path)
+
+
+def _parse_local_app_launcher_args(cli_args: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    """Parse AppLauncher arguments only after the local route is selected."""
+    from isaaclab_arena.evaluation.experiment_runner_local_cli import parse_local_experiment_runner_args
+
+    return parse_local_experiment_runner_args(cli_args)
+
+
+def _run_experiment_runner_cfg_route(cli_args: list[str]) -> int:
+    """Run the typed Experiment Runner route."""
+    route, backend_args = parse_experiment_runner_route(cli_args)
+    cfg = _load_experiment_runner_cfg(route.config_path)
+
+    if route.local:
+        app_launcher_args, trailing_experiment_overrides = _parse_local_app_launcher_args(backend_args)
+    else:
+        trailing_experiment_overrides = backend_args
+
+    cfg = replace(
+        cfg,
+        experiment_overrides=[*cfg.experiment_overrides, *trailing_experiment_overrides],
+    )
+    from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
+
+    parser = argparse.ArgumentParser(add_help=False)
+    assert_hydra_overrides(cfg.experiment_overrides, parser)
+    if route.local:
+        return _run_experiment_runner_cfg_locally(cfg, app_launcher_args)
+
+    from osmo.experiment_dispatcher import submit_experiment_to_osmo
+
+    return submit_experiment_to_osmo(cfg, route.osmo_config_path)
+
+
+def _run_legacy_experiment_runner(cli_args: list[str]) -> int:
+    """Run the deprecated argparse/Namespace evaluation path unchanged."""
+    from isaaclab_arena.evaluation.arena_experiment_config_loader import validate_experiment_config_path
+    from isaaclab_arena.evaluation.legacy_experiment_runner import (
+        legacy_json_experiment_requires_cameras,
+        load_legacy_json_experiment_config,
+        run_legacy_json_in_chunks,
+    )
+    from isaaclab_arena.evaluation.legacy_experiment_runner_cli import parse_legacy_experiment_runner_args
+
+    args_cli, experiment_overrides = parse_legacy_experiment_runner_args(cli_args)
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
     legacy_experiment_config = load_legacy_json_experiment_config(
         experiment_config_path,
@@ -63,69 +204,54 @@ def main():
     ):
         args_cli.enable_cameras = True
 
-    # Print the variations catalogue for each run's environment and exit.
+    simulation_app_context_type = _get_simulation_app_context_type()
+    experiment_loader = _get_experiment_loader()
     if args_cli.list_variations:
-        with SimulationAppContext(args_cli):
-            experiment = load_arena_experiment_from_config_file(
+        with simulation_app_context_type(args_cli):
+            experiment = experiment_loader(
                 experiment_config_path,
                 device=args_cli.device,
                 overrides=experiment_overrides,
             )
             _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
             list_variations(experiment)
-        return
+        return 0
 
-    # Chunked dispatch (--chunk_size N). Splits this config across subprocesses so each
-    # gets a fresh SimulationApp. Required for long sweeps because some host memory leaks
-    # each cycle and is only reclaimed when the process exits — in-process teardown can't
-    # release it.
     if args_cli.chunk_size is not None:
         assert legacy_experiment_config is not None, "--chunk_size currently supports only legacy JSON Experiments"
-
         if len(legacy_experiment_config["jobs"]) > args_cli.chunk_size:
             run_legacy_json_in_chunks(args_cli, legacy_experiment_config)
-            return
+            return 0
 
-    with SimulationAppContext(args_cli):
-        experiment = load_arena_experiment_from_config_file(
+    with simulation_app_context_type(args_cli):
+        experiment = experiment_loader(
             experiment_config_path,
             device=args_cli.device,
             overrides=experiment_overrides,
         )
         _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
-        metrics_logger = MetricsLogger()
-
-        print(build_runs_info_table(experiment, []))
-
-        # One reverse-dated output directory for the Experiment, with one subdirectory
-        # per Run. Always date it so each invocation produces its own report directory.
-        # TODO(alexmillane): Currently each chunk produces its own output directory.
-        # We should use the same output directory for all chunks in the future.
-        experiment_output_dir = Path(timestamped_run_dir(args_cli.output_base_dir))
-
-        if args_cli.record_viewport_video:
-            os.makedirs(experiment_output_dir, exist_ok=True)
-            print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_dir}")
-
-        results = execute_experiment(
+        _execute_experiment_and_report(
             experiment,
-            output_dir=experiment_output_dir,
+            output_base_dir=args_cli.output_base_dir,
             record_viewport_video=args_cli.record_viewport_video,
             record_camera_video=args_cli.record_camera_video,
             continue_on_error=args_cli.continue_on_error,
+            serve_evaluation_report=args_cli.serve_evaluation_report,
+            evaluation_report_port=args_cli.evaluation_report_port,
         )
-        for result in results:
-            if result.metrics is not None:
-                metrics_logger.append_job_metrics(result.run_name, result.metrics)
+    return 0
 
-        print(build_runs_info_table(experiment, results))
-        metrics_logger.print_metrics()
 
-        # Write HTML report.
-        report_path = build_report(experiment_output_dir)
-        if args_cli.serve_evaluation_report:
-            serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
+def main(cli_args: list[str] | None = None) -> int:
+    """Run an Arena Experiment locally or submit it to OSMO."""
+    args = list(sys.argv[1:] if cli_args is None else cli_args)
+    if should_show_experiment_runner_help(args):
+        print_experiment_runner_help()
+        return 0
+    if uses_experiment_runner_cfg(args):
+        return _run_experiment_runner_cfg_route(args)
+    return _run_legacy_experiment_runner(args)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -12,24 +12,38 @@ import os
 import sys
 from dataclasses import replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
 
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    load_arena_experiment_from_config_file,
+    validate_experiment_config_path,
+)
+from isaaclab_arena.evaluation.arena_run import build_runs_info_table
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg, load_experiment_runner_cfg
+from isaaclab_arena.evaluation.experiment_runner_local_cli import parse_local_experiment_runner_args
 from isaaclab_arena.evaluation.experiment_runner_route import (
     parse_experiment_runner_route,
     print_experiment_runner_help,
     should_show_experiment_runner_help,
     uses_experiment_runner_cfg,
 )
-
-if TYPE_CHECKING:
-    from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
-    from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from isaaclab_arena.evaluation.legacy_experiment_runner import (
+    legacy_json_experiment_requires_cameras,
+    load_legacy_json_experiment_config,
+    run_legacy_json_in_chunks,
+)
+from isaaclab_arena.evaluation.legacy_experiment_runner_cli import parse_legacy_experiment_runner_args
+from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg, execute_experiment
+from isaaclab_arena.metrics.metrics_logger import MetricsLogger
+from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+from isaaclab_arena.video.video_recording import timestamped_run_dir
+from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
+from osmo.experiment_dispatcher import submit_experiment_to_osmo
 
 
 def list_variations(experiment: ArenaExperiment) -> None:
     """Print the Hydra-configurable variations for each run's environment."""
-    from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run_cfg
-
     for run_cfg in experiment:
         arena_builder = build_arena_builder_from_run_cfg(run_cfg)
         print(f"=== Variations for run '{run_cfg.name}' ===", flush=True)
@@ -51,22 +65,6 @@ def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: 
     )
 
 
-def _get_simulation_app_context_type() -> Any:
-    """Import the local SimulationApp context only after local execution is selected."""
-    from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext as context_type
-
-    return context_type
-
-
-def _get_experiment_loader() -> Any:
-    """Import the typed Experiment loader only after local execution is selected."""
-    from isaaclab_arena.evaluation.arena_experiment_config_loader import (
-        load_arena_experiment_from_config_file as experiment_loader,
-    )
-
-    return experiment_loader
-
-
 def _execute_experiment_and_report(
     experiment: ArenaExperiment,
     *,
@@ -78,12 +76,6 @@ def _execute_experiment_and_report(
     evaluation_report_port: int,
 ) -> None:
     """Execute a loaded Experiment and produce its metrics and report."""
-    from isaaclab_arena.evaluation.arena_run import build_runs_info_table
-    from isaaclab_arena.evaluation.run_execution import execute_experiment
-    from isaaclab_arena.metrics.metrics_logger import MetricsLogger
-    from isaaclab_arena.video.video_recording import timestamped_run_dir
-    from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
-
     metrics_logger = MetricsLogger()
     print(build_runs_info_table(experiment, []))
 
@@ -118,10 +110,8 @@ def _run_experiment_runner_cfg_locally(cfg: ExperimentRunnerCfg, app_launcher_ar
     if cfg.record_camera_video:
         app_launcher_args.enable_cameras = True
 
-    simulation_app_context_type = _get_simulation_app_context_type()
-    experiment_loader = _get_experiment_loader()
-    with simulation_app_context_type(app_launcher_args):
-        experiment = experiment_loader(
+    with SimulationAppContext(app_launcher_args):
+        experiment = load_arena_experiment_from_config_file(
             cfg.experiment_config,
             device=app_launcher_args.device,
             overrides=cfg.experiment_overrides,
@@ -142,27 +132,13 @@ def _run_experiment_runner_cfg_locally(cfg: ExperimentRunnerCfg, app_launcher_ar
     return 0
 
 
-def _load_experiment_runner_cfg(config_path: str) -> ExperimentRunnerCfg:
-    """Load the typed execution config without importing local runtime modules."""
-    from isaaclab_arena.evaluation.experiment_runner_cfg import load_experiment_runner_cfg
-
-    return load_experiment_runner_cfg(config_path)
-
-
-def _parse_local_app_launcher_args(cli_args: list[str]) -> tuple[argparse.Namespace, list[str]]:
-    """Parse AppLauncher arguments only after the local route is selected."""
-    from isaaclab_arena.evaluation.experiment_runner_local_cli import parse_local_experiment_runner_args
-
-    return parse_local_experiment_runner_args(cli_args)
-
-
 def _run_experiment_runner_cfg_route(cli_args: list[str]) -> int:
     """Run the typed Experiment Runner route."""
     route, backend_args = parse_experiment_runner_route(cli_args)
-    cfg = _load_experiment_runner_cfg(route.config_path)
+    cfg = load_experiment_runner_cfg(route.config_path)
 
     if route.local:
-        app_launcher_args, trailing_experiment_overrides = _parse_local_app_launcher_args(backend_args)
+        app_launcher_args, trailing_experiment_overrides = parse_local_experiment_runner_args(backend_args)
     else:
         trailing_experiment_overrides = backend_args
 
@@ -170,28 +146,16 @@ def _run_experiment_runner_cfg_route(cli_args: list[str]) -> int:
         cfg,
         experiment_overrides=[*cfg.experiment_overrides, *trailing_experiment_overrides],
     )
-    from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
-
     parser = argparse.ArgumentParser(add_help=False)
     assert_hydra_overrides(cfg.experiment_overrides, parser)
     if route.local:
         return _run_experiment_runner_cfg_locally(cfg, app_launcher_args)
-
-    from osmo.experiment_dispatcher import submit_experiment_to_osmo
 
     return submit_experiment_to_osmo(cfg, route.osmo_config_path)
 
 
 def _run_legacy_experiment_runner(cli_args: list[str]) -> int:
     """Run the deprecated argparse/Namespace evaluation path unchanged."""
-    from isaaclab_arena.evaluation.arena_experiment_config_loader import validate_experiment_config_path
-    from isaaclab_arena.evaluation.legacy_experiment_runner import (
-        legacy_json_experiment_requires_cameras,
-        load_legacy_json_experiment_config,
-        run_legacy_json_in_chunks,
-    )
-    from isaaclab_arena.evaluation.legacy_experiment_runner_cli import parse_legacy_experiment_runner_args
-
     args_cli, experiment_overrides = parse_legacy_experiment_runner_args(cli_args)
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
     legacy_experiment_config = load_legacy_json_experiment_config(
@@ -204,11 +168,9 @@ def _run_legacy_experiment_runner(cli_args: list[str]) -> int:
     ):
         args_cli.enable_cameras = True
 
-    simulation_app_context_type = _get_simulation_app_context_type()
-    experiment_loader = _get_experiment_loader()
     if args_cli.list_variations:
-        with simulation_app_context_type(args_cli):
-            experiment = experiment_loader(
+        with SimulationAppContext(args_cli):
+            experiment = load_arena_experiment_from_config_file(
                 experiment_config_path,
                 device=args_cli.device,
                 overrides=experiment_overrides,
@@ -223,8 +185,8 @@ def _run_legacy_experiment_runner(cli_args: list[str]) -> int:
             run_legacy_json_in_chunks(args_cli, legacy_experiment_config)
             return 0
 
-    with simulation_app_context_type(args_cli):
-        experiment = experiment_loader(
+    with SimulationAppContext(args_cli):
+        experiment = load_arena_experiment_from_config_file(
             experiment_config_path,
             device=args_cli.device,
             overrides=experiment_overrides,

--- a/isaaclab_arena/evaluation/experiment_runner_cfg.py
+++ b/isaaclab_arena/evaluation/experiment_runner_cfg.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed configuration for executing a YAML Arena Experiment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+from isaaclab_arena.hydra.typed_yaml import load_typed_yaml_cfg
+
+
+@dataclass
+class ExperimentRunnerCfg:
+    """Configure execution of one typed Arena Experiment."""
+
+    experiment_config: str
+    """Typed Experiment YAML path, relative to this configuration when not absolute."""
+
+    experiment_overrides: list[str] = field(default_factory=list)
+    """Hydra overrides applied to the typed Experiment after its YAML values."""
+
+    output_base_dir: str = "/eval/output"
+    """Base directory receiving the timestamped Experiment output directory."""
+
+    record_viewport_video: bool = False
+    """Whether to record the rendered viewport for each Run."""
+
+    record_camera_video: bool = False
+    """Whether to record observation-camera videos for each Run."""
+
+    continue_on_error: bool = False
+    """Whether to continue with later Runs after a Run fails."""
+
+    serve_evaluation_report: bool = False
+    """Whether to serve the generated evaluation report after execution."""
+
+    evaluation_report_port: int = 8000
+    """Port used when serving the generated evaluation report."""
+
+    def __post_init__(self) -> None:
+        assert self.experiment_config, "experiment_config must not be empty"
+        assert self.output_base_dir, "output_base_dir must not be empty"
+        assert 0 < self.evaluation_report_port < 65536, "evaluation_report_port must be between 1 and 65535"
+
+
+def load_experiment_runner_cfg(config_path: str | Path) -> ExperimentRunnerCfg:
+    """Load an Experiment Runner configuration and resolve its Experiment path."""
+    path = Path(config_path).expanduser().resolve()
+    cfg = load_typed_yaml_cfg(path, ExperimentRunnerCfg, config_name="Experiment Runner")
+
+    experiment_config_path = Path(cfg.experiment_config).expanduser()
+    if not experiment_config_path.is_absolute():
+        experiment_config_path = path.parent / experiment_config_path
+    experiment_config_path = experiment_config_path.resolve()
+
+    assert experiment_config_path.is_file(), f"Experiment config does not exist: '{experiment_config_path}'"
+    assert experiment_config_path.suffix.lower() in {
+        ".yaml",
+        ".yml",
+    }, f"Typed Experiment config must be YAML, got '{experiment_config_path}'"
+    return replace(cfg, experiment_config=str(experiment_config_path))

--- a/isaaclab_arena/evaluation/experiment_runner_local_cli.py
+++ b/isaaclab_arena/evaluation/experiment_runner_local_cli.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parse the Isaac Lab application arguments for local typed evaluation."""
+
+from __future__ import annotations
+
+import argparse
+
+from isaaclab.app import AppLauncher
+
+from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
+
+
+def parse_local_experiment_runner_args(cli_args: list[str]) -> tuple[argparse.Namespace, list[str]]:
+    """Parse AppLauncher arguments and return trailing Experiment overrides."""
+    parser = argparse.ArgumentParser(description="Run a typed Arena Experiment locally.")
+    parser.add_argument(
+        "--list_variations",
+        action="store_true",
+        help="Print configurable environment variations for each Run and exit.",
+    )
+    AppLauncher.add_app_launcher_args(parser)
+    parser.allow_abbrev = False
+    app_launcher_args, experiment_overrides = parser.parse_known_args(cli_args)
+    assert_hydra_overrides(experiment_overrides, parser)
+    return app_launcher_args, experiment_overrides

--- a/isaaclab_arena/evaluation/experiment_runner_route.py
+++ b/isaaclab_arena/evaluation/experiment_runner_route.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Select local execution or OSMO submission for an Experiment Runner configuration."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ExperimentRunnerRoute:
+    """Route one Experiment Runner configuration to local execution or OSMO."""
+
+    config_path: str
+    """Path to the typed Experiment Runner YAML."""
+
+    local: bool
+    """Whether to execute locally instead of submitting to OSMO."""
+
+    osmo_config_path: str | None
+    """Optional path to an OSMO workflow YAML, used only for submission."""
+
+
+def should_show_experiment_runner_help(cli_args: list[str]) -> bool:
+    """Return whether arguments request help for the typed Experiment Runner route."""
+    requests_help = "--help" in cli_args or "-h" in cli_args
+    typed_route_options = {"--config", "--local", "--osmo-config"}
+    uses_typed_route_option = any(
+        arg in typed_route_options or arg.startswith("--config=") or arg.startswith("--osmo-config=")
+        for arg in cli_args
+    )
+    return requests_help and (len(cli_args) == 1 or uses_typed_route_option)
+
+
+def print_experiment_runner_help() -> None:
+    """Print the primary typed Experiment Runner interface."""
+    parser = argparse.ArgumentParser(
+        description="Run a YAML-configured Arena Experiment locally or submit it to OSMO.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""examples:
+  Submit the bundled OpenPI example to OSMO using the default infrastructure config:
+    /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \\
+      --config isaaclab_arena_environments/evaluation_configs/openpi.yaml
+
+  Run it locally against an already-running OpenPI server:
+    /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \\
+      --config isaaclab_arena_environments/evaluation_configs/openpi.yaml \\
+      --local --enable_cameras
+
+With --local, Isaac Lab AppLauncher arguments and trailing Hydra KEY=VALUE Experiment overrides
+are accepted. Without --config, experiment_runner.py uses its deprecated legacy interface.""",
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        metavar="PATH",
+        help="Path to an Experiment Runner YAML configuration.",
+    )
+    parser.add_argument("--local", action="store_true", help="Run locally instead of submitting to OSMO.")
+    parser.add_argument(
+        "--osmo-config",
+        metavar="PATH",
+        help="Optional OSMO infrastructure YAML override; omit it to use osmo/config/arena_experiment_workflow.yaml.",
+    )
+    parser.print_help()
+
+
+def uses_experiment_runner_cfg(cli_args: list[str]) -> bool:
+    """Return whether arguments select the typed Experiment Runner route."""
+    return any(arg == "--config" or arg.startswith("--config=") for arg in cli_args)
+
+
+def parse_experiment_runner_route(cli_args: list[str]) -> tuple[ExperimentRunnerRoute, list[str]]:
+    """Parse routing arguments and return arguments owned by the selected backend."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--config", required=True, help="Path to an Experiment Runner YAML configuration.")
+    parser.add_argument("--local", action="store_true", help="Run locally instead of submitting to OSMO.")
+    parser.add_argument("--osmo-config", help="Path to an OSMO workflow YAML config.")
+    route_args, backend_args = parser.parse_known_args(cli_args)
+
+    if route_args.local and route_args.osmo_config is not None:
+        parser.error("--osmo-config cannot be used with --local")
+
+    return (
+        ExperimentRunnerRoute(
+            config_path=route_args.config,
+            local=route_args.local,
+            osmo_config_path=route_args.osmo_config,
+        ),
+        backend_args,
+    )

--- a/isaaclab_arena/evaluation/legacy_environment_cli_args.py
+++ b/isaaclab_arena/evaluation/legacy_environment_cli_args.py
@@ -7,8 +7,8 @@
 
 from typing import Any
 
-# TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this module with the JSON evaluation-job
-# frontend once experiment_runner loads typed YAML experiments directly.
+# TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this module when the legacy JSON
+# Experiment interface is retired.
 
 
 def legacy_environment_args_to_cli_args(args: dict[str, Any]) -> list[str]:

--- a/isaaclab_arena/evaluation/legacy_eval_config.py
+++ b/isaaclab_arena/evaluation/legacy_eval_config.py
@@ -20,14 +20,14 @@ from isaaclab_arena.evaluation.policy_runner import get_policy_cls
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
 
-# TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this adapter when experiment_runner loads typed YAML
-# experiment files directly. The current JSON format identifies environments and policies
+# TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this adapter when the legacy JSON
+# Experiment interface is retired. The JSON format identifies environments and policies
 # by name and mixes environment-specific and builder values in ``arena_env_args``.
 # This module resolves those names, separates the values into their concrete typed
 # configs, and marks graph-YAML environments for the narrow argparse compatibility
 # path in ``legacy_graph_environment_cli``.
-# The planned Hydra/YAML frontend will compose typed run configs directly, so none
-# of this JSON translation or argparse fallback will be needed.
+# The typed YAML interface already composes Run configurations directly, so none of
+# this JSON translation or argparse fallback is used by the primary route.
 
 
 @dataclass(frozen=True)

--- a/isaaclab_arena/evaluation/legacy_experiment_runner.py
+++ b/isaaclab_arena/evaluation/legacy_experiment_runner.py
@@ -52,7 +52,7 @@ def legacy_json_experiment_requires_cameras(experiment_config: dict) -> bool:
 
 
 def _run_legacy_json_chunk(chunk_label: str, legacy_job_configs: list[dict]) -> int:
-    """Run legacy JSON entries in a fresh experiment_runner subprocess."""
+    """Run legacy JSON entries in a fresh Experiment Runner subprocess."""
     print(f"[experiment_runner] {chunk_label}", flush=True)
     # Serialize this chunk's jobs to a temp config the child loads via --experiment_config.
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:

--- a/isaaclab_arena/evaluation/legacy_experiment_runner_cli.py
+++ b/isaaclab_arena/evaluation/legacy_experiment_runner_cli.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+"""Parse the deprecated Namespace-based Experiment Runner interface."""
+
 import argparse
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
@@ -11,8 +13,8 @@ from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 _DEFAULT_EXPERIMENT_CONFIG_PATH = "isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json"
 
 
-def add_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
-    """Add Experiment Runner specific arguments to the parser."""
+def add_legacy_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
+    """Add deprecated Experiment Runner arguments to the parser."""
     # TODO(cvolk, 2026-07-09): [typed-config-migration] Remove the --eval_jobs_config alias
     # when legacy JSON Experiments are retired. Both flags currently populate experiment_config.
     parser.add_argument(
@@ -78,14 +80,14 @@ def add_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def parse_experiment_runner_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
-    """Parse experiment-runner arguments and return native Hydra override tokens separately.
+def parse_legacy_experiment_runner_args(argv: list[str] | None = None) -> tuple[argparse.Namespace, list[str]]:
+    """Parse deprecated runner arguments and return native Hydra override tokens separately.
 
     Args:
         argv: Arguments to parse, or None to read the process arguments.
     """
     parser = get_isaaclab_arena_cli_parser()
-    add_experiment_runner_arguments(parser)
+    add_legacy_experiment_runner_arguments(parser)
     parser.allow_abbrev = False
     args_cli, experiment_overrides = parser.parse_known_args(argv)
     assert_hydra_overrides(experiment_overrides, parser)

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import torch
-import tqdm
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -19,6 +17,7 @@ from isaaclab_arena.evaluation.policy_runner_cli import (
     add_policy_runner_arguments,
     build_policy_from_cli,
 )
+from isaaclab_arena.evaluation.rollout import rollout_policy
 from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -28,7 +27,6 @@ from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
 
 if TYPE_CHECKING:
-    from isaaclab_arena.metrics.metric_data import MetricsDataCollection
     from isaaclab_arena.policy.policy_base import PolicyBase
 
 
@@ -61,79 +59,6 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     return (
         "cuda" in args_cli.device and hasattr(args_cli, "distributed") and args_cli.distributed and get_world_size() > 1
     )
-
-
-def rollout_policy(
-    env,
-    policy: PolicyBase,
-    num_steps: int | None,
-    num_episodes: int | None,
-) -> MetricsDataCollection | None:
-    assert num_steps is not None or num_episodes is not None, "Either num_steps or num_episodes must be provided"
-    assert num_steps is None or num_episodes is None, "Only one of num_steps or num_episodes must be provided"
-
-    pbar = None
-    try:
-        obs, _ = env.reset()
-        policy.reset()
-        policy.set_task_description(env.unwrapped.get_language_instruction())
-
-        # Setup progress bar based on num_steps or num_episodes
-        if num_steps is not None:
-            pbar = tqdm.tqdm(total=num_steps, desc="Steps", unit="step")
-        else:
-            pbar = tqdm.tqdm(total=num_episodes, desc="Episodes", unit="episode")
-
-        num_episodes_completed = 0
-        num_steps_completed = 0
-
-        while True:
-            with torch.inference_mode():
-                actions = policy.get_action(env, obs)
-                obs, _, terminated, truncated, _ = env.step(actions)
-
-                if terminated.any() or truncated.any():
-                    # Only reset policy for those envs that are terminated or truncated
-                    print(
-                        f"Resetting policy for terminated env_ids: {terminated.nonzero().flatten()}"
-                        f" and truncated env_ids: {truncated.nonzero().flatten()}"
-                    )
-                    env_ids = (terminated | truncated).nonzero().flatten()
-                    policy.reset(env_ids=env_ids)
-                    # Break if number of episodes is reached
-                    completed_episodes = env_ids.shape[0]
-                    num_episodes_completed += completed_episodes
-                    if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-                        metrics = env.unwrapped.compute_metrics()
-                        tqdm.tqdm.write(
-                            f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
-                            f" {metrics_to_plain_python_types(metrics)}"
-                        )
-                    if num_episodes is not None:
-                        pbar.update(completed_episodes)
-                        if num_episodes_completed >= num_episodes:
-                            break
-                # Break if number of steps is reached
-                num_steps_completed += 1
-                if num_steps is not None:
-                    pbar.update(1)
-                    if num_steps_completed >= num_steps:
-                        break
-
-        pbar.close()
-
-    except Exception as e:
-        if pbar is not None:
-            pbar.close()
-        raise RuntimeError(f"Error rolling out policy: {e}")
-
-    else:
-
-        # Only compute metrics if env has non-None metrics.
-        # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
-        if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-            return env.unwrapped.compute_metrics()
-        return None
 
 
 def main():

--- a/isaaclab_arena/evaluation/rollout.py
+++ b/isaaclab_arena/evaluation/rollout.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execute policy rollouts independently of an evaluation frontend."""
+
+from __future__ import annotations
+
+import torch
+import tqdm
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
+from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
+
+if TYPE_CHECKING:
+    from isaaclab_arena.metrics.metric_data import MetricsDataCollection
+    from isaaclab_arena.policy.policy_base import PolicyBase
+
+
+def rollout_policy(
+    env,
+    policy: PolicyBase,
+    num_steps: int | None,
+    num_episodes: int | None,
+) -> MetricsDataCollection | None:
+    """Roll out a policy until its configured step or episode limit."""
+    assert num_steps is not None or num_episodes is not None, "Either num_steps or num_episodes must be provided"
+    assert num_steps is None or num_episodes is None, "Only one of num_steps or num_episodes must be provided"
+
+    pbar = None
+    try:
+        obs, _ = env.reset()
+        policy.reset()
+        policy.set_task_description(env.unwrapped.get_language_instruction())
+
+        if num_steps is not None:
+            pbar = tqdm.tqdm(total=num_steps, desc="Steps", unit="step")
+        else:
+            pbar = tqdm.tqdm(total=num_episodes, desc="Episodes", unit="episode")
+
+        num_episodes_completed = 0
+        num_steps_completed = 0
+
+        while True:
+            with torch.inference_mode():
+                actions = policy.get_action(env, obs)
+                obs, _, terminated, truncated, _ = env.step(actions)
+
+                if terminated.any() or truncated.any():
+                    print(
+                        f"Resetting policy for terminated env_ids: {terminated.nonzero().flatten()}"
+                        f" and truncated env_ids: {truncated.nonzero().flatten()}"
+                    )
+                    env_ids = (terminated | truncated).nonzero().flatten()
+                    policy.reset(env_ids=env_ids)
+                    completed_episodes = env_ids.shape[0]
+                    num_episodes_completed += completed_episodes
+                    if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
+                        metrics = env.unwrapped.compute_metrics()
+                        tqdm.tqdm.write(
+                            f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
+                            f" {metrics_to_plain_python_types(metrics)}"
+                        )
+                    if num_episodes is not None:
+                        pbar.update(completed_episodes)
+                        if num_episodes_completed >= num_episodes:
+                            break
+
+                num_steps_completed += 1
+                if num_steps is not None:
+                    pbar.update(1)
+                    if num_steps_completed >= num_steps:
+                        break
+
+        pbar.close()
+    except Exception as error:
+        if pbar is not None:
+            pbar.close()
+        raise RuntimeError(f"Error rolling out policy: {error}") from error
+    else:
+        if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
+            return env.unwrapped.compute_metrics()
+        return None

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -19,8 +19,8 @@ from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
     LegacyGraphEnvironmentCfg,
     build_arena_builder_from_legacy_graph,
 )
-from isaaclab_arena.evaluation.policy_runner import rollout_policy
 from isaaclab_arena.evaluation.resource_cleanup import close_run_resources
+from isaaclab_arena.evaluation.rollout import rollout_policy
 from isaaclab_arena.metrics.aggregate_metrics import aggregate_metrics
 from isaaclab_arena.variations.variations_hydra import overrides_from_dict
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -59,7 +59,7 @@ def load_arena_experiment_from_yaml(
     Returns:
         Typed Runs in YAML declaration order.
     """
-    run_values_by_name = _read_and_validate_yaml_runs_as_values(yaml_path)
+    run_values_by_name = read_arena_experiment_run_values(yaml_path)
     config_store = ConfigStore.instance()
     # Reuse these internal names so repeated loads replace their process-global ConfigStore entries.
     hydra_config_namespace = "isaaclab_arena_experiment_composition"
@@ -97,7 +97,7 @@ def _assert_run_name_is_hydra_compatible(run_name: str) -> None:
     )
 
 
-def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, dict[str, Any]]:
+def read_arena_experiment_run_values(yaml_path: str | Path) -> dict[str, dict[str, Any]]:
     """Read an Arena Experiment YAML file and return its Run values by name.
 
     This validates the shared YAML envelope. Fields belonging to a Run,

--- a/isaaclab_arena/hydra/typed_yaml.py
+++ b/isaaclab_arena/hydra/typed_yaml.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict YAML loading for typed dataclass configurations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypeVar
+
+from omegaconf import OmegaConf
+from omegaconf.errors import OmegaConfBaseException
+
+CfgT = TypeVar("CfgT")
+
+
+def render_typed_yaml_cfg(cfg: CfgT) -> str:
+    """Render a structured dataclass configuration as YAML.
+
+    Args:
+        cfg: Dataclass configuration instance to render.
+
+    Returns:
+        The YAML representation of the configuration.
+    """
+    try:
+        config = OmegaConf.structured(cfg)
+        return OmegaConf.to_yaml(config, resolve=False)
+    except (OmegaConfBaseException, TypeError, ValueError) as exc:
+        raise ValueError(f"Could not render typed config as YAML: {exc}") from exc
+
+
+def load_typed_yaml_cfg(
+    path: str | Path,
+    cfg_type: type[CfgT],
+    *,
+    config_name: str,
+) -> CfgT:
+    """Load YAML into a structured dataclass configuration.
+
+    Unknown fields and values incompatible with the dataclass schema are rejected.
+
+    Args:
+        path: YAML configuration file to load.
+        cfg_type: Dataclass type defining the configuration schema.
+        config_name: Descriptive configuration name used in validation errors.
+
+    Returns:
+        The loaded dataclass configuration.
+    """
+    config_path = Path(path).expanduser().resolve()
+    assert config_path.is_file(), f"{config_name} config does not exist: '{config_path}'"
+    assert config_path.suffix.lower() in {
+        ".yaml",
+        ".yml",
+    }, f"{config_name} config must be YAML, got '{config_path}'"
+
+    try:
+        schema = OmegaConf.structured(cfg_type)
+        OmegaConf.set_struct(schema, True)
+        config = OmegaConf.merge(schema, OmegaConf.load(config_path))
+        OmegaConf.resolve(config)
+        loaded = OmegaConf.to_object(config)
+    except (OmegaConfBaseException, TypeError, ValueError) as exc:
+        raise ValueError(f"Could not load {config_name} config from '{config_path}': {exc}") from exc
+
+    assert isinstance(loaded, cfg_type)
+    return loaded

--- a/isaaclab_arena/policy/rsl_rl_action_policy.py
+++ b/isaaclab_arena/policy/rsl_rl_action_policy.py
@@ -62,7 +62,7 @@ class RslRlActionPolicy(PolicyBase[RslRlActionPolicyCfg]):
     Loads the checkpoint and agent config (``params/agent.yaml``) produced by
     IsaacLab's ``train.py``. No separate JSON config file is required.
 
-    Example configuration for Experiment Runner:
+    Example configuration for the Experiment Runner:
 
     .. code-block:: json
 

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -78,8 +78,8 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
         assert simulation_is_running
         return []
 
-    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
-    monkeypatch.setattr(experiment_runner, "load_arena_experiment_from_config_file", load_experiment_after_startup)
+    monkeypatch.setattr(experiment_runner, "_get_simulation_app_context_type", lambda: _SimulationAppContext)
+    monkeypatch.setattr(experiment_runner, "_get_experiment_loader", lambda: load_experiment_after_startup)
     monkeypatch.setattr(experiment_runner, "list_variations", lambda _experiment: None)
     monkeypatch.setattr(
         "sys.argv",

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -78,8 +78,12 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
         assert simulation_is_running
         return []
 
-    monkeypatch.setattr(experiment_runner, "_get_simulation_app_context_type", lambda: _SimulationAppContext)
-    monkeypatch.setattr(experiment_runner, "_get_experiment_loader", lambda: load_experiment_after_startup)
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(
+        experiment_runner,
+        "load_arena_experiment_from_config_file",
+        load_experiment_after_startup,
+    )
     monkeypatch.setattr(experiment_runner, "list_variations", lambda _experiment: None)
     monkeypatch.setattr(
         "sys.argv",

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -9,7 +9,7 @@ import subprocess
 
 import pytest
 
-from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
+from isaaclab_arena.evaluation.legacy_experiment_runner_cli import parse_legacy_experiment_runner_args
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function, run_subprocess
 
@@ -19,7 +19,7 @@ DEFAULT_VISUALIZER = "kit"
 
 
 def test_experiment_runner_parses_native_hydra_overrides():
-    args_cli, experiment_overrides = parse_experiment_runner_args([
+    args_cli, experiment_overrides = parse_legacy_experiment_runner_args([
         "--experiment_config",
         "experiment.yaml",
         "runs.baseline.rollout_limit.num_steps=2",
@@ -119,6 +119,47 @@ runs:
         ],
         capture_output=True,
     )
+    assert result is not None
+    run_row = next(line for line in result.stdout.splitlines() if "yaml_baseline" in line and "pending" in line)
+    run_cells = [cell.strip() for cell in run_row.split("|")[1:-1]]
+    assert run_cells[4] == "2"
+
+
+@pytest.mark.with_subprocess
+def test_experiment_runner_cfg_executes_locally(tmp_path):
+    """Execute an Experiment Runner YAML locally with a trailing Experiment override."""
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text(
+        """runs:
+- name: yaml_baseline
+  environment:
+    type: pick_and_place_maple_table
+  policy:
+    type: zero_action
+  rollout_limit:
+    num_steps: 10
+""",
+        encoding="utf-8",
+    )
+    experiment_runner_config_path = tmp_path / "evaluation.yaml"
+    output_path = tmp_path / "output"
+    experiment_runner_config_path.write_text(
+        f"""experiment_config: {experiment_config_path.name}
+output_base_dir: {output_path}
+""",
+        encoding="utf-8",
+    )
+
+    result = run_experiment_runner(
+        str(experiment_runner_config_path),
+        config_option="--config",
+        extra_args=[
+            "--local",
+            "runs.yaml_baseline.rollout_limit.num_steps=2",
+        ],
+        capture_output=True,
+    )
+
     assert result is not None
     run_row = next(line for line in result.stdout.splitlines() if "yaml_baseline" in line and "pending" in line)
     run_cells = [cell.strip() for cell in run_row.split("|")[1:-1]]

--- a/isaaclab_arena/tests/test_experiment_runner_cfg.py
+++ b/isaaclab_arena/tests/test_experiment_runner_cfg.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify the typed-only Experiment Runner YAML contract."""
+
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.evaluation.experiment_runner_cfg import load_experiment_runner_cfg
+
+
+def test_loads_checked_in_openpi_evaluation_config():
+    config_path = (
+        Path(__file__).resolve().parents[2] / "isaaclab_arena_environments" / "evaluation_configs" / "openpi.yaml"
+    )
+
+    cfg = load_experiment_runner_cfg(config_path)
+
+    assert Path(cfg.experiment_config).name == "openpi_experiment.yaml"
+    assert cfg.output_base_dir == "/eval/output"
+    assert not cfg.record_camera_video
+
+
+def test_load_experiment_runner_cfg_resolves_experiment_relative_to_config(tmp_path):
+    experiment_path = tmp_path / "experiments" / "example.yaml"
+    experiment_path.parent.mkdir()
+    experiment_path.write_text("runs: []\n", encoding="utf-8")
+    config_path = tmp_path / "configs" / "evaluation.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        """experiment_config: ../experiments/example.yaml
+experiment_overrides:
+  - runs.baseline.rollout_limit.num_steps=4
+record_camera_video: true
+continue_on_error: true
+evaluation_report_port: 9000
+""",
+        encoding="utf-8",
+    )
+
+    cfg = load_experiment_runner_cfg(config_path)
+
+    assert Path(cfg.experiment_config) == experiment_path.resolve()
+    assert cfg.experiment_overrides == ["runs.baseline.rollout_limit.num_steps=4"]
+    assert cfg.output_base_dir == "/eval/output"
+    assert not cfg.record_viewport_video
+    assert cfg.record_camera_video
+    assert cfg.continue_on_error
+    assert not cfg.serve_evaluation_report
+    assert cfg.evaluation_report_port == 9000
+
+
+def test_load_experiment_runner_cfg_rejects_legacy_json_experiment(tmp_path):
+    experiment_path = tmp_path / "legacy.json"
+    experiment_path.write_text('{"jobs": []}\n', encoding="utf-8")
+    config_path = tmp_path / "evaluation.yaml"
+    config_path.write_text("experiment_config: legacy.json\n", encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="must be YAML"):
+        load_experiment_runner_cfg(config_path)
+
+
+def test_load_experiment_runner_cfg_rejects_unknown_fields(tmp_path):
+    experiment_path = tmp_path / "experiment.yaml"
+    experiment_path.write_text("runs: []\n", encoding="utf-8")
+    config_path = tmp_path / "evaluation.yaml"
+    config_path.write_text(
+        "experiment_config: experiment.yaml\nchunk_size: 2\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="chunk_size"):
+        load_experiment_runner_cfg(config_path)

--- a/isaaclab_arena/tests/test_experiment_runner_route.py
+++ b/isaaclab_arena/tests/test_experiment_runner_route.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify routing between typed local evaluation, OSMO, and the legacy CLI."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_arena.evaluation import experiment_runner
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from isaaclab_arena.evaluation.experiment_runner_route import parse_experiment_runner_route, uses_experiment_runner_cfg
+
+
+def test_parse_experiment_runner_route_leaves_backend_arguments():
+    route, backend_args = parse_experiment_runner_route([
+        "--config",
+        "evaluation.yaml",
+        "--local",
+        "--viz",
+        "none",
+        "runs.demo.rollout_limit.num_steps=4",
+    ])
+
+    assert route.config_path == "evaluation.yaml"
+    assert route.local
+    assert route.osmo_config_path is None
+    assert backend_args == ["--viz", "none", "runs.demo.rollout_limit.num_steps=4"]
+    assert uses_experiment_runner_cfg(["--config=evaluation.yaml"])
+
+
+def test_parse_experiment_runner_route_rejects_osmo_config_for_local_execution():
+    with pytest.raises(SystemExit):
+        parse_experiment_runner_route([
+            "--config",
+            "evaluation.yaml",
+            "--local",
+            "--osmo-config",
+            "osmo.yaml",
+        ])
+
+
+@pytest.mark.parametrize(
+    "cli_args",
+    [
+        ["--help"],
+        ["--config", "evaluation.yaml", "--help"],
+        ["--local", "--help"],
+        ["--osmo-config", "osmo.yaml", "--help"],
+    ],
+)
+def test_typed_experiment_runner_help_exposes_primary_interface(cli_args, capsys, monkeypatch):
+    monkeypatch.setattr(
+        experiment_runner,
+        "_load_experiment_runner_cfg",
+        lambda _path: pytest.fail("help must not load a configuration"),
+    )
+
+    assert experiment_runner.main(cli_args) == 0
+
+    help_text = capsys.readouterr().out
+    assert "--config PATH" in help_text
+    assert "--local" in help_text
+    assert "--osmo-config PATH" in help_text
+    assert "isaaclab_arena_environments/evaluation_configs/openpi.yaml" in help_text
+    assert "osmo/config/arena_experiment_workflow.yaml" in help_text
+    assert "deprecated legacy interface" in help_text
+
+
+def test_main_without_config_preserves_legacy_entry_path(monkeypatch):
+    received_args = None
+
+    def run_legacy(cli_args):
+        nonlocal received_args
+        received_args = cli_args
+        return 17
+
+    monkeypatch.setattr(experiment_runner, "_run_legacy_experiment_runner", run_legacy)
+    monkeypatch.setattr(
+        experiment_runner,
+        "_run_experiment_runner_cfg_route",
+        lambda _args: pytest.fail("typed route must not receive a legacy invocation"),
+    )
+
+    assert experiment_runner.main(["--experiment_config", "legacy.json"]) == 17
+    assert received_args == ["--experiment_config", "legacy.json"]
+
+
+def test_typed_local_route_combines_yaml_and_trailing_overrides(monkeypatch):
+    cfg = ExperimentRunnerCfg(
+        experiment_config="experiment.yaml",
+        experiment_overrides=["runs.demo.rollout_limit.num_steps=2"],
+    )
+    app_launcher_args = SimpleNamespace(device="cuda:0", enable_cameras=False)
+    received = None
+
+    monkeypatch.setattr(experiment_runner, "_load_experiment_runner_cfg", lambda _path: cfg)
+    monkeypatch.setattr(
+        experiment_runner,
+        "_parse_local_app_launcher_args",
+        lambda backend_args: (
+            app_launcher_args,
+            ["runs.demo.rollout_limit.num_steps=4"],
+        ),
+    )
+
+    def run_locally(effective_cfg, received_app_launcher_args):
+        nonlocal received
+        received = (effective_cfg, received_app_launcher_args)
+        return 0
+
+    monkeypatch.setattr(experiment_runner, "_run_experiment_runner_cfg_locally", run_locally)
+    monkeypatch.setattr(
+        "osmo.experiment_dispatcher.submit_experiment_to_osmo",
+        lambda *_args: pytest.fail("local invocation must not submit an OSMO workflow"),
+    )
+
+    result = experiment_runner.main([
+        "--config",
+        "evaluation.yaml",
+        "--local",
+        "--device",
+        "cuda:0",
+        "runs.demo.rollout_limit.num_steps=4",
+    ])
+
+    assert result == 0
+    assert received is not None
+    effective_cfg, received_app_launcher_args = received
+    assert effective_cfg.experiment_overrides == [
+        "runs.demo.rollout_limit.num_steps=2",
+        "runs.demo.rollout_limit.num_steps=4",
+    ]
+    assert received_app_launcher_args is app_launcher_args
+
+
+def test_typed_remote_route_submits_without_entering_local_runtime(monkeypatch):
+    cfg = ExperimentRunnerCfg(experiment_config="experiment.yaml")
+    received = None
+
+    monkeypatch.setattr(experiment_runner, "_load_experiment_runner_cfg", lambda _path: cfg)
+    monkeypatch.setattr(
+        experiment_runner,
+        "_parse_local_app_launcher_args",
+        lambda _args: pytest.fail("remote submission must not parse AppLauncher arguments"),
+    )
+    monkeypatch.setattr(
+        experiment_runner,
+        "_run_experiment_runner_cfg_locally",
+        lambda *_args: pytest.fail("remote submission must not start local evaluation"),
+    )
+
+    def submit(effective_cfg, osmo_config_path):
+        nonlocal received
+        received = (effective_cfg, osmo_config_path)
+        return 23
+
+    monkeypatch.setattr("osmo.experiment_dispatcher.submit_experiment_to_osmo", submit)
+
+    result = experiment_runner.main([
+        "--config",
+        "evaluation.yaml",
+        "--osmo-config",
+        "osmo.yaml",
+        "runs.remote.rollout_limit.num_episodes=3",
+    ])
+
+    assert result == 23
+    assert received is not None
+    effective_cfg, osmo_config_path = received
+    assert effective_cfg.experiment_overrides == ["runs.remote.rollout_limit.num_episodes=3"]
+    assert osmo_config_path == "osmo.yaml"
+
+
+def test_local_typed_execution_applies_experiment_runner_settings(monkeypatch):
+    cfg = ExperimentRunnerCfg(
+        experiment_config="experiment.yaml",
+        experiment_overrides=["runs.demo.rollout_limit.num_steps=4"],
+        output_base_dir="/tmp/evaluation",
+        record_viewport_video=True,
+        record_camera_video=True,
+        continue_on_error=True,
+        serve_evaluation_report=True,
+        evaluation_report_port=9000,
+    )
+    app_launcher_args = SimpleNamespace(device="cuda:1", enable_cameras=False, list_variations=False)
+    load_call = None
+    execution_call = None
+
+    class SimulationContext:
+        def __init__(self, received_args):
+            assert received_args is app_launcher_args
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def load_experiment(path, *, device, overrides):
+        nonlocal load_call
+        load_call = (path, device, overrides)
+        return []
+
+    def execute(experiment, **kwargs):
+        nonlocal execution_call
+        execution_call = (experiment, kwargs)
+
+    monkeypatch.setattr(experiment_runner, "_get_simulation_app_context_type", lambda: SimulationContext)
+    monkeypatch.setattr(experiment_runner, "_get_experiment_loader", lambda: load_experiment)
+    monkeypatch.setattr(experiment_runner, "_execute_experiment_and_report", execute)
+
+    assert experiment_runner._run_experiment_runner_cfg_locally(cfg, app_launcher_args) == 0
+    assert app_launcher_args.enable_cameras
+    assert load_call == (
+        "experiment.yaml",
+        "cuda:1",
+        ["runs.demo.rollout_limit.num_steps=4"],
+    )
+    assert execution_call == (
+        [],
+        {
+            "output_base_dir": "/tmp/evaluation",
+            "record_viewport_video": True,
+            "record_camera_video": True,
+            "continue_on_error": True,
+            "serve_evaluation_report": True,
+            "evaluation_report_port": 9000,
+        },
+    )

--- a/isaaclab_arena/tests/test_experiment_runner_route.py
+++ b/isaaclab_arena/tests/test_experiment_runner_route.py
@@ -56,7 +56,7 @@ def test_parse_experiment_runner_route_rejects_osmo_config_for_local_execution()
 def test_typed_experiment_runner_help_exposes_primary_interface(cli_args, capsys, monkeypatch):
     monkeypatch.setattr(
         experiment_runner,
-        "_load_experiment_runner_cfg",
+        "load_experiment_runner_cfg",
         lambda _path: pytest.fail("help must not load a configuration"),
     )
 
@@ -98,10 +98,10 @@ def test_typed_local_route_combines_yaml_and_trailing_overrides(monkeypatch):
     app_launcher_args = SimpleNamespace(device="cuda:0", enable_cameras=False)
     received = None
 
-    monkeypatch.setattr(experiment_runner, "_load_experiment_runner_cfg", lambda _path: cfg)
+    monkeypatch.setattr(experiment_runner, "load_experiment_runner_cfg", lambda _path: cfg)
     monkeypatch.setattr(
         experiment_runner,
-        "_parse_local_app_launcher_args",
+        "parse_local_experiment_runner_args",
         lambda backend_args: (
             app_launcher_args,
             ["runs.demo.rollout_limit.num_steps=4"],
@@ -115,7 +115,8 @@ def test_typed_local_route_combines_yaml_and_trailing_overrides(monkeypatch):
 
     monkeypatch.setattr(experiment_runner, "_run_experiment_runner_cfg_locally", run_locally)
     monkeypatch.setattr(
-        "osmo.experiment_dispatcher.submit_experiment_to_osmo",
+        experiment_runner,
+        "submit_experiment_to_osmo",
         lambda *_args: pytest.fail("local invocation must not submit an OSMO workflow"),
     )
 
@@ -142,10 +143,10 @@ def test_typed_remote_route_submits_without_entering_local_runtime(monkeypatch):
     cfg = ExperimentRunnerCfg(experiment_config="experiment.yaml")
     received = None
 
-    monkeypatch.setattr(experiment_runner, "_load_experiment_runner_cfg", lambda _path: cfg)
+    monkeypatch.setattr(experiment_runner, "load_experiment_runner_cfg", lambda _path: cfg)
     monkeypatch.setattr(
         experiment_runner,
-        "_parse_local_app_launcher_args",
+        "parse_local_experiment_runner_args",
         lambda _args: pytest.fail("remote submission must not parse AppLauncher arguments"),
     )
     monkeypatch.setattr(
@@ -159,7 +160,7 @@ def test_typed_remote_route_submits_without_entering_local_runtime(monkeypatch):
         received = (effective_cfg, osmo_config_path)
         return 23
 
-    monkeypatch.setattr("osmo.experiment_dispatcher.submit_experiment_to_osmo", submit)
+    monkeypatch.setattr(experiment_runner, "submit_experiment_to_osmo", submit)
 
     result = experiment_runner.main([
         "--config",
@@ -210,8 +211,8 @@ def test_local_typed_execution_applies_experiment_runner_settings(monkeypatch):
         nonlocal execution_call
         execution_call = (experiment, kwargs)
 
-    monkeypatch.setattr(experiment_runner, "_get_simulation_app_context_type", lambda: SimulationContext)
-    monkeypatch.setattr(experiment_runner, "_get_experiment_loader", lambda: load_experiment)
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", SimulationContext)
+    monkeypatch.setattr(experiment_runner, "load_arena_experiment_from_config_file", load_experiment)
     monkeypatch.setattr(experiment_runner, "_execute_experiment_and_report", execute)
 
     assert experiment_runner._run_experiment_runner_cfg_locally(cfg, app_launcher_args) == 0

--- a/isaaclab_arena/tests/test_osmo_experiment_dispatcher.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_dispatcher.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify Arena Experiment discovery and dispatch to OSMO workflows."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from osmo import experiment_dispatcher
+
+
+def _write_experiment(path, policy_values: str) -> None:
+    path.write_text(
+        f"""runs:
+- name: run
+  environment:
+    type: test
+  policy:
+{policy_values}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_discovers_unresolved_openpi_policy_values(tmp_path):
+    experiment_path = tmp_path / "experiment.yaml"
+    experiment_path.write_text(
+        """runs:
+- name: local
+  environment:
+    type: test
+  policy:
+    type: zero_action
+- name: remote
+  environment:
+    type: test
+  policy:
+    type: pi0_remote
+    policy_variant: pi05
+""",
+        encoding="utf-8",
+    )
+
+    assert experiment_dispatcher._get_openpi_run_policy_values(str(experiment_path)) == {
+        "remote": {"type": "pi0_remote", "policy_variant": "pi05"}
+    }
+
+
+def test_dispatches_non_openpi_experiment_to_base_workflow(tmp_path, monkeypatch):
+    experiment_path = tmp_path / "experiment.yaml"
+    _write_experiment(experiment_path, "    type: zero_action")
+    experiment_runner_cfg = ExperimentRunnerCfg(experiment_config=str(experiment_path))
+    osmo_cfg = SimpleNamespace(openpi_server=SimpleNamespace(policy_variant="pi05"))
+    received = None
+
+    class Workflow:
+        def __init__(self, *, cfg, experiment_runner_cfg):
+            nonlocal received
+            received = (cfg, experiment_runner_cfg)
+
+        def submit_workflow(self):
+            return 23
+
+    monkeypatch.setattr(experiment_dispatcher, "load_arena_experiment_workflow_cfg", lambda _path: osmo_cfg)
+    monkeypatch.setattr(experiment_dispatcher, "ArenaExperimentWorkflow", Workflow)
+    monkeypatch.setattr(
+        experiment_dispatcher,
+        "OpenPiArenaExperimentWorkflow",
+        lambda **_kwargs: pytest.fail("non-OpenPI Experiment must not start an OpenPI server"),
+    )
+
+    assert experiment_dispatcher.submit_experiment_to_osmo(experiment_runner_cfg, "osmo.yaml") == 23
+    assert received == (osmo_cfg, experiment_runner_cfg)
+
+
+def test_dispatches_all_openpi_runs_to_one_server_workflow(tmp_path, monkeypatch):
+    experiment_path = tmp_path / "experiment.yaml"
+    experiment_path.write_text(
+        """runs:
+- name: first
+  environment:
+    type: test
+  policy:
+    type: pi0_remote
+- name: second
+  environment:
+    type: test
+  policy:
+    type: pi0_remote
+    policy_variant: pi05
+""",
+        encoding="utf-8",
+    )
+    experiment_runner_cfg = ExperimentRunnerCfg(experiment_config=str(experiment_path))
+    osmo_cfg = SimpleNamespace(openpi_server=SimpleNamespace(policy_variant="pi05"))
+    received = None
+
+    class Workflow:
+        def __init__(self, *, cfg, experiment_runner_cfg, openpi_run_names):
+            nonlocal received
+            received = (cfg, experiment_runner_cfg, openpi_run_names)
+
+        def submit_workflow(self):
+            return 29
+
+    monkeypatch.setattr(experiment_dispatcher, "load_arena_experiment_workflow_cfg", lambda _path: osmo_cfg)
+    monkeypatch.setattr(
+        experiment_dispatcher,
+        "ArenaExperimentWorkflow",
+        lambda **_kwargs: pytest.fail("OpenPI Experiment must use its server workflow"),
+    )
+    monkeypatch.setattr(experiment_dispatcher, "OpenPiArenaExperimentWorkflow", Workflow)
+
+    assert experiment_dispatcher.submit_experiment_to_osmo(experiment_runner_cfg) == 29
+    assert received == (osmo_cfg, experiment_runner_cfg, ["first", "second"])
+
+
+def test_rejects_openpi_variant_mismatch(tmp_path, monkeypatch):
+    experiment_path = tmp_path / "experiment.yaml"
+    _write_experiment(
+        experiment_path,
+        "    type: pi0_remote\n    policy_variant: pi0",
+    )
+    cfg = ExperimentRunnerCfg(experiment_config=str(experiment_path))
+    osmo_cfg = SimpleNamespace(openpi_server=SimpleNamespace(policy_variant="pi05"))
+    monkeypatch.setattr(experiment_dispatcher, "load_arena_experiment_workflow_cfg", lambda _path: osmo_cfg)
+
+    with pytest.raises(AssertionError, match="one shared OpenPI server variant"):
+        experiment_dispatcher.submit_experiment_to_osmo(cfg)
+
+
+def test_applies_openpi_variant_override_before_validation(tmp_path, monkeypatch):
+    experiment_path = tmp_path / "experiment.yaml"
+    _write_experiment(experiment_path, "    type: pi0_remote")
+    cfg = ExperimentRunnerCfg(
+        experiment_config=str(experiment_path),
+        experiment_overrides=["runs.run.policy.policy_variant=pi0"],
+    )
+    osmo_cfg = SimpleNamespace(openpi_server=SimpleNamespace(policy_variant="pi05"))
+    monkeypatch.setattr(experiment_dispatcher, "load_arena_experiment_workflow_cfg", lambda _path: osmo_cfg)
+
+    with pytest.raises(AssertionError, match="one shared OpenPI server variant"):
+        experiment_dispatcher.submit_experiment_to_osmo(cfg)

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify OSMO workflow construction for a complete Arena Experiment."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from isaaclab_arena.hydra.typed_yaml import load_typed_yaml_cfg
+from osmo.tasks.experiment_runner_task import (
+    REMOTE_EVALUATION_CONFIG_PATH,
+    REMOTE_EXPERIMENT_PATH,
+    ExperimentRunnerTaskCfg,
+)
+from osmo.tasks.openpi_server_task import OPENPI_SERVER_PORT, OpenPiServerTask, OpenPiServerTaskCfg
+from osmo.workflows.arena_experiment_workflow import (
+    STAGED_EXPERIMENT_FILENAME,
+    ArenaExperimentWorkflow,
+    ArenaExperimentWorkflowCfg,
+    OpenPiArenaExperimentWorkflow,
+    load_arena_experiment_workflow_cfg,
+)
+from osmo.workflows.workflow import WorkflowCfg, WorkflowPriority
+from osmo.workflows.workflow_constants import OSMO_TASK_OUTPUT_DIR
+
+
+def _write_zero_action_experiment(path: Path) -> bytes:
+    source = b"""# Preserve this exact source.\nruns:\n- name: baseline\n  environment:\n    type: pick_and_place_maple_table\n  policy:\n    type: zero_action\n  rollout_limit:\n    num_steps: 2\n"""
+    path.write_bytes(source)
+    return source
+
+
+def _write_openpi_experiment(path: Path) -> bytes:
+    source = b"""runs:
+- name: first
+  environment:
+    type: pick_and_place_maple_table
+  policy:
+    type: pi0_remote
+    policy_variant: pi05
+  rollout_limit:
+    num_steps: 2
+- name: second
+  environment:
+    type: pick_and_place_maple_table
+  policy:
+    type: pi0_remote
+    policy_variant: pi05
+  rollout_limit:
+    num_steps: 2
+"""
+    path.write_bytes(source)
+    return source
+
+
+def _experiment_runner_cfg(experiment_config_path: Path, **values) -> ExperimentRunnerCfg:
+    return ExperimentRunnerCfg(experiment_config=str(experiment_config_path), **values)
+
+
+def _task_file(task: dict, remote_path: str) -> dict:
+    return next(file for file in task["files"] if file["path"] == remote_path)
+
+
+def _load_embedded_experiment_runner_cfg(config_contents: str, tmp_path: Path) -> ExperimentRunnerCfg:
+    config_path = tmp_path / "embedded-evaluation.yaml"
+    config_path.write_text(config_contents, encoding="utf-8")
+    return load_typed_yaml_cfg(
+        config_path,
+        ExperimentRunnerCfg,
+        config_name="embedded Experiment Runner",
+    )
+
+
+def test_loads_bundled_and_custom_workflow_configs(tmp_path):
+    """Load typed OSMO config independently from the evaluation and Experiment configs."""
+    default_cfg = load_arena_experiment_workflow_cfg()
+
+    assert default_cfg.workflow.workflow_name == "arena-experiment"
+    assert default_cfg.workflow.priority is WorkflowPriority.NORMAL
+    assert default_cfg.experiment_runner_task.image.endswith("isaaclab_arena:latest")
+    assert default_cfg.experiment_runner_task.output_url.endswith("/{{workflow_id}}")
+    assert default_cfg.openpi_server.policy_variant == "pi05"
+    assert default_cfg.openpi_server.client_ping_timeout == 300.0
+    assert default_cfg.openpi_server.policy_config == "pi05_droid_jointpos_polaris"
+
+    custom_config_path = tmp_path / "osmo.yaml"
+    custom_config_path.write_text(
+        """
+workflow:
+  workflow_name: custom-experiment
+  priority: HIGH
+  cpus: 8
+experiment_runner_task:
+  image: registry.example.com/arena:test
+openpi_server:
+  image: registry.example.com/openpi:test
+""",
+        encoding="utf-8",
+    )
+    custom_cfg = load_arena_experiment_workflow_cfg(custom_config_path)
+
+    assert custom_cfg.workflow.workflow_name == "custom-experiment"
+    assert custom_cfg.workflow.priority is WorkflowPriority.HIGH
+    assert custom_cfg.workflow.cpus == 8
+    assert custom_cfg.workflow.gpus == WorkflowCfg().gpus
+    assert custom_cfg.experiment_runner_task.image == "registry.example.com/arena:test"
+    assert custom_cfg.openpi_server.image == "registry.example.com/openpi:test"
+    assert custom_cfg.openpi_server.client_ping_timeout == OpenPiServerTaskCfg().client_ping_timeout
+    assert custom_cfg.openpi_server.policy_dir == OpenPiServerTaskCfg().policy_dir
+
+
+def test_one_experiment_builds_one_lead_experiment_runner_task_from_typed_config(tmp_path):
+    """Represent the full Experiment with one workflow and one typed evaluation task."""
+    experiment_config_path = tmp_path / "source.yaml"
+    _write_zero_action_experiment(experiment_config_path)
+    source_cfg = _experiment_runner_cfg(
+        experiment_config_path,
+        experiment_overrides=["runs.baseline.rollout_limit.num_steps=4"],
+        output_base_dir="/local/output",
+        record_camera_video=True,
+        continue_on_error=True,
+        serve_evaluation_report=True,
+    )
+    workflow = ArenaExperimentWorkflow(
+        cfg=ArenaExperimentWorkflowCfg(
+            workflow=WorkflowCfg(workflow_name="zero-action-experiment"),
+            experiment_runner_task=ExperimentRunnerTaskCfg(),
+        ),
+        experiment_runner_cfg=source_cfg,
+    )
+
+    workflow_dict = workflow.generate_workflow()
+    tasks = workflow_dict["workflow"]["groups"][0]["tasks"]
+
+    assert workflow_dict["workflow"]["name"] == "zero-action-experiment"
+    assert len(tasks) == 1
+    assert tasks[0]["name"] == "experiment_runner"
+    assert tasks[0]["lead"] is True
+    assert _task_file(tasks[0], REMOTE_EXPERIMENT_PATH) == {
+        "localpath": STAGED_EXPERIMENT_FILENAME,
+        "path": REMOTE_EXPERIMENT_PATH,
+    }
+    command = _task_file(tasks[0], "/tmp/entry.sh")["contents"]
+    assert (
+        f"isaaclab_arena/evaluation/experiment_runner.py --config {REMOTE_EVALUATION_CONFIG_PATH} "
+        "--local --viz none --enable_cameras"
+        in command
+    )
+    assert "--experiment_config" not in command
+    assert "--output_base_dir" not in command
+    assert "--record_camera_video" not in command
+    assert "runs.baseline" not in command
+    assert "policy_runner.py" not in command
+
+    embedded_cfg = _load_embedded_experiment_runner_cfg(
+        _task_file(tasks[0], REMOTE_EVALUATION_CONFIG_PATH)["contents"],
+        tmp_path,
+    )
+    assert embedded_cfg == ExperimentRunnerCfg(
+        experiment_config=REMOTE_EXPERIMENT_PATH,
+        experiment_overrides=["runs.baseline.rollout_limit.num_steps=4"],
+        output_base_dir=OSMO_TASK_OUTPUT_DIR,
+        record_camera_video=True,
+        continue_on_error=True,
+        serve_evaluation_report=False,
+    )
+    assert source_cfg.output_base_dir == "/local/output"
+    assert source_cfg.experiment_config == str(experiment_config_path)
+    assert source_cfg.serve_evaluation_report
+
+
+def test_stages_exact_experiment_source(tmp_path):
+    """Copy the source Experiment YAML unchanged into the OSMO submission staging directory."""
+    experiment_config_path = tmp_path / "source.yaml"
+    source = _write_zero_action_experiment(experiment_config_path)
+    workflow = ArenaExperimentWorkflow(
+        cfg=ArenaExperimentWorkflowCfg(),
+        experiment_runner_cfg=_experiment_runner_cfg(experiment_config_path),
+    )
+    staging_dir = tmp_path / "staging"
+    staging_dir.mkdir()
+
+    workflow._stage_submission_files(staging_dir)
+
+    assert (staging_dir / STAGED_EXPERIMENT_FILENAME).read_bytes() == source
+
+
+def test_submission_stages_workflow_and_experiment_together(tmp_path, monkeypatch):
+    """Submit the embedded evaluation config and exact Experiment from one directory."""
+    experiment_config_path = tmp_path / "source.yaml"
+    source = _write_zero_action_experiment(experiment_config_path)
+    workflow = ArenaExperimentWorkflow(
+        cfg=ArenaExperimentWorkflowCfg(),
+        experiment_runner_cfg=_experiment_runner_cfg(experiment_config_path),
+    )
+    captured_staging_dir = None
+
+    def capture_submission(command, cwd):
+        nonlocal captured_staging_dir
+        captured_staging_dir = Path(cwd)
+        assert command[:4] == ["osmo", "workflow", "submit", "workflow.yaml"]
+        rendered_workflow = (captured_staging_dir / "workflow.yaml").read_text(encoding="utf-8")
+        assert REMOTE_EVALUATION_CONFIG_PATH in rendered_workflow
+        assert f"output_base_dir: '{OSMO_TASK_OUTPUT_DIR}'" in rendered_workflow
+        assert (captured_staging_dir / STAGED_EXPERIMENT_FILENAME).read_bytes() == source
+        return SimpleNamespace(returncode=23)
+
+    monkeypatch.setattr("osmo.workflows.workflow.subprocess.run", capture_submission)
+
+    assert workflow.submit_workflow() == 23
+    assert captured_staging_dir is not None
+    assert not captured_staging_dir.exists()
+
+
+def test_openpi_workflow_embeds_trailing_server_endpoint_overrides(tmp_path):
+    """Connect all OpenPI Runs to one co-scheduled server through trailing overrides."""
+    experiment_config_path = tmp_path / "source.yaml"
+    _write_openpi_experiment(experiment_config_path)
+    user_overrides = [
+        "runs.first.policy.remote_host=user-host",
+        "runs.first.policy.remote_port=9999",
+        "runs.first.policy.ping_timeout=10.0",
+    ]
+    source_cfg = _experiment_runner_cfg(
+        experiment_config_path,
+        experiment_overrides=user_overrides,
+        output_base_dir="/local/output",
+    )
+    workflow = OpenPiArenaExperimentWorkflow(
+        cfg=ArenaExperimentWorkflowCfg(),
+        experiment_runner_cfg=source_cfg,
+        openpi_run_names=["first", "second"],
+    )
+
+    workflow_dict = workflow.generate_workflow()
+    tasks = workflow_dict["workflow"]["groups"][0]["tasks"]
+    assert [task["name"] for task in tasks] == ["experiment_runner", "policy_server"]
+    assert [task["lead"] for task in tasks] == [True, False]
+
+    eval_command = _task_file(tasks[0], "/tmp/entry.sh")["contents"]
+    assert "--local --viz none --enable_cameras" in eval_command
+    embedded_contents = _task_file(tasks[0], REMOTE_EVALUATION_CONFIG_PATH)["contents"]
+    host_token = OpenPiServerTask.host_token()
+    assert host_token in embedded_contents
+    assert host_token in workflow.render_yaml()
+
+    resolved_contents = embedded_contents.replace(host_token, "10.0.0.42").replace(
+        OSMO_TASK_OUTPUT_DIR,
+        "/osmo/output",
+    )
+    embedded_cfg = _load_embedded_experiment_runner_cfg(resolved_contents, tmp_path)
+    assert embedded_cfg.experiment_config == REMOTE_EXPERIMENT_PATH
+    assert embedded_cfg.output_base_dir == "/osmo/output"
+    assert embedded_cfg.experiment_overrides == [
+        *user_overrides,
+        'runs.first.policy.remote_host="10.0.0.42"',
+        f"runs.first.policy.remote_port={OPENPI_SERVER_PORT}",
+        "runs.first.policy.ping_timeout=300.0",
+        'runs.second.policy.remote_host="10.0.0.42"',
+        f"runs.second.policy.remote_port={OPENPI_SERVER_PORT}",
+        "runs.second.policy.ping_timeout=300.0",
+    ]
+    assert source_cfg.experiment_overrides == user_overrides
+    assert source_cfg.output_base_dir == "/local/output"
+
+    server_command = _task_file(tasks[1], "/tmp/entry.sh")["contents"]
+    assert "scripts/serve_policy.py policy:checkpoint" in server_command
+    assert "--policy.config=pi05_droid_jointpos_polaris" in server_command
+    assert "policy_runner.py" not in workflow.render_yaml()
+
+
+def test_rejects_legacy_json_experiment(tmp_path):
+    """Keep the OSMO workflow path restricted to typed YAML Experiments."""
+    experiment_config_path = tmp_path / "legacy.json"
+    experiment_config_path.write_text('{"jobs": []}', encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="typed YAML Experiments only"):
+        ArenaExperimentWorkflow(
+            cfg=ArenaExperimentWorkflowCfg(),
+            experiment_runner_cfg=_experiment_runner_cfg(experiment_config_path),
+        )

--- a/isaaclab_arena/tests/test_report.py
+++ b/isaaclab_arena/tests/test_report.py
@@ -28,7 +28,7 @@ def test_episode_video_filename_roundtrip_no_rebuild():
 
 
 def test_build_report_smoke(tmp_path):
-    # One job sub-directory (experiment_runner layout) with two cameras, two envs, two rebuilds, plus a
+    # One Run subdirectory (Experiment Runner layout) with two cameras, two envs, two rebuilds, plus a
     # flat file (policy_runner layout) and stray files the scanner must ignore.
     job_dir = tmp_path / "pick_and_place"
     job_dir.mkdir()

--- a/isaaclab_arena/tests/test_typed_yaml.py
+++ b/isaaclab_arena/tests/test_typed_yaml.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify strict typed YAML loading without importing the simulation runtime."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from isaaclab_arena.hydra.typed_yaml import load_typed_yaml_cfg, render_typed_yaml_cfg
+
+
+@dataclass
+class ExampleCfg:
+    required_name: str
+    count: int = 2
+
+
+def test_load_typed_yaml_applies_values_and_schema_defaults(tmp_path):
+    config_path = tmp_path / "example.yaml"
+    config_path.write_text("required_name: example\n", encoding="utf-8")
+
+    cfg = load_typed_yaml_cfg(config_path, ExampleCfg, config_name="example")
+
+    assert cfg == ExampleCfg(required_name="example", count=2)
+
+
+def test_render_typed_yaml_round_trips_without_resolving_template_tokens(tmp_path):
+    config_path = tmp_path / "rendered.yaml"
+    config_path.write_text(
+        render_typed_yaml_cfg(ExampleCfg(required_name="{{host:server}}", count=4)),
+        encoding="utf-8",
+    )
+
+    cfg = load_typed_yaml_cfg(config_path, ExampleCfg, config_name="example")
+
+    assert cfg == ExampleCfg(required_name="{{host:server}}", count=4)
+
+
+def test_load_typed_yaml_rejects_unknown_fields(tmp_path):
+    config_path = tmp_path / "unknown.yaml"
+    config_path.write_text("required_name: example\nunknown: true\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unknown"):
+        load_typed_yaml_cfg(config_path, ExampleCfg, config_name="example")
+
+
+def test_load_typed_yaml_rejects_incompatible_values(tmp_path):
+    config_path = tmp_path / "wrong_type.yaml"
+    config_path.write_text("required_name: example\ncount: not-an-integer\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="count"):
+        load_typed_yaml_cfg(config_path, ExampleCfg, config_name="example")
+
+
+def test_load_typed_yaml_rejects_missing_required_fields(tmp_path):
+    config_path = tmp_path / "missing.yaml"
+    config_path.write_text("count: 3\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="required_name"):
+        load_typed_yaml_cfg(config_path, ExampleCfg, config_name="example")

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -44,7 +44,7 @@ def timestamped_run_dir(base_dir: str) -> str:
     """Append a reverse-dated subdirectory to ``base_dir``, e.g. ``base_dir/2026-06-16_14-42-54``.
 
     Mirrors Isaac Lab's log layout so repeated runs land in distinct folders. Call once per run and
-    share the result across recorders (and, for the Experiment Runner, across jobs).
+    share the result across recorders and, for the Experiment Runner, across Runs.
     """
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     return os.path.join(base_dir, timestamp)

--- a/isaaclab_arena/visualization/report.py
+++ b/isaaclab_arena/visualization/report.py
@@ -108,7 +108,7 @@ def _scan_jobs(root: pathlib.Path) -> list[JobReport]:
     """Recursively scan ``root`` for episode results and recorder mp4s and group them by job.
 
     Intended for use with two different output folder structures:
-    - The experiment_runner.py writes one per-job sub-directory under ``root``.
+    - The Experiment Runner writes one per-Run subdirectory under ``root``.
     - The policy_runner.py writes directly under ``root``.
 
     Files that do not match the recorder's naming pattern are ignored.

--- a/isaaclab_arena_dreamzero/policy/dreamzero_remote_policy.py
+++ b/isaaclab_arena_dreamzero/policy/dreamzero_remote_policy.py
@@ -227,7 +227,7 @@ class DreamZeroRemotePolicy(PolicyBase):
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> DreamZeroRemotePolicy:
-        """JSON-jobs-config path used by ``experiment_runner``.
+        """Legacy JSON Experiment path used by the Experiment Runner.
 
         Overrides ``PolicyBase.from_dict`` because our ``__init__`` takes an
         adapter alongside the config dataclass. An optional

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -190,9 +190,9 @@ def get_isaaclab_arena_environments_cli_parser(
     return args_parser
 
 
-# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this construction pipeline after experiment_runner,
-# policy_runner, imitation-learning scripts, and notebooks pass typed environment and
-# builder configs instead of an argparse Namespace.
+# TODO(cvolk, 2026-07-03): [typed-config-migration] Delete this construction pipeline after the legacy Arena
+# Experiment Runner interface, deprecated Policy Runner, imitation-learning scripts, and notebooks pass typed
+# environment and builder configs instead of an argparse Namespace.
 def get_arena_builder_from_cli(
     args_cli: argparse.Namespace,
     hydra_overrides: list[str] | None = None,

--- a/isaaclab_arena_environments/evaluation_configs/openpi.yaml
+++ b/isaaclab_arena_environments/evaluation_configs/openpi.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Submit to OSMO:
+#   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+#     --config isaaclab_arena_environments/evaluation_configs/openpi.yaml
+# Run locally against an already-running OpenPI server:
+#   /isaac-sim/python.sh isaaclab_arena/evaluation/experiment_runner.py \
+#     --config isaaclab_arena_environments/evaluation_configs/openpi.yaml --local --enable_cameras
+experiment_config: ../experiment_configs/openpi_experiment.yaml
+output_base_dir: /eval/output
+record_viewport_video: false
+record_camera_video: false
+continue_on_error: false
+serve_evaluation_report: false
+evaluation_report_port: 8000

--- a/isaaclab_arena_environments/experiment_configs/openpi_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/openpi_experiment.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# One Arena Experiment with one Run backed by an OpenPI policy server.
+runs:
+- name: openpi_maple_table
+  environment:
+    type: pick_and_place_maple_table
+    enable_cameras: true
+    embodiment: droid_abs_joint_pos
+    pick_up_object: rubiks_cube_hot3d_robolab
+    destination_location: bowl_ycb_robolab
+    hdr: home_office_robolab
+  policy:
+    type: pi0_remote
+    policy_variant: pi05
+  rollout_limit:
+    num_episodes: 1

--- a/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy_runner.py
+++ b/isaaclab_arena_gr00t/tests/test_gr00t_remote_closedloop_policy_runner.py
@@ -119,7 +119,7 @@ def test_policy_runner_with_gr00t_remote_closedloop_policy_multi_env():
 
 
 def test_experiment_runner_with_gr00t_remote_closedloop_policy(tmp_path):
-    """Run the Experiment Runner with the GR00T remote closed-loop policy."""
+    """Run experiment_runner with the GR00T remote closed-loop policy."""
     remote_host, remote_port, timeout_sec = _get_gr00t_remote_server()
     config_path = _write_eval_jobs_config(tmp_path, remote_host, remote_port)
 

--- a/isaaclab_arena_openpi/policy/__init__.py
+++ b/isaaclab_arena_openpi/policy/__init__.py
@@ -2,8 +2,3 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-
-
-def ensure_openpi_policy_registered() -> None:
-    """Register the first-party OpenPI policy for typed Experiment composition."""
-    from isaaclab_arena_openpi.policy import pi0_remote_policy  # noqa: F401

--- a/isaaclab_arena_openpi/policy/__init__.py
+++ b/isaaclab_arena_openpi/policy/__init__.py
@@ -2,3 +2,8 @@
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+
+def ensure_openpi_policy_registered() -> None:
+    """Register the first-party OpenPI policy for typed Experiment composition."""
+    from isaaclab_arena_openpi.policy import pi0_remote_policy  # noqa: F401

--- a/isaaclab_arena_openpi/policy/pi0_remote_config.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_config.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Literal
 
 from isaaclab_arena.policy.policy_base import PolicyCfg
 
@@ -21,7 +20,7 @@ MAX_RECONNECT_ATTEMPTS = 3
 class Pi0RemotePolicyCfg(PolicyCfg):
     """Connection + runtime config for ``Pi0RemotePolicy``."""
 
-    openpi_embodiment_adapter: Literal["droid"] = "droid"
+    openpi_embodiment_adapter: str = "droid"
     """Adapter used to translate Arena observations and policy actions."""
 
     policy_variant: str = DEFAULT_VARIANT
@@ -34,3 +33,7 @@ class Pi0RemotePolicyCfg(PolicyCfg):
 
     ping_timeout: float | None = 20.0
     """Seconds to wait for a keepalive pong before dropping, or None to wait indefinitely."""
+
+    def __post_init__(self) -> None:
+        if self.openpi_embodiment_adapter != "droid":
+            raise ValueError(f"Unknown openpi_embodiment_adapter {self.openpi_embodiment_adapter!r}; expected 'droid'")

--- a/isaaclab_arena_openpi/tests/test_typed_experiment_config.py
+++ b/isaaclab_arena_openpi/tests/test_typed_experiment_config.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify OpenPI policy composition through typed Arena Experiment YAML."""
+
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
+from isaaclab_arena.evaluation import arena_experiment_config_loader
+from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_experiment_from_config_file
+from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
+from isaaclab_arena_openpi.policy.pi0_remote_config import Pi0RemotePolicyCfg
+
+
+def _write_openpi_experiment(path: Path, *, adapter: str = "droid") -> Path:
+    path.write_text(
+        f"""
+runs:
+- name: remote
+  environment:
+    type: test_environment
+  policy:
+    type: pi0_remote
+    openpi_embodiment_adapter: {adapter}
+    remote_host: localhost
+    remote_port: 8000
+  rollout_limit:
+    num_steps: 1
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_typed_openpi_experiment_composes_runtime_endpoint_overrides(tmp_path, monkeypatch):
+    """Register OpenPI and apply the runtime server endpoint through Hydra overrides."""
+    experiment_path = _write_openpi_experiment(tmp_path / "openpi.yaml")
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_environment_cfg_types",
+        lambda: {"test_environment": ArenaEnvironmentCfg},
+    )
+
+    experiment = load_arena_experiment_from_config_file(
+        experiment_path,
+        device="cuda:1",
+        overrides=[
+            "runs.remote.policy.remote_host='{{host:policy_server}}'",
+            "runs.remote.policy.remote_port=8123",
+        ],
+    )
+
+    assert len(experiment) == 1
+    assert isinstance(experiment[0].policy, Pi0RemotePolicyCfg)
+    assert experiment[0].policy.remote_host == "{{host:policy_server}}"
+    assert experiment[0].policy.remote_port == 8123
+    assert experiment[0].environment_builder.device == "cuda:1"
+
+
+def test_typed_openpi_experiment_rejects_unknown_adapter(tmp_path):
+    """Reject adapter names after Hydra constructs the typed policy config."""
+    experiment_path = _write_openpi_experiment(tmp_path / "openpi.yaml", adapter="unknown")
+
+    with pytest.raises(ValueError, match="Unknown openpi_embodiment_adapter 'unknown'; expected 'droid'"):
+        load_arena_experiment_from_yaml(
+            experiment_path,
+            environment_cfg_types={"test_environment": ArenaEnvironmentCfg},
+            policy_cfg_types={"pi0_remote": Pi0RemotePolicyCfg},
+        )

--- a/osmo/config/arena_experiment_workflow.yaml
+++ b/osmo/config/arena_experiment_workflow.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OSMO infrastructure defaults for an Arena Experiment workflow.
+workflow:
+  workflow_name: arena-experiment
+  pool: isaac-dev-l40s-04
+  priority: NORMAL
+  cpus: 15
+  gpus: 1
+  memory: 128Gi
+  storage: 200Gi
+  platform: ovx-l40s
+  exec_timeout: 1d
+  queue_timeout: 2d
+  dry_run: false
+
+experiment_runner_task:
+  image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
+  output_url: swift://pdx.s8k.io/AUTH_team-isaac/isaaclab_arena/workflows/{{workflow_id}}
+
+openpi_server:
+  image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:openpi_server
+  policy_variant: pi05
+  client_ping_timeout: 300.0
+  policy_config: pi05_droid_jointpos_polaris
+  policy_dir: gs://openpi-assets-simeval/pi05_droid_jointpos

--- a/osmo/experiment_dispatcher.py
+++ b/osmo/experiment_dispatcher.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dispatch a complete Arena Experiment to OSMO."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hydra.core.override_parser.overrides_parser import OverridesParser
+
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from isaaclab_arena.hydra.experiment_composition import read_arena_experiment_run_values
+from isaaclab_arena_openpi.policy.pi0_remote_config import DEFAULT_VARIANT
+from osmo.workflows.arena_experiment_workflow import (
+    ArenaExperimentWorkflow,
+    OpenPiArenaExperimentWorkflow,
+    load_arena_experiment_workflow_cfg,
+)
+
+
+def submit_experiment_to_osmo(
+    experiment_runner_cfg: ExperimentRunnerCfg,
+    osmo_config_path: str | None = None,
+) -> int:
+    """Build and submit one OSMO Workflow for a complete Arena Experiment.
+
+    Args:
+        experiment_runner_cfg: Final evaluation configuration, including trailing Experiment overrides.
+        osmo_config_path: Optional path to the OSMO infrastructure configuration.
+
+    Returns:
+        The OSMO submission process status.
+    """
+    openpi_run_policy_values = _get_openpi_run_policy_values(experiment_runner_cfg.experiment_config)
+    osmo_cfg = load_arena_experiment_workflow_cfg(osmo_config_path)
+
+    if not openpi_run_policy_values:
+        workflow = ArenaExperimentWorkflow(cfg=osmo_cfg, experiment_runner_cfg=experiment_runner_cfg)
+        return workflow.submit_workflow()
+
+    _assert_openpi_variants_match_server(
+        experiment_runner_cfg,
+        openpi_run_policy_values,
+        configured_variant=osmo_cfg.openpi_server.policy_variant,
+    )
+    workflow = OpenPiArenaExperimentWorkflow(
+        cfg=osmo_cfg,
+        experiment_runner_cfg=experiment_runner_cfg,
+        openpi_run_names=list(openpi_run_policy_values),
+    )
+    return workflow.submit_workflow()
+
+
+def _get_openpi_run_policy_values(experiment_config_path: str) -> dict[str, dict[str, Any]]:
+    """Return unresolved policy values for Runs selecting the OpenPI client."""
+    openpi_run_policy_values = {}
+    for run_name, run_values in read_arena_experiment_run_values(experiment_config_path).items():
+        policy_values = run_values.get("policy")
+        if isinstance(policy_values, dict) and policy_values.get("type") == "pi0_remote":
+            openpi_run_policy_values[run_name] = policy_values
+    return openpi_run_policy_values
+
+
+def _assert_openpi_variants_match_server(
+    experiment_runner_cfg: ExperimentRunnerCfg,
+    openpi_run_policy_values: dict[str, dict[str, Any]],
+    *,
+    configured_variant: str,
+) -> None:
+    """Validate effective OpenPI Run variants against the shared OSMO server."""
+    run_variants = {
+        run_name: policy_values.get("policy_variant", DEFAULT_VARIANT)
+        for run_name, policy_values in openpi_run_policy_values.items()
+    }
+    variant_paths = {f"runs.{run_name}.policy.policy_variant": run_name for run_name in openpi_run_policy_values}
+    for override in OverridesParser.create().parse_overrides(experiment_runner_cfg.experiment_overrides):
+        run_name = variant_paths.get(override.key_or_group)
+        if run_name is not None:
+            run_variants[run_name] = override.value()
+
+    incompatible_runs = {
+        run_name: variant for run_name, variant in run_variants.items() if variant != configured_variant
+    }
+    assert not incompatible_runs, (
+        f"OpenPI Runs require variants {incompatible_runs}, but the OSMO server is configured for "
+        f"'{configured_variant}'. One Arena Experiment currently supports one shared OpenPI server variant."
+    )

--- a/osmo/tasks/base_task.py
+++ b/osmo/tasks/base_task.py
@@ -41,12 +41,19 @@ class BaseTask(ABC):
             "credentials": self._get_credentials(),
             "downloadType": "download",
             "environment": self._get_environment(),
-            "files": [{"path": "/tmp/entry.sh", "contents": block_literal_str(self._get_run_script())}],
+            "files": [
+                {"path": "/tmp/entry.sh", "contents": block_literal_str(self._get_run_script())},
+                *self._get_additional_files(),
+            ],
             "image": self._get_image(),
             "inputs": self._get_inputs(),
             "outputs": self._get_outputs(),
             "lead": self.lead,
         }
+
+    def _get_additional_files(self) -> list[dict[str, Any]]:
+        """Return additional files made available to the task."""
+        return []
 
     def _get_environment(self) -> dict[str, str]:
         """Return environment variables for the task."""

--- a/osmo/tasks/experiment_runner_task.py
+++ b/osmo/tasks/experiment_runner_task.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OSMO task that executes a complete Arena Experiment through ``experiment_runner.py``."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+from osmo.tasks.base_task import BaseTask, TaskCfg
+from osmo.workflows.utils.yaml_utils import block_literal_str
+from osmo.workflows.workflow_constants import DATASET_SWIFT_URL
+
+EXPERIMENT_RUNNER_SCRIPT = "isaaclab_arena/evaluation/experiment_runner.py"
+REMOTE_EVALUATION_CONFIG_PATH = "/tmp/arena_evaluation.yaml"
+REMOTE_EXPERIMENT_PATH = "/tmp/arena_experiment.yaml"
+
+
+@dataclass
+class ExperimentRunnerTaskCfg(TaskCfg):
+    """OSMO infrastructure configuration for an Arena Experiment evaluation task."""
+
+    image: str = "nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest"
+    """Container image the evaluation task runs in."""
+
+    output_url: str | None = DATASET_SWIFT_URL
+    """Object-storage URL receiving the task's OSMO output directory."""
+
+
+class ExperimentRunnerTask(BaseTask):
+    """Lead OSMO task that runs every Run in one staged Arena Experiment."""
+
+    def __init__(
+        self,
+        task_cfg: ExperimentRunnerTaskCfg,
+        evaluation_config_contents: str,
+        staged_experiment_filename: str,
+        enable_cameras: bool = False,
+        lead: bool | None = None,
+    ) -> None:
+        super().__init__(task_cfg=task_cfg, lead=lead)
+        self.evaluation_config_contents = evaluation_config_contents
+        self.staged_experiment_filename = staged_experiment_filename
+        self.enable_cameras = enable_cameras
+
+    @staticmethod
+    def get_task_name() -> str:
+        return "experiment_runner"
+
+    def _get_image(self) -> str:
+        return self.task_cfg.image
+
+    def _get_inputs(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_outputs(self) -> list[dict[str, Any]]:
+        if self.task_cfg.output_url is None:
+            return []
+        return [{"url": self.task_cfg.output_url}]
+
+    def _get_additional_files(self) -> list[dict[str, Any]]:
+        """Attach the derived Evaluation Configuration and exact source Experiment YAML."""
+        return [
+            {
+                "path": REMOTE_EVALUATION_CONFIG_PATH,
+                "contents": block_literal_str(self.evaluation_config_contents),
+            },
+            {"localpath": self.staged_experiment_filename, "path": REMOTE_EXPERIMENT_PATH},
+        ]
+
+    def _get_run_script(self) -> str:
+        command = [
+            "/isaac-sim/python.sh",
+            EXPERIMENT_RUNNER_SCRIPT,
+            "--config",
+            REMOTE_EVALUATION_CONFIG_PATH,
+            "--local",
+            "--viz",
+            "none",
+        ]
+        if self.enable_cameras:
+            command.append("--enable_cameras")
+        return f"set -euo pipefail\n{shlex.join(command)}\n"

--- a/osmo/tasks/openpi_server_task.py
+++ b/osmo/tasks/openpi_server_task.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OSMO task that serves an OpenPI policy for an Arena Experiment."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from osmo.tasks.base_task import BaseTask, TaskCfg
+
+OPENPI_APP_DIR = "/app"
+OPENPI_SERVER_PORT = 8000
+XLA_PYTHON_CLIENT_MEM_FRACTION = "0.5"
+
+
+@dataclass
+class OpenPiServerTaskCfg(TaskCfg):
+    """OSMO infrastructure configuration for an OpenPI server task."""
+
+    image: str = "nvcr.io/nvstaging/isaac-amr/isaaclab_arena:openpi_server"
+    """Container image that serves the OpenPI policy."""
+
+    policy_variant: str = "pi05"
+    """Arena OpenPI policy variant served by the configured checkpoint."""
+
+    client_ping_timeout: float = 300.0
+    """WebSocket keepalive timeout used by OpenPI clients co-scheduled with this server."""
+
+    policy_config: str = "pi05_droid_jointpos_polaris"
+    """OpenPI policy configuration name."""
+
+    policy_dir: str = "gs://openpi-assets-simeval/pi05_droid_jointpos"
+    """OpenPI checkpoint directory."""
+
+
+class OpenPiServerTask(BaseTask):
+    """OSMO task that serves an OpenPI policy."""
+
+    def __init__(
+        self,
+        task_cfg: OpenPiServerTaskCfg,
+        lead: bool | None = None,
+    ) -> None:
+        super().__init__(task_cfg=task_cfg, lead=lead)
+
+    @staticmethod
+    def get_task_name() -> str:
+        return "policy_server"
+
+    def _get_image(self) -> str:
+        return self.task_cfg.image
+
+    def _get_inputs(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_outputs(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_run_script(self) -> str:
+        return (
+            "set -euxo pipefail\n"
+            "nvidia-smi\n"
+            f"export XLA_PYTHON_CLIENT_MEM_FRACTION={XLA_PYTHON_CLIENT_MEM_FRACTION}\n"
+            f"cd {OPENPI_APP_DIR}\n"
+            "uv run scripts/serve_policy.py policy:checkpoint \\\n"
+            f"  --policy.config={self.task_cfg.policy_config} \\\n"
+            f"  --policy.dir={self.task_cfg.policy_dir}\n"
+        )

--- a/osmo/workflows/arena_experiment_workflow.py
+++ b/osmo/workflows/arena_experiment_workflow.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""OSMO workflow for running one complete Arena Experiment."""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Sequence
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+from isaaclab_arena.evaluation.experiment_runner_cfg import ExperimentRunnerCfg
+from isaaclab_arena.hydra.typed_yaml import load_typed_yaml_cfg, render_typed_yaml_cfg
+from osmo.tasks.base_task import BaseTask
+from osmo.tasks.experiment_runner_task import REMOTE_EXPERIMENT_PATH, ExperimentRunnerTask, ExperimentRunnerTaskCfg
+from osmo.tasks.openpi_server_task import OPENPI_SERVER_PORT, OpenPiServerTask, OpenPiServerTaskCfg
+from osmo.workflows.workflow import Workflow, WorkflowCfg
+from osmo.workflows.workflow_constants import OSMO_TASK_OUTPUT_DIR
+
+DEFAULT_WORKFLOW_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "arena_experiment_workflow.yaml"
+STAGED_EXPERIMENT_FILENAME = "experiment.yaml"
+
+
+@dataclass
+class ArenaExperimentWorkflowCfg:
+    """OSMO configuration for an Arena Experiment workflow and its tasks."""
+
+    workflow: WorkflowCfg = field(default_factory=WorkflowCfg)
+    """Workflow-level scheduling, resource, and timeout configuration."""
+
+    experiment_runner_task: ExperimentRunnerTaskCfg = field(default_factory=ExperimentRunnerTaskCfg)
+    """Configuration for the task that runs the Experiment."""
+
+    openpi_server: OpenPiServerTaskCfg = field(default_factory=OpenPiServerTaskCfg)
+    """Configuration for the OpenPI policy server task."""
+
+
+def load_arena_experiment_workflow_cfg(
+    config_path: str | Path | None = None,
+) -> ArenaExperimentWorkflowCfg:
+    """Load the bundled or user-provided OSMO workflow configuration."""
+    path = DEFAULT_WORKFLOW_CONFIG_PATH if config_path is None else Path(config_path)
+    return load_typed_yaml_cfg(
+        path,
+        ArenaExperimentWorkflowCfg,
+        config_name="OSMO Arena Experiment workflow",
+    )
+
+
+class ArenaExperimentWorkflow(Workflow):
+    """One OSMO Workflow containing one lead task for a complete Arena Experiment."""
+
+    task_cls_list = [ExperimentRunnerTask]
+
+    def __init__(
+        self,
+        cfg: ArenaExperimentWorkflowCfg,
+        experiment_runner_cfg: ExperimentRunnerCfg,
+        group_name: str = "arena",
+    ) -> None:
+        experiment_config_path = Path(experiment_runner_cfg.experiment_config).expanduser().resolve()
+        assert experiment_config_path.is_file(), f"Experiment config does not exist: {experiment_config_path}"
+        assert experiment_config_path.suffix.lower() in {".yaml", ".yml"}, "OSMO supports typed YAML Experiments only"
+
+        self.experiment_config_path = experiment_config_path
+        self.experiment_runner_cfg = experiment_runner_cfg
+        self.cfg = cfg
+        super().__init__(
+            workflow_cfg=cfg.workflow,
+            task_cfg=cfg.experiment_runner_task,
+            group_name=group_name,
+        )
+
+    def _get_tasks(self) -> list[BaseTask]:
+        """Create the lead task that executes the staged Experiment Runner configuration."""
+        return [self._create_experiment_runner_task(lead=self.lead_flags[0])]
+
+    def _create_experiment_runner_task(self, lead: bool) -> ExperimentRunnerTask:
+        """Create an Experiment Runner task from the remote Evaluation Configuration."""
+        remote_cfg = self._get_remote_experiment_runner_cfg()
+        return ExperimentRunnerTask(
+            self.cfg.experiment_runner_task,
+            evaluation_config_contents=render_typed_yaml_cfg(remote_cfg),
+            staged_experiment_filename=STAGED_EXPERIMENT_FILENAME,
+            enable_cameras=self._requires_camera_support(),
+            lead=lead,
+        )
+
+    def _get_remote_experiment_runner_cfg(self) -> ExperimentRunnerCfg:
+        """Derive the Experiment Runner config consumed inside the OSMO evaluation task."""
+        return replace(
+            self.experiment_runner_cfg,
+            experiment_config=REMOTE_EXPERIMENT_PATH,
+            experiment_overrides=[
+                *self.experiment_runner_cfg.experiment_overrides,
+                *self._get_generated_experiment_overrides(),
+            ],
+            output_base_dir=OSMO_TASK_OUTPUT_DIR,
+            serve_evaluation_report=False,
+        )
+
+    def _get_generated_experiment_overrides(self) -> list[str]:
+        """Return workflow-generated Experiment overrides appended after user values."""
+        return []
+
+    def _requires_camera_support(self) -> bool:
+        """Return whether AppLauncher must enable camera support for this evaluation."""
+        return self.experiment_runner_cfg.record_camera_video
+
+    def _stage_submission_files(self, staging_dir: Path) -> None:
+        """Stage the source Experiment YAML byte-for-byte beside the workflow YAML."""
+        shutil.copyfile(self.experiment_config_path, staging_dir / STAGED_EXPERIMENT_FILENAME)
+
+
+class OpenPiArenaExperimentWorkflow(ArenaExperimentWorkflow):
+    """Arena Experiment workflow with one shared OpenPI policy server."""
+
+    task_cls_list = [ExperimentRunnerTask, OpenPiServerTask]
+    lead_list = [True, False]
+
+    def __init__(
+        self,
+        cfg: ArenaExperimentWorkflowCfg,
+        experiment_runner_cfg: ExperimentRunnerCfg,
+        openpi_run_names: Sequence[str],
+        group_name: str = "arena",
+    ) -> None:
+        assert openpi_run_names, "OpenPI workflow requires at least one OpenPI Run"
+        self.openpi_run_names = list(openpi_run_names)
+        super().__init__(
+            cfg=cfg,
+            experiment_runner_cfg=experiment_runner_cfg,
+            group_name=group_name,
+        )
+
+    def _get_tasks(self) -> list[BaseTask]:
+        """Create the lead Experiment Runner task and its non-lead OpenPI server."""
+        experiment_runner_lead, openpi_server_lead = self.lead_flags
+        return [
+            self._create_experiment_runner_task(lead=experiment_runner_lead),
+            OpenPiServerTask(
+                self.cfg.openpi_server,
+                lead=openpi_server_lead,
+            ),
+        ]
+
+    def _get_generated_experiment_overrides(self) -> list[str]:
+        """Build trailing Hydra overrides connecting OpenPI Runs to their server task."""
+        host_token = OpenPiServerTask.host_token()
+        endpoint_overrides = []
+        for run_name in self.openpi_run_names:
+            endpoint_overrides.extend([
+                f'runs.{run_name}.policy.remote_host="{host_token}"',
+                f"runs.{run_name}.policy.remote_port={OPENPI_SERVER_PORT}",
+                f"runs.{run_name}.policy.ping_timeout={self.cfg.openpi_server.client_ping_timeout}",
+            ])
+        return endpoint_overrides
+
+    def _requires_camera_support(self) -> bool:
+        """Enable camera support required by the OpenPI observation policy."""
+        return True

--- a/osmo/workflows/workflow.py
+++ b/osmo/workflows/workflow.py
@@ -151,24 +151,26 @@ class Workflow:
         return tasks
 
     def _submit_rendered_workflow(self, rendered: str) -> int:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", prefix="arena_", delete=False) as f:
-            f.write(rendered)
-            rendered_path = f.name
+        with tempfile.TemporaryDirectory(prefix="arena_") as staging_dir_str:
+            staging_dir = Path(staging_dir_str)
+            rendered_path = staging_dir / "workflow.yaml"
+            rendered_path.write_text(rendered, encoding="utf-8")
+            self._stage_submission_files(staging_dir)
 
-        cmd = ["osmo", "workflow", "submit", rendered_path]
-        if self.workflow_cfg.pool:
-            cmd.extend(["--pool", self.workflow_cfg.pool])
-        if self.workflow_cfg.priority:
-            cmd.extend(["--priority", self.workflow_cfg.priority.value])
+            cmd = ["osmo", "workflow", "submit", rendered_path.name]
+            if self.workflow_cfg.pool:
+                cmd.extend(["--pool", self.workflow_cfg.pool])
+            if self.workflow_cfg.priority:
+                cmd.extend(["--priority", self.workflow_cfg.priority.value])
 
-        print(f"Submitting workflow '{self.workflow_cfg.workflow_name}':")
-        print(f"  {' '.join(cmd)}\n")
+            print(f"Submitting workflow '{self.workflow_cfg.workflow_name}':")
+            print(f"  {' '.join(cmd)}\n")
 
-        try:
-            result = subprocess.run(cmd)
+            result = subprocess.run(cmd, cwd=staging_dir)
             return result.returncode
-        finally:
-            Path(rendered_path).unlink(missing_ok=True)
+
+    def _stage_submission_files(self, staging_dir: Path) -> None:
+        """Stage local files referenced by the workflow alongside its rendered YAML."""
 
     def _create_resource_dict(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary
Unify Arena Experiment execution

## Detailed description
- Depends on #896, which establishes the Experiment Runner name and entry point.
- Adds one typed YAML entry point for local execution or OSMO submission while preserving the deprecated path used when `--config` is omitted.
- Separates the Arena Experiment, runner process, and OSMO infrastructure into typed YAML contracts; the source Experiment is staged unchanged.
- Maps one complete Arena Experiment to one OSMO workflow and co-schedules one shared OpenPI server with injected endpoint overrides.
- Removes typed Run execution from `policy_runner.py`; generic camera preflight and policy-extension discovery remain bounded follow-ups.