### PR TITLE
Fix graph camera setup for DROID scenes

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -131,8 +131,17 @@ class AssetCatalogue:
 
     def to_catalog_string(self) -> str:
         """Format this catalogue as the user-message vocabulary block."""
+
+        def _profile_suffix(entry: dict[str, Any]) -> str:
+            profiles = entry.get("camera_profiles", [])
+            if not profiles:
+                return "  camera_profiles=[]"
+            rendered = ", ".join(f"{p['name']}: {p['description']}" for p in profiles)
+            return f"  camera_profiles=[{rendered}]"
+
         embodiment_lines = "\n".join(
-            f"- {e['name']}  tags={e['tags']}" for e in sorted(self.embodiments, key=lambda e: e["name"])
+            f"- {e['name']}  tags={e['tags']}{_profile_suffix(e)}"
+            for e in sorted(self.embodiments, key=lambda e: e["name"])
         )
         background_lines = "\n".join(
             f"- {b['name']}  tags={b['tags']}" for b in sorted(self.backgrounds, key=lambda b: b["name"])
@@ -149,7 +158,10 @@ class AssetCatalogue:
 
 def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalogue:
     """Collect registered embodiments, backgrounds, and pick-up objects from ``AssetRegistry``."""
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+
     registry = registry or AssetRegistry()
+    camera_profiles = CameraProfileRegistry()
     catalogue = AssetCatalogue()
     # TODO(qianl): handle optional lights and hdr images.
     # TODO(qianl): add tag to filter out validated/agent-ready assets only.
@@ -159,7 +171,17 @@ def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalog
         cls = registry.get_asset_by_name(name)
         tags = getattr(cls, "tags", None) or []
         if "embodiment" in tags:
-            catalogue.embodiments.append({"name": name, "tags": [t for t in tags if t != "embodiment"]})
+            catalogue.embodiments.append({
+                "name": name,
+                "tags": [t for t in tags if t != "embodiment"],
+                "camera_profiles": [
+                    {
+                        "name": profile_name,
+                        "description": camera_profiles.get_camera_profile_by_name(profile_name).description,
+                    }
+                    for profile_name in camera_profiles.get_compatible_profile_names(name)
+                ],
+            })
         elif "background" in tags:
             catalogue.backgrounds.append({"name": name, "tags": [t for t in tags if t != "background"]})
         elif "object" in tags:

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -104,6 +104,10 @@ GUIDANCE:
   If multiple reasonable matches are found, return the closest match or the one with the most specific name.
 - For embodiment, if the prompt only mention the robot family (driod/franka) and there are multiple
   variance of that family in EMBODIMENTS, pick the one with the default tag.
+- If an EMBODIMENT entry lists camera_profiles, put one of those exact names in
+  ``embodiment.camera_profile`` only when the prompt asks for that camera setup.
+- Use only exact camera-profile names listed for the selected embodiment. Leave
+  ``embodiment.camera_profile`` unset when no listed profile is requested.
 - For multiple instances of the same registry asset, use semantic (left/right) or numerical (1/2/3)
   suffixes in ``id``.
 - Only populate ``object_references`` when the prompt explicitly mentions surfaces or appliances

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, get_args, get_origin
 
 from isaaclab_arena.assets.registries import (
     AssetRegistry,
+    CameraProfileRegistry,
     DeviceRegistry,
     EnvironmentRegistry,
     HDRImageRegistry,
@@ -67,6 +68,15 @@ def register_hdr(cls):
         print(f"WARNING: HDRImage {cls.name} is already registered. Doing nothing.")
     else:
         HDRImageRegistry().register(cls, cls.name)
+    return cls
+
+
+def register_camera_profile(cls):
+    registry = CameraProfileRegistry()
+    if registry.is_registered(cls.name, ensure_loaded=False):
+        print(f"WARNING: Camera profile {cls.name} is already registered. Doing nothing.")
+    else:
+        registry.register(cls, cls.name)
     return cls
 
 

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.assets.asset import Asset
     from isaaclab_arena.assets.hdr_image import HDRImage
     from isaaclab_arena.assets.teleop_device_base import TeleopDeviceBase
+    from isaaclab_arena.embodiments.camera_profile import CameraProfileBase
     from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
     from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
     from isaaclab_arena.relations.relations import RelationBase
@@ -265,6 +266,28 @@ class HDRImageRegistry(Registry):
         return random.choice(hdrs)
 
 
+class CameraProfileRegistry(Registry):
+    """Registry for named embodiment camera profiles."""
+
+    def get_camera_profile_by_name(self, name: str) -> type["CameraProfileBase"]:
+        ensure_assets_registered()
+        return self.get_component_by_name(name)
+
+    def get_compatible_profile_names(self, embodiment_registry_name: str) -> list[str]:
+        ensure_assets_registered()
+        names = [
+            name
+            for name, profile in self._components.items()
+            if embodiment_registry_name in profile.compatible_embodiments
+        ]
+        return sorted(names)
+
+    def apply_camera_profile(self, profile_name: str, embodiment_registry_name: str, embodiment: Any) -> None:
+        profile = self.get_camera_profile_by_name(profile_name)
+        profile.assert_compatible(embodiment_registry_name)
+        profile.apply(embodiment)
+
+
 class EnvironmentRegistry(Registry):
     """Registry for Arena environment factories and their configs."""
 
@@ -350,6 +373,7 @@ REGISTRIES = (
     RetargeterRegistry,
     PolicyRegistry,
     HDRImageRegistry,
+    CameraProfileRegistry,
     ObjectRelationLibraryRegistry,
     TaskRegistry,
 )

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -128,6 +128,12 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
             " the YAML declares under `cli_override_specs` are added to the parser dynamically."
         ),
     )
+    env_graph_spec_group.add_argument(
+        "--use_staging_assets",
+        action="store_true",
+        default=False,
+        help="For graph-spec environments, use the CAP staging asset route for the Maple table and DROID stand.",
+    )
 
 
 def add_external_environments_cli_args(parser: argparse.ArgumentParser) -> None:

--- a/isaaclab_arena/embodiments/__init__.py
+++ b/isaaclab_arena/embodiments/__init__.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .agibot.agibot import *
+from .droid.camera_profile_library import *
 from .droid.droid import *
 from .franka.franka import *
 from .g1.g1 import *

--- a/isaaclab_arena/embodiments/camera_profile.py
+++ b/isaaclab_arena/embodiments/camera_profile.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
+
+
+class CameraProfileBase(ABC):
+    """Named reviewed camera setup that can be applied to a compatible embodiment."""
+
+    name: ClassVar[str]
+    description: ClassVar[str]
+    compatible_embodiments: ClassVar[frozenset[str]]
+
+    @classmethod
+    def assert_compatible(cls, embodiment_registry_name: str) -> None:
+        assert embodiment_registry_name in cls.compatible_embodiments, (
+            f"Camera profile '{cls.name}' is not compatible with embodiment "
+            f"'{embodiment_registry_name}'. Compatible embodiments: {sorted(cls.compatible_embodiments)}"
+        )
+
+    @classmethod
+    @abstractmethod
+    def apply(cls, embodiment: EmbodimentBase) -> None:
+        """Apply this camera profile to an already constructed embodiment."""

--- a/isaaclab_arena/embodiments/droid/camera_profile_library.py
+++ b/isaaclab_arena/embodiments/droid/camera_profile_library.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from isaaclab_arena.assets.register import register_camera_profile
+from isaaclab_arena.embodiments.camera_profile import CameraProfileBase
+
+
+@register_camera_profile
+class DroidWorkspaceExteriorRgbdProfile(CameraProfileBase):
+    """DROID workspace exterior RGB-D camera profile used by the GaP bridge."""
+
+    name = "droid_workspace_exterior_rgbd"
+    description = "Exterior workspace RGB-D camera named exterior_cam, 800x512, with live pose and intrinsics."
+    compatible_embodiments = frozenset({"droid_abs_joint_pos"})
+
+    @classmethod
+    def apply(cls, embodiment):
+        from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariation
+        from isaaclab_arena_environments.maple_cameras import MapleDroidPerceptionCameraCfg
+
+        embodiment.camera_config = MapleDroidPerceptionCameraCfg()
+        variation = CameraExtrinsicsVariation(camera_name="exterior_cam")
+        if variation.name not in embodiment.variations:
+            embodiment.add_variation(variation)

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -7,14 +7,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from isaaclab_arena.assets.asset import Asset
-from isaaclab_arena.assets.object_reference import ObjectReference, OpenableObjectReference
 from isaaclab_arena.assets.object_type import ObjectType
