### PR TITLE
Represent Experiment Runs as a named mapping

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment.py
+++ b/isaaclab_arena/evaluation/arena_experiment.py
@@ -3,17 +3,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Represent declarative and executable Arena Experiments."""
+"""Represent Arena Experiment configurations."""
 
 from dataclasses import dataclass
-from typing import TypeAlias
 
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 
 
 @dataclass
-class ArenaExperimentDefinitionCfg:
-    """Declare the named Runs that form one Arena Experiment."""
+class ArenaExperimentCfg:
+    """Configure the named Runs that form one Arena Experiment."""
 
     runs: dict[str, ArenaRunCfg]
     """Runs keyed by the names used for overrides, execution, and results."""
@@ -27,7 +26,3 @@ class ArenaExperimentDefinitionCfg:
                 "Run name is defined by its Experiment Definition mapping key and cannot be overridden: "
                 f"expected '{run_name}', got '{run_cfg.name}'"
             )
-
-
-ArenaExperiment: TypeAlias = list[ArenaRunCfg]
-"""An Experiment expressed as its ordered list of Runs."""

--- a/isaaclab_arena/evaluation/arena_experiment.py
+++ b/isaaclab_arena/evaluation/arena_experiment.py
@@ -3,11 +3,31 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Represent an Arena Experiment as an ordered list of Runs."""
+"""Represent declarative and executable Arena Experiments."""
 
+from dataclasses import dataclass
 from typing import TypeAlias
 
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
+
+
+@dataclass
+class ArenaExperimentDefinitionCfg:
+    """Declare the named Runs that form one Arena Experiment."""
+
+    runs: dict[str, ArenaRunCfg]
+    """Runs keyed by the names used for overrides, execution, and results."""
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.runs, dict) and self.runs, "Experiment Definition must contain at least one Run"
+        for run_name, run_cfg in self.runs.items():
+            assert isinstance(run_name, str) and run_name, "Experiment Definition Run names must be non-empty strings"
+            assert isinstance(run_cfg, ArenaRunCfg), f"Experiment Definition Run '{run_name}' must be an ArenaRunCfg"
+            assert run_cfg.name == run_name, (
+                "Run name is defined by its Experiment Definition mapping key and cannot be overridden: "
+                f"expected '{run_name}', got '{run_cfg.name}'"
+            )
+
 
 ArenaExperiment: TypeAlias = list[ArenaRunCfg]
 """An Experiment expressed as its ordered list of Runs."""

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -13,9 +13,10 @@ from pathlib import Path
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment, ArenaExperimentDefinitionCfg
+from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
+from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_definition_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
 
