### PR TITLE
Add optional camera tiling via ArenaCameraCfg

### DIFF
--- a/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
@@ -110,7 +110,10 @@ Environment Description
             camera_offset = Pose(position_xyz=(0.12515, 0.0, 0.06776), rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469))
             # Get assets
             embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(
-                enable_cameras=args_cli.enable_cameras, camera_offset=camera_offset
+                enable_cameras=args_cli.enable_cameras
+            )
+            embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(
+                pos=camera_offset.position_xyz, rot=camera_offset.rotation_xyzw, convention="opengl"
             )
             kitchen_background = self.asset_registry.get_asset_by_name("lightwheel_robocasa_kitchen")(
                 style_id=args_cli.kitchen_style
@@ -224,7 +227,8 @@ Step-by-Step Breakdown
 .. code-block:: python
 
     camera_offset = Pose(position_xyz=(0.12515, 0.0, 0.06776), rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469))
-    embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras, camera_offset=camera_offset)
+    embodiment = self.asset_registry.get_asset_by_name(args_cli.embodiment)(enable_cameras=args_cli.enable_cameras)
+    embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(pos=camera_offset.position_xyz, rot=camera_offset.rotation_xyzw, convention="opengl")
     kitchen_background = self.asset_registry.get_asset_by_name("lightwheel_robocasa_kitchen")(style_id=args_cli.kitchen_style)
     kitchen_counter_top = ObjectReference(
         name="kitchen_counter_top",

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -380,26 +380,20 @@ class DroidEventCfg:
             ],
         },
     )
-    randomize_franka_joint_state = None
-    # EventTerm(
-    #     func=franka_stack_events.randomize_joint_by_gaussian_offset,
-    #     mode="reset",
-    #     params={
-    #         "mean": 0.0,
-    #         "std": 0.02,
-    #         "asset_cfg": SceneEntityCfg("robot"),
-    #     },
-    # )
+    randomize_franka_joint_state = EventTerm(
+        func=franka_stack_events.randomize_joint_by_gaussian_offset,
+        mode="reset",
+        params={
+            "mean": 0.0,
+            "std": 0.02,
+            "asset_cfg": SceneEntityCfg("robot"),
+        },
+    )
 
 
 @configclass
 class DroidCameraCfg(ArenaCameraCfg):
-    """DROID three-camera rig using standard (untiled) cameras, mounted with pre-set poses.
-
-    This is the source of truth for the DROID camera poses and intrinsics. Inherits
-    :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`, whose ``get_cfg`` returns the untiled
-    rig or a tiled copy per ``use_tiled_camera``.
-    """
+    """Configuration for cameras. DROID cameras are mounted with pre-set poses."""
 
     external_camera: CameraCfg = CameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/external_camera",

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -6,7 +6,6 @@
 
 import torch
 from abc import ABC
-from dataclasses import MISSING
 from typing import Any
 
 import isaaclab.envs.mdp as mdp_isaac_lab
@@ -28,7 +27,6 @@ from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.markers.config import FRAME_MARKER_CFG
 from isaaclab.sensors.camera.camera_cfg import CameraCfg
-from isaaclab.sensors.camera.tiled_camera_cfg import TiledCameraCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg, OffsetCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.utils import configclass
@@ -40,6 +38,7 @@ from isaaclab_arena.embodiments.droid.actions import BinaryJointPositionZeroToOn
 from isaaclab_arena.embodiments.droid.observations import arm_joint_pos, ee_pos, ee_quat, gripper_pos
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import franka_stack_events
+from isaaclab_arena.utils.cameras import ArenaCameraCfg
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariation
 
@@ -381,69 +380,65 @@ class DroidEventCfg:
             ],
         },
     )
-    randomize_franka_joint_state = EventTerm(
-        func=franka_stack_events.randomize_joint_by_gaussian_offset,
-        mode="reset",
-        params={
-            "mean": 0.0,
-            "std": 0.02,
-            "asset_cfg": SceneEntityCfg("robot"),
-        },
-    )
+    randomize_franka_joint_state = None
+    # EventTerm(
+    #     func=franka_stack_events.randomize_joint_by_gaussian_offset,
+    #     mode="reset",
+    #     params={
+    #         "mean": 0.0,
+    #         "std": 0.02,
+    #         "asset_cfg": SceneEntityCfg("robot"),
+    #     },
+    # )
 
 
 @configclass
-class DroidCameraCfg:
-    """Configuration for cameras. DROID cameras are mounted with pre-set poses."""
+class DroidCameraCfg(ArenaCameraCfg):
+    """DROID three-camera rig using standard (untiled) cameras, mounted with pre-set poses.
 
-    external_camera: CameraCfg | TiledCameraCfg = MISSING
-    external_camera_2: CameraCfg | TiledCameraCfg = MISSING
-    wrist_camera: CameraCfg | TiledCameraCfg = MISSING
+    This is the source of truth for the DROID camera poses and intrinsics. Inherits
+    :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`, whose ``get_cfg`` returns the untiled
+    rig or a tiled copy per ``use_tiled_camera``.
+    """
 
