### PR TITLE
Add Cosmos3 Policy

### DIFF
--- a/isaaclab_arena_cosmos3/__init__.py
+++ b/isaaclab_arena_cosmos3/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import pkgutil
+
+import isaaclab_arena_cosmos3
+
+for _importer, _modname, _ispkg in pkgutil.iter_modules(isaaclab_arena_cosmos3.__path__):
+    if not _ispkg:
+        importlib.import_module(f"isaaclab_arena_cosmos3.{_modname}")

--- a/isaaclab_arena_cosmos3/docker/COSMOS3_COMMIT
+++ b/isaaclab_arena_cosmos3/docker/COSMOS3_COMMIT
@@ -1,1 +1,1 @@
-TODO: pin a known-working cosmos-framework commit
+0fa3ba479a7c1c5be28f81fe084b9ea544d697c9

--- a/isaaclab_arena_cosmos3/docker/COSMOS3_COMMIT
+++ b/isaaclab_arena_cosmos3/docker/COSMOS3_COMMIT
@@ -1,0 +1,1 @@
+TODO: pin a known-working cosmos-framework commit

--- a/isaaclab_arena_cosmos3/docker/run_cosmos3_server.sh
+++ b/isaaclab_arena_cosmos3/docker/run_cosmos3_server.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Build (if needed) and run the cosmos3 inference server in Docker.
+#
+# Usage:
+#   ./run_cosmos3_server.sh                           # build if missing, then run
+#   ./run_cosmos3_server.sh -r                        # force rebuild, then run
+#   ./run_cosmos3_server.sh -s <path>                 # build from a local cosmos-framework checkout (implies rebuild)
+#   ./run_cosmos3_server.sh -p <port>                 # listen on a custom port (default: 8000)
+#   ./run_cosmos3_server.sh -h                        # help
+#
+# The pinned commit lives in the COSMOS3_COMMIT file next to this script. To bump
+# it, edit that file.
+#
+# The server container must have access to the cosmos3 model weights. Set the
+# HF_TOKEN environment variable or mount a HF cache directory with:
+#   -e HF_TOKEN=$HF_TOKEN -v /path/to/hf_cache:/workspace/.cache/huggingface
+#
+# Env overrides:
+#   IMAGE_NAME    Local image name (default: isaaclab_arena_cosmos3-server)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_NAME="${IMAGE_NAME:-isaaclab_arena_cosmos3-server}"
+IMAGE_TAG="latest"
+COSMOS_REPO="https://github.com/NVIDIA/cosmos-framework"
+
+PORT=8000
+FORCE_REBUILD=false
+SRC_DIR=""
+
+print_help() {
+    cat <<EOF
+Helper script to build and run the cosmos3 inference server in Docker.
+
+Usage:
+  $(basename "$0") [options]
+
+Options:
+  -r              Force rebuilding of the server image.
+  -s <path>       Build from a local cosmos-framework checkout instead of cloning
+                  at the pinned commit. Implies -r.
+  -p <port>       Port for the policy server to listen on (default: 8000).
+  -h              Show this help and exit.
+EOF
+}
+
+while getopts ":rs:p:h" opt; do
+    case "$opt" in
+        r) FORCE_REBUILD=true ;;
+        s) SRC_DIR="$OPTARG"; FORCE_REBUILD=true ;;
+        p) PORT="$OPTARG" ;;
+        h) print_help; exit 0 ;;
+        \?) echo "unknown option: -$OPTARG" >&2; print_help; exit 1 ;;
+        :) echo "option -$OPTARG requires an argument" >&2; exit 1 ;;
+    esac
+done
+
+if [ "$FORCE_REBUILD" = true ] || \
+   [ -z "$(docker images -q "${IMAGE_NAME}:${IMAGE_TAG}" 2>/dev/null)" ]; then
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    if [ -n "$SRC_DIR" ]; then
+        COSMOS_DIR="$SRC_DIR"
+        echo "Using local cosmos-framework checkout at ${COSMOS_DIR}"
+    else
+        PINNED_COMMIT="$(tr -d '[:space:]' < "${SCRIPT_DIR}/COSMOS3_COMMIT")"
+        COSMOS_DIR="$TMPDIR/cosmos-framework"
+        echo "Cloning cosmos-framework at ${PINNED_COMMIT} ..."
+        GIT_LFS_SKIP_SMUDGE=1 git clone --quiet --filter=blob:none "$COSMOS_REPO" "$COSMOS_DIR"
+        (cd "$COSMOS_DIR" && git checkout "$PINNED_COMMIT")
+    fi
+
+    # Build a Docker image from cosmos-framework.
+    # cosmos-framework provides its own Dockerfile; we use it directly.
+    echo "Building ${IMAGE_NAME}:${IMAGE_TAG} from ${COSMOS_DIR}"
+    docker build \
+        --network=host \
+        -f "$COSMOS_DIR/docker/Dockerfile" \
+        -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+        "$COSMOS_DIR"
+else
+    echo "Image ${IMAGE_NAME}:${IMAGE_TAG} already exists. Not rebuilding (use -r to force)."
+fi
+
+echo "Running ${IMAGE_NAME}:${IMAGE_TAG} on port ${PORT}"
+
+docker run --rm -it --gpus all --network=host \
+    -e HF_TOKEN="${HF_TOKEN:-}" \
+    -e HF_HOME="${HF_HOME:-/workspace/.cache/huggingface}" \
+    "${IMAGE_NAME}:${IMAGE_TAG}" \
+    python -m cosmos_framework.scripts.action_policy_server_robolab --port "${PORT}"

