### PR TITLE
Add object mass variation

### DIFF
--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -54,6 +54,10 @@ class ObjectBase(Asset, ABC):
             prim_path = "{ENV_REGEX_NS}/" + self.name
         self.prim_path = prim_path
         self.object_type = object_type
+        if self.object_type == ObjectType.RIGID:
+            from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation  # noqa: PLC0415
+
+            self.add_variation(ObjectMassVariation(self.name))
         self.initial_pose: Pose | PoseRange | PosePerEnv | None = None
         self.initial_velocity: Velocity | None = None
         self.object_cfg = None

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -32,6 +32,7 @@ from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.velocity import Velocity
+from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
 __all__ = [
     "ObjectBase",
@@ -55,8 +56,6 @@ class ObjectBase(Asset, ABC):
         self.prim_path = prim_path
         self.object_type = object_type
         if self.object_type == ObjectType.RIGID:
-            from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation  # noqa: PLC0415
-
             self.add_variation(ObjectMassVariation(self.name))
         self.initial_pose: Pose | PoseRange | PosePerEnv | None = None
         self.initial_velocity: Velocity | None = None

--- a/isaaclab_arena/tests/test_object_mass_variation.py
+++ b/isaaclab_arena/tests/test_object_mass_variation.py
@@ -1,0 +1,345 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pytest
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation, ObjectMassVariationCfg
+from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
+
+HEADLESS = True
+TEST_ASSET_NAME = "sphere"
+TEST_EVENT_NAME = f"{TEST_ASSET_NAME}_mass_variation"
+TEST_MASS = 0.125
+TEST_HYDRA_MASS = 0.25
+
+
+def get_test_environment(
+    *, enabled: bool, mass: float = TEST_MASS, min_mass: float = 1e-6, recompute_inertia: bool = True
+):
+    """Build a minimal arena env with an optional enabled object mass variation."""
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+
+    sphere = AssetRegistry().get_asset_by_name(TEST_ASSET_NAME)()
+    assert sphere.name == TEST_ASSET_NAME
+
+    variation = sphere.get_variation("mass")
+    variation.apply_cfg(
+        ObjectMassVariationCfg(
+            sampler_cfg=UniformSamplerCfg(low=[mass], high=[mass]),
+            min_mass=min_mass,
+            recompute_inertia=recompute_inertia,
+        )
+    )
+    if enabled:
+        variation.enable()
+    assert variation.enabled is enabled
+
+    return IsaacLabArenaEnvironment(
+        name="test_object_mass_variation",
+        scene=Scene(assets=[sphere]),
+    )
+
+
+def test_invalid_min_mass_is_rejected():
+    with pytest.raises(AssertionError, match="min_mass"):
+        ObjectMassVariation("cube", ObjectMassVariationCfg(min_mass=0.0))
+
+
+def _test_object_mass_variation_registration(simulation_app):
+    import torch
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_reference import ObjectReference
+    from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+    from isaaclab_arena.utils.pose import Pose
+
+    registry = AssetRegistry()
+    sphere = registry.get_asset_by_name("sphere")()
+    assert "mass" in sphere.variations
+
+    dome_light = registry.get_asset_by_name("light")()
+    assert "mass" not in dome_light.variations
+
+    table = registry.get_asset_by_name("table")()
+    assert "mass" not in table.variations
+
+    can_a = Object(name="can_a", object_type=ObjectType.RIGID, usd_path="/tmp/can_a.usd")
+    can_b = Object(name="can_b", object_type=ObjectType.RIGID, usd_path="/tmp/can_b.usd")
+    can_a.bounding_box = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(0.1, 0.1, 0.2))
+    can_b.bounding_box = AxisAlignedBoundingBox(min_point=(0.0, 0.0, 0.0), max_point=(0.2, 0.2, 0.3))
+    with (
+        patch("isaaclab_arena.assets.object_set.detect_object_type", return_value=ObjectType.RIGID),
+        patch("isaaclab_arena.assets.object_set.find_shallowest_rigid_body", return_value="/rigid"),
+        patch("isaaclab_arena.assets.object_set.torch.randint", return_value=torch.tensor([0, 1])),
+    ):
+        obj_set = RigidObjectSet(name="cans", objects=[can_a, can_b], random_choice=True)
+    assert "mass" in obj_set.variations
+
+    class DefaultPrim:
+        def GetPath(self):
+            return "/World/parent"
+
+    class Stage:
+        def GetDefaultPrim(self):
+            return DefaultPrim()
+
+        def GetPrimAtPath(self, prim_path):
+            return object()
+
+    class OpenStage:
+        def __init__(self, path):
+            pass
+
+        def __enter__(self):
+            return Stage()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    parent = SimpleNamespace(
+        name="parent",
+        usd_path="/tmp/parent.usd",
+        scale=(1.0, 1.0, 1.0),
+        initial_pose=None,
+    )
+    with (
+        patch("isaaclab_arena.assets.object_reference.open_stage", OpenStage),
+        patch(
+            "isaaclab_arena.assets.object_reference.get_prim_pose_in_default_prim_frame", return_value=Pose.identity()
+        ),
+    ):
+        object_ref = ObjectReference(
+            name="object_ref",
+            prim_path="{ENV_REGEX_NS}/parent/object_ref",
+            parent_asset=parent,
+            object_type=ObjectType.RIGID,
+        )
+    assert "mass" in object_ref.variations
+    return True
+
+
+def _test_disabled_object_mass_variation_not_in_events_cfg(simulation_app):
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    arena_env = get_test_environment(enabled=False)
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env_cfg, _ = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli)).compose_manager_cfg()
+
+    assert not hasattr(env_cfg.events, TEST_EVENT_NAME), (
+        f"Disabled variation must not add '{TEST_EVENT_NAME}' to env_cfg.events; "
+        f"got event fields: {sorted(vars(env_cfg.events))}."
+    )
+    return True
+
+
+def _test_enabled_object_mass_variation_in_events_cfg(simulation_app):
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.variations.object_mass_variation import apply_object_mass_from_sampler
+
+    arena_env = get_test_environment(enabled=True)
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env_cfg, _ = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli)).compose_manager_cfg()
+
+    assert hasattr(
+        env_cfg.events, TEST_EVENT_NAME
+    ), f"Expected env_cfg.events to contain '{TEST_EVENT_NAME}'; got event fields: {sorted(vars(env_cfg.events))}."
+    event_cfg = getattr(env_cfg.events, TEST_EVENT_NAME)
+    assert event_cfg.func is apply_object_mass_from_sampler
+    assert event_cfg.mode == "reset"
+    assert event_cfg.params["asset_cfg"].name == TEST_ASSET_NAME
+    assert event_cfg.params["recompute_inertia"] is True
+    return True
+
+
+def _test_object_mass_variation_realized_and_recorded(simulation_app):
+    import warp as wp
+
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env = ArenaEnvBuilder(
+        get_test_environment(enabled=True),
+        arena_env_builder_cfg_from_argparse(args_cli),
+    ).make_registered()
+    try:
+        env.reset()
+        asset = env.unwrapped.scene[TEST_ASSET_NAME]
+
+        mass = wp.to_torch(asset.data.body_mass).clone()
+        torch.testing.assert_close(
+            mass[0, 0],
+            torch.tensor(TEST_MASS, device=mass.device, dtype=mass.dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+        record = env.unwrapped.variation_recorder[f"{TEST_ASSET_NAME}.mass"]
+        episode_idx = env.unwrapped.get_episode_index(0)
+        recorded_mass = record.sample_for_episode(0, episode_idx)
+        assert recorded_mass.tolist() == pytest.approx([TEST_MASS], abs=1e-6)
+
+        first_inertia = wp.to_torch(asset.data.body_inertia).clone()
+        env.reset()
+        second_inertia = wp.to_torch(asset.data.body_inertia).clone()
+        torch.testing.assert_close(second_inertia, first_inertia, atol=1e-6, rtol=1e-6)
+    finally:
+        env.close()
+    return True
+
+
+def _test_hydra_override_applies_object_mass_variation(simulation_app):
+    import warp as wp
+
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env = ArenaEnvBuilder(
+        get_test_environment(enabled=False),
+        arena_env_builder_cfg_from_argparse(args_cli),
+        hydra_overrides=[
+            f"{TEST_ASSET_NAME}.mass.enabled=true",
+            f"{TEST_ASSET_NAME}.mass.sampler_cfg.low=[{TEST_HYDRA_MASS}]",
+            f"{TEST_ASSET_NAME}.mass.sampler_cfg.high=[{TEST_HYDRA_MASS}]",
+            f"{TEST_ASSET_NAME}.mass.recompute_inertia=false",
+        ],
+    ).make_registered()
+    try:
+        env.reset()
+        asset = env.unwrapped.scene[TEST_ASSET_NAME]
+        mass = wp.to_torch(asset.data.body_mass).clone()
+        torch.testing.assert_close(
+            mass[0, 0],
+            torch.tensor(TEST_HYDRA_MASS, device=mass.device, dtype=mass.dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+        record = env.unwrapped.variation_recorder[f"{TEST_ASSET_NAME}.mass"]
+        episode_idx = env.unwrapped.get_episode_index(0)
+        recorded_mass = record.sample_for_episode(0, episode_idx)
+        assert recorded_mass.tolist() == pytest.approx([TEST_HYDRA_MASS], abs=1e-6)
+        assert record.cfg.recompute_inertia is False
+    finally:
+        env.close()
+    return True
+
+
+def _test_object_mass_variation_partial_reset_accepts_sequence_env_ids(simulation_app):
+    import warp as wp
+
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "3"])
+    env = ArenaEnvBuilder(
+        get_test_environment(enabled=True),
+        arena_env_builder_cfg_from_argparse(args_cli),
+    ).make_registered()
+    try:
+        env.reset()
+        asset = env.unwrapped.scene[TEST_ASSET_NAME]
+        mass = wp.to_torch(asset.data.body_mass).clone()
+        manual_masses = torch.tensor([[0.2], [0.3], [0.4]], device=mass.device, dtype=mass.dtype)
+        env_ids = torch.arange(3, device=asset.device, dtype=torch.int32)
+        body_ids = torch.tensor([0], device=asset.device, dtype=torch.int32)
+        asset.set_masses_index(masses=manual_masses, body_ids=body_ids, env_ids=env_ids)
+
+        env.unwrapped.reset(env_ids=[1])
+
+        mass_after_reset = wp.to_torch(asset.data.body_mass).clone()
+        expected_masses = manual_masses.clone()
+        expected_masses[1, 0] = TEST_MASS
+        torch.testing.assert_close(mass_after_reset[:, 0], expected_masses[:, 0], atol=1e-6, rtol=1e-6)
+
+        record = env.unwrapped.variation_recorder[f"{TEST_ASSET_NAME}.mass"]
+        episode_idx = env.unwrapped.get_episode_index(1)
+        recorded_mass = record.sample_for_episode(1, episode_idx)
+        assert recorded_mass.tolist() == pytest.approx([TEST_MASS], abs=1e-6)
+    finally:
+        env.close()
+    return True
+
+
+def _test_object_mass_sample_below_min_mass_fails(simulation_app):
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    builder = ArenaEnvBuilder(
+        get_test_environment(enabled=True, mass=0.01, min_mass=0.02),
+        arena_env_builder_cfg_from_argparse(args_cli),
+    )
+    env = None
+    try:
+        with pytest.raises(AssertionError, match="below min_mass"):
+            env = builder.make_registered()
+            env.reset()
+    finally:
+        if env is not None:
+            env.close()
+    return True
+
+
+def test_object_mass_variation_registration():
+    assert run_simulation_app_function(
+        _test_object_mass_variation_registration,
+        headless=HEADLESS,
+    )
+
+
+def test_disabled_object_mass_variation_not_in_events_cfg():
+    assert run_simulation_app_function(
+        _test_disabled_object_mass_variation_not_in_events_cfg,
+        headless=HEADLESS,
+    )
+
+
+def test_enabled_object_mass_variation_in_events_cfg():
+    assert run_simulation_app_function(
+        _test_enabled_object_mass_variation_in_events_cfg,
+        headless=HEADLESS,
+    )
+
+
+def test_object_mass_variation_realized_and_recorded():
+    assert run_simulation_app_function(
+        _test_object_mass_variation_realized_and_recorded,
+        headless=HEADLESS,
+    )
+
+
+def test_hydra_override_applies_object_mass_variation():
+    assert run_simulation_app_function(
+        _test_hydra_override_applies_object_mass_variation,
+        headless=HEADLESS,
+    )
+
+
+def test_object_mass_variation_partial_reset_accepts_sequence_env_ids():
+    assert run_simulation_app_function(
+        _test_object_mass_variation_partial_reset_accepts_sequence_env_ids,
+        headless=HEADLESS,
+    )
+
+
+def test_object_mass_sample_below_min_mass_fails():
+    assert run_simulation_app_function(
+        _test_object_mass_sample_below_min_mass_fails,
+        headless=HEADLESS,
+    )

--- a/isaaclab_arena/tests/test_object_mass_variation.py
+++ b/isaaclab_arena/tests/test_object_mass_variation.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
-from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation, ObjectMassVariationCfg
+from isaaclab_arena.variations.object_mass_variation import ObjectMassVariationCfg
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
 HEADLESS = True
@@ -19,9 +19,18 @@ TEST_HYDRA_MASS = 0.25
 
 
 def get_test_environment(
-    *, enabled: bool, mass: float = TEST_MASS, min_mass: float = 1e-6, recompute_inertia: bool = True
+    *,
+    enabled: bool,
+    mass: float = TEST_MASS,
+    mass_low: float | None = None,
+    mass_high: float | None = None,
+    recompute_inertia: bool = True,
 ):
-    """Build a minimal arena env with an optional enabled object mass variation."""
+    """Build a minimal arena env with an optional enabled object mass variation.
+
+    By default the mass sampler is a point mass (``low == high == mass``). Pass ``mass_low``/``mass_high``
+    to sample over a range instead (used to draw distinct per-env masses).
+    """
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
     from isaaclab_arena.scene.scene import Scene
@@ -29,11 +38,12 @@ def get_test_environment(
     sphere = AssetRegistry().get_asset_by_name(TEST_ASSET_NAME)()
     assert sphere.name == TEST_ASSET_NAME
 
+    low = [mass_low if mass_low is not None else mass]
+    high = [mass_high if mass_high is not None else mass]
     variation = sphere.get_variation("mass")
     variation.apply_cfg(
         ObjectMassVariationCfg(
-            sampler_cfg=UniformSamplerCfg(low=[mass], high=[mass]),
-            min_mass=min_mass,
+            sampler_cfg=UniformSamplerCfg(low=low, high=high),
             recompute_inertia=recompute_inertia,
         )
     )
@@ -45,11 +55,6 @@ def get_test_environment(
         name="test_object_mass_variation",
         scene=Scene(assets=[sphere]),
     )
-
-
-def test_invalid_min_mass_is_rejected():
-    with pytest.raises(AssertionError, match="min_mass"):
-        ObjectMassVariation("cube", ObjectMassVariationCfg(min_mass=0.0))
 
 
 def _test_object_mass_variation_registration(simulation_app):
@@ -148,7 +153,7 @@ def _test_disabled_object_mass_variation_not_in_events_cfg(simulation_app):
 def _test_enabled_object_mass_variation_in_events_cfg(simulation_app):
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
-    from isaaclab_arena.variations.object_mass_variation import apply_object_mass_from_sampler
+    from isaaclab_arena.variations.object_mass_variation import ApplyObjectMassFromSampler
 
     arena_env = get_test_environment(enabled=True)
     args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
@@ -158,7 +163,7 @@ def _test_enabled_object_mass_variation_in_events_cfg(simulation_app):
         env_cfg.events, TEST_EVENT_NAME
     ), f"Expected env_cfg.events to contain '{TEST_EVENT_NAME}'; got event fields: {sorted(vars(env_cfg.events))}."
     event_cfg = getattr(env_cfg.events, TEST_EVENT_NAME)
-    assert event_cfg.func is apply_object_mass_from_sampler
+    assert event_cfg.func is ApplyObjectMassFromSampler
     assert event_cfg.mode == "reset"
     assert event_cfg.params["asset_cfg"].name == TEST_ASSET_NAME
     assert event_cfg.params["recompute_inertia"] is True
@@ -197,6 +202,47 @@ def _test_object_mass_variation_realized_and_recorded(simulation_app):
         env.reset()
         second_inertia = wp.to_torch(asset.data.body_inertia).clone()
         torch.testing.assert_close(second_inertia, first_inertia, atol=1e-6, rtol=1e-6)
+    finally:
+        env.close()
+    return True
+
+
+def _test_object_mass_variation_scales_inertia(simulation_app):
+    """With recompute_inertia, each env's inertia scales linearly with its sampled mass.
+
+    Draws distinct per-env masses over a range, then checks ``inertia / mass`` is the same across
+    envs (i.e. inertia == default_inertia * mass / default_mass), directly validating the scaling.
+    """
+    import warp as wp
+
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "4", "--seed", "0"])
+    env = ArenaEnvBuilder(
+        get_test_environment(enabled=True, mass_low=0.1, mass_high=3.0, recompute_inertia=True),
+        arena_env_builder_cfg_from_argparse(args_cli),
+    ).make_registered()
+    try:
+        env.reset()
+        asset = env.unwrapped.scene[TEST_ASSET_NAME]
+        masses = wp.to_torch(asset.data.body_mass)[:, 0].clone()  # (num_envs,)
+        inertias = wp.to_torch(asset.data.body_inertia)[:, 0].clone()  # (num_envs, K)
+
+        # The test is only meaningful if the envs actually drew different masses.
+        assert (masses.max() - masses.min()).item() > 0.1, f"expected a spread of per-env masses, got {masses}."
+
+        # inertia == default_inertia * (mass / default_mass) => inertia / mass is constant across envs.
+        inertia_per_mass = inertias / masses[:, None]
+        reference = inertia_per_mass[0]
+        significant = reference.abs() > 1e-9  # ignore identically-zero inertia components
+        for env_id in range(1, masses.shape[0]):
+            torch.testing.assert_close(
+                inertia_per_mass[env_id][significant],
+                reference[significant],
+                rtol=1e-4,
+                atol=1e-8,
+            )
     finally:
         env.close()
     return True