-    def __post_init__(self):
-        # Get configuration from private attributes set by embodiment constructor
-        # These use getattr with defaults to avoid scene parser treating them as assets
-        is_tiled_camera = getattr(self, "_is_tiled_camera", True)
-
-        CameraClass = TiledCameraCfg if is_tiled_camera else CameraCfg
-        OffsetClass = CameraClass.OffsetCfg
-
-        self.external_camera = CameraClass(
-            prim_path="{ENV_REGEX_NS}/Robot/external_camera",
-            height=720,
-            width=1280,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=2.1,
-                focus_distance=28.0,
-                horizontal_aperture=5.376,
-                vertical_aperture=3.024,
-            ),
-            offset=OffsetClass(pos=(0.05, 0.57, 0.66), rot=(-0.195, 0.399, 0.805, -0.393), convention="opengl"),
-        )
-        self.external_camera_2 = CameraClass(
-            prim_path="{ENV_REGEX_NS}/Robot/external_camera_2",
-            height=720,
-            width=1280,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=2.1,
-                focus_distance=28.0,
-                horizontal_aperture=5.376,
-                vertical_aperture=3.024,
-            ),
-            offset=OffsetClass(pos=(0.05, -0.57, 0.66), rot=(0.399, -0.195, -0.393, 0.805), convention="opengl"),
-        )
-        self.wrist_camera = CameraClass(
-            prim_path="{ENV_REGEX_NS}/Robot/Gripper/Robotiq_2F_85/base_link/wrist_camera",
-            height=720,
-            width=1280,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=2.8,
-                focus_distance=28.0,
-                horizontal_aperture=5.376,
-                vertical_aperture=3.024,
-            ),
-            offset=OffsetClass(pos=(0.011, -0.031, -0.074), rot=(0.570, 0.576, -0.409, -0.420), convention="opengl"),
-        )
+    external_camera: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/external_camera",
+        height=720,
+        width=1280,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=2.1,
+            focus_distance=28.0,
+            horizontal_aperture=5.376,
+            vertical_aperture=3.024,
+        ),
+        offset=CameraCfg.OffsetCfg(pos=(0.05, 0.57, 0.66), rot=(-0.195, 0.399, 0.805, -0.393), convention="opengl"),
+    )
+    external_camera_2: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/external_camera_2",
+        height=720,
+        width=1280,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=2.1,
+            focus_distance=28.0,
+            horizontal_aperture=5.376,
+            vertical_aperture=3.024,
+        ),
+        offset=CameraCfg.OffsetCfg(pos=(0.05, -0.57, 0.66), rot=(0.399, -0.195, -0.393, 0.805), convention="opengl"),
+    )
+    wrist_camera: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/Gripper/Robotiq_2F_85/base_link/wrist_camera",
+        height=720,
+        width=1280,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=2.8,
+            focus_distance=28.0,
+            horizontal_aperture=5.376,
+            vertical_aperture=3.024,
+        ),
+        offset=CameraCfg.OffsetCfg(
+            pos=(0.011, -0.031, -0.074), rot=(0.570, 0.576, -0.409, -0.420), convention="opengl"
+        ),
+    )

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -11,7 +11,7 @@ from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
-from isaaclab_arena.utils.cameras import make_camera_observation_cfg
+from isaaclab_arena.utils.cameras import ArenaCameraCfg, make_camera_observation_cfg
 from isaaclab_arena.utils.configclass import combine_configclass_instances
 from isaaclab_arena.utils.pose import Pose
 
@@ -67,7 +67,7 @@ class EmbodimentBase(Asset):
                 return combine_configclass_instances(
                     "SceneCfg",
                     self.scene_config,
-                    self.camera_config,
+                    self.get_camera_cfg(),
                 )
         return self.scene_config
 
@@ -107,6 +107,16 @@ class EmbodimentBase(Asset):
         """Optional USD prim path for rebasing teleop poses (e.g. robot base link). Returns None if not set."""
 
     def get_camera_cfg(self) -> Any:
+        """Return the concrete camera-rig configclass to build the scene from.
+
+        For a rig that mixes in :class:`ArenaCameraCfg`, resolves via its ``get_cfg`` (tiled or
+        untiled per its flag). Embodiments not yet migrated assign a raw camera-rig configclass
+        to ``camera_config``, which is returned as-is.
+        """
+        if self.camera_config is None:
+            return None
+        if isinstance(self.camera_config, ArenaCameraCfg):
+            return self.camera_config.get_cfg()
         return self.camera_config
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -107,17 +107,13 @@ class EmbodimentBase(Asset):
         """Optional USD prim path for rebasing teleop poses (e.g. robot base link). Returns None if not set."""
 
     def get_camera_cfg(self) -> Any:
-        """Return the concrete camera-rig configclass to build the scene from.
-
-        For a rig that mixes in :class:`ArenaCameraCfg`, resolves via its ``get_cfg`` (tiled or
-        untiled per its flag). Embodiments not yet migrated assign a raw camera-rig configclass
-        to ``camera_config``, which is returned as-is.
-        """
         if self.camera_config is None:
             return None