--- a/isaaclab_arena_cosmos3/policy/__init__.py
+++ b/isaaclab_arena_cosmos3/policy/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
+++ b/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+MAX_RECONNECT_ATTEMPTS = 3
+
+
+@dataclass
+class Cosmos3RemotePolicyArgs:
+    """Configuration for :class:`Cosmos3RemotePolicy`.
+
+    The cosmos3 server is a separate process (typically in its own Docker
+    container) that listens on a WebSocket port using the OpenPI protocol.
+    """
+
+    remote_host: str = "localhost"
+    """Hostname or IP of the cosmos3 inference server."""
+
+    remote_port: int = 8000
+    """Port the cosmos3 inference server listens on."""
+
+    num_envs: int = 1
+    """Number of parallel simulation environments.
+
+    Used to pre-allocate per-environment action caches.  Must match the
+    ``--num_envs`` value passed to the environment builder.
+    """

--- a/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
+++ b/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
@@ -23,10 +23,3 @@ class Cosmos3RemotePolicyArgs:
 
     remote_port: int = 8000
     """Port the cosmos3 inference server listens on."""
-
-    num_envs: int = 1
-    """Number of parallel simulation environments.
-
-    Used to pre-allocate per-environment action caches.  Must match the
-    ``--num_envs`` value passed to the environment builder.
-    """

--- a/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
+++ b/isaaclab_arena_cosmos3/policy/cosmos3_remote_config.py
@@ -23,3 +23,6 @@ class Cosmos3RemotePolicyArgs:
 
     remote_port: int = 8000
     """Port the cosmos3 inference server listens on."""
+
+    policy_device: str = "cuda"
+    """Torch device for action tensors (e.g. 'cuda', 'cuda:0', 'cpu')."""