-from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry
+from isaaclab_arena.assets.registries import AssetRegistry, CameraProfileRegistry, ObjectRelationLibraryRegistry
 from isaaclab_arena.environment_spec.arena_env_graph_task_conversion_utils import build_task_from_spec
 from isaaclab_arena.environment_spec.arena_env_graph_types import SpatialRelationSpec
-from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
-from isaaclab_arena.scene.scene import Scene
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.usd_helpers import has_light, open_stage
 
@@ -22,7 +18,12 @@ _DEFAULT_LIGHT_ASSET_NAME = "light"
 _DEFAULT_LIGHT_NODE_ID = "auto_dome_light"
 
 if TYPE_CHECKING:
+    from isaaclab_arena.assets.asset import Asset
     from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+
+
+ObjectReference = None
+OpenableObjectReference = None
 
 
 def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec, enable_cameras: bool = False) -> Any:
@@ -32,6 +33,9 @@ def build_arena_env_from_graph_spec(graph_spec: ArenaEnvGraphSpec, enable_camera
         graph_spec: A validated graph spec (asset refs exist, ids unique, etc.).
         enable_cameras: Forwarded to the embodiment so its cameras are added.
     """
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+
     assets_by_node_id = _instantiate_assets_from_spec(graph_spec, AssetRegistry(), enable_cameras=enable_cameras)
     _ensure_scene_lighting(graph_spec, assets_by_node_id)
     _attach_spatial_relations_to_assets(graph_spec.relations, assets_by_node_id)
@@ -85,18 +89,43 @@ def _prim_path_for_relative(registry_name: str, prim_path: str) -> str:
     return f"{{ENV_REGEX_NS}}/{registry_name}/{prim_path.lstrip('/')}"
 
 
+def _object_reference_classes() -> tuple[Any, Any]:
+    """Lazily import object-reference classes after SimulationApp has initialized pxr extensions."""
+    global ObjectReference, OpenableObjectReference
+    if ObjectReference is None or OpenableObjectReference is None:
+        from isaaclab_arena.assets.object_reference import ObjectReference as _ObjectReference
+        from isaaclab_arena.assets.object_reference import OpenableObjectReference as _OpenableObjectReference
+
+        if ObjectReference is None:
+            ObjectReference = _ObjectReference
+        if OpenableObjectReference is None:
+            OpenableObjectReference = _OpenableObjectReference
+    return ObjectReference, OpenableObjectReference
+
+
 def _instantiate_assets_from_spec(
     graph_spec: ArenaEnvGraphSpec, asset_registry: Any, enable_cameras: bool = False
 ) -> dict[str, type[Asset]]:
     """Return ``{asset.id: live_asset}`` after materializing the typed graph spec."""
     assets_by_node_id: dict[str, type[Asset]] = {}
 
-    embodiment_params = dict(graph_spec.embodiment.params)
+    embodiment_spec = graph_spec.embodiment
+    embodiment_params = dict(embodiment_spec.params)
     if enable_cameras:
         embodiment_params.setdefault("enable_cameras", True)
-    assets_by_node_id[graph_spec.embodiment.id] = asset_registry.get_asset_by_name(graph_spec.embodiment.registry_name)(
-        **embodiment_params
-    )
+    embodiment = asset_registry.get_asset_by_name(embodiment_spec.registry_name)(**embodiment_params)
+    camera_profile = getattr(embodiment_spec, "camera_profile", None)
+    if camera_profile is not None:
+        assert enable_cameras, (
+            f"Embodiment '{embodiment_spec.registry_name}' selects camera_profile "
+            f"'{camera_profile}', but cameras are disabled. Pass --enable_cameras."
+        )
+        CameraProfileRegistry().apply_camera_profile(
+            camera_profile,
+            embodiment_spec.registry_name,
+            embodiment,
+        )
+    assets_by_node_id[embodiment_spec.id] = embodiment
 
     assets_by_node_id[graph_spec.background.id] = asset_registry.get_asset_by_name(graph_spec.background.registry_name)(
         **graph_spec.background.params
@@ -108,6 +137,7 @@ def _instantiate_assets_from_spec(
         assets_by_node_id[obj.id] = asset_registry.get_asset_by_name(obj.registry_name)(**params)
 
     for ref in graph_spec.object_references or []:
+        object_reference_cls, openable_object_reference_cls = _object_reference_classes()
         assert ref.prim_path is not None, "Object reference must have a prim path"
         ref_params = dict(ref.params)
         openable_joint_name = ref_params.pop("openable_joint_name", None)
@@ -122,12 +152,12 @@ def _instantiate_assets_from_spec(
             assert (
                 ref.object_type == ObjectType.ARTICULATION
             ), f"Openable object reference '{ref.id}' must use object_type='articulation'"
-            assets_by_node_id[ref.id] = OpenableObjectReference(
+            assets_by_node_id[ref.id] = openable_object_reference_cls(
                 openable_joint_name=openable_joint_name,
                 **common_kwargs,
             )
         else:
-            assets_by_node_id[ref.id] = ObjectReference(object_type=ref.object_type, **common_kwargs)
+            assets_by_node_id[ref.id] = object_reference_cls(object_type=ref.object_type, **common_kwargs)
 
     return assets_by_node_id
 

--- a/isaaclab_arena/environment_spec/arena_env_graph_spec.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_spec.py
@@ -15,6 +15,7 @@ from isaaclab_arena.environment_spec.arena_env_graph_types import (
     AssetSpec,
     CliOverrideSpec,
     CompositeTaskSpec,
+    EmbodimentSpec,
     ObjectReferenceSpec,
     SpatialRelationSpec,
     TaskSpec,
@@ -30,7 +31,7 @@ class ArenaEnvGraphSpec(BaseModel):
     """Environment graph spec — the single source of truth for scene layout and tasks."""
 
     env_name: str = Field(min_length=1, description="Short snake_case label summarizing the scene and tasks.")
-    embodiment: AssetSpec = Field(description="The robot that performs the tasks.")
+    embodiment: EmbodimentSpec = Field(description="The robot that performs the tasks.")
     background: AssetSpec = Field(description="The static scene the robot and objects sit in.")
     objects: list[AssetSpec] = Field(default_factory=list, description="Movable scene objects, including distractors.")
     object_references: list[ObjectReferenceSpec] | None = Field(

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -14,7 +14,12 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from isaaclab_arena.assets.object_type import ObjectType
-from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
+from isaaclab_arena.assets.registries import (
+    AssetRegistry,
+    CameraProfileRegistry,
+    ObjectRelationLibraryRegistry,
+    TaskRegistry,
+)
 
 
 def _extract_asset_usd_path(asset_cls: type, **params: Any) -> str | None:
@@ -66,6 +71,26 @@ class AssetSpec(BaseModel):
         usd_path = _extract_asset_usd_path(asset_cls, **self.params)
         assert usd_path, f"asset {self.registry_name!r} has no usd_path"
         return usd_path
+
+
+class EmbodimentSpec(AssetSpec):
+    """Registered embodiment node with an optional reviewed camera profile."""
+
+    camera_profile: str | None = Field(
+        default=None,
+        description=(
+            "Optional exact registered camera-profile name compatible with this embodiment. "
+            "Leave unset to use the embodiment's default cameras."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_camera_profile(self) -> EmbodimentSpec:
+        if self.camera_profile is None:
+            return self
+        profile_cls = CameraProfileRegistry().get_camera_profile_by_name(self.camera_profile)
+        profile_cls.assert_compatible(self.registry_name)
+        return self
 
 
 class ObjectReferenceSpec(BaseModel):

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -20,6 +20,7 @@ from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSp
 from isaaclab_arena.environment_spec.arena_env_graph_types import (
     AssetSpec,
     CompositeTaskSpec,
+    EmbodimentSpec,
     TaskCompositionType,
     TaskSpec,
 )
@@ -27,12 +28,25 @@ from isaaclab_arena.environment_spec.arena_env_graph_types import (
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
 
 
+def test_graph_yaml_cli_accepts_use_staging_assets_flag(monkeypatch):
+    import sys
+
+    from isaaclab_arena_environments.cli import get_isaaclab_arena_environments_cli_parser
+
+    yaml_path = str(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
+    monkeypatch.setattr(sys, "argv", ["policy_runner.py", "--env_graph_spec_yaml", yaml_path, "--use_staging_assets"])
+    args = get_isaaclab_arena_environments_cli_parser().parse_args()
+    assert args.use_staging_assets is True
+
+
 def _test_arena_env_graph_conversion_builds_sequential_pick_and_place_task(simulation_app):
     from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
     from isaaclab_arena.tasks.sequential_task_base import SequentialTaskBase
+    from isaaclab_arena_environments.cap_asset_overrides import cap_asset_registry_overrides_for_graph_spec
 
     spec = ArenaEnvGraphSpec.from_yaml(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
-    arena_env = spec.to_arena_env()
+    with cap_asset_registry_overrides_for_graph_spec(spec, use_staging_assets=True, local_asset_root=None):
+        arena_env = spec.to_arena_env()
 
     assert arena_env.name == "pick_and_place_maple_table_default"
     assert isinstance(arena_env.task, SequentialTaskBase)
@@ -66,7 +80,7 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
 
     # --env_graph_spec_yaml with no example-environment subcommand: parses (subcommand is
     # optional) and the runner builds the env from the graph spec instead of the registry.
-    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path]
+    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path, "--use_staging_assets"]
     args = get_isaaclab_arena_environments_cli_parser().parse_args()
 
     builder = get_arena_builder_from_cli(args)
@@ -113,7 +127,7 @@ def test_get_arena_builder_from_cli_builds_env_from_graph_yaml():
 def _minimal_scene_spec(*, objects: list[AssetSpec]) -> ArenaEnvGraphSpec:
     return ArenaEnvGraphSpec(
         env_name="lighting_test",
-        embodiment=AssetSpec(id="robot", registry_name="droid_abs_joint_pos"),
+        embodiment=EmbodimentSpec(id="robot", registry_name="droid_abs_joint_pos"),
         background=AssetSpec(id="background", registry_name="maple_table_robolab"),
         objects=objects,
         task=CompositeTaskSpec(
@@ -135,11 +149,13 @@ def _minimal_scene_spec(*, objects: list[AssetSpec]) -> ArenaEnvGraphSpec:
 
 def _test_default_light_is_injected_when_scene_has_none(simulation_app):
     from isaaclab_arena.assets.object_library import DomeLight
+    from isaaclab_arena_environments.cap_asset_overrides import cap_asset_registry_overrides_for_graph_spec
 
     # A single YCB object with no light asset and no light baked into its USD: the converter
     # must inject a default light so the env does not render black.
     spec = _minimal_scene_spec(objects=[AssetSpec(id="mug", registry_name="mug_ycb_robolab")])
-    arena_env = spec.to_arena_env()
+    with cap_asset_registry_overrides_for_graph_spec(spec, use_staging_assets=True, local_asset_root=None):
+        arena_env = spec.to_arena_env()
 
     assert any(isinstance(asset, DomeLight) for asset in arena_env.scene.assets.values())
 
@@ -150,7 +166,8 @@ def _test_default_light_is_injected_when_scene_has_none(simulation_app):
             AssetSpec(id="my_light", registry_name="light"),
         ]
     )
-    explicit_env = explicit.to_arena_env()
+    with cap_asset_registry_overrides_for_graph_spec(explicit, use_staging_assets=True, local_asset_root=None):
+        explicit_env = explicit.to_arena_env()
     assert sum(isinstance(asset, DomeLight) for asset in explicit_env.scene.assets.values()) == 1
 
     return True
@@ -225,3 +242,42 @@ def test_openable_reference_is_instantiated_without_duplicate_object_type():
 
     result = run_simulation_app_function(_test_openable_reference_is_instantiated_without_duplicate_object_type)
     assert result
+
+
+def test_instantiate_assets_applies_selected_camera_profile(monkeypatch):
+    from types import SimpleNamespace
+
+    from isaaclab_arena.environment_spec import arena_env_graph_conversion_utils as conversion
+
+    class AssetRegistry:
+        def get_asset_by_name(self, registry_name):
+            return lambda **params: SimpleNamespace(name=registry_name, params=params)
+
+    calls = []
+
+    class Registry:
+        def apply_camera_profile(self, profile_name, embodiment_registry_name, embodiment):
+            calls.append((profile_name, embodiment_registry_name, embodiment.name, embodiment.params))
+
+    graph_spec = SimpleNamespace(
+        embodiment=SimpleNamespace(
+            id="robot",
+            registry_name="droid_abs_joint_pos",
+            camera_profile="unit_test_droid_profile",
+            params={},
+        ),
+        background=SimpleNamespace(id="background", registry_name="maple_table_robolab", params={}),
+        objects=[],
+        object_references=[],
+    )
+    monkeypatch.setattr(conversion, "CameraProfileRegistry", Registry)
+
+    assets = conversion._instantiate_assets_from_spec(graph_spec, AssetRegistry(), enable_cameras=True)
+
+    assert assets["robot"].params["enable_cameras"] is True
+    assert calls == [(
+        "unit_test_droid_profile",
+        "droid_abs_joint_pos",
+        "droid_abs_joint_pos",
+        {"enable_cameras": True},
+    )]

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -293,3 +293,52 @@ def test_graph_spec_omits_empty_optional_fields_from_dict():
     assert "object_references" not in dumped
     assert "cli_override_specs" not in dumped
     assert spec.cli_override_specs is None
+
+
+def _register_unit_test_droid_camera_profile():
+    from isaaclab_arena.assets.register import register_camera_profile
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+    from isaaclab_arena.embodiments.camera_profile import CameraProfileBase
+
+    registry = CameraProfileRegistry()
+    if registry.is_registered("unit_test_droid_profile", ensure_loaded=False):
+        return
+
+    @register_camera_profile
+    class UnitTestDroidProfile(CameraProfileBase):
+        name = "unit_test_droid_profile"
+        description = "Unit-test RGB-D profile."
+        compatible_embodiments = frozenset({"droid_abs_joint_pos"})
+
+        @classmethod
+        def apply(cls, embodiment):
+            return None
+
+
+def test_graph_spec_embodiment_accepts_camera_profile():
+    _register_unit_test_droid_camera_profile()
+    data = _minimal_env_graph_data()
+    data["embodiment"] = {
+        "id": "robot",
+        "registry_name": "droid_abs_joint_pos",
+        "camera_profile": "unit_test_droid_profile",
+        "params": {},
+    }
+    spec = ArenaEnvGraphSpec.from_dict(data)
+    assert spec.embodiment.camera_profile == "unit_test_droid_profile"
+    assert spec.to_dict()["embodiment"]["camera_profile"] == "unit_test_droid_profile"
+
+
+def test_graph_spec_rejects_camera_profile_for_incompatible_embodiment():
+    _register_unit_test_droid_camera_profile()
+    data = _minimal_env_graph_data()
+    data["embodiment"]["camera_profile"] = "unit_test_droid_profile"
+    with pytest.raises(ValidationError, match="is not compatible with embodiment"):
+        ArenaEnvGraphSpec.from_dict(data)
+
+
+def test_graph_spec_rejects_unknown_camera_profile():
+    data = _minimal_env_graph_data()
+    data["embodiment"]["camera_profile"] = "missing_camera_profile"
+    with pytest.raises(ValidationError, match="component missing_camera_profile not found"):
+        ArenaEnvGraphSpec.from_dict(data)

--- a/isaaclab_arena/tests/test_camera_profiles.py
+++ b/isaaclab_arena/tests/test_camera_profiles.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_unit_test_droid_profile():
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+
+    registry = CameraProfileRegistry()
+    registry._components.pop("unit_test_droid_profile", None)
+    yield
+    registry._components.pop("unit_test_droid_profile", None)
+
+
+def _register_unit_test_droid_profile(calls=None):
+    from isaaclab_arena.assets.register import register_camera_profile
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+    from isaaclab_arena.embodiments.camera_profile import CameraProfileBase
+
+    calls = [] if calls is None else calls
+    registry = CameraProfileRegistry()
+    if registry.is_registered("unit_test_droid_profile", ensure_loaded=False):
+        return
+
+    @register_camera_profile
+    class UnitTestDroidProfile(CameraProfileBase):
+        name = "unit_test_droid_profile"
+        description = "Unit-test RGB-D profile."
+        compatible_embodiments = frozenset({"droid_abs_joint_pos"})
+
+        @classmethod
+        def apply(cls, embodiment):
+            calls.append(embodiment.name)
+
+
+def test_camera_profile_registry_applies_compatible_profile():
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+
+    calls = []
+    _register_unit_test_droid_profile(calls)
+    registry = CameraProfileRegistry()
+    assert "unit_test_droid_profile" in registry.get_compatible_profile_names("droid_abs_joint_pos")
+    registry.apply_camera_profile("unit_test_droid_profile", "droid_abs_joint_pos", SimpleNamespace(name="robot"))
+    assert calls == ["robot"]
+
+
+def test_camera_profile_registry_rejects_incompatible_profile():
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+
+    _register_unit_test_droid_profile()
+    with pytest.raises(AssertionError, match="is not compatible with embodiment"):
+        CameraProfileRegistry().apply_camera_profile(
+            "unit_test_droid_profile",
+            "franka_ik",
+            SimpleNamespace(name="robot"),
+        )
+
+
+def test_droid_workspace_exterior_rgbd_profile_is_registered():
+    from isaaclab_arena.assets.registries import CameraProfileRegistry
+
+    profile = CameraProfileRegistry().get_camera_profile_by_name("droid_workspace_exterior_rgbd")
+    assert profile.name == "droid_workspace_exterior_rgbd"
+    assert profile.compatible_embodiments == frozenset({"droid_abs_joint_pos"})
+    assert "exterior" in profile.description.lower()
+    assert "rgb-d" in profile.description.lower()
+
+
+def test_maple_gap_profile_uses_named_camera_profile(monkeypatch):
+    from isaaclab_arena_environments import pick_and_place_maple_table_environment as maple
+
+    calls = []
+
+    class Registry:
+        def apply_camera_profile(self, profile_name, embodiment_registry_name, embodiment):
+            calls.append((profile_name, embodiment_registry_name, embodiment.name))
+
+    monkeypatch.setattr(maple, "CameraProfileRegistry", Registry, raising=False)
+
+    embodiment = SimpleNamespace(name="robot")
+    maple._apply_gap_camera_profile("droid_abs_joint_pos", embodiment)
+
+    assert calls == [("droid_workspace_exterior_rgbd", "droid_abs_joint_pos", "robot")]

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -118,6 +118,125 @@ class TestGenerateSpec:
         assert any("is not in the background prim tree" in line for line in agent_obj.traces)
 
 
+def test_asset_catalogue_lists_compatible_camera_profiles():
+    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import AssetCatalogue
+
+    catalogue = AssetCatalogue(
+        embodiments=[{
+            "name": "droid_abs_joint_pos",
+            "tags": ["default"],
+            "camera_profiles": [{
+                "name": "droid_workspace_exterior_rgbd",
+                "description": "Exterior RGB-D workspace camera.",
+            }],
+        }]
+    )
+    text = catalogue.to_catalog_string()
+    assert "- droid_abs_joint_pos  tags=['default']" in text
+    assert "camera_profiles=[droid_workspace_exterior_rgbd: Exterior RGB-D workspace camera.]" in text
+
+
+def test_agentic_build_preview_forwards_enable_cameras(monkeypatch, tmp_path):
+    from types import SimpleNamespace
+
+    from isaaclab_arena_examples.agentic_environment_generation import environment_generation_runner as runner
+
+    yaml_path = tmp_path / "env.yaml"
+    yaml_path.write_text("env_name: unused\n", encoding="utf-8")
+    calls = []
+
+    class Spec:
+        embodiment = SimpleNamespace(registry_name="droid_abs_joint_pos")
+
+        @classmethod
+        def from_yaml(cls, path):
+            assert path == yaml_path
+            return cls()
+
+        def to_arena_env(self, enable_cameras=False):
+            calls.append(enable_cameras)
+            return SimpleNamespace(name="env")
+
+    class Builder:
+        def __init__(self, arena_env, cfg):
+            self.arena_env = arena_env
+
+        def make_registered(self):
+            return SimpleNamespace()
+
+    monkeypatch.setattr(runner, "arena_env_builder_cfg_from_argparse", lambda args: SimpleNamespace())
+    monkeypatch.setattr("isaaclab_arena.environment_spec.arena_env_graph_spec.ArenaEnvGraphSpec", Spec)
+    monkeypatch.setattr("isaaclab_arena.environments.arena_env_builder.ArenaEnvBuilder", Builder)
+
+    runner.build_env_from_env_graph_spec(yaml_path, SimpleNamespace(enable_cameras=True))
+    assert calls == [True]
+
+
+def test_agentic_build_preview_routes_cap_asset_overrides(monkeypatch, tmp_path):
+    from contextlib import contextmanager
+    from types import SimpleNamespace
+
+    from isaaclab_arena_examples.agentic_environment_generation import environment_generation_runner as runner
+
+    yaml_path = tmp_path / "env.yaml"
+    yaml_path.write_text("env_name: unused\n", encoding="utf-8")
+    calls = []
+
+    class Spec:
+        embodiment = SimpleNamespace(registry_name="droid_abs_joint_pos")
+
+        @classmethod
+        def from_yaml(cls, path):
+            assert path == yaml_path
+            return cls()
+
+        def to_arena_env(self, enable_cameras=False):
+            calls.append(("to_arena_env", enable_cameras))
+            return SimpleNamespace(name="env")
+
+    class Builder:
+        def __init__(self, arena_env, cfg):
+            calls.append(("builder", arena_env, cfg))
+
+        def make_registered(self):
+            calls.append(("make_registered",))
+            return SimpleNamespace()
+
+    @contextmanager
+    def override_context(spec, *, use_staging_assets, local_asset_root):
+        calls.append(("override_enter", spec, use_staging_assets, local_asset_root))
+        yield
+        calls.append(("override_exit",))
+
+    def apply_overrides(arena_env, *, use_staging_assets, local_asset_root):
+        calls.append(("apply_overrides", arena_env, use_staging_assets, local_asset_root))
+
+    monkeypatch.delenv("CAP_LOCAL_ASSET_ROOT", raising=False)
+    monkeypatch.setattr(runner, "arena_env_builder_cfg_from_argparse", lambda args: SimpleNamespace(kind="cfg"))
+    monkeypatch.setattr("isaaclab_arena.environment_spec.arena_env_graph_spec.ArenaEnvGraphSpec", Spec)
+    monkeypatch.setattr("isaaclab_arena.environments.arena_env_builder.ArenaEnvBuilder", Builder)
+    monkeypatch.setattr(
+        "isaaclab_arena_environments.cap_asset_overrides.cap_asset_registry_overrides_for_graph_spec",
+        override_context,
+    )
+    monkeypatch.setattr(
+        "isaaclab_arena_environments.cap_asset_overrides.apply_cap_asset_overrides",
+        apply_overrides,
+    )
+
+    runner.build_env_from_env_graph_spec(
+        yaml_path,
+        SimpleNamespace(enable_cameras=True, use_staging_assets=True),
+    )
+
+    assert calls[0][0] == "override_enter"
+    assert calls[0][2:] == (True, None)
+    assert calls[1] == ("to_arena_env", True)
+    assert calls[2][0] == "override_exit"
+    assert calls[3][0] == "apply_overrides"
+    assert calls[3][2:] == (True, None)
+
+
 # ---------------------------------------------------------------------------
 # Live endpoint (network + auth required)
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/tests/test_maple_cameras.py
+++ b/isaaclab_arena/tests/test_maple_cameras.py
@@ -38,3 +38,20 @@ def test_agentview_quat_is_xyzw_and_looks_at_target():
     # Quaternions are equal up to sign; compare with the sign aligned.
     sign = 1.0 if float((torch.tensor(q_xyzw) * q_roundtrip).sum()) >= 0 else -1.0
     assert torch.allclose(torch.tensor(q_xyzw, dtype=torch.float32), sign * q_roundtrip, atol=1e-5)
+
+
+def test_droid_workspace_profile_installs_exterior_rgbd_camera():
+    from isaaclab_arena.assets.registries import AssetRegistry, CameraProfileRegistry
+
+    embodiment = AssetRegistry().get_asset_by_name("droid_abs_joint_pos")(enable_cameras=True)
+    CameraProfileRegistry().apply_camera_profile(
+        "droid_workspace_exterior_rgbd",
+        "droid_abs_joint_pos",
+        embodiment,
+    )
+
+    camera_cfg = embodiment.camera_config.exterior_cam
+    assert camera_cfg.height == 512
+    assert camera_cfg.width == 800
+    assert camera_cfg.data_types == ["rgb", "distance_to_image_plane"]
+    assert "camera_extrinsics_exterior_cam" in embodiment.variations

--- a/isaaclab_arena/tests/test_maple_staging_override.py
+++ b/isaaclab_arena/tests/test_maple_staging_override.py
@@ -8,16 +8,18 @@
 import json
 from types import SimpleNamespace
 
-from isaaclab_arena_environments.pick_and_place_maple_table_environment import (
-    _PROD_NUCLEUS_HOST,
-    _STAGING_NUCLEUS_HOST,
-    _apply_local_droid_asset_override,
-    _load_local_asset_provenance,
-    _local_asset_path,
-    _local_asset_subclass,
-    _staging_subclass,
-    _to_staging_url,
+from isaaclab_arena_environments.cap_asset_overrides import _PROD_NUCLEUS_HOST, _STAGING_NUCLEUS_HOST
+from isaaclab_arena_environments.cap_asset_overrides import (
+    apply_local_droid_asset_override as _apply_local_droid_asset_override,
 )
+from isaaclab_arena_environments.cap_asset_overrides import (
+    apply_staging_stand_override as _apply_staging_stand_override,
+)
+from isaaclab_arena_environments.cap_asset_overrides import load_local_asset_provenance as _load_local_asset_provenance
+from isaaclab_arena_environments.cap_asset_overrides import local_asset_path as _local_asset_path
+from isaaclab_arena_environments.cap_asset_overrides import local_asset_subclass as _local_asset_subclass
+from isaaclab_arena_environments.cap_asset_overrides import staging_subclass as _staging_subclass
+from isaaclab_arena_environments.cap_asset_overrides import to_staging_url as _to_staging_url
 
 
 def test_pick_targets_typed_cli_preserves_absent_and_explicit_lists():
@@ -60,7 +62,6 @@ def test_droid_stand_staging_override_is_instance_local():
     the shared object in place. (Deferred imports: instantiating the embodiment needs the booted app.)
     """
     from isaaclab_arena.embodiments.droid.droid import DroidAbsoluteJointPositionEmbodiment
-    from isaaclab_arena_environments.pick_and_place_maple_table_environment import _apply_staging_stand_override
 
     staged_emb = DroidAbsoluteJointPositionEmbodiment(enable_cameras=False)
     prod_url = staged_emb.scene_config.stand.spawn.usd_path
@@ -174,3 +175,88 @@ def test_local_asset_provenance_requires_schema_and_tree_hash(tmp_path, monkeypa
     provenance_path.write_text(json.dumps({"schema_version": 1, "tree_sha256": "nope"}), encoding="utf-8")
     with pytest.raises(RuntimeError, match="invalid baked CAP asset provenance"):
         _load_local_asset_provenance(tmp_path)
+
+
+def test_apply_cap_asset_overrides_routes_graph_env_maple_and_droid_staging():
+    from isaaclab_arena_environments.cap_asset_overrides import apply_cap_asset_overrides
+
+    table_url = f"https://{_PROD_NUCLEUS_HOST}/Assets/Isaac/6.0/Isaac/IsaacLab/Arena/x/maple_table.usda"
+    stand_url = f"https://{_PROD_NUCLEUS_HOST}/Assets/Isaac/6.0/Isaac/IsaacLab/Arena/x/droid_stand.usda"
+    table = SimpleNamespace(name="maple_table_robolab", usd_path=table_url, bounding_box=object())
+    stand = SimpleNamespace(spawn=SimpleNamespace(usd_path=stand_url))
+    robot = SimpleNamespace(spawn=SimpleNamespace(usd_path=f"https://{_PROD_NUCLEUS_HOST}/Assets/robot.usd"))
+    embodiment = SimpleNamespace(
+        name="droid_abs_joint_pos",
+        scene_config=SimpleNamespace(robot=robot, stand=stand),
+    )
+    arena_env = SimpleNamespace(scene=SimpleNamespace(assets={"table": table}), embodiment=embodiment)
+
+    provenance = apply_cap_asset_overrides(arena_env, use_staging_assets=True, local_asset_root=None)
+
+    assert _STAGING_NUCLEUS_HOST in table.usd_path
+    assert table.bounding_box is None
+    assert embodiment.scene_config.stand is not stand
+    assert embodiment.scene_config.stand.spawn.usd_path != stand_url
+    assert _STAGING_NUCLEUS_HOST in embodiment.scene_config.stand.spawn.usd_path
+    assert stand.spawn.usd_path == stand_url
+    assert provenance["table_source_usd"] == table_url
+    assert provenance["table_resolved_usd"] == table.usd_path
+    assert provenance["droid_stand_staging_usd"] == embodiment.scene_config.stand.spawn.usd_path
+
+
+def test_graph_spec_asset_registry_override_is_temporary():
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena_environments.cap_asset_overrides import cap_asset_registry_overrides_for_graph_spec
+
+    registry = AssetRegistry()
+    original_cls = registry.get_asset_by_name("maple_table_robolab")
+    graph_spec = SimpleNamespace(
+        embodiment=SimpleNamespace(registry_name="droid_abs_joint_pos"),
+        background=SimpleNamespace(registry_name="maple_table_robolab"),
+        objects=[],
+    )
+
+    with cap_asset_registry_overrides_for_graph_spec(
+        graph_spec,
+        use_staging_assets=True,
+        local_asset_root=None,
+    ):
+        staged_cls = registry.get_asset_by_name("maple_table_robolab")
+        assert staged_cls is not original_cls
+        assert _STAGING_NUCLEUS_HOST in staged_cls.usd_path
+
+    assert registry.get_asset_by_name("maple_table_robolab") is original_cls
+
+
+def test_graph_spec_local_asset_root_rejects_non_droid_embodiment(tmp_path):
+    import pytest
+
+    from isaaclab_arena_environments.cap_asset_overrides import cap_asset_registry_overrides_for_graph_spec
+
+    graph_spec = SimpleNamespace(
+        embodiment=SimpleNamespace(registry_name="franka_ik"),
+        background=SimpleNamespace(registry_name="maple_table_robolab"),
+        objects=[],
+    )
+
+    with pytest.raises(AssertionError, match="CAP_LOCAL_ASSET_ROOT contains the CAP DROID scene closure"):
+        with cap_asset_registry_overrides_for_graph_spec(
+            graph_spec,
+            use_staging_assets=False,
+            local_asset_root=tmp_path,
+        ):
+            pass
+
+
+def test_apply_cap_asset_overrides_local_asset_root_rejects_non_droid_embodiment(tmp_path):
+    import pytest
+
+    from isaaclab_arena_environments.cap_asset_overrides import apply_cap_asset_overrides
+
+    arena_env = SimpleNamespace(
+        scene=SimpleNamespace(assets={}),
+        embodiment=SimpleNamespace(name="franka_ik"),
+    )
+
+    with pytest.raises(AssertionError, match="CAP_LOCAL_ASSET_ROOT contains the CAP DROID scene closure"):
+        apply_cap_asset_overrides(arena_env, use_staging_assets=False, local_asset_root=tmp_path)

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -105,3 +105,9 @@ def test_infer_returns_none_with_validation_traces_on_invalid_spec(spec_inferenc
     assert data["embodiment"]["registry_name"] == "not_a_real_asset"
     assert traces
     assert any("registry_name" in line for line in traces)
+
+
+def test_system_prompt_explains_camera_profile_selection():
+    prompt = SpecInference._system_prompt()
+    assert "camera_profile" in prompt
+    assert "Use only exact camera-profile names listed for the selected embodiment" in prompt

--- a/isaaclab_arena_environments/cap_asset_overrides.py
+++ b/isaaclab_arena_environments/cap_asset_overrides.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CAP-specific Maple/DROID asset routing helpers.
+
+These helpers keep the registered Maple environment and graph-YAML environments on the same staging/local
+asset path logic. They intentionally target only the CAP Maple table and DROID scene closure.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import re
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import urlparse
+
+_PROD_NUCLEUS_HOST = "omniverse-content-production.s3-us-west-2.amazonaws.com"
+_STAGING_NUCLEUS_HOST = "omniverse-content-staging.s3.us-west-2.amazonaws.com"
+_LOCAL_ASSET_HOSTS = {
+    _PROD_NUCLEUS_HOST,
+    _STAGING_NUCLEUS_HOST,
+    "omniverse-content-production.s3.us-west-2.amazonaws.com",
+}
+_ASSET_PROVENANCE_FILE = "CAP_ASSET_PROVENANCE.json"
+
+
+def to_staging_url(url: str) -> str:
+    """Rewrite a production Nucleus asset URL to its Isaac staging-bucket equivalent."""
+    staged = url.replace(_PROD_NUCLEUS_HOST, _STAGING_NUCLEUS_HOST)
+    assert staged != url, f"staging override did not rewrite the production host in: {url}"
+    return staged
+
+
+def local_asset_path(source_url: str, local_root: str | Path) -> str:
+    """Map one approved Isaac asset URL into the image's host-qualified local mirror."""
+    parsed = urlparse(source_url)
+    if parsed.scheme != "https" or parsed.netloc not in _LOCAL_ASSET_HOSTS:
+        raise RuntimeError(f"unsupported CAP asset source URL: {source_url}")
+    root = Path(local_root).expanduser().resolve()
+    target = (root / parsed.netloc / parsed.path.lstrip("/")).resolve()
+    if not target.is_relative_to(root):
+        raise RuntimeError(f"CAP asset source escapes the local asset root: {source_url}")
+    if not target.is_file():
+        raise FileNotFoundError(f"baked CAP asset is missing: {target} (source: {source_url})")
+    return str(target)
+
+
+def load_local_asset_provenance(local_root: str | Path) -> dict:
+    """Read and validate the baked CAP asset provenance file."""
+    path = Path(local_root).expanduser().resolve() / _ASSET_PROVENANCE_FILE
+    try:
+        provenance = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"invalid baked CAP asset provenance: {path}") from exc
+    tree_hash = provenance.get("tree_sha256")
+    if (
+        provenance.get("schema_version") != 1
+        or not isinstance(tree_hash, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", tree_hash)
+    ):
+        raise RuntimeError(f"invalid baked CAP asset provenance schema or tree hash: {path}")
+    expected_tree_hash = os.environ.get("CAP_IMAGE_ASSET_TREE_SHA256")
+    if expected_tree_hash and tree_hash != expected_tree_hash:
+        raise RuntimeError(f"baked CAP asset tree hash {tree_hash} does not match image pin {expected_tree_hash}")
+    return provenance
+
+
+def staging_subclass(asset_cls: type) -> tuple[type, str]:
+    """Return an instance-local staging subclass without mutating the registered asset class."""
+    staged = to_staging_url(asset_cls.usd_path)
+    return type(f"{asset_cls.__name__}Staging", (asset_cls,), {"usd_path": staged}), staged
+
+
+def local_asset_subclass(asset_cls: type, local_root: str | Path) -> tuple[type, str, str]:
+    """Return an instance-local asset subclass backed by the baked mirror."""
+    source_url = getattr(asset_cls, "usd_path", None)
+    if not source_url:
+        raise RuntimeError(f"CAP asset class has no usd_path: {asset_cls.__name__}")
+    local_path = local_asset_path(source_url, local_root)
+    localized = type(f"{asset_cls.__name__}Local", (asset_cls,), {"usd_path": local_path})
+    return localized, source_url, local_path
+
+
+def assert_cap_local_asset_root_supports_embodiment(
+    embodiment_registry_name: str,
+    *,
+    local_asset_root: Path | None,
+) -> None:
+    """Fail closed when the baked CAP asset closure is requested for a non-DROID embodiment."""
+    if local_asset_root is None:
+        return
+    assert "droid" in embodiment_registry_name, (
+        "CAP_LOCAL_ASSET_ROOT contains the CAP DROID scene closure; "
+        f"got unsupported embodiment '{embodiment_registry_name}'."
+    )
+
+
+def _graph_spec_asset_registry_names(graph_spec) -> list[str]:
+    names = [graph_spec.background.registry_name]
+    names.extend(obj.registry_name for obj in graph_spec.objects)
+    return list(dict.fromkeys(names))
+
+
+def _routed_graph_asset_class(
+    registry_name: str,
+    asset_cls: type,
+    *,
+    use_staging_assets: bool,
+    local_asset_root: Path | None,
+) -> type:
+    routed_cls = asset_cls
+    if use_staging_assets and registry_name == "maple_table_robolab":
+        routed_cls, _ = staging_subclass(routed_cls)
+    if local_asset_root is not None:
+        source_url = getattr(routed_cls, "usd_path", None)
+        if source_url:
+            routed_cls, _, _ = local_asset_subclass(routed_cls, local_asset_root)
+    return routed_cls
+
+
+@contextmanager
+def cap_asset_registry_overrides_for_graph_spec(
+    graph_spec,
+    *,
+    use_staging_assets: bool,
+    local_asset_root: Path | None,
+):
+    """Temporarily route graph-spec USD asset classes before they are instantiated.
+
+    Graph conversion constructs assets immediately, and USD-backed assets may open their USD files inside
+    ``__init__``. For the unpromoted Maple/DROID CAP assets this means routing must happen before
+    ``ArenaEnvGraphSpec.to_arena_env()``.
+    """
+    assert_cap_local_asset_root_supports_embodiment(
+        graph_spec.embodiment.registry_name,
+        local_asset_root=local_asset_root,
+    )
+    if not use_staging_assets and local_asset_root is None:
+        yield
+        return
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+
+    registry = AssetRegistry()
+    originals: dict[str, type] = {}
+    try:
+        for registry_name in _graph_spec_asset_registry_names(graph_spec):
+            asset_cls = registry.get_asset_by_name(registry_name)
+            routed_cls = _routed_graph_asset_class(
+                registry_name,
+                asset_cls,
+                use_staging_assets=use_staging_assets,
+                local_asset_root=local_asset_root,
+            )
+            if routed_cls is not asset_cls:
+                originals[registry_name] = asset_cls
+                registry._components[registry_name] = routed_cls
+        yield
+    finally:
+        registry._components.update(originals)
+
+
+def apply_staging_stand_override(embodiment) -> str:
+    """Point a DROID embodiment's stand at staging without mutating shared defaults."""
+    stand_usd = getattr(embodiment.scene_config.stand.spawn, "usd_path", None)
+    assert stand_usd, (
+        "--use_staging_assets set but the DROID stand has no spawn.usd_path to rewrite "
+        f"(stand spawn: {type(embodiment.scene_config.stand.spawn).__name__})."
+    )
+    staged = to_staging_url(stand_usd)
+    stand = copy.deepcopy(embodiment.scene_config.stand)
+    stand.spawn.usd_path = staged
+    embodiment.scene_config.stand = stand
+    return staged
+
+
+def apply_local_droid_asset_override(embodiment, local_root: str | Path) -> dict[str, str]:
+    """Localize DROID robot and stand spawn configs without mutating shared defaults."""
+    source_urls = {}
+    local_paths = {}
+    for name in ("robot", "stand"):
+        asset_cfg = getattr(embodiment.scene_config, name)
+        source_url = getattr(asset_cfg.spawn, "usd_path", None)
+        if not source_url:
+            raise RuntimeError(f"DROID {name} has no spawn.usd_path to localize")
+        localized_cfg = copy.deepcopy(asset_cfg)
+        localized_cfg.spawn.usd_path = local_asset_path(source_url, local_root)
+        setattr(embodiment.scene_config, name, localized_cfg)
+        source_urls[f"{name}_source_usd"] = source_url
+        local_paths[f"{name}_local_usd"] = localized_cfg.spawn.usd_path
+    return {**source_urls, **local_paths}
+
+
+def refresh_object_asset_cfg(asset) -> None:
+    """Refresh cached object/event configs after changing an already-instantiated asset's USD path."""
+    if hasattr(asset, "_init_object_cfg"):
+        asset.object_cfg = asset._init_object_cfg()
+    if hasattr(asset, "_init_event_cfg"):
+        asset.event_cfg = asset._init_event_cfg()
+
+
+def rewrite_usd_backed_asset(asset, new_usd_path: str) -> str:
+    """Rewrite an instantiated USD-backed asset and refresh its cached config."""
+    old_usd_path = getattr(asset, "usd_path", None)
+    if not old_usd_path:
+        raise RuntimeError(f"asset {getattr(asset, 'name', type(asset).__name__)} has no usd_path to rewrite")
+    asset.usd_path = new_usd_path
+    asset.bounding_box = None
+    refresh_object_asset_cfg(asset)
+    return old_usd_path
+
+
+def apply_cap_asset_overrides(
+    arena_env,
+    *,
+    use_staging_assets: bool,
+    local_asset_root: Path | None,
+) -> dict[str, object]:
+    """Apply CAP Maple/DROID staging and local asset routing to a built Arena environment."""
+    provenance: dict[str, object] = {
+        "asset_channel": "staging" if use_staging_assets else "production",
+        "asset_materialization": "local_baked" if local_asset_root is not None else "remote",
+        "asset_source_urls": {},
+        "asset_resolved_usds": {},
+    }
+    if not use_staging_assets and local_asset_root is None:
+        return provenance
+
+    embodiment = arena_env.embodiment
+    assert_cap_local_asset_root_supports_embodiment(
+        getattr(embodiment, "name", ""),
+        local_asset_root=local_asset_root,
+    )
+
+    for asset in arena_env.scene.assets.values():
+        if getattr(asset, "name", None) == "maple_table_robolab":
+            source_url = asset.usd_path
+            resolved = source_url
+            if source_url.startswith("https://"):
+                if use_staging_assets and _PROD_NUCLEUS_HOST in source_url:
+                    resolved = to_staging_url(source_url)
+                if local_asset_root is not None:
+                    resolved = local_asset_path(resolved, local_asset_root)
+            if resolved != source_url:
+                rewrite_usd_backed_asset(asset, resolved)
+            provenance["table_source_usd"] = source_url
+            provenance["table_resolved_usd"] = resolved
+
+    if "droid" in getattr(embodiment, "name", ""):
+        if use_staging_assets:
+            provenance["droid_stand_staging_usd"] = apply_staging_stand_override(embodiment)
+        if local_asset_root is not None:
+            provenance["droid_asset_paths"] = apply_local_droid_asset_override(embodiment, local_asset_root)
+
+    if local_asset_root is not None:
+        provenance["baked_asset_tree_sha256"] = load_local_asset_provenance(local_asset_root)["tree_sha256"]
+    return provenance

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry
@@ -229,8 +231,28 @@ def _arena_env_from_graph_spec(env_graph_spec_yaml: str, args_cli: argparse.Name
     """Build the arena env from a graph spec YAML, applying any CLI node overrides."""
     spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
     spec.apply_cli_override_args(args_cli)
-    # cameras are enabled in embodiment, need to pass along to the env
-    return spec.to_arena_env(enable_cameras=args_cli.enable_cameras)
+    from isaaclab_arena_environments.cap_asset_overrides import (
+        apply_cap_asset_overrides,
+        cap_asset_registry_overrides_for_graph_spec,
+    )
+
+    configured_local_root = os.environ.get("CAP_LOCAL_ASSET_ROOT")
+    local_asset_root = Path(configured_local_root).expanduser().resolve() if configured_local_root else None
+    use_staging_assets = getattr(args_cli, "use_staging_assets", False)
+    # USD-backed graph assets may open their USDs during construction, so route classes before to_arena_env().
+    with cap_asset_registry_overrides_for_graph_spec(
+        spec,
+        use_staging_assets=use_staging_assets,
+        local_asset_root=local_asset_root,
+    ):
+        # cameras are enabled in embodiment, need to pass along to the env
+        arena_env = spec.to_arena_env(enable_cameras=args_cli.enable_cameras)
+    apply_cap_asset_overrides(
+        arena_env,
+        use_staging_assets=use_staging_assets,
+        local_asset_root=local_asset_root,
+    )
+    return arena_env
 
 
 def _arena_env_from_example_name(example_environment: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:

--- a/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
+++ b/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
@@ -6,16 +6,23 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena.assets.registries import CameraProfileRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+from isaaclab_arena_environments.cap_asset_overrides import (
+    apply_local_droid_asset_override as _apply_local_droid_asset_override,
+)
+from isaaclab_arena_environments.cap_asset_overrides import (
+    apply_staging_stand_override as _apply_staging_stand_override,
+)
+from isaaclab_arena_environments.cap_asset_overrides import load_local_asset_provenance as _load_local_asset_provenance
+from isaaclab_arena_environments.cap_asset_overrides import local_asset_subclass as _local_asset_subclass
+from isaaclab_arena_environments.cap_asset_overrides import staging_subclass as _staging_subclass
 
 if TYPE_CHECKING:
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
@@ -27,25 +34,21 @@ if TYPE_CHECKING:
 # Only applied under --gap_profile.
 _REACH_BOX = dict(x_min=0.05, x_max=0.45, y_min=-0.25, y_max=0.25)
 
-# Opt-in dev override for the two unpromoted srl_robolab assets from PR #786 (the Maple table and the DROID
-# stand): both 404 on the production Nucleus but 200 on the Isaac staging bucket (CI used staging). The
-# override is a targeted production->staging HOST swap for ONLY those two files; everything else (robolab
-# objects, etc.) stays on production. Off by default (production, documented promotion blocker); never a
-# silent fallback. Enable with --use_staging_assets for development/evaluation until the assets are promoted.
-_PROD_NUCLEUS_HOST = "omniverse-content-production.s3-us-west-2.amazonaws.com"
-_STAGING_NUCLEUS_HOST = "omniverse-content-staging.s3.us-west-2.amazonaws.com"
-_LOCAL_ASSET_HOSTS = {
-    _PROD_NUCLEUS_HOST,
-    _STAGING_NUCLEUS_HOST,
-    "omniverse-content-production.s3.us-west-2.amazonaws.com",
-}
-_ASSET_PROVENANCE_FILE = "CAP_ASSET_PROVENANCE.json"
 # Keep exact-layout bodies just above the tabletop. A larger drop introduces avoidable lateral drift before
 # the policy's first observation, which weakens millimeter-scale distance control.
 _CONTROLLED_ON_CLEARANCE_M = 0.001
 _CONTROLLED_TABLE_EDGE_MARGIN_M = 0.05
 _CONTROLLED_PICK_WORKSPACE = dict(x_min=0.05, x_max=0.45, y_min=-0.25, y_max=0.25)
 _CONTROLLED_DESTINATION_WORKSPACE = dict(x_min=0.45, x_max=0.55, y_min=-0.25, y_max=0.25)
+
+
+def _apply_gap_camera_profile(embodiment_registry_name: str, embodiment) -> None:
+    """Apply the reviewed DROID exterior RGB-D camera profile used by GaP."""
+    CameraProfileRegistry().apply_camera_profile(
+        "droid_workspace_exterior_rgbd",
+        embodiment_registry_name,
+        embodiment,
+    )
 
 
 def _compute_controlled_object_bin_layout(
@@ -127,107 +130,6 @@ def _compute_controlled_object_bin_layout(
             raise ValueError(f"controlled layout puts {name} origin outside the DROID workspace: {position}")
 
     return pick_position, destination_position, actual_gap_m
-
-
-def _to_staging_url(url: str) -> str:
-    """Rewrite a production Nucleus asset URL to its Isaac staging-bucket equivalent (host swap only)."""
-    staged = url.replace(_PROD_NUCLEUS_HOST, _STAGING_NUCLEUS_HOST)
-    assert staged != url, f"staging override did not rewrite the production host in: {url}"
-    return staged
-
-
-def _staging_subclass(asset_cls: type) -> tuple[type, str]:
-    """Return a subclass of ``asset_cls`` whose ``usd_path`` points at staging, plus that URL.
-
-    A dynamic subclass is used (not an in-place edit of ``asset_cls.usd_path``) because the asset registry
-    hands back a SHARED class; mutating it would leak the staging URL into later non-staging jobs/rebuilds in
-    the same eval_runner process. The registered class is left untouched.
-    """
-    staged = _to_staging_url(asset_cls.usd_path)
-    return type(f"{asset_cls.__name__}Staging", (asset_cls,), {"usd_path": staged}), staged
-
-
-def _local_asset_path(source_url: str, local_root: str | Path) -> str:
-    """Map one approved Isaac asset URL into the image's host-qualified local mirror."""
-    parsed = urlparse(source_url)
-    if parsed.scheme != "https" or parsed.netloc not in _LOCAL_ASSET_HOSTS:
-        raise RuntimeError(f"unsupported CAP asset source URL: {source_url}")
-    root = Path(local_root).expanduser().resolve()
-    target = (root / parsed.netloc / parsed.path.lstrip("/")).resolve()
-    if not target.is_relative_to(root):
-        raise RuntimeError(f"CAP asset source escapes the local asset root: {source_url}")
-    if not target.is_file():
-        raise FileNotFoundError(f"baked CAP asset is missing: {target} (source: {source_url})")
-    return str(target)
-
-
-def _local_asset_subclass(asset_cls: type, local_root: str | Path) -> tuple[type, str, str]:
-    """Return an instance-local asset subclass backed by the baked mirror."""
-    source_url = getattr(asset_cls, "usd_path", None)
-    if not source_url:
-        raise RuntimeError(f"CAP asset class has no usd_path: {asset_cls.__name__}")
-    local_path = _local_asset_path(source_url, local_root)
-    localized = type(f"{asset_cls.__name__}Local", (asset_cls,), {"usd_path": local_path})
-    return localized, source_url, local_path
-
-
-def _load_local_asset_provenance(local_root: str | Path) -> dict:
-    path = Path(local_root).expanduser().resolve() / _ASSET_PROVENANCE_FILE
-    try:
-        provenance = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"invalid baked CAP asset provenance: {path}") from exc
-    tree_hash = provenance.get("tree_sha256")
-    if (
-        provenance.get("schema_version") != 1
-        or not isinstance(tree_hash, str)
-        or not re.fullmatch(r"[0-9a-f]{64}", tree_hash)
-    ):
-        raise RuntimeError(f"invalid baked CAP asset provenance schema or tree hash: {path}")
-    expected_tree_hash = os.environ.get("CAP_IMAGE_ASSET_TREE_SHA256")
-    if expected_tree_hash and tree_hash != expected_tree_hash:
-        raise RuntimeError(f"baked CAP asset tree hash {tree_hash} does not match image pin {expected_tree_hash}")
-    return provenance
-
-
-def _apply_staging_stand_override(embodiment) -> str:
-    """Point a DROID embodiment's stand at the staging asset, INSTANCE-LOCALLY, and return the staged URL.
-
-    The stand AssetBaseCfg is a class-level configclass default shared across embodiment instances, so the
-    spawn cfg is deep-copied before its usd_path is rewritten and the copy is reassigned — editing in place
-    would leak the staging URL into other (stock) embodiments. Asserts the stand has a rewritable usd_path.
-    """
-    import copy
-
-    stand_usd = getattr(embodiment.scene_config.stand.spawn, "usd_path", None)
-    assert stand_usd, (
-        "--use_staging_assets set but the DROID stand has no spawn.usd_path to rewrite "
-        f"(stand spawn: {type(embodiment.scene_config.stand.spawn).__name__})."
-    )
-    staged = _to_staging_url(stand_usd)  # asserts the production host was actually rewritten
-    stand = copy.deepcopy(embodiment.scene_config.stand)
-    stand.spawn.usd_path = staged
-    embodiment.scene_config.stand = stand
-    return staged
-
-
-def _apply_local_droid_asset_override(embodiment, local_root: str | Path) -> dict[str, str]:
-    """Localize DROID robot and stand spawn configs without mutating shared defaults."""
-    import copy
-
-    source_urls = {}
-    local_paths = {}
-    for name in ("robot", "stand"):
-        asset_cfg = getattr(embodiment.scene_config, name)
-        source_url = getattr(asset_cfg.spawn, "usd_path", None)
-        if not source_url:
-            raise RuntimeError(f"DROID {name} has no spawn.usd_path to localize")
-        localized_cfg = copy.deepcopy(asset_cfg)
-        localized_cfg.spawn.usd_path = _local_asset_path(source_url, local_root)
-        setattr(embodiment.scene_config, name, localized_cfg)
-        source_urls[f"{name}_source_usd"] = source_url
-        local_paths[f"{name}_local_usd"] = localized_cfg.spawn.usd_path
-    return {**source_urls, **local_paths}
 
 
 @dataclass
@@ -476,11 +378,7 @@ class PickAndPlaceMapleTableEnvironment(ArenaEnvironmentFactory[PickAndPlaceMapl
         # (stock DROID only varies wrist_camera). The GaP job enables the Hydra key
         # camera_extrinsics_exterior_cam.enabled=true to activate the variation.
         if gap_profile:  # asserted above to imply enable_cameras + DROID
-            from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariation
-            from isaaclab_arena_environments.maple_cameras import MapleDroidPerceptionCameraCfg
-
-            embodiment.camera_config = MapleDroidPerceptionCameraCfg()
-            embodiment.add_variation(CameraExtrinsicsVariation(camera_name="exterior_cam"))
+            _apply_gap_camera_profile(cfg.embodiment, embodiment)
 
         # Step 5: Compose the scene
         scene = Scene(

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -28,6 +28,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -202,9 +203,27 @@ def build_env_from_env_graph_spec(env_graph_spec_path: Path, args_cli: argparse.
     """Build a gymnasium env from an environment graph spec YAML."""
     from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena_environments.cap_asset_overrides import (
+        apply_cap_asset_overrides,
+        cap_asset_registry_overrides_for_graph_spec,
+    )
 
     loaded_env_graph_spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_path)
-    arena_env = loaded_env_graph_spec.to_arena_env()
+    configured_local_root = os.environ.get("CAP_LOCAL_ASSET_ROOT")
+    local_asset_root = Path(configured_local_root).expanduser().resolve() if configured_local_root else None
+    use_staging_assets = getattr(args_cli, "use_staging_assets", False)
+    # USD-backed graph assets may open their USDs during construction, so route classes before to_arena_env().
+    with cap_asset_registry_overrides_for_graph_spec(
+        loaded_env_graph_spec,
+        use_staging_assets=use_staging_assets,
+        local_asset_root=local_asset_root,
+    ):
+        arena_env = loaded_env_graph_spec.to_arena_env(enable_cameras=args_cli.enable_cameras)
+    apply_cap_asset_overrides(
+        arena_env,
+        use_staging_assets=use_staging_assets,
+        local_asset_root=local_asset_root,
+    )
     # TODO(cvolk, 2026-07-06): [typed-config-migration] Pass ArenaEnvBuilderCfg into this function after this
     # runner stops carrying all configuration in one argparse Namespace.
     builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli))


### PR DESCRIPTION
## Summary
Fix graph camera setup for DROID graph specs

## Detailed description
- Generated graph YAMLs could not request the reviewed DROID exterior RGB-D camera profile, so camera setup depended on non-graph Maple environment wiring.
- Adds registered camera profiles, routes the DROID exterior RGB-D profile through agentic generation and graph-spec builds, and fails closed when a profile is selected without cameras enabled.
- Shares CAP Maple/DROID staging and local asset routing with graph-YAML builds so generated DROID scenes can run directly without mutating shared registered asset classes.
- Validated with `pre-commit run --all-files` and focused graph/camera/asset tests: 53 passed, 3 skipped.