-        if isinstance(self.camera_config, ArenaCameraCfg):
-            return self.camera_config.get_cfg()
-        return self.camera_config
+        # In Arena we expect camera configs to inherit from ArenaCameraCfg.
+        assert isinstance(
+            self.camera_config, ArenaCameraCfg
+        ), f"Expected camera_config to inherit from ArenaCameraCfg; got {type(self.camera_config).__name__}."
+        return self.camera_config.get_cfg()
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
         if scene_config is None or not hasattr(scene_config, "robot"):

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -6,7 +6,6 @@
 
 import torch
 from collections.abc import Sequence
-from dataclasses import MISSING
 
 import isaaclab.envs.mdp as mdp_isaac_lab
 import isaaclab.sim as sim_utils
@@ -25,7 +24,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import RewardTermCfg, SceneEntityCfg
 from isaaclab.markers.config import FRAME_MARKER_CFG
-from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
+from isaaclab.sensors import CameraCfg
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg, OffsetCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
@@ -38,6 +37,7 @@ from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.embodiments.common.mimic_utils import get_rigid_and_articulated_object_poses
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.observations import gripper_pos
+from isaaclab_arena.utils.cameras import ArenaCameraCfg
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariation
 
@@ -72,8 +72,6 @@ class FrankaEmbodimentBase(EmbodimentBase):
         initial_joint_pose: list[float] | None = None,
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
-        camera_offset: Pose | None = _DEFAULT_CAMERA_OFFSET,
-        is_tiled_camera: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose, concatenate_observation_terms, arm_mode)
         self.event_config = FrankaEventCfg()
@@ -82,8 +80,6 @@ class FrankaEmbodimentBase(EmbodimentBase):
         self.reward_config = FrankaRewardsCfg()
         self.mimic_env = FrankaMimicEnv
         self.camera_config = FrankaCameraCfg()
-        self.camera_config._is_tiled_camera = is_tiled_camera
-        self.camera_config._camera_offset = camera_offset
         self.scene_config = FrankaSceneCfg()
         self.observation_config = FrankaObservationsCfg()
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
@@ -110,8 +106,6 @@ class FrankaIKEmbodiment(FrankaEmbodimentBase):
         initial_joint_pose: list[float] | None = None,
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
-        camera_offset: Pose | None = _DEFAULT_CAMERA_OFFSET,
-        is_tiled_camera: bool = False,
     ):
         super().__init__(
             enable_cameras=enable_cameras,
@@ -119,8 +113,6 @@ class FrankaIKEmbodiment(FrankaEmbodimentBase):
             initial_joint_pose=initial_joint_pose,
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
-            camera_offset=camera_offset,
-            is_tiled_camera=is_tiled_camera,
         )
         self.scene_config.robot = _FRANKA_IK_REL_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
         self.action_config = FrankaIKActionCfg()
@@ -167,8 +159,6 @@ class FrankaJointPosEmbodiment(FrankaEmbodimentBase):
         initial_joint_pose: list[float] | None = None,
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
-        camera_offset: Pose | None = _DEFAULT_CAMERA_OFFSET,
-        is_tiled_camera: bool = False,
     ):
         super().__init__(
             enable_cameras=enable_cameras,
@@ -176,8 +166,6 @@ class FrankaJointPosEmbodiment(FrankaEmbodimentBase):
             initial_joint_pose=initial_joint_pose,
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
-            camera_offset=camera_offset,
-            is_tiled_camera=is_tiled_camera,
         )
         self.action_config = FrankaJointPosActionsCfg()
         self.scene_config.robot = _FRANKA_JOINT_POS_CFG.replace(prim_path="{ENV_REGEX_NS}/Robot")
@@ -249,35 +237,29 @@ class FrankaSceneCfg:
 
 
 @configclass
-class FrankaCameraCfg:
-    """Configuration for cameras."""
+class FrankaCameraCfg(ArenaCameraCfg):
+    """Franka wrist-camera rig using a standard (untiled) camera.
 
-    wrist_cam: CameraCfg | TiledCameraCfg = MISSING
+    Source of truth for the wrist-camera intrinsics and default pose. Tiling is selected via
+    the inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from
+    the embodiment's ``camera_offset``.
+    """
 
-    def __post_init__(self):
-        is_tiled_camera = getattr(self, "_is_tiled_camera", False)
-        camera_offset = getattr(self, "_camera_offset", _DEFAULT_CAMERA_OFFSET)
-
-        CameraClass = TiledCameraCfg if is_tiled_camera else CameraCfg
-        OffsetClass = CameraClass.OffsetCfg
-
-        common_kwargs = dict(
-            prim_path="{ENV_REGEX_NS}/Robot/panda_hand/wrist_cam",
-            update_period=0.0,
-            height=84,
-            width=84,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=2.8, focus_distance=28, horizontal_aperture=5.376, vertical_aperture=3.024
-            ),
-        )
-        offset = OffsetClass(
-            pos=camera_offset.position_xyz,
-            rot=camera_offset.rotation_xyzw,
+    wrist_cam: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/panda_hand/wrist_cam",
+        update_period=0.0,
+        height=84,
+        width=84,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=2.8, focus_distance=28, horizontal_aperture=5.376, vertical_aperture=3.024
+        ),
+        offset=CameraCfg.OffsetCfg(
+            pos=_DEFAULT_CAMERA_OFFSET.position_xyz,
+            rot=_DEFAULT_CAMERA_OFFSET.rotation_xyzw,
             convention="ros",
-        )
-
-        self.wrist_cam = CameraClass(offset=offset, **common_kwargs)
+        ),
+    )
 
 
 @configclass

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -238,12 +238,7 @@ class FrankaSceneCfg:
 
 @configclass
 class FrankaCameraCfg(ArenaCameraCfg):