@@ -56,7 +57,33 @@ def load_arena_experiment_from_config_file(
             legacy_experiment_config = json.load(experiment_config_file)
         return run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
 
-    yaml_experiment = load_arena_experiment_from_yaml(
+    experiment_definition = load_arena_experiment_definition_from_config_file(
+        path,
+        device=device,
+        overrides=overrides,
+    )
+    return list(experiment_definition.runs.values())
+
+
+def load_arena_experiment_definition_from_config_file(
+    experiment_config_path: str | Path,
+    *,
+    device: str,
+    overrides: list[str] | None = None,
+) -> ArenaExperimentDefinitionCfg:
+    """Load a typed YAML Experiment Definition and apply its process device.
+
+    Args:
+        experiment_config_path: Path to a typed YAML Experiment Definition.
+        device: Process-wide simulation device applied to every Run.
+        overrides: Hydra overrides applied after the YAML values.
+
+    Returns:
+        The composed Experiment Definition with typed Runs.
+    """
+    path = validate_experiment_config_path(experiment_config_path)
+    assert path.suffix.lower() in {".yaml", ".yml"}, "Experiment Definitions must use typed YAML"
+    experiment_definition = load_arena_experiment_definition_from_yaml(
         path,
         environment_cfg_types=_registered_environment_cfg_types(),
         policy_cfg_types=_registered_policy_cfg_types(),
@@ -66,15 +93,15 @@ def load_arena_experiment_from_config_file(
     # TODO(cvolk, 2026-07-09): [typed-config-migration] Make device a process-level
     # evaluation setting shared by AppLauncher and Run execution. Then remove device
     # from ArenaEnvBuilderCfg and delete this per-Run copy.
-    experiment_with_process_device: ArenaExperiment = []
-    for run_config in yaml_experiment:
+    runs_with_process_device: dict[str, ArenaRunCfg] = {}
+    for run_name, run_config in experiment_definition.runs.items():
         environment_builder_with_process_device = replace(run_config.environment_builder, device=device)
         run_config_with_process_device = replace(
             run_config,
             environment_builder=environment_builder_with_process_device,
         )
-        experiment_with_process_device.append(run_config_with_process_device)
-    return experiment_with_process_device
+        runs_with_process_device[run_name] = run_config_with_process_device
+    return ArenaExperimentDefinitionCfg(runs=runs_with_process_device)
 
 
 def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -13,10 +13,10 @@ from pathlib import Path
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment, ArenaExperimentDefinitionCfg
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_definition_from_yaml
+from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
 from isaaclab_arena_environments.cli import ensure_environments_registered
 
@@ -38,7 +38,7 @@ def load_arena_experiment_from_config_file(
     *,
     device: str,
     overrides: list[str] | None = None,
-) -> ArenaExperiment:
+) -> ArenaExperimentCfg:
     """Load a JSON or YAML Arena Experiment and apply its process device.
 
     Args:
@@ -47,7 +47,7 @@ def load_arena_experiment_from_config_file(
         overrides: Hydra overrides applied to typed YAML Experiments.
 
     Returns:
-        The ordered typed Runs that make up the Experiment.
+        The composed Experiment configuration with named typed Runs.
     """
     path = validate_experiment_config_path(experiment_config_path)
 
@@ -55,35 +55,10 @@ def load_arena_experiment_from_config_file(
         assert not overrides, "Experiment overrides are supported only for typed YAML Experiments"
         with path.open(encoding="utf-8") as experiment_config_file:
             legacy_experiment_config = json.load(experiment_config_file)
-        return run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
+        run_cfgs = run_cfgs_from_legacy_eval_config(legacy_experiment_config, device=device)
+        return ArenaExperimentCfg(runs={run_cfg.name: run_cfg for run_cfg in run_cfgs})
 
-    experiment_definition = load_arena_experiment_definition_from_config_file(
-        path,
-        device=device,
-        overrides=overrides,
-    )
-    return list(experiment_definition.runs.values())
-
-
-def load_arena_experiment_definition_from_config_file(
-    experiment_config_path: str | Path,
-    *,
-    device: str,
-    overrides: list[str] | None = None,
-) -> ArenaExperimentDefinitionCfg:
-    """Load a typed YAML Experiment Definition and apply its process device.
-
-    Args:
-        experiment_config_path: Path to a typed YAML Experiment Definition.
-        device: Process-wide simulation device applied to every Run.
-        overrides: Hydra overrides applied after the YAML values.
-
-    Returns:
-        The composed Experiment Definition with typed Runs.
-    """
-    path = validate_experiment_config_path(experiment_config_path)
-    assert path.suffix.lower() in {".yaml", ".yml"}, "Experiment Definitions must use typed YAML"
-    experiment_definition = load_arena_experiment_definition_from_yaml(
+    experiment_cfg = load_arena_experiment_from_yaml(
         path,
         environment_cfg_types=_registered_environment_cfg_types(),
         policy_cfg_types=_registered_policy_cfg_types(),
@@ -94,14 +69,14 @@ def load_arena_experiment_definition_from_config_file(
     # evaluation setting shared by AppLauncher and Run execution. Then remove device
     # from ArenaEnvBuilderCfg and delete this per-Run copy.
     runs_with_process_device: dict[str, ArenaRunCfg] = {}
-    for run_name, run_config in experiment_definition.runs.items():
+    for run_name, run_config in experiment_cfg.runs.items():
         environment_builder_with_process_device = replace(run_config.environment_builder, device=device)
         run_config_with_process_device = replace(
             run_config,
             environment_builder=environment_builder_with_process_device,
         )
         runs_with_process_device[run_name] = run_config_with_process_device
-    return ArenaExperimentDefinitionCfg(runs=runs_with_process_device)
+    return ArenaExperimentCfg(runs=runs_with_process_device)
 
 
 def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -48,7 +48,7 @@ def load_arena_experiment_from_config_file(
         overrides: Hydra overrides applied to typed YAML Experiments.
 
     Returns:
-        The composed Experiment configuration with named typed Runs.
+        The loaded, typed Experiment configuration with the process device applied.
     """
     path = validate_experiment_config_path(experiment_config_path)
 

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from importlib import import_module
 from pathlib import Path
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
@@ -61,7 +62,7 @@ def load_arena_experiment_from_config_file(
     experiment_cfg = load_arena_experiment_from_yaml(
         path,
         environment_cfg_types=_registered_environment_cfg_types(),
-        policy_cfg_types=_registered_policy_cfg_types(),
+        policy_cfg_type_resolver=_resolve_policy_cfg_type_from_name_or_class_path,
         overrides=overrides,
     )
 
@@ -90,11 +91,15 @@ def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
     return environment_cfg_types
 
 
-def _registered_policy_cfg_types() -> dict[str, type[PolicyCfg]]:
-    """Return registered policy selector names and their config types."""
+def _resolve_policy_cfg_type_from_name_or_class_path(policy_name_or_class_path: str) -> type[PolicyCfg]:
+    """Return the config type for a registered policy name or dotted class path."""
     registry = PolicyRegistry()
-    policy_cfg_types: dict[str, type[PolicyCfg]] = {}
-    for name in registry.get_all_keys():
-        policy_type = registry.get_component_by_name(name)
-        policy_cfg_types[name] = registry.get_policy_cfg_type(policy_type)
-    return policy_cfg_types
+    if registry.is_registered(policy_name_or_class_path):
+        policy_type = registry.get_policy(policy_name_or_class_path)
+    else:
+        assert (
+            "." in policy_name_or_class_path
+        ), f"Policy type must be a registered name or dotted Python class path, got {policy_name_or_class_path!r}"
+        module_path, class_name = policy_name_or_class_path.rsplit(".", 1)
+        policy_type = getattr(import_module(module_path), class_name)
+    return registry.get_policy_cfg_type(policy_type)

--- a/isaaclab_arena/evaluation/arena_run.py
+++ b/isaaclab_arena/evaluation/arena_run.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
 from prettytable import PrettyTable
@@ -95,7 +96,7 @@ class ArenaRunResult:
     """Metrics aggregated over all successful rebuilds, when provided by the task."""
 
 
-def build_runs_info_table(run_cfgs: list[ArenaRunCfg], results: list[ArenaRunResult]) -> PrettyTable:
+def build_runs_info_table(run_cfgs: Iterable[ArenaRunCfg], results: Iterable[ArenaRunResult]) -> PrettyTable:
     """Build a table containing the configuration and current status of every Run."""
     results_by_name = {result.run_name: result for result in results}
     table = PrettyTable(

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -6,7 +6,7 @@
 import os
 from pathlib import Path
 
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
@@ -27,9 +27,9 @@ from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 
 # TODO(cvolk): Move experiment-level variation inspection out of this CLI entry point.
 # Run orchestration belongs in evaluation; catalogue formatting belongs in variations.
-def list_variations(experiment: ArenaExperiment) -> None:
+def list_variations(experiment_cfg: ArenaExperimentCfg) -> None:
     """Print the Hydra-configurable variations for each run's environment."""
-    for run_cfg in experiment:
+    for run_cfg in experiment_cfg.runs.values():
         arena_builder = build_arena_builder_from_run_cfg(run_cfg)
         print(f"=== Variations for run '{run_cfg.name}' ===", flush=True)
         print(arena_builder.get_variations_catalogue_as_string(), flush=True)
@@ -41,9 +41,13 @@ def list_variations(experiment: ArenaExperiment) -> None:
 # update each factory to honor it or reject unsupported cameras, and apply YAML
 # values and Hydra overrides before startup. Enable AppLauncher when any Run enables
 # cameras, then remove this getattr and the requirement to also pass --enable_cameras.
-def _assert_camera_support_enabled(experiment: ArenaExperiment, enable_cameras: bool) -> None:
+def _assert_camera_support_enabled(experiment_cfg: ArenaExperimentCfg, enable_cameras: bool) -> None:
     """Check that AppLauncher enabled camera support requested by typed Runs."""
-    camera_run_names = [run_cfg.name for run_cfg in experiment if getattr(run_cfg.environment, "enable_cameras", False)]
+    camera_run_names = [
+        run_cfg.name
+        for run_cfg in experiment_cfg.runs.values()
+        if getattr(run_cfg.environment, "enable_cameras", False)
+    ]
     assert not camera_run_names or enable_cameras, (
         f"Runs {camera_run_names} enable environment cameras. Pass --enable_cameras so AppLauncher enables "
         "camera support before the typed Experiment is composed."
@@ -66,13 +70,13 @@ def main():
     # Print the variations catalogue for each run's environment and exit.
     if args_cli.list_variations:
         with SimulationAppContext(args_cli):
-            experiment = load_arena_experiment_from_config_file(
+            experiment_cfg = load_arena_experiment_from_config_file(
                 experiment_config_path,
                 device=args_cli.device,
                 overrides=experiment_overrides,
             )
-            _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
-            list_variations(experiment)
+            _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
+            list_variations(experiment_cfg)
         return
 
     # Chunked dispatch (--chunk_size N). Splits this config across subprocesses so each
@@ -87,15 +91,15 @@ def main():
             return
 
     with SimulationAppContext(args_cli):
-        experiment = load_arena_experiment_from_config_file(
+        experiment_cfg = load_arena_experiment_from_config_file(
             experiment_config_path,
             device=args_cli.device,
             overrides=experiment_overrides,
         )
-        _assert_camera_support_enabled(experiment, args_cli.enable_cameras)
+        _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
         metrics_logger = MetricsLogger()
 
-        print(build_runs_info_table(experiment, []))
+        print(build_runs_info_table(experiment_cfg.runs.values(), []))
 
         # One reverse-dated output directory for the Experiment, with one subdirectory
         # per Run. Always date it so each invocation produces its own report directory.
@@ -108,7 +112,7 @@ def main():
             print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_dir}")
 
         results = execute_experiment(
-            experiment,
+            experiment_cfg,
             output_dir=experiment_output_dir,
             record_viewport_video=args_cli.record_viewport_video,
             record_camera_video=args_cli.record_camera_video,
@@ -118,7 +122,7 @@ def main():
             if result.metrics is not None:
                 metrics_logger.append_job_metrics(result.run_name, result.metrics)
 
-        print(build_runs_info_table(experiment, results))
+        print(build_runs_info_table(experiment_cfg.runs.values(), results))
         metrics_logger.print_metrics()
 
         # Write HTML report.

--- a/isaaclab_arena/evaluation/experiment_runner_cli.py
+++ b/isaaclab_arena/evaluation/experiment_runner_cli.py
@@ -23,7 +23,7 @@ def add_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
         default=_DEFAULT_EXPERIMENT_CONFIG_PATH,
         help=(
             "Path to a typed YAML Experiment or legacy JSON evaluation config. "
-            "For YAML, append Hydra KEY=VALUE overrides to the command."
+            "For YAML, append Hydra KEY=VALUE overrides for fields on declared Runs."
         ),
     )
     parser.add_argument(

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg, ArenaRunResult, RunStatus
 from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
     LegacyGraphEnvironmentCfg,
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 
 
 def execute_experiment(
-    run_cfgs: list[ArenaRunCfg],
+    experiment_cfg: ArenaExperimentCfg,
     output_dir: Path,
     record_viewport_video: bool = False,
     record_camera_video: bool = False,
@@ -43,7 +44,7 @@ def execute_experiment(
     """Execute an experiment's runs in order and return their results.
 
     Args:
-        run_cfgs: Ordered run configurations that make up the experiment.
+        experiment_cfg: Named Run configurations that make up the Experiment.
         output_dir: Directory containing one output subdirectory per run.
         record_viewport_video: Whether to record the viewport for each run.
         record_camera_video: Whether to record observation cameras for each run.
@@ -53,7 +54,7 @@ def execute_experiment(
         One result per attempted run, in execution order.
     """
     results = []
-    for run_cfg in run_cfgs:
+    for run_cfg in experiment_cfg.runs.values():
         print(f"Running run '{run_cfg.name}'", flush=True)
         run_output_dir = output_dir / run_cfg.name
         try:

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -20,7 +20,7 @@ from omegaconf import OmegaConf
 from omegaconf.errors import OmegaConfBaseException
 
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment, ArenaExperimentDefinitionCfg
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.policy.policy_base import PolicyCfg
 
@@ -36,13 +36,13 @@ def _get_new_hydra_context_if_none_exists() -> AbstractContextManager[None]:
     return initialize(version_base=None, config_path=None)
 
 
-def load_arena_experiment_definition_from_yaml(
+def load_arena_experiment_from_yaml(
     yaml_path: str | Path,
     *,
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
     policy_cfg_types: dict[str, type[PolicyCfg]],
     overrides: list[str] | None = None,
-) -> ArenaExperimentDefinitionCfg:
+) -> ArenaExperimentCfg:
     """Load a YAML Arena Experiment Definition as a typed named-Run mapping.
 
     Each mapping entry below runs declares one Run using its key as the Run
@@ -81,42 +81,15 @@ def load_arena_experiment_definition_from_yaml(
             hydra_experiment_config_name = f"{hydra_config_namespace}_root"
             config_store.store(
                 name=hydra_experiment_config_name,
-                node=ArenaExperimentDefinitionCfg(runs=arena_runs_by_name),
+                node=ArenaExperimentCfg(runs=arena_runs_by_name),
             )
             composed_experiment = compose(config_name=hydra_experiment_config_name, overrides=overrides or [])
-            experiment_definition = OmegaConf.to_object(composed_experiment)
+            experiment_cfg = OmegaConf.to_object(composed_experiment)
     except (HydraException, OmegaConfBaseException, TypeError, ValueError) as exc:
         raise ValueError(f"Could not compose Arena Experiment '{yaml_path}': {exc}") from exc
 
-    assert isinstance(experiment_definition, ArenaExperimentDefinitionCfg)
-    return experiment_definition
-
-
-def load_arena_experiment_from_yaml(
-    yaml_path: str | Path,
-    *,
-    environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
-    policy_cfg_types: dict[str, type[PolicyCfg]],
-    overrides: list[str] | None = None,
-) -> ArenaExperiment:
-    """Load a YAML Arena Experiment as an ordered list of typed Runs.
-
-    Args:
-        yaml_path: Path to the Arena Experiment YAML file.
-        environment_cfg_types: Environment selector names mapped to typed configuration classes.
-        policy_cfg_types: Policy selector names mapped to typed configuration classes.
-        overrides: Hydra overrides rooted at runs, applied after the YAML values.
-
-    Returns:
-        Typed Runs in Experiment Definition mapping order.
-    """
-    experiment_definition = load_arena_experiment_definition_from_yaml(
-        yaml_path,
-        environment_cfg_types=environment_cfg_types,
-        policy_cfg_types=policy_cfg_types,
-        overrides=overrides,
-    )
-    return list(experiment_definition.runs.values())
+    assert isinstance(experiment_cfg, ArenaExperimentCfg)
+    return experiment_cfg
 
 
 def _assert_run_name_is_hydra_compatible(run_name: str) -> None:

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -20,7 +20,7 @@ from omegaconf import OmegaConf
 from omegaconf.errors import OmegaConfBaseException
 
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperiment, ArenaExperimentDefinitionCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.policy.policy_base import PolicyCfg
 
@@ -36,14 +36,14 @@ def _get_new_hydra_context_if_none_exists() -> AbstractContextManager[None]:
     return initialize(version_base=None, config_path=None)
 
 
-def load_arena_experiment_from_yaml(
+def load_arena_experiment_definition_from_yaml(
     yaml_path: str | Path,
     *,
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
     policy_cfg_types: dict[str, type[PolicyCfg]],
     overrides: list[str] | None = None,
-) -> ArenaExperiment:
-    """Load a YAML Arena Experiment as an ordered list of typed Runs.
+) -> ArenaExperimentDefinitionCfg:
+    """Load a YAML Arena Experiment Definition as a typed named-Run mapping.
 
     Each mapping entry below runs declares one Run using its key as the Run
     name. The environment.type and policy.type selectors choose concrete
@@ -57,7 +57,7 @@ def load_arena_experiment_from_yaml(
         overrides: Hydra overrides rooted at runs, applied after the YAML values.
 
     Returns:
-        Typed Runs in YAML mapping declaration order.
+        The typed Experiment Definition, preserving YAML mapping declaration order.
     """
     run_values_by_name = _read_and_validate_yaml_runs_as_values(yaml_path)
     config_store = ConfigStore.instance()
@@ -79,18 +79,44 @@ def load_arena_experiment_from_yaml(
                 for index, (run_name, run_values) in enumerate(run_values_by_name.items())
             }
             hydra_experiment_config_name = f"{hydra_config_namespace}_root"
-            config_store.store(name=hydra_experiment_config_name, node={"runs": arena_runs_by_name})
+            config_store.store(
+                name=hydra_experiment_config_name,
+                node=ArenaExperimentDefinitionCfg(runs=arena_runs_by_name),
+            )
             composed_experiment = compose(config_name=hydra_experiment_config_name, overrides=overrides or [])
-            experiment = [OmegaConf.to_object(composed_experiment.runs[run_name]) for run_name in run_values_by_name]
+            experiment_definition = OmegaConf.to_object(composed_experiment)
     except (HydraException, OmegaConfBaseException, TypeError, ValueError) as exc:
         raise ValueError(f"Could not compose Arena Experiment '{yaml_path}': {exc}") from exc
 
-    assert all(isinstance(run, ArenaRunCfg) for run in experiment)
-    for run_name, run in zip(run_values_by_name, experiment):
-        assert (
-            run.name == run_name
-        ), f"Run name is defined by its mapping key and cannot be overridden: expected '{run_name}', got '{run.name}'"
-    return experiment
+    assert isinstance(experiment_definition, ArenaExperimentDefinitionCfg)
+    return experiment_definition
+
+
+def load_arena_experiment_from_yaml(
+    yaml_path: str | Path,
+    *,
+    environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
+    policy_cfg_types: dict[str, type[PolicyCfg]],
+    overrides: list[str] | None = None,
+) -> ArenaExperiment:
+    """Load a YAML Arena Experiment as an ordered list of typed Runs.
+
+    Args:
+        yaml_path: Path to the Arena Experiment YAML file.
+        environment_cfg_types: Environment selector names mapped to typed configuration classes.
+        policy_cfg_types: Policy selector names mapped to typed configuration classes.
+        overrides: Hydra overrides rooted at runs, applied after the YAML values.
+
+    Returns:
+        Typed Runs in Experiment Definition mapping order.
+    """
+    experiment_definition = load_arena_experiment_definition_from_yaml(
+        yaml_path,
+        environment_cfg_types=environment_cfg_types,
+        policy_cfg_types=policy_cfg_types,
+        overrides=overrides,
+    )
+    return list(experiment_definition.runs.values())
 
 
 def _assert_run_name_is_hydra_compatible(run_name: str) -> None:

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -48,14 +48,14 @@ def load_arena_experiment_from_yaml(
 
     Each entry in the runs mapping declares one Run using its key as the Run
     name. The environment.type selector chooses from the supplied mapping,
-    policy.type is resolved when its Run is built, and Hydra overrides are
-    applied after YAML values.
+    policy.type is resolved when its Run is built. Hydra overrides can update
+    fields on Runs declared in YAML, but cannot add Runs.
 
     Args:
         yaml_path: Path to the Arena Experiment YAML file.
         environment_cfg_types: Environment selector names mapped to typed configuration classes.
         policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
-        overrides: Hydra overrides rooted at runs, applied after the YAML values.
+        overrides: Hydra field overrides for Runs already declared in YAML.
 
     Returns:
         The typed Experiment Definition, preserving YAML mapping declaration order.

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import Any
@@ -40,20 +41,20 @@ def load_arena_experiment_from_yaml(
     yaml_path: str | Path,
     *,
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
-    policy_cfg_types: dict[str, type[PolicyCfg]],
+    policy_cfg_type_resolver: Callable[[str], type[PolicyCfg]],
     overrides: list[str] | None = None,
 ) -> ArenaExperimentCfg:
     """Load a YAML Arena Experiment Definition as a typed named-Run mapping.
 
-    Each mapping entry below runs declares one Run using its key as the Run
-    name. The environment.type and policy.type selectors choose concrete
-    configuration classes from the supplied mappings, and Hydra overrides are
+    Each entry in the runs mapping declares one Run using its key as the Run
+    name. The environment.type selector chooses from the supplied mapping,
+    policy.type is resolved when its Run is built, and Hydra overrides are
     applied after YAML values.
 
     Args:
         yaml_path: Path to the Arena Experiment YAML file.
         environment_cfg_types: Environment selector names mapped to typed configuration classes.
-        policy_cfg_types: Policy selector names mapped to typed configuration classes.
+        policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
         overrides: Hydra overrides rooted at runs, applied after the YAML values.
 
     Returns:
@@ -74,7 +75,7 @@ def load_arena_experiment_from_yaml(
                     run_name,
                     run_values,
                     environment_cfg_types,
-                    policy_cfg_types,
+                    policy_cfg_type_resolver,
                 )
                 for index, (run_name, run_values) in enumerate(run_values_by_name.items())
             }
@@ -149,7 +150,7 @@ def _build_arena_run_cfg_from_yaml_values(
     run_name: str,
     run_values: dict[str, Any],
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
-    policy_cfg_types: dict[str, type[PolicyCfg]],
+    policy_cfg_type_resolver: Callable[[str], type[PolicyCfg]],
 ) -> ArenaRunCfg:
     """Build one typed Arena Run from its unresolved YAML values.
 
@@ -160,7 +161,7 @@ def _build_arena_run_cfg_from_yaml_values(
         run_name: Name declared by the Run's YAML mapping key.
         run_values: Unresolved values declared for the Run.
         environment_cfg_types: Environment selectors mapped to typed configuration classes.
-        policy_cfg_types: Policy selectors mapped to typed configuration classes.
+        policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
 
     Returns:
         The fully composed typed Run configuration.
@@ -181,6 +182,11 @@ def _build_arena_run_cfg_from_yaml_values(
         environment_cfg_types,
         ArenaEnvironmentCfg,
     )
+    policy_cfg_types: dict[str, type[PolicyCfg]] = {}
+    if isinstance(policy_values, dict):
+        policy_selector = policy_values.get("type")
+        if isinstance(policy_selector, str) and policy_selector:
+            policy_cfg_types[policy_selector] = policy_cfg_type_resolver(policy_selector)
     policy = _compose_typed_config_from_yaml_selector(
         config_store,
         hydra_policy_config_name,

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -45,10 +45,10 @@ def load_arena_experiment_from_yaml(
 ) -> ArenaExperiment:
     """Load a YAML Arena Experiment as an ordered list of typed Runs.
 
-    Each item below runs declares one Run, including its name. The
-    environment.type and policy.type selectors choose concrete configuration
-    classes from the supplied mappings, and Hydra overrides are applied after
-    YAML values.
+    Each mapping entry below runs declares one Run using its key as the Run
+    name. The environment.type and policy.type selectors choose concrete
+    configuration classes from the supplied mappings, and Hydra overrides are
+    applied after YAML values.
 
     Args:
         yaml_path: Path to the Arena Experiment YAML file.
@@ -57,7 +57,7 @@ def load_arena_experiment_from_yaml(
         overrides: Hydra overrides rooted at runs, applied after the YAML values.
 
     Returns:
-        Typed Runs in YAML declaration order.
+        Typed Runs in YAML mapping declaration order.
     """
     run_values_by_name = _read_and_validate_yaml_runs_as_values(yaml_path)
     config_store = ConfigStore.instance()
@@ -86,6 +86,10 @@ def load_arena_experiment_from_yaml(
         raise ValueError(f"Could not compose Arena Experiment '{yaml_path}': {exc}") from exc
 
     assert all(isinstance(run, ArenaRunCfg) for run in experiment)
+    for run_name, run in zip(run_values_by_name, experiment):
+        assert (
+            run.name == run_name
+        ), f"Run name is defined by its mapping key and cannot be overridden: expected '{run_name}', got '{run.name}'"
     return experiment
 
 
@@ -107,7 +111,7 @@ def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, d
         yaml_path: Path to the Arena Experiment YAML file.
 
     Returns:
-        Run names mapped to their unresolved YAML values, in sequence order.
+        Run names mapped to their unresolved YAML values, in mapping declaration order.
     """
     path = Path(yaml_path)
     assert path.suffix.lower() in {".yaml", ".yml"}, f"Experiment config must be YAML, got '{path}'"
@@ -122,18 +126,19 @@ def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, d
     unknown_fields = sorted(set(raw_experiment_config.keys()) - {"runs"})
     assert not unknown_fields, f"Unknown Experiment fields: {', '.join(unknown_fields)}"
     assert "runs" in raw_experiment_config, "Experiment config is missing the 'runs' field"
-    assert OmegaConf.is_list(raw_experiment_config.runs), "Experiment 'runs' must be a sequence"
+    assert OmegaConf.is_dict(
+        raw_experiment_config.runs
+    ), "Experiment 'runs' must be a mapping from Run names to Run configurations"
     assert raw_experiment_config.runs, "Experiment must define at least one Run"
 
     runs: dict[str, dict[str, Any]] = {}
-    for index, raw_run_config in enumerate(raw_experiment_config.runs):
-        assert OmegaConf.is_dict(raw_run_config), f"Run at index {index} must be a mapping"
+    for run_name, raw_run_config in raw_experiment_config.runs.items():
+        assert isinstance(run_name, str) and run_name, "Experiment Run names must be non-empty strings"
+        _assert_run_name_is_hydra_compatible(run_name)
+        assert OmegaConf.is_dict(raw_run_config), f"Run '{run_name}' must be a mapping"
         run_values = OmegaConf.to_container(raw_run_config, resolve=False)
         assert isinstance(run_values, dict)
-        run_name = run_values.pop("name", None)
-        assert isinstance(run_name, str) and run_name, f"Run at index {index} must define a non-empty string 'name'"
-        _assert_run_name_is_hydra_compatible(run_name)
-        assert run_name not in runs, f"Experiment Run name '{run_name}' is duplicated"
+        assert "name" not in run_values, f"Run '{run_name}' must not define 'name'; its mapping key is the Run name"
         runs[run_name] = run_values
     return runs
 
@@ -153,7 +158,7 @@ def _build_arena_run_cfg_from_yaml_values(
         config_store: Hydra store used for the temporary typed schemas.
         hydra_config_namespace: Unique prefix for this Experiment's temporary Hydra configs.
         index: Position of the Run in YAML declaration order.
-        run_name: Name declared by the Run's YAML sequence item.
+        run_name: Name declared by the Run's YAML mapping key.
         run_values: Unresolved values declared for the Run.
         environment_cfg_types: Environment selectors mapped to typed configuration classes.
         policy_cfg_types: Policy selectors mapped to typed configuration classes.

--- a/isaaclab_arena/tests/test_arena_experiment.py
+++ b/isaaclab_arena/tests/test_arena_experiment.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import pytest
 
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentDefinitionCfg
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.policy.policy_base import PolicyCfg
 
@@ -29,14 +29,14 @@ def _run(name: str) -> ArenaRunCfg:
     return ArenaRunCfg(name=name, environment=_EnvironmentCfg(), policy=_PolicyCfg())
 
 
-def test_experiment_definition_preserves_named_run_order():
+def test_experiment_cfg_preserves_named_run_order():
     second = _run("second")
     first = _run("first")
 
-    definition = ArenaExperimentDefinitionCfg(runs={"second": second, "first": first})
+    experiment_cfg = ArenaExperimentCfg(runs={"second": second, "first": first})
 
-    assert list(definition.runs) == ["second", "first"]
-    assert list(definition.runs.values()) == [second, first]
+    assert list(experiment_cfg.runs) == ["second", "first"]
+    assert list(experiment_cfg.runs.values()) == [second, first]
 
 
 @pytest.mark.parametrize(
@@ -48,6 +48,6 @@ def test_experiment_definition_preserves_named_run_order():
         ({"mapping_name": _run("run_name")}, "cannot be overridden"),
     ],
 )
-def test_experiment_definition_rejects_invalid_named_runs(runs, error):
+def test_experiment_cfg_rejects_invalid_named_runs(runs, error):
     with pytest.raises(AssertionError, match=error):
-        ArenaExperimentDefinitionCfg(runs=runs)
+        ArenaExperimentCfg(runs=runs)

--- a/isaaclab_arena/tests/test_arena_experiment.py
+++ b/isaaclab_arena/tests/test_arena_experiment.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test Arena Experiment declarations and execution ordering."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentDefinitionCfg
+from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
+from isaaclab_arena.policy.policy_base import PolicyCfg
+
+
+@dataclass
+class _EnvironmentCfg(ArenaEnvironmentCfg):
+    pass
+
+
+@dataclass
+class _PolicyCfg(PolicyCfg):
+    pass
+
+
+def _run(name: str) -> ArenaRunCfg:
+    return ArenaRunCfg(name=name, environment=_EnvironmentCfg(), policy=_PolicyCfg())
+
+
+def test_experiment_definition_preserves_named_run_order():
+    second = _run("second")
+    first = _run("first")
+
+    definition = ArenaExperimentDefinitionCfg(runs={"second": second, "first": first})
+
+    assert list(definition.runs) == ["second", "first"]
+    assert list(definition.runs.values()) == [second, first]
+
+
+@pytest.mark.parametrize(
+    ("runs", "error"),
+    [
+        ({}, "must contain at least one Run"),
+        ({"": _run("run")}, "names must be non-empty strings"),
+        ({"run": object()}, "must be an ArenaRunCfg"),
+        ({"mapping_name": _run("run_name")}, "cannot be overridden"),
+    ],
+)
+def test_experiment_definition_rejects_invalid_named_runs(runs, error):
+    with pytest.raises(AssertionError, match=error):
+        ArenaExperimentDefinitionCfg(runs=runs)

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -47,8 +47,8 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
     )
     monkeypatch.setattr(
         arena_experiment_config_loader,
-        "_registered_policy_cfg_types",
-        lambda: {"zero_action": ZeroActionPolicyCfg},
+        "_resolve_policy_cfg_type_from_name_or_class_path",
+        lambda policy_name_or_class_path: {"zero_action": ZeroActionPolicyCfg}[policy_name_or_class_path],
     )
 
     experiment_cfg = load_arena_experiment_from_config_file(
@@ -69,6 +69,14 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
     assert runs["baseline"].environment.light_intensity == 750.0
     assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
     assert all(run.environment_builder.device == "cuda:1" for run in runs.values())
+
+
+def test_policy_config_type_resolves_from_dotted_class_path():
+    policy_cfg_type = arena_experiment_config_loader._resolve_policy_cfg_type_from_name_or_class_path(
+        "isaaclab_arena.policy.zero_action_policy.ZeroActionPolicy"
+    )
+
+    assert policy_cfg_type is ZeroActionPolicyCfg
 
 
 def test_load_legacy_json_experiment_returns_canonical_cfg(tmp_path, monkeypatch):

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -6,16 +6,16 @@
 """Test loading Arena Experiments at the evaluation boundary."""
 
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 from isaaclab_arena.evaluation import arena_experiment_config_loader, experiment_runner
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
-    load_arena_experiment_definition_from_config_file,
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
+from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.evaluation.experiment_runner import _assert_camera_support_enabled
 from isaaclab_arena.evaluation.legacy_experiment_runner import legacy_json_experiment_requires_cameras
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
@@ -30,6 +30,15 @@ GETTING_STARTED_YAML_PATH = (
 )
 
 
+def _experiment_cfg(enable_cameras: bool = False) -> ArenaExperimentCfg:
+    run_cfg = ArenaRunCfg(
+        name="baseline",
+        environment=PickAndPlaceMapleTableEnvironmentCfg(enable_cameras=enable_cameras),
+        policy=ZeroActionPolicyCfg(),
+    )
+    return ArenaExperimentCfg(runs={run_cfg.name: run_cfg})
+
+
 def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
     monkeypatch.setattr(
         arena_experiment_config_loader,
@@ -42,31 +51,48 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
         lambda: {"zero_action": ZeroActionPolicyCfg},
     )
 
-    experiment_definition = load_arena_experiment_definition_from_config_file(
+    experiment_cfg = load_arena_experiment_from_config_file(
         GETTING_STARTED_YAML_PATH,
         device="cuda:1",
         overrides=["runs.baseline.environment.light_intensity=750.0"],
     )
-    experiment = list(experiment_definition.runs.values())
+    runs = experiment_cfg.runs
 
-    assert list(experiment_definition.runs) == [
+    assert isinstance(experiment_cfg, ArenaExperimentCfg)
+    assert list(runs) == [
         "baseline",
         "swap_objects",
         "change_background_hdr",
         "parallel_envs",
     ]
-    assert isinstance(experiment[0].environment, PickAndPlaceMapleTableEnvironmentCfg)
-    assert experiment[0].environment.light_intensity == 750.0
-    assert all(run.policy == ZeroActionPolicyCfg() for run in experiment)
-    assert all(run.environment_builder.device == "cuda:1" for run in experiment)
+    assert isinstance(runs["baseline"].environment, PickAndPlaceMapleTableEnvironmentCfg)
+    assert runs["baseline"].environment.light_intensity == 750.0
+    assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
+    assert all(run.environment_builder.device == "cuda:1" for run in runs.values())
 
-    runtime_experiment = load_arena_experiment_from_config_file(
-        GETTING_STARTED_YAML_PATH,
-        device="cuda:1",
-        overrides=["runs.baseline.environment.light_intensity=750.0"],
+
+def test_load_legacy_json_experiment_returns_canonical_cfg(tmp_path, monkeypatch):
+    config_path = tmp_path / "experiment.json"
+    config_path.write_text('{"jobs": []}', encoding="utf-8")
+    run_cfg = _experiment_cfg().runs["baseline"]
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "run_cfgs_from_legacy_eval_config",
+        lambda _config, device: [run_cfg],
     )
-    assert isinstance(runtime_experiment, list)
-    assert runtime_experiment == experiment
+
+    experiment_cfg = load_arena_experiment_from_config_file(config_path, device="cuda:1")
+
+    assert isinstance(experiment_cfg, ArenaExperimentCfg)
+    assert experiment_cfg.runs == {"baseline": run_cfg}
+
+
+def test_empty_legacy_json_experiment_is_rejected(tmp_path):
+    config_path = tmp_path / "experiment.json"
+    config_path.write_text('{"jobs": []}', encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="must contain at least one Run"):
+        load_arena_experiment_from_config_file(config_path, device="cuda:0")
 
 
 def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):
@@ -86,7 +112,7 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
 
     def load_experiment_after_startup(*_args, **_kwargs):
         assert simulation_is_running
-        return []
+        return _experiment_cfg()
 
     monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
     monkeypatch.setattr(experiment_runner, "load_arena_experiment_from_config_file", load_experiment_after_startup)
@@ -105,15 +131,12 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
 
 
 def test_typed_camera_run_requires_prelaunch_camera_flag():
-    camera_run = SimpleNamespace(
-        name="camera_run",
-        environment=SimpleNamespace(enable_cameras=True),
-    )
+    experiment_cfg = _experiment_cfg(enable_cameras=True)
 
     with pytest.raises(AssertionError, match="Pass --enable_cameras"):
-        _assert_camera_support_enabled([camera_run], enable_cameras=False)
+        _assert_camera_support_enabled(experiment_cfg, enable_cameras=False)
 
-    _assert_camera_support_enabled([camera_run], enable_cameras=True)
+    _assert_camera_support_enabled(experiment_cfg, enable_cameras=True)
 
 
 def test_legacy_json_camera_detection_is_preserved():

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -12,6 +12,7 @@ import pytest
 
 from isaaclab_arena.evaluation import arena_experiment_config_loader, experiment_runner
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    load_arena_experiment_definition_from_config_file,
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
@@ -41,13 +42,14 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
         lambda: {"zero_action": ZeroActionPolicyCfg},
     )
 
-    experiment = load_arena_experiment_from_config_file(
+    experiment_definition = load_arena_experiment_definition_from_config_file(
         GETTING_STARTED_YAML_PATH,
         device="cuda:1",
         overrides=["runs.baseline.environment.light_intensity=750.0"],
     )
+    experiment = list(experiment_definition.runs.values())
 
-    assert [run.name for run in experiment] == [
+    assert list(experiment_definition.runs) == [
         "baseline",
         "swap_objects",
         "change_background_hdr",
@@ -57,6 +59,14 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
     assert experiment[0].environment.light_intensity == 750.0
     assert all(run.policy == ZeroActionPolicyCfg() for run in experiment)
     assert all(run.environment_builder.device == "cuda:1" for run in experiment)
+
+    runtime_experiment = load_arena_experiment_from_config_file(
+        GETTING_STARTED_YAML_PATH,
+        device="cuda:1",
+        overrides=["runs.baseline.environment.light_intensity=750.0"],
+    )
+    assert isinstance(runtime_experiment, list)
+    assert runtime_experiment == experiment
 
 
 def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -25,11 +25,15 @@ GETTING_STARTED_EXPERIMENT_PATH = (
 )
 
 
+def _policy_cfg_type_for_name_or_class_path(policy_name_or_class_path: str) -> type[ZeroActionPolicyCfg]:
+    return {"zero_action": ZeroActionPolicyCfg}[policy_name_or_class_path]
+
+
 def _load_experiment(config_path: str | Path, overrides: list[str] | None = None):
     return load_arena_experiment_from_yaml(
         config_path,
         environment_cfg_types={"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
-        policy_cfg_types={"zero_action": ZeroActionPolicyCfg},
+        policy_cfg_type_resolver=_policy_cfg_type_for_name_or_class_path,
         overrides=overrides,
     )
 

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -6,6 +6,7 @@
 """Test Hydra composition of typed YAML Experiments."""
 
 from pathlib import Path
+from yaml.constructor import ConstructorError
 
 import pytest
 from hydra import initialize
@@ -80,7 +81,7 @@ def test_repeated_composition_reuses_config_store_entries(tmp_path):
         tmp_path,
         """
 runs:
-  - name: first
+  first:
     environment:
       type: pick_and_place_maple_table
       light_intensity: 600.0
@@ -97,7 +98,7 @@ runs:
             tmp_path,
             """
 runs:
-  - name: second
+  second:
     environment:
       type: pick_and_place_maple_table
       light_intensity: 700.0
@@ -142,13 +143,13 @@ def test_runs_keep_yaml_order_and_hydra_overrides_take_precedence(tmp_path):
         tmp_path,
         """
 runs:
-  - name: first
+  first:
     environment:
       type: pick_and_place_maple_table
       light_intensity: 600.0
     policy:
       type: zero_action
-  - name: second
+  second:
     environment:
       type: pick_and_place_maple_table
     policy:
@@ -205,25 +206,40 @@ runs:
     ],
 )
 def test_invalid_run_configuration_is_rejected(tmp_path, run_contents, exception_type, error):
-    config_path = _write_experiment(tmp_path, f"runs:\n  - name: invalid{run_contents}")
+    config_path = _write_experiment(tmp_path, f"runs:\n  invalid:{run_contents}")
 
     with pytest.raises(exception_type, match=error):
         _load_experiment(config_path)
 
 
-def test_run_name_is_required(tmp_path):
+def test_runs_must_be_a_mapping(tmp_path):
     config_path = _write_experiment(
         tmp_path,
         """
 runs:
-  - environment:
+  - name: baseline
+    environment:
       type: pick_and_place_maple_table
     policy:
       type: zero_action
 """,
     )
 
-    with pytest.raises(AssertionError, match="must define a non-empty string 'name'"):
+    with pytest.raises(AssertionError, match="must be a mapping from Run names"):
+        _load_experiment(config_path)
+
+
+def test_experiment_requires_at_least_one_run(tmp_path):
+    config_path = _write_experiment(tmp_path, "runs: {}\n")
+
+    with pytest.raises(AssertionError, match="must define at least one Run"):
+        _load_experiment(config_path)
+
+
+def test_run_name_must_be_non_empty(tmp_path):
+    config_path = _write_experiment(tmp_path, 'runs:\n  "": {}\n')
+
+    with pytest.raises(AssertionError, match="Run names must be non-empty strings"):
         _load_experiment(config_path)
 
 
@@ -232,7 +248,7 @@ def test_run_name_must_be_hydra_compatible(tmp_path):
         tmp_path,
         """
 runs:
-  - name: 01_baseline
+  "01_baseline":
     environment:
       type: pick_and_place_maple_table
     policy:
@@ -244,17 +260,40 @@ runs:
         _load_experiment(config_path)
 
 
-def test_duplicate_run_name_is_rejected(tmp_path):
+def test_duplicate_run_mapping_key_is_rejected(tmp_path):
     config_path = _write_experiment(
         tmp_path,
         """
 runs:
-  - name: maple_table
-    environment:
-      type: pick_and_place_maple_table
-    policy:
-      type: zero_action
-  - name: maple_table
+  maple_table: {}
+  maple_table: {}
+""",
+    )
+
+    with pytest.raises(ConstructorError, match="duplicate key maple_table"):
+        _load_experiment(config_path)
+
+
+def test_run_configuration_must_be_a_mapping(tmp_path):
+    config_path = _write_experiment(
+        tmp_path,
+        """
+runs:
+  maple_table: true
+""",
+    )
+
+    with pytest.raises(AssertionError, match="Run 'maple_table' must be a mapping"):
+        _load_experiment(config_path)
+
+
+def test_run_must_not_repeat_its_mapping_key_as_name(tmp_path):
+    config_path = _write_experiment(
+        tmp_path,
+        """
+runs:
+  maple_table:
+    name: other_name
     environment:
       type: pick_and_place_maple_table
     policy:
@@ -262,8 +301,25 @@ runs:
 """,
     )
 
-    with pytest.raises(AssertionError, match="Run name 'maple_table' is duplicated"):
+    with pytest.raises(AssertionError, match="must not define 'name'"):
         _load_experiment(config_path)
+
+
+def test_run_mapping_key_cannot_be_overridden(tmp_path):
+    config_path = _write_experiment(
+        tmp_path,
+        """
+runs:
+  maple_table:
+    environment:
+      type: pick_and_place_maple_table
+    policy:
+      type: zero_action
+""",
+    )
+
+    with pytest.raises(AssertionError, match="cannot be overridden"):
+        _load_experiment(config_path, overrides=["runs.maple_table.name=other_name"])
 
 
 def test_unknown_hydra_override_is_rejected(tmp_path):
@@ -271,7 +327,7 @@ def test_unknown_hydra_override_is_rejected(tmp_path):
         tmp_path,
         """
 runs:
-  - name: maple_table
+  maple_table:
     environment:
       type: pick_and_place_maple_table
     policy:

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -342,3 +342,11 @@ runs:
 
     with pytest.raises(ValueError, match="unknown_field"):
         _load_experiment(config_path, overrides=["runs.maple_table.environment.unknown_field=true"])
+
+
+def test_hydra_override_cannot_add_run():
+    with pytest.raises(ValueError, match="Error merging override"):
+        _load_experiment(
+            GETTING_STARTED_EXPERIMENT_PATH,
+            overrides=["+runs.new_run={environment:{type:pick_and_place_maple_table},policy:{type:zero_action}}"],
+        )

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -13,11 +13,8 @@ from hydra import initialize
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
 
-from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentDefinitionCfg
-from isaaclab_arena.hydra.experiment_composition import (
-    load_arena_experiment_definition_from_yaml,
-    load_arena_experiment_from_yaml,
-)
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
+from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
@@ -37,15 +34,6 @@ def _load_experiment(config_path: str | Path, overrides: list[str] | None = None
     )
 
 
-def _load_experiment_definition(config_path: str | Path, overrides: list[str] | None = None):
-    return load_arena_experiment_definition_from_yaml(
-        config_path,
-        environment_cfg_types={"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
-        policy_cfg_types={"zero_action": ZeroActionPolicyCfg},
-        overrides=overrides,
-    )
-
-
 def _write_experiment(tmp_path: Path, contents: str) -> Path:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text(contents, encoding="utf-8")
@@ -53,10 +41,10 @@ def _write_experiment(tmp_path: Path, contents: str) -> Path:
 
 
 def test_getting_started_experiment_composes_typed_runs():
-    experiment_definition = _load_experiment_definition(GETTING_STARTED_EXPERIMENT_PATH)
-    runs = experiment_definition.runs
+    experiment_cfg = _load_experiment(GETTING_STARTED_EXPERIMENT_PATH)
+    runs = experiment_cfg.runs
 
-    assert isinstance(experiment_definition, ArenaExperimentDefinitionCfg)
+    assert isinstance(experiment_cfg, ArenaExperimentCfg)
     assert list(runs) == [
         "baseline",
         "swap_objects",
@@ -125,10 +113,8 @@ runs:
 
         assert set(ConfigStore.instance().repo) == config_store_names_after_first_load
 
-    assert first_experiment[0].name == "first"
-    assert first_experiment[0].environment.light_intensity == 600.0
-    assert second_experiment[0].name == "second"
-    assert second_experiment[0].environment.light_intensity == 700.0
+    assert first_experiment.runs["first"].environment.light_intensity == 600.0
+    assert second_experiment.runs["second"].environment.light_intensity == 700.0
 
 
 def _test_getting_started_experiment_executes_baseline_run(simulation_app, output_dir: Path):
@@ -136,7 +122,7 @@ def _test_getting_started_experiment_executes_baseline_run(simulation_app, outpu
     from isaaclab_arena.evaluation.arena_run import RunStatus
     from isaaclab_arena.evaluation.run_execution import build_and_run
 
-    baseline_run = _load_experiment(GETTING_STARTED_EXPERIMENT_PATH)[0]
+    baseline_run = _load_experiment(GETTING_STARTED_EXPERIMENT_PATH).runs["baseline"]
 
     result = build_and_run(baseline_run, output_dir=output_dir)
 
@@ -172,7 +158,7 @@ runs:
 """,
     )
 
-    experiment_definition = _load_experiment_definition(
+    experiment_cfg = _load_experiment(
         config_path,
         overrides=[
             "runs.first.environment.light_intensity=750.0",
@@ -180,9 +166,9 @@ runs:
         ],
     )
 
-    assert list(experiment_definition.runs) == ["first", "second"]
-    assert experiment_definition.runs["first"].environment.light_intensity == 750.0
-    assert experiment_definition.runs["second"].environment.enable_cameras is True
+    assert list(experiment_cfg.runs) == ["first", "second"]
+    assert experiment_cfg.runs["first"].environment.light_intensity == 750.0
+    assert experiment_cfg.runs["second"].environment.enable_cameras is True
 
 
 @pytest.mark.parametrize(

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -13,7 +13,11 @@ from hydra import initialize
 from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
 
-from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentDefinitionCfg
+from isaaclab_arena.hydra.experiment_composition import (
+    load_arena_experiment_definition_from_yaml,
+    load_arena_experiment_from_yaml,
+)
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
@@ -33,6 +37,15 @@ def _load_experiment(config_path: str | Path, overrides: list[str] | None = None
     )
 
 
+def _load_experiment_definition(config_path: str | Path, overrides: list[str] | None = None):
+    return load_arena_experiment_definition_from_yaml(
+        config_path,
+        environment_cfg_types={"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
+        policy_cfg_types={"zero_action": ZeroActionPolicyCfg},
+        overrides=overrides,
+    )
+
+
 def _write_experiment(tmp_path: Path, contents: str) -> Path:
     config_path = tmp_path / "experiment.yaml"
     config_path.write_text(contents, encoding="utf-8")
@@ -40,29 +53,31 @@ def _write_experiment(tmp_path: Path, contents: str) -> Path:
 
 
 def test_getting_started_experiment_composes_typed_runs():
-    runs = _load_experiment(GETTING_STARTED_EXPERIMENT_PATH)
+    experiment_definition = _load_experiment_definition(GETTING_STARTED_EXPERIMENT_PATH)
+    runs = experiment_definition.runs
 
-    assert [run.name for run in runs] == [
+    assert isinstance(experiment_definition, ArenaExperimentDefinitionCfg)
+    assert list(runs) == [
         "baseline",
         "swap_objects",
         "change_background_hdr",
         "parallel_envs",
     ]
-    assert runs[0].environment == PickAndPlaceMapleTableEnvironmentCfg(
+    assert runs["baseline"].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
         hdr="home_office_robolab",
     )
-    assert runs[1].environment == PickAndPlaceMapleTableEnvironmentCfg(
+    assert runs["swap_objects"].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
         pick_up_object="mustard_bottle_hot3d_robolab",
         destination_location="wooden_bowl_hot3d_robolab",
         hdr="home_office_robolab",
     )
-    assert runs[2].environment.hdr == "billiard_hall_robolab"
-    assert all(run.policy == ZeroActionPolicyCfg() for run in runs)
-    assert [run.environment_builder.num_envs for run in runs] == [1, 1, 1, 64]
-    assert runs[3].environment_builder.env_spacing == 2.5
-    assert [run.rollout_limit.num_steps for run in runs] == [50, 50, 50, 100]
+    assert runs["change_background_hdr"].environment.hdr == "billiard_hall_robolab"
+    assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
+    assert [run.environment_builder.num_envs for run in runs.values()] == [1, 1, 1, 64]
+    assert runs["parallel_envs"].environment_builder.env_spacing == 2.5
+    assert [run.rollout_limit.num_steps for run in runs.values()] == [50, 50, 50, 100]
 
 
 def test_experiment_composition_preserves_caller_owned_hydra_context():
@@ -157,7 +172,7 @@ runs:
 """,
     )
 
-    runs = _load_experiment(
+    experiment_definition = _load_experiment_definition(
         config_path,
         overrides=[
             "runs.first.environment.light_intensity=750.0",
@@ -165,9 +180,9 @@ runs:
         ],
     )
 
-    assert [run.name for run in runs] == ["first", "second"]
-    assert runs[0].environment.light_intensity == 750.0
-    assert runs[1].environment.enable_cameras is True
+    assert list(experiment_definition.runs) == ["first", "second"]
+    assert experiment_definition.runs["first"].environment.light_intensity == 750.0
+    assert experiment_definition.runs["second"].environment.enable_cameras is True
 
 
 @pytest.mark.parametrize(

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -98,13 +98,13 @@ def test_experiment_runner_from_typed_yaml(tmp_path):
     experiment_config_path.write_text(
         """
 runs:
-- name: yaml_baseline
-  environment:
-    type: pick_and_place_maple_table
-  policy:
-    type: zero_action
-  rollout_limit:
-    num_steps: 10
+  yaml_baseline:
+    environment:
+      type: pick_and_place_maple_table
+    policy:
+      type: zero_action
+    rollout_limit:
+      num_steps: 10
 """,
         encoding="utf-8",
     )

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -10,6 +10,7 @@ import pytest
 
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation import run_execution
+from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg, ArenaRunResult, RolloutLimitCfg, RunStatus
 from isaaclab_arena.policy.policy_base import PolicyCfg
 
@@ -51,6 +52,10 @@ def _run(**overrides):
     }
     values.update(overrides)
     return ArenaRunCfg(**values)
+
+
+def _experiment(*run_cfgs: ArenaRunCfg) -> ArenaExperimentCfg:
+    return ArenaExperimentCfg(runs={run_cfg.name: run_cfg for run_cfg in run_cfgs})
 
 
 def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch, tmp_path):
@@ -151,7 +156,10 @@ def test_execute_experiment_runs_in_declaration_order(monkeypatch, tmp_path):
 
     monkeypatch.setattr(run_execution, "build_and_run", build_and_run)
 
-    results = run_execution.execute_experiment([_run(name="first"), _run(name="second")], output_dir=tmp_path)
+    results = run_execution.execute_experiment(
+        _experiment(_run(name="first"), _run(name="second")),
+        output_dir=tmp_path,
+    )
 
     assert [result.run_name for result in results] == ["first", "second"]
     assert received == [
@@ -172,7 +180,7 @@ def test_execute_experiment_records_failure_and_continues(monkeypatch, tmp_path)
     monkeypatch.setattr(run_execution, "build_and_run", build_and_run)
 
     results = run_execution.execute_experiment(
-        [_run(name="failing"), _run(name="passing")],
+        _experiment(_run(name="failing"), _run(name="passing")),
         output_dir=tmp_path,
         continue_on_error=True,
     )
@@ -195,7 +203,7 @@ def test_execute_experiment_stops_on_failure_by_default(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="rollout failed"):
         run_execution.execute_experiment(
-            [_run(name="failing"), _run(name="not_attempted")],
+            _experiment(_run(name="failing"), _run(name="not_attempted")),
             output_dir=tmp_path,
         )
 

--- a/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
@@ -5,52 +5,52 @@
 
 # Typed YAML equivalent of eval_jobs_configs/getting_started_jobs_config.json.
 runs:
-- name: baseline
-  environment:
-    type: pick_and_place_maple_table
-    embodiment: droid_rel_joint_pos
-    pick_up_object: rubiks_cube_hot3d_robolab
-    destination_location: bowl_ycb_robolab
-    hdr: home_office_robolab
-  policy:
-    type: zero_action
-  rollout_limit:
-    num_steps: 50
+  baseline:
+    environment:
+      type: pick_and_place_maple_table
+      embodiment: droid_rel_joint_pos
+      pick_up_object: rubiks_cube_hot3d_robolab
+      destination_location: bowl_ycb_robolab
+      hdr: home_office_robolab
+    policy:
+      type: zero_action
+    rollout_limit:
+      num_steps: 50
 
-- name: swap_objects
-  environment:
-    type: pick_and_place_maple_table
-    embodiment: droid_rel_joint_pos
-    pick_up_object: mustard_bottle_hot3d_robolab
-    destination_location: wooden_bowl_hot3d_robolab
-    hdr: home_office_robolab
-  policy:
-    type: zero_action
-  rollout_limit:
-    num_steps: 50
+  swap_objects:
+    environment:
+      type: pick_and_place_maple_table
+      embodiment: droid_rel_joint_pos
+      pick_up_object: mustard_bottle_hot3d_robolab
+      destination_location: wooden_bowl_hot3d_robolab
+      hdr: home_office_robolab
+    policy:
+      type: zero_action
+    rollout_limit:
+      num_steps: 50
 
-- name: change_background_hdr
-  environment:
-    type: pick_and_place_maple_table
-    embodiment: droid_rel_joint_pos
-    pick_up_object: rubiks_cube_hot3d_robolab
-    destination_location: bowl_ycb_robolab
-    hdr: billiard_hall_robolab
-  policy:
-    type: zero_action
-  rollout_limit:
-    num_steps: 50
+  change_background_hdr:
+    environment:
+      type: pick_and_place_maple_table
+      embodiment: droid_rel_joint_pos
+      pick_up_object: rubiks_cube_hot3d_robolab
+      destination_location: bowl_ycb_robolab
+      hdr: billiard_hall_robolab
+    policy:
+      type: zero_action
+    rollout_limit:
+      num_steps: 50
 
-- name: parallel_envs
-  environment:
-    type: pick_and_place_maple_table
-    embodiment: droid_rel_joint_pos
-    pick_up_object: rubiks_cube_hot3d_robolab
-    destination_location: bowl_ycb_robolab
-  policy:
-    type: zero_action
-  environment_builder:
-    num_envs: 64
-    env_spacing: 2.5
-  rollout_limit:
-    num_steps: 100
+  parallel_envs:
+    environment:
+      type: pick_and_place_maple_table
+      embodiment: droid_rel_joint_pos
+      pick_up_object: rubiks_cube_hot3d_robolab
+      destination_location: bowl_ycb_robolab
+    policy:
+      type: zero_action
+    environment_builder:
+      num_envs: 64
+      env_spacing: 2.5
+    rollout_limit:
+      num_steps: 100


### PR DESCRIPTION
## Summary
Represent Arena Experiments as typed, named Run mappings that Hydra can consume directly.

## Detailed description
Before this change, an Experiment declared its Runs as a YAML sequence, with each Run carrying a separate `name` field:

```yaml
runs:
  - name: first_run
    environment:
      type: pick_and_place_maple_table
    policy:
      type: zero_action

  - name: second_run
    environment:
      type: pick_and_place_maple_table
    policy:
      type: zero_action
    environment_builder:
      num_envs: 64
```

That representation is readable, but its user-facing name is only a value inside a sequence item. 

This PR makes the name the mapping key:

```yaml
runs:
  first_run:
    environment:
      type: pick_and_place_maple_table
    policy:
      type: zero_action

  second_run:
    environment:
      type: pick_and_place_maple_table
    policy:
      type: zero_action
    environment_builder:
      num_envs: 64
```

The key now appears before the Run value, remains the single source of Run identity, and creates a real Hydra path. A user can override the parallel Run without knowing its position:

```text
runs.second_run.environment_builder.num_envs=8
```
instead of
```text
runs.1.environment_builder.num_envs=8
```

The named mapping is represented explicitly through a new Cfg:

```python
@dataclass
class ArenaExperimentCfg:
    """Configure the named Runs that form one Arena Experiment."""

    runs: dict[str, ArenaRunCfg]
```

`ArenaExperimentCfg` is the single Experiment representation. The former `ArenaExperiment = list[ArenaRunCfg]` Definition is removed

Typed YAML composition now resolves `policy.type` as each Run is built. Core policies may continue using a registered name such as `zero_action`; an extension policy may provide a dotted class path such as `package.policy.Policy`. Importing that class registers its typed policy config without making the core loader import extension packages up front.