--- a/isaaclab_arena_cosmos3/policy/cosmos3_remote_policy.py
+++ b/isaaclab_arena_cosmos3/policy/cosmos3_remote_policy.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import gymnasium as gym
+import numpy as np
+import torch
+from abc import ABC, abstractmethod
+from typing import Any
+
+import websockets.exceptions
+from openpi_client import websocket_client_policy
+
+from isaaclab_arena.assets.register import register_policy
+from isaaclab_arena.policy.policy_base import PolicyBase
+from isaaclab_arena_cosmos3.policy.cosmos3_remote_config import MAX_RECONNECT_ATTEMPTS, Cosmos3RemotePolicyArgs
+
+
+class Cosmos3EmbodimentAdapter(ABC):
+    """Translates between arena's gym observation dict and the cosmos3 wire
+    format for a specific physical embodiment (DROID).
+
+    Subclasses declare the embodiment-specific action layout and observation keys.
+    """
+
+    action_dim: int
+    open_loop_horizon: int
+
+    @abstractmethod
+    def extract(self, observation: dict[str, Any], env_id: int) -> Any:
+        """Pull a single env's tensors out of the arena gym observation dict.
+
+        ``env_id`` selects which slice of each per-env tensor to read. Cosmos3's
+        wire format takes one observation per request, so the policy loops over
+        envs and calls this once per env to assemble the per-env requests.
+
+        Concrete return type is adapter-defined (typically a frozen dataclass);
+        the policy treats it as an opaque value to round-trip through
+        :meth:`pack_request`.
+        """
+
+    @abstractmethod
+    def pack_request(self, extracted: Any, language_instruction: str) -> dict[str, Any]:
+        """Build the wire-format request payload the cosmos3 server expects."""
+
+
+@register_policy
+class Cosmos3RemotePolicy(PolicyBase):
+    """Cosmos3 remote closed-loop policy, parameterized by an embodiment adapter.
+
+    Cosmos3 is NVIDIA's World-Action Model (WAM) post-trained on the DROID
+    dataset.  It jointly processes language, images, and action sequences to
+    predict chunks of future robot actions.
+
+    Action handling is straight chunk replay: the policy fetches one
+    ``(open_loop_horizon, action_dim)`` chunk from the server and yields
+    rows in order.
+    """
+
+    name = "cosmos3_remote"
+    config_class = Cosmos3RemotePolicyArgs
+
+    def __init__(self, config: Cosmos3RemotePolicyArgs, cosmos3_embodiment_adapter: Cosmos3EmbodimentAdapter) -> None:
+        super().__init__(config)
+        self._cosmos3_embodiment_adapter = cosmos3_embodiment_adapter
+        self._open_loop_horizon = cosmos3_embodiment_adapter.open_loop_horizon
+
+        self._remote_host = config.remote_host
+        self._remote_port = config.remote_port
+
+        print(f"[Cosmos3RemotePolicy] Connecting to cosmos3 server at {self._remote_host}:{self._remote_port} ...")
+        self._websocket_client = websocket_client_policy.WebsocketClientPolicy(
+            host=self._remote_host, port=self._remote_port
+        )
+        print("[Cosmos3RemotePolicy] Connected.")
+
+        # Per-env action cache. Lazy-allocated on the first get_action call when
+        # num_envs is known. Cosmos3's wire format is one obs per request, so we
+        # keep one chunk + one step counter per env and loop over them.
+        self._cached_action_chunks: list[np.ndarray | None] | None = None
+        self._next_chunk_steps: list[int] | None = None
+        self.task_description: str | None = None
+
+    @staticmethod
+    def add_args_to_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        group = parser.add_argument_group(
+            "Cosmos3 Remote Policy",
+            "Arguments for the cosmos3 remote client.",
+        )
+        group.add_argument(
+            "--cosmos3_embodiment_adapter",
+            type=str,
+            default="droid",
+            choices=["droid"],
+            help="Cosmos3-side embodiment adapter for obs / action wire format (default: droid).",
+        )
+        group.add_argument("--remote_host", type=str, default="localhost", help="Cosmos3 server host.")
+        group.add_argument("--remote_port", type=int, default=8000, help="Cosmos3 server port.")
+        return parser
+
+    @staticmethod
+    def from_args(args: argparse.Namespace) -> Cosmos3RemotePolicy:
+        cosmos3_embodiment_adapter = _resolve_cosmos3_embodiment_adapter(args.cosmos3_embodiment_adapter)
+        return Cosmos3RemotePolicy(
+            Cosmos3RemotePolicyArgs(
+                remote_host=args.remote_host,
+                remote_port=args.remote_port,
+            ),
+            cosmos3_embodiment_adapter=cosmos3_embodiment_adapter,
+        )
+
+    @classmethod
+    def from_dict(cls, config_dict: dict[str, Any]) -> Cosmos3RemotePolicy:
+        """JSON-jobs-config path used by ``eval_runner``.
+
+        Overrides ``PolicyBase.from_dict`` because our ``__init__`` takes an
+        adapter alongside the config dataclass.
+        # TODO(cvolk, 2026-05-18): add a RemotePolicy base class to unify this and other remote policies.
+        """
+        config_dict = dict(config_dict)
+        adapter_key = config_dict.pop("cosmos3_embodiment_adapter", "droid")
+        cosmos3_embodiment_adapter = _resolve_cosmos3_embodiment_adapter(adapter_key)
+        return cls(Cosmos3RemotePolicyArgs(**config_dict), cosmos3_embodiment_adapter=cosmos3_embodiment_adapter)
+
+    def get_action(self, env: gym.Env, observation: dict[str, Any]) -> torch.Tensor:
+        assert self.task_description, (
+            "Cosmos3RemotePolicy requires a non-empty language instruction"
+            " (set via --language_instruction or on the task definition)."
+        )
+
+        num_envs = env.unwrapped.num_envs
+        self._maybe_init_per_env_state(num_envs)
+
+        # Cosmos3 server takes one obs per request, so we iterate over envs
+        # and send one inference per env that needs a fresh chunk.
+        actions = []
+        for env_id in range(num_envs):
+            chunk_exhausted = (
+                self._cached_action_chunks[env_id] is None
+                or self._next_chunk_steps[env_id] >= self._open_loop_horizon
+            )
+            if chunk_exhausted:
+                self._cached_action_chunks[env_id] = self._fetch_action_chunk(observation, env_id)
+                self._next_chunk_steps[env_id] = 0
+            actions.append(self._cached_action_chunks[env_id][self._next_chunk_steps[env_id]])
+            self._next_chunk_steps[env_id] += 1
+
+        batch = np.stack(actions)  # (num_envs, action_dim)
+        return torch.from_numpy(batch).to(dtype=torch.float32, device=env.unwrapped.device)
+
+    def reset(self, env_ids: torch.Tensor | None = None) -> None:
+        if self._cached_action_chunks is None:
+            return  # not yet initialized; nothing to clear
+        ids = range(len(self._cached_action_chunks)) if env_ids is None else env_ids.reshape(-1).tolist()
+        for env_id in ids:
+            self._cached_action_chunks[env_id] = None
+            self._next_chunk_steps[env_id] = 0
+
+    def close(self) -> None:
+        """Release the local websocket connection to the cosmos3 server.
+
+        Does NOT stop the cosmos3 server process that runs in a separate
+        container (or machine) and outlives this client.
+        """
+        _close_websocket_best_effort(self._websocket_client)
+        self._websocket_client = None
+
+    def _maybe_init_per_env_state(self, num_envs: int) -> None:
+        if self._cached_action_chunks is None:
+            self._cached_action_chunks = [None] * num_envs
+            self._next_chunk_steps = [0] * num_envs
+            return
+        assert len(self._cached_action_chunks) == num_envs, (
+            f"Cosmos3RemotePolicy num_envs changed from {len(self._cached_action_chunks)}"
+            f" to {num_envs} mid-rollout; recreate the policy for the new num_envs."
+        )
+
+    def _fetch_action_chunk(self, observation: dict[str, Any], env_id: int) -> np.ndarray:
+        extracted = self._cosmos3_embodiment_adapter.extract(observation, env_id)
+        request = self._cosmos3_embodiment_adapter.pack_request(extracted, self.task_description)
+        response = self._call_server_with_retry(request)
+
+        chunk = np.asarray(response["action"])
+        assert (
+            chunk.ndim == 2 and chunk.shape[1] == self._cosmos3_embodiment_adapter.action_dim
+        ), f"Expected action of shape (H, {self._cosmos3_embodiment_adapter.action_dim}); got {chunk.shape}"
+        assert (
+            chunk.shape[0] >= self._open_loop_horizon
+        ), f"Server returned horizon {chunk.shape[0]} < configured open_loop_horizon {self._open_loop_horizon}"
+
+        chunk = chunk[: self._open_loop_horizon].astype(np.float32, copy=True)
+        chunk = self._postprocess_chunk(chunk)
+        return chunk
+
+    def _postprocess_chunk(self, chunk: np.ndarray) -> np.ndarray:
+        """Apply post-processing to the action chunk.
+
+        Binarizes the last dimension (gripper): values > 0.5 → 1.0, others → 0.0.
+        This matches the cosmos3 RoboLab client's ``_postprocess_chunk`` behavior.
+        """
+        chunk = chunk.copy()
+        chunk[..., -1] = (chunk[..., -1] > 0.5).astype(chunk.dtype)
+        return chunk
+
+    def _call_server_with_retry(self, server_request: dict[str, Any]) -> dict[str, Any]:
+        """Send the request, reconnecting up to ``MAX_RECONNECT_ATTEMPTS`` times.
+
+        On any reconnect the cached chunks are flushed so the caller's next
+        ``get_action`` re-queries with a fresh observation rather than
+        replaying a potentially-stale chunk against the new server state.
+        """
+        for attempt_index in range(MAX_RECONNECT_ATTEMPTS):
+            try:
+                return self._websocket_client.infer(server_request)
+            except (
+                websockets.exceptions.ConnectionClosedError,
+                websockets.exceptions.ConnectionClosedOK,
+                OSError,
+            ) as exc:
+                is_last_attempt = (attempt_index + 1) >= MAX_RECONNECT_ATTEMPTS
+                if is_last_attempt:
+                    raise
+                print(
+                    f"[Cosmos3RemotePolicy] Connection lost ({exc}); reconnecting"
+                    f" (attempt {attempt_index + 1}/{MAX_RECONNECT_ATTEMPTS - 1}) ..."
+                )
+                _close_websocket_best_effort(self._websocket_client)
+                self._websocket_client = websocket_client_policy.WebsocketClientPolicy(
+                    host=self._remote_host, port=self._remote_port
+                )
+                # Flush every env's cache: the reconnected server may have lost
+                # state, so we force a fresh observation on the next get_action
+                # for each env rather than replay cached actions.
+                if self._cached_action_chunks is not None:
+                    for i in range(len(self._cached_action_chunks)):
+                        self._cached_action_chunks[i] = None
+                        self._next_chunk_steps[i] = 0
+        raise RuntimeError("unreachable")
+
+    @property
+    def is_remote(self) -> bool:
+        return True
+
+def _close_websocket_best_effort(client: websocket_client_policy.WebsocketClientPolicy | None) -> None:
+    """Best-effort close of the websocket inside ``client``.
+
+    Swallows the typical "peer already gone" errors so the teardown and
+    reconnect paths can call this without crashing.
+    """
+    if client is None:
+        return
+    try:
+        ws = getattr(client, "_ws", None)
+        if ws is not None:
+            ws.close()
+    except (websockets.exceptions.ConnectionClosed, OSError):
+        pass
+
+
+def _resolve_cosmos3_embodiment_adapter(key: str) -> Cosmos3EmbodimentAdapter:
+    """Instantiate the adapter registered under ``key``.
+
+    Imports are deferred to call time so adapter modules can ``from
+    cosmos3_remote_policy import Cosmos3EmbodimentAdapter`` at module top
+    without creating a circular import.
+    """
+    if key == "droid":
+        from isaaclab_arena_cosmos3.policy.droid_adapter import Cosmos3DroidAdapter
+
+        return Cosmos3DroidAdapter()
+    raise ValueError(f"Unknown cosmos3_embodiment_adapter {key!r}; expected 'droid'")