-    """Franka wrist-camera rig using a standard (untiled) camera.
-
-    Source of truth for the wrist-camera intrinsics and default pose. Tiling is selected via
-    the inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from
-    the embodiment's ``camera_offset``.
-    """
+    """Configuration for cameras."""
 
     wrist_cam: CameraCfg = CameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/panda_hand/wrist_cam",

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -21,7 +21,7 @@ from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.managers.action_manager import ActionTermCfg
-from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
+from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 from isaaclab_teleop import XrCfg
@@ -32,6 +32,7 @@ from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.terms.events import reset_all_articulation_joints
+from isaaclab_arena.utils.cameras import ArenaCameraCfg
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena_g1.g1_env.mdp import g1_events as g1_events_mdp
 from isaaclab_arena_g1.g1_env.mdp import g1_observations as g1_observations_mdp
@@ -119,8 +120,6 @@ class G1WBCJointEmbodiment(G1EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
-        use_tiled_camera: bool = True,  # Default to tiled for parallel evaluation
         lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
@@ -129,17 +128,11 @@ class G1WBCJointEmbodiment(G1EmbodimentBase):
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
         self.event_config = G1WBCJointEventCfg()
-        # Create camera config with private attributes to avoid scene parser issues
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
 
 
 @register_asset
 class G1WBCPinkEmbodiment(G1EmbodimentBase):
-    """Embodiment for the G1 robot with WBC policy and PINK IK upperbody control.
-
-    By default uses regular camera for single-environment applications.
-    """
+    """Embodiment for the G1 robot with WBC policy and PINK IK upperbody control."""
 
     name = "g1_wbc_pink"
     tags = ["embodiment", "default"]
@@ -148,8 +141,6 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
-        use_tiled_camera: bool = False,  # Default to regular for single env
         lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
@@ -161,9 +152,6 @@ class G1WBCPinkEmbodiment(G1EmbodimentBase):
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.action.concatenate_terms = self.concatenate_observation_terms
         self.event_config = G1WBCPinkEventCfg()
-        # Create camera config with private attributes to avoid scene parser issues
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
 
 
 @register_asset
@@ -181,8 +169,6 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
-        use_tiled_camera: bool = False,
         lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
@@ -195,8 +181,6 @@ class G1WBCAgilePinkEmbodiment(G1EmbodimentBase):
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.action.concatenate_terms = self.concatenate_observation_terms
         self.event_config = G1WBCPinkEventCfg()
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
 
 
 @register_asset
@@ -217,8 +201,6 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_G1_CAMERA_OFFSET,
-        use_tiled_camera: bool = True,
         lock_waist: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose)
@@ -228,8 +210,6 @@ class G1WBCAgileJointEmbodiment(G1EmbodimentBase):
         self.observation_config.policy.concatenate_terms = self.concatenate_observation_terms
         self.observation_config.wbc.concatenate_terms = self.concatenate_observation_terms
         self.event_config = G1WBCJointEventCfg()
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
 
 
 # Default Arena G1 articulation config used by all non-AGILE G1 embodiments. Kept at
@@ -506,38 +486,30 @@ class G1AgileSceneCfg(G1SceneCfg):
 
 
 @configclass
-class G1CameraCfg:
-    """Configuration for cameras."""
+class G1CameraCfg(ArenaCameraCfg):
+    """G1 head-camera rig using a standard (untiled) camera.
 
-    robot_head_cam: CameraCfg | TiledCameraCfg = MISSING
+    Source of truth for the head-camera intrinsics and default pose. Tiling is selected via the
+    inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from the
+    embodiment's ``camera_offset``.
+    """
 
-    def __post_init__(self):
-        # Get configuration from private attributes set by embodiment constructor
-        # These use getattr with defaults to avoid scene parser treating them as assets
-        is_tiled_camera = getattr(self, "_is_tiled_camera", True)
-        camera_offset = getattr(self, "_camera_offset", _DEFAULT_G1_CAMERA_OFFSET)
-
-        CameraClass = TiledCameraCfg if is_tiled_camera else CameraCfg
-        OffsetClass = CameraClass.OffsetCfg
-
-        common_kwargs = dict(
-            prim_path="{ENV_REGEX_NS}/Robot/head_link/RobotHeadCam",
-            update_period=0.0,
-            height=480,
-            width=640,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(
-                focal_length=15,
-                clipping_range=(0.1, 5),
-            ),
-        )
-        offset = OffsetClass(
-            pos=camera_offset.position_xyz,
-            rot=camera_offset.rotation_xyzw,
+    robot_head_cam: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/head_link/RobotHeadCam",
+        update_period=0.0,
+        height=480,
+        width=640,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=15,
+            clipping_range=(0.1, 5),
+        ),
+        offset=CameraCfg.OffsetCfg(
+            pos=_DEFAULT_G1_CAMERA_OFFSET.position_xyz,
+            rot=_DEFAULT_G1_CAMERA_OFFSET.rotation_xyzw,
             convention="ros",
-        )
-
-        self.robot_head_cam = CameraClass(offset=offset, **common_kwargs)
+        ),
+    )
 
 
 @configclass