@@ -276,18 +322,19 @@ def _test_object_mass_variation_partial_reset_accepts_sequence_env_ids(simulatio
     return True
 
 
-def _test_object_mass_sample_below_min_mass_fails(simulation_app):
+def _test_object_mass_sample_below_floor_fails(simulation_app):
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
     args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    # Sample a mass below the fixed physical floor (_MIN_PHYSICAL_MASS_KG = 1e-6) to trip the guard.
     builder = ArenaEnvBuilder(
-        get_test_environment(enabled=True, mass=0.01, min_mass=0.02),
+        get_test_environment(enabled=True, mass=1e-9),
         arena_env_builder_cfg_from_argparse(args_cli),
     )
     env = None
     try:
-        with pytest.raises(AssertionError, match="below min_mass"):
+        with pytest.raises(AssertionError, match="minimum physical mass"):
             env = builder.make_registered()
             env.reset()
     finally:
@@ -324,6 +371,13 @@ def test_object_mass_variation_realized_and_recorded():
     )
 
 
+def test_object_mass_variation_scales_inertia():
+    assert run_simulation_app_function(
+        _test_object_mass_variation_scales_inertia,
+        headless=HEADLESS,
+    )
+
+
 def test_hydra_override_applies_object_mass_variation():
     assert run_simulation_app_function(
         _test_hydra_override_applies_object_mass_variation,
@@ -338,8 +392,8 @@ def test_object_mass_variation_partial_reset_accepts_sequence_env_ids():
     )
 
 