--- a/isaaclab_arena_cosmos3/policy/cosmos3_remote_policy.py
+++ b/isaaclab_arena_cosmos3/policy/cosmos3_remote_policy.py
@@ -71,6 +71,7 @@ class Cosmos3RemotePolicy(PolicyBase):
 
         self._remote_host = config.remote_host
         self._remote_port = config.remote_port
+        self.device = config.policy_device
 
         print(f"[Cosmos3RemotePolicy] Connecting to cosmos3 server at {self._remote_host}:{self._remote_port} ...")
         self._websocket_client = websocket_client_policy.WebsocketClientPolicy(
@@ -100,6 +101,12 @@ class Cosmos3RemotePolicy(PolicyBase):
         )
         group.add_argument("--remote_host", type=str, default="localhost", help="Cosmos3 server host.")
         group.add_argument("--remote_port", type=int, default=8000, help="Cosmos3 server port.")
+        group.add_argument(
+            "--policy_device",
+            type=str,
+            default="cuda",
+            help="Torch device for action tensors (e.g. 'cuda', 'cuda:0', 'cpu').",
+        )
         return parser
 
     @staticmethod
@@ -109,6 +116,7 @@ class Cosmos3RemotePolicy(PolicyBase):
             Cosmos3RemotePolicyArgs(
                 remote_host=args.remote_host,
                 remote_port=args.remote_port,
+                policy_device=getattr(args, "policy_device", "cuda"),
             ),
             cosmos3_embodiment_adapter=cosmos3_embodiment_adapter,
         )
@@ -140,8 +148,7 @@ class Cosmos3RemotePolicy(PolicyBase):
         actions = []
         for env_id in range(num_envs):
             chunk_exhausted = (
-                self._cached_action_chunks[env_id] is None
-                or self._next_chunk_steps[env_id] >= self._open_loop_horizon
+                self._cached_action_chunks[env_id] is None or self._next_chunk_steps[env_id] >= self._open_loop_horizon
             )
             if chunk_exhausted:
                 self._cached_action_chunks[env_id] = self._fetch_action_chunk(observation, env_id)
@@ -150,7 +157,7 @@ class Cosmos3RemotePolicy(PolicyBase):
             self._next_chunk_steps[env_id] += 1
 
         batch = np.stack(actions)  # (num_envs, action_dim)
-        return torch.from_numpy(batch).to(dtype=torch.float32, device=env.unwrapped.device)
+        return torch.from_numpy(batch).to(dtype=torch.float32, device=self.device)
 
     def reset(self, env_ids: torch.Tensor | None = None) -> None:
         if self._cached_action_chunks is None:
@@ -244,6 +251,7 @@ class Cosmos3RemotePolicy(PolicyBase):
     @property
     def is_remote(self) -> bool:
         return True