--- a/isaaclab_arena/embodiments/g1/g1.py
+++ b/isaaclab_arena/embodiments/g1/g1.py
@@ -487,12 +487,7 @@ class G1AgileSceneCfg(G1SceneCfg):
 
 @configclass
 class G1CameraCfg(ArenaCameraCfg):
-    """G1 head-camera rig using a standard (untiled) camera.
-
-    Source of truth for the head-camera intrinsics and default pose. Tiling is selected via the
-    inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from the
-    embodiment's ``camera_offset``.
-    """
+    """Configuration for cameras."""
 
     robot_head_cam: CameraCfg = CameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/head_link/RobotHeadCam",

--- a/isaaclab_arena/embodiments/gr1t2/gr1t2.py
+++ b/isaaclab_arena/embodiments/gr1t2/gr1t2.py
@@ -21,7 +21,7 @@ from isaaclab.managers import EventTermCfg as EventTerm
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
-from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
+from isaaclab.sensors import CameraCfg
 from isaaclab.utils import configclass
 from isaaclab_assets.robots.fourier import GR1T2_CFG
 from isaaclab_tasks.manager_based.manipulation.pick_place.pickplace_gr1t2_env_cfg import ActionsCfg as GR1T2ActionsCfg
@@ -33,6 +33,7 @@ from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.embodiments.common.mimic_utils import get_rigid_and_articulated_object_poses
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.terms.events import reset_all_articulation_joints
+from isaaclab_arena.utils.cameras import ArenaCameraCfg
 from isaaclab_arena.utils.pose import Pose
 
 ARM_JOINT_NAMES_LIST = [
@@ -128,18 +129,12 @@ class GR1T2JointEmbodiment(GR1T2EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_CAMERA_OFFSET,
-        use_tiled_camera: bool = True,  # Default to tiled for parallel evaluation
     ):
         super().__init__(enable_cameras, initial_pose)
         # Joint positional control
         self.action_config = GR1T2JointPositionActionCfg()
         # Tuned arm joints pd gains, smoother motions and less oscillations
         self.scene_config = GR1T2HighPDSceneCfg()
-        # Create camera config with private attributes to avoid scene parser issues
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
-        self.camera_config.__post_init__()  # Re-run to apply any custom offset
         # Lock waist joints
         self.scene_config.robot.actuators["trunk"] = ImplicitActuatorCfg(
             joint_names_expr=["waist_.*"],
@@ -152,10 +147,7 @@ class GR1T2JointEmbodiment(GR1T2EmbodimentBase):
 
 @register_asset
 class GR1T2PinkEmbodiment(GR1T2EmbodimentBase):
-    """Embodiment for the GR1T2 robot with PINK IK end-effector control.
-
-    By default uses regular camera for single-environment applications.
-    """
+    """Embodiment for the GR1T2 robot with PINK IK end-effector control."""
 
     name = "gr1_pink"
     tags = ["embodiment", "default"]
@@ -164,16 +156,10 @@ class GR1T2PinkEmbodiment(GR1T2EmbodimentBase):
         self,
         enable_cameras: bool = False,
         initial_pose: Pose | None = None,
-        camera_offset: Pose | None = _DEFAULT_CAMERA_OFFSET,
-        use_tiled_camera: bool = False,  # Default to regular for single env
     ):
         super().__init__(enable_cameras, initial_pose)
         # Pink IK EEF control
         self.action_config = GR1T2ActionsCfg()
-        # Create camera config with private attributes to avoid scene parser issues
-        self.camera_config._is_tiled_camera = use_tiled_camera
-        self.camera_config._camera_offset = camera_offset
-        self.camera_config.__post_init__()  # Re-run to apply any custom offset
 
         # Lock waist joints
         self.scene_config.robot.actuators["trunk"] = ImplicitActuatorCfg(
@@ -359,35 +345,27 @@ class GR1T2HighPDSceneCfg:
 
 
 @configclass
-class GR1T2CameraCfg:
-    """Configuration for cameras."""
+class GR1T2CameraCfg(ArenaCameraCfg):
+    """GR1T2 head POV camera rig using a standard (untiled) camera.
 
-    robot_pov_cam: CameraCfg | TiledCameraCfg = MISSING
+    Source of truth for the POV-camera intrinsics and default pose. Tiling is selected via the
+    inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from the
+    embodiment's ``camera_offset``.
+    """
 
-    def __post_init__(self):
-        # Get configuration from private attributes set by embodiment constructor
-        # These use getattr with defaults to avoid scene parser treating them as assets
-        is_tiled_camera = getattr(self, "_is_tiled_camera", True)
-        camera_offset = getattr(self, "_camera_offset", _DEFAULT_CAMERA_OFFSET)
-
-        CameraClass = TiledCameraCfg if is_tiled_camera else CameraCfg
-        OffsetClass = CameraClass.OffsetCfg
-
-        common_kwargs = dict(
-            prim_path="{ENV_REGEX_NS}/Robot/head_yaw_link/RobotPOVCam",
-            update_period=0.0,
-            height=512,
-            width=512,
-            data_types=["rgb"],
-            spawn=sim_utils.PinholeCameraCfg(focal_length=18.15, clipping_range=(0.01, 1.0e5)),
-        )
-        offset = OffsetClass(
-            pos=camera_offset.position_xyz,
-            rot=camera_offset.rotation_xyzw,
+    robot_pov_cam: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/head_yaw_link/RobotPOVCam",
+        update_period=0.0,
+        height=512,
+        width=512,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(focal_length=18.15, clipping_range=(0.01, 1.0e5)),
+        offset=CameraCfg.OffsetCfg(
+            pos=_DEFAULT_CAMERA_OFFSET.position_xyz,
+            rot=_DEFAULT_CAMERA_OFFSET.rotation_xyzw,
             convention="opengl",
-        )
-
-        self.robot_pov_cam = CameraClass(offset=offset, **common_kwargs)
+        ),
+    )
 
 
 # NOTE(alexmillane, 2025.07.25): This is partially copied from pickplace_gr1t2_env_cfg.py

--- a/isaaclab_arena/embodiments/gr1t2/gr1t2.py
+++ b/isaaclab_arena/embodiments/gr1t2/gr1t2.py
@@ -346,12 +346,7 @@ class GR1T2HighPDSceneCfg:
 
 @configclass
 class GR1T2CameraCfg(ArenaCameraCfg):
-    """GR1T2 head POV camera rig using a standard (untiled) camera.
-
-    Source of truth for the POV-camera intrinsics and default pose. Tiling is selected via the
-    inherited :class:`~isaaclab_arena.utils.cameras.ArenaCameraCfg`; the offset is set from the
-    embodiment's ``camera_offset``.
-    """
+    """Configuration for cameras."""
 
     robot_pov_cam: CameraCfg = CameraCfg(
         prim_path="{ENV_REGEX_NS}/Robot/head_yaw_link/RobotPOVCam",

--- a/isaaclab_arena/tests/test_isaaclab_bug_get_local_poses.py
+++ b/isaaclab_arena/tests/test_isaaclab_bug_get_local_poses.py
@@ -38,7 +38,7 @@ def _test_get_local_poses_matches_camera_offset_cfg(simulation_app) -> bool:
 
     arena_env = IsaacLabArenaEnvironment(
         name="test_isaac_lab_bug_local_poses",
-        embodiment=FrankaIKEmbodiment(enable_cameras=True, camera_offset=TEST_CAMERA_OFFSET),
+        embodiment=FrankaIKEmbodiment(enable_cameras=True),
         scene=Scene(),
     )
     args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1", "--enable_cameras"])

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -22,16 +22,14 @@ from isaaclab_arena.utils.pose import PoseRange
 
 
 class ArenaCameraCfg:
-    """Mixin for embodiment camera-rig configclasses that exposes an untiled/tiled selector.
+    """Parent class for camera configs in Arena.
 
-    A rig configclass subclasses this and declares its cameras as ``CameraCfg`` fields (the
-    untiled source of truth). :meth:`get_cfg` then returns the rig untiled, or a tiled copy of
-    it, per :attr:`use_tiled_camera`. Embodiments assign such a rig to ``camera_config``; the
-    env builder resolves it via :meth:`get_cfg`.
+    CameraCfg configclasses subclass this and declare camera fields (as per usual). The get_cfg
+    then returns the rig un-tiled, or a tiled copy dependent on the value of ``use_tiled_camera``.
     """
 
+    # Backing flag; tiled by default. Kept as a ClassVar so it is not treated as a camera field; instances shadow it.
     _use_tiled_camera: ClassVar[bool] = True
-    """Backing flag; tiled by default. Kept as a ClassVar so it is not treated as a camera field; instances shadow it."""
 
     @property
     def use_tiled_camera(self) -> bool:
@@ -42,12 +40,8 @@ class ArenaCameraCfg:
     def use_tiled_camera(self, use_tiled_camera: bool) -> None:
         self._use_tiled_camera = use_tiled_camera
 
-    def set_use_tiled_camera(self, use_tiled_camera: bool) -> None:
-        """Select whether :meth:`get_cfg` returns tiled cameras."""
-        self._use_tiled_camera = use_tiled_camera
-
     def get_cfg(self) -> Any:
-        """Return a copy of this rig, tiled or untiled per :attr:`use_tiled_camera`.
+        """Return the tiled or un-tiled version of the CameraCfg.
 
         A copy is returned so callers may freely combine or mutate it without affecting this instance.
         """
@@ -56,10 +50,7 @@ class ArenaCameraCfg:
         return self.copy()
 
     def _tiled_rig(self) -> Any:
-        """Return a copy of this rig with every untiled CameraCfg field converted to tiled.
-
-        This instance is left untouched; non-camera fields and already-tiled cameras are copied as-is.
-        """
+        """Return a copy of this rig with every untiled CameraCfg field converted to tiled."""
         tiled = self.copy()
         for f in fields(tiled):
             value = getattr(tiled, f.name)
@@ -68,11 +59,7 @@ class ArenaCameraCfg:
         return tiled
 
     def _as_tiled_camera_cfg(self, camera_cfg: CameraCfg) -> TiledCameraCfg:
-        """Return a TiledCameraCfg mirroring the settings of an untiled CameraCfg.
-
-        All init fields are copied except ``class_type``, so the returned cfg keeps the tiled
-        camera's own ``class_type``.
-        """
+        """Return a TiledCameraCfg mirroring the settings of an untiled CameraCfg."""
         init_fields = {
             f.name: getattr(camera_cfg, f.name) for f in fields(camera_cfg) if f.init and f.name != "class_type"
         }

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -7,18 +7,76 @@ import inspect
 import numpy as np
 from contextlib import suppress
 from dataclasses import fields, is_dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from isaaclab.envs import mdp
 from isaaclab.envs.common import ViewerCfg
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
 from isaaclab.managers import SceneEntityCfg
-from isaaclab.sensors import CameraCfg  # noqa: F401
+from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.utils.configclass import make_configclass
 from isaaclab_arena.utils.pose import PoseRange
+
+
+class ArenaCameraCfg:
+    """Mixin for embodiment camera-rig configclasses that exposes an untiled/tiled selector.
+
+    A rig configclass subclasses this and declares its cameras as ``CameraCfg`` fields (the
+    untiled source of truth). :meth:`get_cfg` then returns the rig untiled, or a tiled copy of
+    it, per :attr:`use_tiled_camera`. Embodiments assign such a rig to ``camera_config``; the
+    env builder resolves it via :meth:`get_cfg`.
+    """
+
+    _use_tiled_camera: ClassVar[bool] = True
+    """Backing flag; tiled by default. Kept as a ClassVar so it is not treated as a camera field; instances shadow it."""
+
+    @property
+    def use_tiled_camera(self) -> bool:
+        """Whether :meth:`get_cfg` returns tiled cameras."""
+        return self._use_tiled_camera
+
+    @use_tiled_camera.setter
+    def use_tiled_camera(self, use_tiled_camera: bool) -> None:
+        self._use_tiled_camera = use_tiled_camera
+
+    def set_use_tiled_camera(self, use_tiled_camera: bool) -> None:
+        """Select whether :meth:`get_cfg` returns tiled cameras."""
+        self._use_tiled_camera = use_tiled_camera
+
+    def get_cfg(self) -> Any:
+        """Return a copy of this rig, tiled or untiled per :attr:`use_tiled_camera`.
+
+        A copy is returned so callers may freely combine or mutate it without affecting this instance.
+        """
+        if self._use_tiled_camera:
+            return self._tiled_rig()
+        return self.copy()
+
+    def _tiled_rig(self) -> Any:
+        """Return a copy of this rig with every untiled CameraCfg field converted to tiled.
+
+        This instance is left untouched; non-camera fields and already-tiled cameras are copied as-is.
+        """
+        tiled = self.copy()
+        for f in fields(tiled):
+            value = getattr(tiled, f.name)
+            if isinstance(value, CameraCfg) and not isinstance(value, TiledCameraCfg):
+                setattr(tiled, f.name, self._as_tiled_camera_cfg(value))
+        return tiled
+
+    def _as_tiled_camera_cfg(self, camera_cfg: CameraCfg) -> TiledCameraCfg:
+        """Return a TiledCameraCfg mirroring the settings of an untiled CameraCfg.
+
+        All init fields are copied except ``class_type``, so the returned cfg keeps the tiled
+        camera's own ``class_type``.
+        """
+        init_fields = {
+            f.name: getattr(camera_cfg, f.name) for f in fields(camera_cfg) if f.init and f.name != "class_type"
+        }
+        return TiledCameraCfg(**init_fields)
 
 
 def make_camera_observation_cfg(

--- a/isaaclab_arena_environments/gr1_put_and_close_door_environment.py
+++ b/isaaclab_arena_environments/gr1_put_and_close_door_environment.py
@@ -21,6 +21,9 @@ RANDOMIZATION_HALF_RANGE_X_M = 0.03
 RANDOMIZATION_HALF_RANGE_Y_M = 0.01
 RANDOMIZATION_HALF_RANGE_Z_M = 0.0
 
+# The GR1 embodiments that are compatible with this environment.
+GR1_EMBODIMENTS = ("gr1_joint", "gr1_pink")
+
 
 @dataclass
 class GR1PutAndCloseDoorEnvironmentCfg(ArenaEnvironmentCfg):
@@ -117,6 +120,9 @@ class GR1PutAndCloseDoorEnvironment(ArenaEnvironmentFactory[GR1PutAndCloseDoorEn
                     setattr(self.datagen_config, key, value)
 
         camera_offset = Pose(position_xyz=(0.12515, 0.0, 0.06776), rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469))
+        assert (
+            cfg.embodiment in GR1_EMBODIMENTS
+        ), f"{self.name} only supports GR1 embodiments {GR1_EMBODIMENTS}, got '{cfg.embodiment}'."
         embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)
         embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(
             pos=camera_offset.position_xyz,

--- a/isaaclab_arena_environments/gr1_put_and_close_door_environment.py
+++ b/isaaclab_arena_environments/gr1_put_and_close_door_environment.py
@@ -50,6 +50,7 @@ class GR1PutAndCloseDoorEnvironment(ArenaEnvironmentFactory[GR1PutAndCloseDoorEn
     def build(self, cfg: GR1PutAndCloseDoorEnvironmentCfg) -> IsaacLabArenaEnvironment:
         """Build the environment from its typed configuration."""
         from isaaclab.envs.mimic_env_cfg import MimicEnvCfg
+        from isaaclab.sensors import CameraCfg
         from isaaclab.utils import configclass
 
         from isaaclab_arena.assets.object_reference import ObjectReference, OpenableObjectReference
@@ -116,8 +117,11 @@ class GR1PutAndCloseDoorEnvironment(ArenaEnvironmentFactory[GR1PutAndCloseDoorEn
                     setattr(self.datagen_config, key, value)
 
         camera_offset = Pose(position_xyz=(0.12515, 0.0, 0.06776), rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469))
-        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(
-            enable_cameras=cfg.enable_cameras, camera_offset=camera_offset
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)
+        embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(
+            pos=camera_offset.position_xyz,
+            rot=camera_offset.rotation_xyzw,
+            convention="opengl",
         )
         kitchen_background = self.asset_registry.get_asset_by_name("lightwheel_robocasa_kitchen")(
             style_id=cfg.kitchen_style

--- a/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
+++ b/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
@@ -84,6 +84,9 @@ HETERO_FIXED_OBJECTS = [
     ("lime01_fruits_veggies_robolab", 0.5, 0.15),
 ]
 
+# The GR1 embodiments that are compatible with this environment.
+GR1_EMBODIMENTS = ("gr1_joint", "gr1_pink")
+
 
 @dataclass
 class GR1TableMultiObjectNoCollisionEnvironmentCfg(ArenaEnvironmentCfg):
@@ -130,6 +133,9 @@ class GR1TableMultiObjectNoCollisionEnvironment(ArenaEnvironmentFactory[GR1Table
             position_xyz=(0.12515, 0.0, 0.06776),
             rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469),
         )
+        assert (
+            cfg.embodiment in GR1_EMBODIMENTS
+        ), f"{self.name} only supports GR1 embodiments {GR1_EMBODIMENTS}, got '{cfg.embodiment}'."
         embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)
         embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(
             pos=camera_offset.position_xyz,

--- a/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
+++ b/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
@@ -136,7 +136,7 @@ class GR1TableMultiObjectNoCollisionEnvironment(ArenaEnvironmentFactory[GR1Table
             rot=camera_offset.rotation_xyzw,
             convention="opengl",
         )
-        embodiment.camera_config.set_use_tiled_camera(cfg.num_envs > 1)
+        embodiment.camera_config.use_tiled_camera = cfg.num_envs > 1
         embodiment.set_initial_pose(
             Pose(
                 position_xyz=(1.2, 0.0, 0.995),

--- a/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
+++ b/isaaclab_arena_environments/gr1_table_multi_object_no_collision_environment.py
@@ -117,6 +117,8 @@ class GR1TableMultiObjectNoCollisionEnvironment(ArenaEnvironmentFactory[GR1Table
 
     def build(self, cfg: GR1TableMultiObjectNoCollisionEnvironmentCfg) -> IsaacLabArenaEnvironment:
         """Build the environment from its typed configuration."""
+        from isaaclab.sensors import CameraCfg
+
         from isaaclab_arena.assets.object_reference import ObjectReference
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.relations.relations import IsAnchor
@@ -128,11 +130,13 @@ class GR1TableMultiObjectNoCollisionEnvironment(ArenaEnvironmentFactory[GR1Table
             position_xyz=(0.12515, 0.0, 0.06776),
             rotation_xyzw=(0.11204, -0.17712, -0.79108, 0.57469),
         )
-        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(
-            enable_cameras=cfg.enable_cameras,
-            camera_offset=camera_offset,
-            use_tiled_camera=(cfg.num_envs > 1),
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)
+        embodiment.camera_config.robot_pov_cam.offset = CameraCfg.OffsetCfg(
+            pos=camera_offset.position_xyz,
+            rot=camera_offset.rotation_xyzw,
+            convention="opengl",
         )
+        embodiment.camera_config.set_use_tiled_camera(cfg.num_envs > 1)
         embodiment.set_initial_pose(
             Pose(
                 position_xyz=(1.2, 0.0, 0.995),


### PR DESCRIPTION
## Summary
Encapsulate the tiling behaviour of cameras in Arena.

## Detail
- Add `ArenaCameraCfg` (`isaaclab_arena/utils/cameras.py`): a mixin for camera-rig configclasses that declare cameras once as untiled `CameraCfg`; `get_cfg()` returns them untiled or as a tiled copy per a `use_tiled_camera` flag.
- Allows to remove brittle `__post_init__` and `getattr` code.
- Route the droid, franka, g1, and gr1t2 embodiments through `ArenaCameraCfg`, defaulting to tiled cameras.

## Limitations
- For simplicity all cameras in a rig switch simultaneously between tiled and untiled.