-def test_object_mass_sample_below_min_mass_fails():
+def test_object_mass_sample_below_floor_fails():
     assert run_simulation_app_function(
-        _test_object_mass_sample_below_min_mass_fails,
+        _test_object_mass_sample_below_floor_fails,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/variations/object_mass_variation.py
+++ b/isaaclab_arena/variations/object_mass_variation.py
@@ -26,6 +26,10 @@ from isaaclab_arena.variations.variation_base import RunTimeVariationBase, Varia
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedEnv
 
+# Smallest physically meaningful mass [kg]. Sampled masses below this would inject invalid
+# (near-zero / NaN-prone) values into the physics engine, so they are rejected rather than clamped.
+_MIN_PHYSICAL_MASS_KG = 1e-6
+
 
 @configclass
 class ObjectMassVariationCfg(VariationBaseCfg):
@@ -36,9 +40,6 @@ class ObjectMassVariationCfg(VariationBaseCfg):
 
     recompute_inertia: bool = True
     """Whether to scale inertia tensors by the sampled-mass/default-mass ratio."""
-
-    min_mass: float = 1e-6
-    """Minimum allowed sampled mass [kg]. Values below this fail instead of being clamped."""
 
 
 class ObjectMassVariation(RunTimeVariationBase):
@@ -66,13 +67,6 @@ class ObjectMassVariation(RunTimeVariationBase):
         super().__init__(cfg=cfg if cfg is not None else ObjectMassVariationCfg(), name=name)
         self.asset_name = asset_name
 
-    def apply_cfg(self, cfg: ObjectMassVariationCfg) -> None:
-        """Apply and validate the mass variation config."""
-        super().apply_cfg(cfg)
-        assert (
-            cfg.min_mass >= 1e-6
-        ), f"ObjectMassVariation requires min_mass >= 1e-6 to avoid invalid physics masses; got {cfg.min_mass}."
-
     def build_event_cfg(self) -> tuple[str, EventTermCfg]:
         assert self._sampler is not None, (
             f"ObjectMassVariation on '{self.asset_name}' is enabled but no sampler is set; "
@@ -80,19 +74,18 @@ class ObjectMassVariation(RunTimeVariationBase):
         )
         event_name = f"{self.asset_name}_mass_variation"
         event_cfg = EventTermCfg(
-            func=apply_object_mass_from_sampler,
+            func=ApplyObjectMassFromSampler,
             mode="reset",
             params={
                 "asset_cfg": SceneEntityCfg(self.asset_name),
                 "sampler": self._sampler,
                 "recompute_inertia": self.cfg.recompute_inertia,
-                "min_mass": self.cfg.min_mass,
             },
         )
         return event_name, event_cfg
 
 
-class apply_object_mass_from_sampler(ManagerTermBase):
+class ApplyObjectMassFromSampler(ManagerTermBase):
     """Event term: set a rigid object's absolute mass from sampler draws.
 
     The sampler must produce one scalar per environment. Defaults are snapshotted
@@ -105,24 +98,20 @@ class apply_object_mass_from_sampler(ManagerTermBase):
 
         self.asset_cfg: SceneEntityCfg = cfg.params["asset_cfg"]
         sampler: ContinuousSampler = cfg.params["sampler"]
-        min_mass: float = cfg.params["min_mass"]
 
         self.asset = env.scene[self.asset_cfg.name]
         assert hasattr(self.asset, "set_masses_index") and hasattr(self.asset, "set_inertias_index"), (
-            "apply_object_mass_from_sampler expects a rigid object-like asset with mass/inertia setters at "
+            "ApplyObjectMassFromSampler expects a rigid object-like asset with mass/inertia setters at "
             f"scene['{self.asset_cfg.name}']; got {type(self.asset).__name__}."
         )
         assert tuple(sampler.shape_per_sample) == (1,), (
-            "apply_object_mass_from_sampler expects a sampler with shape_per_sample (1,) over absolute mass; "
+            "ApplyObjectMassFromSampler expects a sampler with shape_per_sample (1,) over absolute mass; "
             f"got {tuple(sampler.shape_per_sample)}."
         )
-        assert (
-            min_mass >= 1e-6
-        ), f"apply_object_mass_from_sampler requires min_mass >= 1e-6 to avoid invalid physics masses; got {min_mass}."
-        selected_bodies = self._selected_body_count()
-        assert selected_bodies == 1, (
-            "apply_object_mass_from_sampler currently supports exactly one selected body; "
-            f"'{self.asset_cfg.name}' selected {selected_bodies} bodies."
+        selected_bodies_count = self._selected_body_count()
+        assert selected_bodies_count == 1, (
+            "ApplyObjectMassFromSampler currently supports exactly one selected body; "
+            f"'{self.asset_cfg.name}' selected {selected_bodies_count} bodies."
         )
 
         self._default_mass: torch.Tensor | None = None
@@ -153,7 +142,6 @@ class apply_object_mass_from_sampler(ManagerTermBase):
         asset_cfg: SceneEntityCfg,  # noqa: ARG002
         sampler: ContinuousSampler,
         recompute_inertia: bool,
-        min_mass: float,
     ):
         if self._default_mass is None:
             self._default_mass = wp.to_torch(self.asset.data.body_mass).clone()
@@ -169,17 +157,20 @@ class apply_object_mass_from_sampler(ManagerTermBase):
             env_ids = torch.as_tensor(env_ids, device=self.asset.device, dtype=torch.int32).reshape(-1)
         body_ids = self._body_ids_tensor()
 
+        # TODO(tstuyck, 2026-07-17): The sampler draws on CPU, so this moves the samples to the sim
+        # device every reset. Make ContinuousSampler device-aware (draw directly on device) to drop
+        # this transfer here and in the other variations that copy sampler output onto the device.
         sample = sampler.sample(num_samples=len(env_ids), env_ids=env_ids)
         masses_to_apply = sample.to(device=self._default_mass.device, dtype=self._default_mass.dtype)
         if masses_to_apply.numel() > 0:
-            assert torch.all(masses_to_apply >= min_mass), (
-                "ObjectMassVariation sampled a mass below min_mass. Constrain sampler_cfg.low or lower min_mass "
-                f"within the supported range. min sampled mass={float(masses_to_apply.min())}, min_mass={min_mass}."
+            assert torch.all(masses_to_apply >= _MIN_PHYSICAL_MASS_KG), (
+                f"ObjectMassVariation sampled a mass below the minimum physical mass ({_MIN_PHYSICAL_MASS_KG} kg); "
+                f"constrain sampler_cfg.low. min sampled mass={float(masses_to_apply.min())}."
             )
 
-        masses = wp.to_torch(self.asset.data.body_mass).clone()
-        masses[env_ids[:, None], body_ids] = masses_to_apply
-        self.asset.set_masses_index(masses=masses[env_ids[:, None], body_ids], body_ids=body_ids, env_ids=env_ids)
+        # set_masses_index writes only the (env_ids, body_ids) subset, so pass the sampled masses
+        # straight through instead of cloning the full body_mass tensor to slice the same subset back out.
+        self.asset.set_masses_index(masses=masses_to_apply, body_ids=body_ids, env_ids=env_ids)
 
         if recompute_inertia:
             default_masses = self._default_mass[env_ids[:, None], body_ids]
@@ -187,11 +178,8 @@ class apply_object_mass_from_sampler(ManagerTermBase):
                 "ObjectMassVariation cannot recompute inertia from non-positive default mass values; "
                 f"default masses={default_masses}."
             )
+            # Scale each inertia tensor by the same factor the mass changed by (uniform-density
+            # assumption: I ∝ m for a fixed shape), always relative to the snapshotted default inertia.
             ratios = masses_to_apply / default_masses
-            inertias = wp.to_torch(self.asset.data.body_inertia).clone()
-            inertias[env_ids[:, None], body_ids] = self._default_inertia[env_ids[:, None], body_ids] * ratios[..., None]
-            self.asset.set_inertias_index(
-                inertias=inertias[env_ids[:, None], body_ids],
-                body_ids=body_ids,
-                env_ids=env_ids,
-            )
+            new_inertias = self._default_inertia[env_ids[:, None], body_ids] * ratios[..., None]
+            self.asset.set_inertias_index(inertias=new_inertias, body_ids=body_ids, env_ids=env_ids)

--- a/isaaclab_arena/variations/object_mass_variation.py
+++ b/isaaclab_arena/variations/object_mass_variation.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-env object mass variation.
+
+Samples an absolute mass for a rigid object at reset and applies it through the
+same mass/inertia setters used by Isaac Lab's rigid-body mass randomizer.
+"""
+
+from __future__ import annotations
+
+import torch
+from dataclasses import field
+from typing import TYPE_CHECKING
+
+import warp as wp
+from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
+from isaaclab.utils import configclass
+
+from isaaclab_arena.variations.continuous_sampler import ContinuousSampler
+from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
+from isaaclab_arena.variations.variation_base import RunTimeVariationBase, VariationBaseCfg
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+
+@configclass
+class ObjectMassVariationCfg(VariationBaseCfg):
+    """Configuration for ObjectMassVariation."""
+
+    sampler_cfg: UniformSamplerCfg = field(default_factory=lambda: UniformSamplerCfg(low=[0.05], high=[2.0]))
+    """Uniform distribution over absolute object mass [kg]."""
+
+    recompute_inertia: bool = True
+    """Whether to scale inertia tensors by the sampled-mass/default-mass ratio."""
+
+    min_mass: float = 1e-6
+    """Minimum allowed sampled mass [kg]. Values below this fail instead of being clamped."""
+
+
+class ObjectMassVariation(RunTimeVariationBase):
+    """Vary a rigid object's absolute mass at reset.
+
+    Each reset samples one scalar mass per resetting environment. The event
+    applies the sample directly, so the recorded variation value is the
+    simulated mass.
+
+    Args:
+        asset_name: Scene-entity name of the target rigid object.
+        cfg: Tunable parameters. Override the mass distribution via
+            ``cfg.sampler_cfg``.
+        name: Identifier under which this variation is registered on the asset.
+    """
+
+    cfg: ObjectMassVariationCfg
+
+    def __init__(
+        self,
+        asset_name: str,
+        cfg: ObjectMassVariationCfg | None = None,
+        name: str = "mass",
+    ):
+        super().__init__(cfg=cfg if cfg is not None else ObjectMassVariationCfg(), name=name)
+        self.asset_name = asset_name
+
+    def apply_cfg(self, cfg: ObjectMassVariationCfg) -> None:
+        """Apply and validate the mass variation config."""
+        super().apply_cfg(cfg)
+        assert (
+            cfg.min_mass >= 1e-6
+        ), f"ObjectMassVariation requires min_mass >= 1e-6 to avoid invalid physics masses; got {cfg.min_mass}."
+
+    def build_event_cfg(self) -> tuple[str, EventTermCfg]:
+        assert self._sampler is not None, (
+            f"ObjectMassVariation on '{self.asset_name}' is enabled but no sampler is set; "
+            "call apply_cfg with a cfg that sets sampler_cfg before building the env."
+        )
+        event_name = f"{self.asset_name}_mass_variation"
+        event_cfg = EventTermCfg(
+            func=apply_object_mass_from_sampler,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(self.asset_name),
+                "sampler": self._sampler,
+                "recompute_inertia": self.cfg.recompute_inertia,
+                "min_mass": self.cfg.min_mass,
+            },
+        )
+        return event_name, event_cfg
+
+
+class apply_object_mass_from_sampler(ManagerTermBase):
+    """Event term: set a rigid object's absolute mass from sampler draws.
+
+    The sampler must produce one scalar per environment. Defaults are snapshotted
+    on the first call so repeated resets always apply the new mass relative to
+    the original inertia tensor, not the previous reset's randomized tensor.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+
+        self.asset_cfg: SceneEntityCfg = cfg.params["asset_cfg"]
+        sampler: ContinuousSampler = cfg.params["sampler"]
+        min_mass: float = cfg.params["min_mass"]
+
+        self.asset = env.scene[self.asset_cfg.name]
+        assert hasattr(self.asset, "set_masses_index") and hasattr(self.asset, "set_inertias_index"), (
+            "apply_object_mass_from_sampler expects a rigid object-like asset with mass/inertia setters at "
+            f"scene['{self.asset_cfg.name}']; got {type(self.asset).__name__}."
+        )
+        assert tuple(sampler.shape_per_sample) == (1,), (
+            "apply_object_mass_from_sampler expects a sampler with shape_per_sample (1,) over absolute mass; "
+            f"got {tuple(sampler.shape_per_sample)}."
+        )
+        assert (
+            min_mass >= 1e-6
+        ), f"apply_object_mass_from_sampler requires min_mass >= 1e-6 to avoid invalid physics masses; got {min_mass}."
+        selected_bodies = self._selected_body_count()
+        assert selected_bodies == 1, (
+            "apply_object_mass_from_sampler currently supports exactly one selected body; "
+            f"'{self.asset_cfg.name}' selected {selected_bodies} bodies."
+        )
+
+        self._default_mass: torch.Tensor | None = None
+        self._default_inertia: torch.Tensor | None = None
+
+    def _selected_body_count(self) -> int:
+        """Return how many body IDs this term will update."""
+        body_ids = self.asset_cfg.body_ids
+        if body_ids == slice(None):
+            return self.asset.num_bodies
+        if isinstance(body_ids, int):
+            return 1
+        return len(body_ids)
+
+    def _body_ids_tensor(self) -> torch.Tensor:
+        """Return the selected body IDs as an index tensor."""
+        body_ids = self.asset_cfg.body_ids
+        if body_ids == slice(None):
+            return torch.arange(self.asset.num_bodies, dtype=torch.int32, device=self.asset.device)
+        if isinstance(body_ids, int):
+            body_ids = [body_ids]
+        return torch.tensor(body_ids, dtype=torch.int32, device=self.asset.device)
+
+    def __call__(
+        self,
+        env: ManagerBasedEnv,
+        env_ids: torch.Tensor | None,
+        asset_cfg: SceneEntityCfg,  # noqa: ARG002
+        sampler: ContinuousSampler,
+        recompute_inertia: bool,
+        min_mass: float,
+    ):
+        if self._default_mass is None:
+            self._default_mass = wp.to_torch(self.asset.data.body_mass).clone()
+        if self._default_inertia is None:
+            self._default_inertia = wp.to_torch(self.asset.data.body_inertia).clone()
+
+        assert self._default_mass is not None
+        assert self._default_inertia is not None
+
+        if env_ids is None:
+            env_ids = torch.arange(env.scene.num_envs, device=self.asset.device, dtype=torch.int32)
+        else:
+            env_ids = torch.as_tensor(env_ids, device=self.asset.device, dtype=torch.int32).reshape(-1)
+        body_ids = self._body_ids_tensor()
+
+        sample = sampler.sample(num_samples=len(env_ids), env_ids=env_ids)
+        masses_to_apply = sample.to(device=self._default_mass.device, dtype=self._default_mass.dtype)
+        if masses_to_apply.numel() > 0:
+            assert torch.all(masses_to_apply >= min_mass), (
+                "ObjectMassVariation sampled a mass below min_mass. Constrain sampler_cfg.low or lower min_mass "
+                f"within the supported range. min sampled mass={float(masses_to_apply.min())}, min_mass={min_mass}."
+            )
+
+        masses = wp.to_torch(self.asset.data.body_mass).clone()
+        masses[env_ids[:, None], body_ids] = masses_to_apply
+        self.asset.set_masses_index(masses=masses[env_ids[:, None], body_ids], body_ids=body_ids, env_ids=env_ids)
+
+        if recompute_inertia:
+            default_masses = self._default_mass[env_ids[:, None], body_ids]
+            assert torch.all(default_masses > 0.0), (
+                "ObjectMassVariation cannot recompute inertia from non-positive default mass values; "
+                f"default masses={default_masses}."
+            )
+            ratios = masses_to_apply / default_masses
+            inertias = wp.to_torch(self.asset.data.body_inertia).clone()
+            inertias[env_ids[:, None], body_ids] = self._default_inertia[env_ids[:, None], body_ids] * ratios[..., None]
+            self.asset.set_inertias_index(
+                inertias=inertias[env_ids[:, None], body_ids],
+                body_ids=body_ids,
+                env_ids=env_ids,
+            )


### PR DESCRIPTION
## Summary
Add runtime object mass variation

## Detailed description
- Adds a rigid-object runtime variation for per-env sampled mass.
- Registers mass on rigid ObjectBase assets for Hydra configuration and recording.
- Covers event composition, Hydra overrides, recorder output, partial reset, and invalid mass handling.

<img width="1691" height="1023" alt="mass_sensitivity_combined" src="https://github.com/user-attachments/assets/31f959d5-d66c-4185-9b5f-838a05360714" />