+
 
 def _close_websocket_best_effort(client: websocket_client_policy.WebsocketClientPolicy | None) -> None:
     """Best-effort close of the websocket inside ``client``.

--- a/isaaclab_arena_cosmos3/policy/droid_adapter.py
+++ b/isaaclab_arena_cosmos3/policy/droid_adapter.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from dataclasses import dataclass
+from typing import Any
+
+from openpi_client import image_tools
+
+from isaaclab_arena_cosmos3.policy.cosmos3_remote_policy import Cosmos3EmbodimentAdapter
+
+
+@dataclass(frozen=True)
+class Cosmos3DroidObservation:
+    """Per-env tensors needed to assemble a cosmos3 DROID request."""
+
+    left_image: np.ndarray  # (H, W, 3) uint8 — over-shoulder left / external_camera
+    right_image: np.ndarray  # (H, W, 3) uint8 — over-shoulder right / external_camera_2
+    wrist_image: np.ndarray  # (H, W, 3) uint8 — wrist camera
+    joint_position: np.ndarray  # (7,) float32
+    gripper_position: np.ndarray  # (1,) float32
+
+
+class Cosmos3DroidAdapter(Cosmos3EmbodimentAdapter):
+    """Wire format for upstream cosmos3 DROID checkpoint.
+
+    Cosmos3 composes three camera views into a single 720×640 image
+    and sends it under the ``observation/image`` key (unlike pi0 which
+    sends separate per-camera keys).
+    """
+
+    # Fixed by upstream cosmos3 droid checkpoint: 7 panda joints + 1 gripper command.
+    action_dim = 8
+
+    # Cosmos3 predicts 32 action steps per inference call.
+    open_loop_horizon = 32
+
+    # Image dimensions for cosmos3's composed input.
+    image_w = 640
+    image_h = 360
+
+    # Arena observation keys — follow the same convention as Pi0DroidAdapter:
+    #   camera_obs group  — from isaaclab_arena.utils.cameras.make_camera_observation_cfg
+    #   policy group      — standard Isaac Lab ObservationsCfg field name
+    arena_camera_obs_group = "camera_obs"
+    arena_policy_obs_group = "policy"
+
+    # Camera field names in the arena observation dict.
+    # The "_rgb" suffix is appended by make_camera_observation_cfg.
+    arena_left_camera_key = "external_camera_rgb"
+    arena_right_camera_key = "external_camera_2_rgb"
+    arena_wrist_camera_key = "wrist_camera_rgb"
+
+    def extract(self, observation: dict[str, Any], env_id: int) -> Cosmos3DroidObservation:
+        cam = observation[self.arena_camera_obs_group]
+        proprio = observation[self.arena_policy_obs_group]
+        return Cosmos3DroidObservation(
+            left_image=cam[self.arena_left_camera_key][env_id].detach().cpu().numpy(),
+            right_image=cam[self.arena_right_camera_key][env_id].detach().cpu().numpy(),
+            wrist_image=cam[self.arena_wrist_camera_key][env_id].detach().cpu().numpy(),
+            joint_position=proprio["joint_pos"][env_id].detach().cpu().numpy(),
+            gripper_position=proprio["gripper_pos"][env_id].detach().cpu().numpy(),
+        )
+
+    def pack_request(self, extracted: Cosmos3DroidObservation, language_instruction: str) -> dict[str, Any]:
+        """Build the cosmos3 wire-format request.
+
+        Composes a single 720×640 image by vertically stacking:
+        - wrist image resized to (360, 640)
+        - left + right images each downsampled to (180, 320) and stacked horizontally
+        """
+        # Resize wrist to target dimensions using openpi's resize_with_pad.
+        wrist = image_tools.resize_with_pad(extracted.wrist_image, self.image_h, self.image_w)
+
+        # Resize left/right to full size first, then bilinear downsample.
+        half_size = (self.image_h // 2, self.image_w // 2)  # (180, 320)
+
+        left = image_tools.resize_with_pad(extracted.left_image, self.image_h, self.image_w)
+        left_t = torch.from_numpy(left).permute(2, 0, 1).unsqueeze(0).float()
+        left_t = F.interpolate(left_t, size=half_size, mode="bilinear", align_corners=False)
+        left = left_t.squeeze(0).permute(1, 2, 0).numpy().astype(wrist.dtype)
+
+        right = image_tools.resize_with_pad(extracted.right_image, self.image_h, self.image_w)
+        right_t = torch.from_numpy(right).permute(2, 0, 1).unsqueeze(0).float()
+        right_t = F.interpolate(right_t, size=half_size, mode="bilinear", align_corners=False)
+        right = right_t.squeeze(0).permute(1, 2, 0).numpy().astype(wrist.dtype)
+
+        # Compose: vstack(wrist, hstack(left, right)) → (720, 640, 3)
+        image = np.concatenate((wrist, np.concatenate((left, right), axis=1)), axis=0)
+        assert image.shape == (self.image_h + self.image_h // 2, self.image_w, 3), (
+            f"Expected composed image shape (720, 640, 3); got {image.shape}"
+        )
+
+        return {
+            "observation/image": image,
+            "observation/joint_position": extracted.joint_position,
+            "observation/gripper_position": extracted.gripper_position,
+            "prompt": language_instruction,
+        }

--- a/isaaclab_arena_cosmos3/policy/droid_adapter.py
+++ b/isaaclab_arena_cosmos3/policy/droid_adapter.py
@@ -30,7 +30,7 @@ class Cosmos3DroidObservation:
 class Cosmos3DroidAdapter(Cosmos3EmbodimentAdapter):
     """Wire format for upstream cosmos3 DROID checkpoint.
 
-    Cosmos3 composes three camera views into a single 720×640 image
+    Cosmos3 composes three camera views into a single 540×640 image
     and sends it under the ``observation/image`` key (unlike pi0 which
     sends separate per-camera keys).
     """
@@ -71,7 +71,7 @@ class Cosmos3DroidAdapter(Cosmos3EmbodimentAdapter):
     def pack_request(self, extracted: Cosmos3DroidObservation, language_instruction: str) -> dict[str, Any]:
         """Build the cosmos3 wire-format request.
 
-        Composes a single 720×640 image by vertically stacking:
+        Composes a single 540×640 image by vertically stacking:
         - wrist image resized to (360, 640)
         - left + right images each downsampled to (180, 320) and stacked horizontally
         """
@@ -91,11 +91,10 @@ class Cosmos3DroidAdapter(Cosmos3EmbodimentAdapter):
         right_t = F.interpolate(right_t, size=half_size, mode="bilinear", align_corners=False)
         right = right_t.squeeze(0).permute(1, 2, 0).numpy().astype(wrist.dtype)
 
-        # Compose: vstack(wrist, hstack(left, right)) → (720, 640, 3)
+        # Compose: vstack(wrist, hstack(left, right)) → (540, 640, 3)
         image = np.concatenate((wrist, np.concatenate((left, right), axis=1)), axis=0)
-        assert image.shape == (self.image_h + self.image_h // 2, self.image_w, 3), (
-            f"Expected composed image shape (720, 640, 3); got {image.shape}"
-        )
+        expected_shape = (self.image_h + self.image_h // 2, self.image_w, 3)  # (540, 640, 3)
+        assert image.shape == expected_shape, f"Expected composed image shape {expected_shape}; got {image.shape}"
 
         return {
             "observation/image": image,

--- a/isaaclab_arena_cosmos3/tests/__init__.py
+++ b/isaaclab_arena_cosmos3/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/isaaclab_arena_cosmos3/tests/test_cosmos3_remote_policy.py
+++ b/isaaclab_arena_cosmos3/tests/test_cosmos3_remote_policy.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import types
+
+import pytest
+import websockets.exceptions
+from openpi_client import websocket_client_policy
+
+from isaaclab_arena_cosmos3.policy.cosmos3_remote_config import MAX_RECONNECT_ATTEMPTS, Cosmos3RemotePolicyArgs
+from isaaclab_arena_cosmos3.policy.cosmos3_remote_policy import Cosmos3RemotePolicy
+from isaaclab_arena_cosmos3.policy.droid_adapter import Cosmos3DroidAdapter
+
+
+def _fake_env(num_envs: int = 1):
+    return types.SimpleNamespace(unwrapped=types.SimpleNamespace(num_envs=num_envs, device=torch.device("cpu")))
+
+
+def _fake_observation(num_envs: int = 1) -> dict:
+    return {
+        "camera_obs": {
+            "external_camera_rgb": torch.zeros((num_envs, 720, 1280, 3), dtype=torch.uint8),
+            "external_camera_2_rgb": torch.zeros((num_envs, 720, 1280, 3), dtype=torch.uint8),
+            "wrist_camera_rgb": torch.zeros((num_envs, 720, 1280, 3), dtype=torch.uint8),
+        },
+        "policy": {
+            "joint_pos": torch.zeros((num_envs, 7), dtype=torch.float32),
+            "gripper_pos": torch.zeros((num_envs, 1), dtype=torch.float32),
+        },
+    }
+
+
+def _synthetic_chunk() -> np.ndarray:
+    """A horizon=32, action_dim=8 chunk shaped like cosmos3 droid output."""
+    actions = np.tile(
+        np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], dtype=np.float32),
+        (32, 1),
+    )
+    # Distinguish row 0 from row 1 so chunk advancement is observable.
+    actions[0, -1] = 0.2
+    actions[1, -1] = 0.7
+    return actions
+
+
+def _patch_websocket_client(monkeypatch, infer_impl=None) -> None:
+    monkeypatch.setattr(
+        websocket_client_policy.WebsocketClientPolicy,
+        "_wait_for_server",
+        lambda self: (None, {}),
+    )
+    if infer_impl is None:
+        infer_impl = lambda self, request: {"action": _synthetic_chunk()}  # noqa: E731
+    monkeypatch.setattr(
+        websocket_client_policy.WebsocketClientPolicy,
+        "infer",
+        infer_impl,
+    )
+
+
+@pytest.fixture
+def make_policy(monkeypatch):
+    _patch_websocket_client(monkeypatch)
+
+    def _factory():
+        return Cosmos3RemotePolicy(
+            Cosmos3RemotePolicyArgs(),
+            cosmos3_embodiment_adapter=Cosmos3DroidAdapter(),
+        )
+
+    return _factory
+
+
+def test_droid_adapter_uses_cosmos3_wire_keys():
+    """The wire-format contract between Cosmos3DroidAdapter and the cosmos3 server."""
+    adapter = Cosmos3DroidAdapter()
+    extracted = adapter.extract(_fake_observation(), env_id=0)
+    server_request = adapter.pack_request(extracted, "pick up the block")
+
+    assert set(server_request.keys()) == {
+        "observation/image",
+        "observation/joint_position",
+        "observation/gripper_position",
+        "prompt",
+    }
+    # Cosmos3 composes three cameras into a single 720×640 image.
+    assert server_request["observation/image"].shape == (720, 640, 3)
+    assert server_request["observation/image"].dtype == np.uint8
+    assert server_request["observation/joint_position"].shape == (7,)
+    assert server_request["observation/gripper_position"].shape == (1,)
+    assert server_request["prompt"] == "pick up the block"
+
+
+def test_droid_adapter_extract_reads_three_cameras():
+    """extract() pulls left, right, and wrist cameras from the arena obs dict."""
+    adapter = Cosmos3DroidAdapter()
+    obs = _fake_observation(num_envs=2)
+
+    # Set distinguishable values on the wrist camera.
+    obs["camera_obs"]["wrist_camera_rgb"][0] = torch.full((720, 1280, 3), 42, dtype=torch.uint8)
+
+    extracted = adapter.extract(obs, env_id=0)
+    assert extracted.wrist_image.shape == (720, 1280, 3)
+    assert (extracted.wrist_image == 42).all()
+    assert extracted.left_image.shape == (720, 1280, 3)
+    assert extracted.right_image.shape == (720, 1280, 3)
+    assert extracted.joint_position.shape == (7,)
+    assert extracted.gripper_position.shape == (1,)
+
+
+def test_from_dict_resolves_adapter(monkeypatch):
+    """eval_runner path: JSON dict -> Cosmos3RemotePolicy with adapter resolved from the dict."""
+    _patch_websocket_client(monkeypatch)
+    policy = Cosmos3RemotePolicy.from_dict({
+        "remote_host": "localhost",
+        "remote_port": 8000,
+        "cosmos3_embodiment_adapter": "droid",
+    })
+    assert isinstance(policy._cosmos3_embodiment_adapter, Cosmos3DroidAdapter)
+    assert policy._open_loop_horizon == 32
+
+
+def test_from_dict_defaults_adapter_to_droid(monkeypatch):
+    """When cosmos3_embodiment_adapter is omitted from the dict, it defaults to 'droid'."""
+    _patch_websocket_client(monkeypatch)
+    policy = Cosmos3RemotePolicy.from_dict({
+        "remote_host": "localhost",
+        "remote_port": 8000,
+    })
+    assert isinstance(policy._cosmos3_embodiment_adapter, Cosmos3DroidAdapter)
+
+
+def test_close_is_idempotent(make_policy):
+    """close() drops the client and tolerates a second call."""
+    policy = make_policy()
+    assert policy._websocket_client is not None
+    policy.close()
+    assert policy._websocket_client is None
+    policy.close()  # second call must not raise
+
+
+def test_get_action_caches_chunk_and_advances_index(make_policy):
+    """Two consecutive get_action calls replay rows 0 and 1 from one fetched chunk."""
+    policy = make_policy()
+    policy.set_task_description("pick up the block")
+    env = _fake_env(num_envs=1)
+    obs = _fake_observation()
+
+    first_action = policy.get_action(env, obs)
+    second_action = policy.get_action(env, obs)
+
+    assert first_action.shape == (1, 8) and second_action.shape == (1, 8)
+    assert first_action.dtype == torch.float32
+    assert first_action[0, -1].item() == pytest.approx(0.2)
+    assert second_action[0, -1].item() == pytest.approx(0.7)
+
+
+def test_get_action_parallel_envs_loops_per_env(monkeypatch):
+    """num_envs>1: one infer per env per chunk refill, batched into (num_envs, action_dim)."""
+    call_count = {"n": 0}
+
+    def counting_infer(self, request):
+        call_count["n"] += 1
+        return {"action": _synthetic_chunk()}
+
+    _patch_websocket_client(monkeypatch, infer_impl=counting_infer)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    num_envs = 3
+    env = _fake_env(num_envs=num_envs)
+    obs = _fake_observation(num_envs=num_envs)
+
+    first_action = policy.get_action(env, obs)
+    second_action = policy.get_action(env, obs)
+
+    # One infer call per env on the first get_action (cache miss); none on the
+    # second (chunk row 1 is still cached for each env).
+    assert call_count["n"] == num_envs
+    assert first_action.shape == (num_envs, 8)
+    assert second_action.shape == (num_envs, 8)
+    for env_id in range(num_envs):
+        assert first_action[env_id, -1].item() == pytest.approx(0.2)
+        assert second_action[env_id, -1].item() == pytest.approx(0.7)
+
+
+def test_reset_honors_env_ids(monkeypatch):
+    """reset(env_ids) clears only those envs' caches; others keep replaying."""
+    _patch_websocket_client(monkeypatch)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+    env = _fake_env(num_envs=3)
+    obs = _fake_observation(num_envs=3)
+
+    policy.get_action(env, obs)  # populates caches for all 3 envs
+
+    policy.reset(env_ids=torch.tensor([0, 2]))
+
+    assert policy._cached_action_chunks[0] is None
+    assert policy._cached_action_chunks[1] is not None  # untouched
+    assert policy._cached_action_chunks[2] is None
+    assert policy._next_chunk_steps == [0, 1, 0]
+
+
+def test_gripper_binarization(monkeypatch):
+    """Gripper values > 0.5 are binarized to 1.0; others stay 0.0."""
+    # Raw chunk with mixed gripper values.
+    chunk = np.zeros((32, 8), dtype=np.float32)
+    chunk[:, -1] = np.array([0.0, 0.3, 0.5, 0.51, 0.7, 1.0, 0.49, 0.8] + [0.0] * 24, dtype=np.float32)
+
+    def custom_infer(self, request):
+        return {"action": chunk.copy()}
+
+    _patch_websocket_client(monkeypatch, infer_impl=custom_infer)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    result = policy._fetch_action_chunk(_fake_observation(), env_id=0)
+
+    # Check gripper dimension binarization.
+    expected_gripper = np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0] + [0.0] * 24, dtype=np.float32)
+    np.testing.assert_array_equal(result[:, -1], expected_gripper)
+    # Non-gripper dimensions unchanged.
+    assert result[3, 0] == 0.0  # joint values preserved
+
+
+def test_call_server_with_retry_reconnects_on_drop(monkeypatch):
+    """Drop the first connection; second call succeeds and cache is flushed."""
+    call_count = {"n": 0}
+    successful_response = {"action": np.zeros((32, 8), dtype=np.float32)}
+
+    def flaky_infer(self, request):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise websockets.exceptions.ConnectionClosedError(None, None)
+        return successful_response
+
+    _patch_websocket_client(monkeypatch, infer_impl=flaky_infer)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+    policy._cached_action_chunks = [np.zeros((32, 8), dtype=np.float32)]
+    policy._next_chunk_steps = [5]
+
+    response = policy._call_server_with_retry({"prompt": "x"})
+
+    assert response is successful_response
+    assert call_count["n"] == 2
+    assert policy._cached_action_chunks == [None]
+    assert policy._next_chunk_steps == [0]
+
+
+def test_call_server_with_retry_gives_up_after_max_attempts(monkeypatch):
+    def always_drops(self, request):
+        raise websockets.exceptions.ConnectionClosedError(None, None)
+
+    _patch_websocket_client(monkeypatch, infer_impl=always_drops)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    with pytest.raises(websockets.exceptions.ConnectionClosedError):
+        policy._call_server_with_retry({"prompt": "x"})
+
+
+def test_get_action_asserts_when_no_task_description(make_policy):
+    """get_action raises AssertionError if set_task_description was never called."""
+    policy = make_policy()
+    env = _fake_env()
+    obs = _fake_observation()
+
+    with pytest.raises(AssertionError, match="language instruction"):
+        policy.get_action(env, obs)
+
+
+def test_fetch_action_chunk_asserts_on_shape_mismatch(monkeypatch):
+    """_fetch_action_chunk asserts when response action has wrong action_dim."""
+    def bad_shape_infer(self, request):
+        return {"action": np.zeros((32, 6), dtype=np.float32)}  # expects 8
+
+    _patch_websocket_client(monkeypatch, infer_impl=bad_shape_infer)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    with pytest.raises(AssertionError, match="Expected action of shape"):
+        policy._fetch_action_chunk(_fake_observation(), env_id=0)
+
+
+def test_fetch_action_chunk_truncates_chunk_to_horizon(monkeypatch):
+    """When the server returns more than horizon steps, only horizon are kept."""
+    def oversized_infer(self, request):
+        return {"action": np.ones((40, 8), dtype=np.float32)}
+
+    _patch_websocket_client(monkeypatch, infer_impl=oversized_infer)
+    policy = Cosmos3RemotePolicy(Cosmos3RemotePolicyArgs(), cosmos3_embodiment_adapter=Cosmos3DroidAdapter())
+    policy.set_task_description("pick up the block")
+
+    chunk = policy._fetch_action_chunk(_fake_observation(), env_id=0)
+    assert chunk.shape == (32, 8)

--- a/isaaclab_arena_cosmos3/tests/test_cosmos3_remote_policy.py
+++ b/isaaclab_arena_cosmos3/tests/test_cosmos3_remote_policy.py
@@ -13,7 +13,7 @@ import pytest
 import websockets.exceptions
 from openpi_client import websocket_client_policy
 
-from isaaclab_arena_cosmos3.policy.cosmos3_remote_config import MAX_RECONNECT_ATTEMPTS, Cosmos3RemotePolicyArgs
+from isaaclab_arena_cosmos3.policy.cosmos3_remote_config import Cosmos3RemotePolicyArgs
 from isaaclab_arena_cosmos3.policy.cosmos3_remote_policy import Cosmos3RemotePolicy
 from isaaclab_arena_cosmos3.policy.droid_adapter import Cosmos3DroidAdapter
 
@@ -88,8 +88,8 @@ def test_droid_adapter_uses_cosmos3_wire_keys():
         "observation/gripper_position",
         "prompt",
     }
-    # Cosmos3 composes three cameras into a single 720×640 image.
-    assert server_request["observation/image"].shape == (720, 640, 3)
+    # Cosmos3 composes three cameras into a single 540×640 image.
+    assert server_request["observation/image"].shape == (540, 640, 3)
     assert server_request["observation/image"].dtype == np.uint8
     assert server_request["observation/joint_position"].shape == (7,)
     assert server_request["observation/gripper_position"].shape == (1,)
@@ -278,6 +278,7 @@ def test_get_action_asserts_when_no_task_description(make_policy):
 
 def test_fetch_action_chunk_asserts_on_shape_mismatch(monkeypatch):
     """_fetch_action_chunk asserts when response action has wrong action_dim."""
+
     def bad_shape_infer(self, request):
         return {"action": np.zeros((32, 6), dtype=np.float32)}  # expects 8
 
@@ -291,6 +292,7 @@ def test_fetch_action_chunk_asserts_on_shape_mismatch(monkeypatch):
 
 def test_fetch_action_chunk_truncates_chunk_to_horizon(monkeypatch):
     """When the server returns more than horizon steps, only horizon are kept."""
+
     def oversized_infer(self, request):
         return {"action": np.ones((40, 8), dtype=np.float32)}
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ RUNTIME_DEPS = [
     "pytest",
     "pydantic>=2.0",
     "openai>=2.0",
+    # openpi remote policy client
+    "openpi-client",
     # Sensitivity analysis (isaaclab_arena.analysis.sensitivity), imported at module level.
     "sbi",
     "scipy",


### PR DESCRIPTION
## Summary
Add Cosmos3 Policy support via `openpi-server`.

## Detailed description
- Introduced isaaclab_arena_cosmos3 Extension: Created a new extension package dedicated to Cosmos3 policy integration.

- Added OpenPI Client & Policy: Implemented Cosmos3RemotePolicy which establishes a WebSocket connection to a remote inference server using `openpi_client`.