### PR TITLE
Add inline Experiment Runner preview

### DIFF
--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -1,10 +1,11 @@
 Evaluation Types
 =================
 
-Isaac Lab Arena supports two main ways to run policy evaluation: a single-job
-**policy runner** (single or multi-GPU) and an **Experiment Runner** for
-multiple jobs in one process. This section summarizes when to use each and how
-they work. Each section below links to the relevant concept docs:
+Isaac Lab Arena supports two evaluation entry points: an **Experiment Runner**
+for inline environment previews and configured typed Runs, and a **policy
+runner** for compatibility workflows such as distributed execution. This
+section summarizes when to use each and how they work. Each section below links
+to the relevant concept docs:
 :doc:`Policy Design <index>`,
 :doc:`Environment Design <../concept_overview>`, and
 :doc:`Metrics Design <../task/concept_metrics_design>`.
@@ -39,7 +40,7 @@ Summary
      - ``policy_runner.py``
      - Yes (torchrun)
    * - Experiment Runner
-     - Multiple jobs (env/policy combos) in sequence
+     - Quick registered-environment preview or configured typed Runs
      - ``experiment_runner.py``
      - No
 
@@ -47,9 +48,9 @@ Summary
 --------------------------------------------------------
 
 The **policy runner** (``isaaclab_arena/evaluation/policy_runner.py``) runs one
-evaluation job: one environment configuration and one policy. It is the right
-choice for ad-hoc runs, debugging, or when you want to drive one scenario with
-full control over CLI arguments.
+environment configuration and one policy. Use it when compatibility with
+graph-spec or external environments, arbitrary policy CLI configuration, or
+distributed execution is required.
 
 **Design context:** For how policies are defined and integrated with environments,
 see :doc:`Policy Design <index>`.
@@ -139,109 +140,100 @@ registered policies, policy-specific flags are generated from their ``PolicyCfg`
 
 .. _sequential-batch-experiment-runner:
 
-2. Experiment Runner — batch jobs
---------------------------------------------
+2. Experiment Runner — inline preview and configured Runs
+---------------------------------------------------------
 
 The **Experiment Runner** (``isaaclab_arena/evaluation/experiment_runner.py``)
-runs a **batch** of evaluation jobs sequentially in a single process. Each job can have
-a different environment (scene/object/embodiment), policy type, policy config,
-and length (steps or episodes). This is suited for benchmarking many
-configurations (e.g. many objects or tasks) without launching multiple processes
-by hand. Persistence of the simulation application is maintained between jobs.
+executes typed Arena Runs. It accepts exactly one input source:
 
-**Design context:** For how environments are composed and how metrics are
-defined and computed, see :doc:`Environment Design <../concept_overview>`
-and :doc:`Metrics Design <../task/concept_metrics_design>`. Policies used per job
-follow :doc:`Policy Design <index>`.
+- ``--environment NAME`` creates one inline ``preview`` Run for a registered
+  environment.
+- ``--experiment_config PATH`` loads named Runs from a typed YAML Experiment
+  Definition or a legacy JSON configuration.
 
-**Features:**
+Inline environment preview
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- One JSON config file (``--eval_jobs_config``) listing all jobs.
-- Jobs run one after another; each job builds its environment, creates the
-  policy from the job config, runs ``rollout_policy``, then tears down the env
-  before the next job.
-- If a job fails, the runner continues with the next job and marks the failed
-  job accordingly.
-- Metrics are aggregated and printed at the end (e.g. via ``MetricsLogger``).
-- **Distributed evaluation is not supported**: the Experiment Runner
-  runs in a single process. For multi-GPU, use multiple policy runner
-  invocations (e.g. with ``torchrun``) or split the batch across machines.
-
-.. todo::
-
-    Experiment with distributed evaluation in the Experiment Runner.
-
-**Jobs config format**
-
-The config file must be a JSON object with a ``"jobs"`` array. Each job is an
-object with:
-
-- ``name``: Unique job name (for logging and metrics).
-- ``arena_env_args``: Environment arguments as a dict (e.g. ``environment``,
-  ``num_envs``, ``object``, ``embodiment``, ``enable_cameras``, etc.). Converted
-  internally to the same CLI-style list the policy runner uses.
-- ``policy_type``: Same as policy runner (registered name or dotted class path).
-- ``policy_config_dict``: Policy configuration (e.g. checkpoint path, model
-  options). Deserialized through the policy's registered config type; the
-  deprecated CLI conversion fallback remains for legacy policies without one.
-- ``num_steps`` or ``num_episodes`` (optional): Simulation length for this job.
-  If both are omitted, the runner uses the policy’s length if defined, or a CLI
-  default (e.g. ``--num_steps``).
-
-**Example config structure**
-
-.. code-block:: json
-
-   {
-     "jobs": [
-       {
-         "name": "gr1_open_microwave_cracker_box",
-         "arena_env_args": {
-           "environment": "gr1_open_microwave",
-           "object": "cracker_box",
-           "embodiment": "gr1_joint",
-           "num_envs": 4
-         },
-         "num_steps": 500,
-         "policy_type": "zero_action",
-         "policy_config_dict": {}
-       },
-       {
-         "name": "gr1_sequential_static_manipulation_put_ranch_dressing_bottle_in_fridge_and_close_door",
-         "arena_env_args": {
-           "enable_cameras": true,
-           "environment": "gr1_sequential_static_manipulation",
-           "object": "ranch_dressing_hope_robolab",
-           "embodiment": "gr1_joint"
-         },
-         "num_steps": 100,
-         "policy_type": "isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy",
-         "policy_config_dict": {
-           "policy_config_yaml_path": "isaaclab_arena_gr00t/policy/config/gr1_manip_ranch_bottle_gr00t_closedloop_config.yaml",
-           "policy_device": "cuda:0",
-           "remote_host": "127.0.0.1",
-           "remote_port": 5555
-          }
-       }
-     ]
-   }
-
-**Running the Experiment Runner**
+Use inline mode to build and inspect a registered environment without first
+writing an Experiment YAML:
 
 .. code-block:: bash
 
    python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --eval_jobs_config path/to/eval_jobs_config.json \
-     --num_steps 1000
+     --environment pick_and_place_maple_table
 
-If any job needs cameras, set ``enable_cameras: true`` in that job’s
-``arena_env_args``; the Experiment Runner automatically enables camera support if any job requires it.
+The generated ``preview`` Run uses ``zero_action`` for 100 steps, one
+environment, and one rebuild. Trailing Hydra overrides are relative to that
+Run. Select an explicit limit with ``--num_steps`` or ``--num_episodes``, or
+override the corresponding ``rollout_limit.*`` field:
+
+.. code-block:: bash
+
+   python isaaclab_arena/evaluation/experiment_runner.py \
+     --viz kit \
+     --environment pick_and_place_maple_table \
+     --num_envs 4 \
+     environment.embodiment=droid_rel_joint_pos \
+     environment.pick_up_object=mustard_bottle_hot3d_robolab \
+     rollout_limit.num_steps=500 \
+     num_rebuilds=2 \
+     +variations.light.hdr_image.enabled=true
+
+Use the ``environment.*``, ``environment_builder.*``,
+``rollout_limit.*``, ``variations.*``, and ``num_rebuilds`` namespaces. The
+leading ``+`` is required when adding entries to the initially empty
+``variations`` mapping. Prefer shared builder flags such as ``--num_envs`` and
+``--mimic`` when available; inline composition also copies them into matching
+environment-specific fields. Use ``environment_builder.*`` for builder fields
+without a shared CLI flag.
+
+Add ``--enable_cameras`` when the preview needs camera sensors.
+``--record_camera_video`` enables camera support automatically. Inline mode
+supports registered environments and the zero-action policy. Use
+``policy_runner.py`` for graph-spec or external environments, arbitrary policy
+CLI configuration, and distributed execution.
+
+Configured Experiments
+^^^^^^^^^^^^^^^^^^^^^^
+
+For repeatable or multi-Run evaluation, declare typed Runs in YAML:
+
+.. code-block:: yaml
+
+   runs:
+     baseline:
+       environment:
+         type: pick_and_place_maple_table
+         embodiment: droid_rel_joint_pos
+       policy:
+         type: zero_action
+       rollout_limit:
+         num_steps: 50
+
+Run the definition with:
+
+.. code-block:: bash
+
+   python isaaclab_arena/evaluation/experiment_runner.py \
+     --viz kit \
+     --experiment_config isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
+
+Configured-Experiment overrides use the complete named-Run path, for example
+``runs.baseline.rollout_limit.num_steps=100``. Runs execute sequentially in one
+Isaac Sim process. Metrics and reports use the same execution path in inline
+and configured modes.
+
+Legacy JSON configs and the ``--eval_jobs_config`` alias remain supported for
+compatibility. New Experiment Definitions should use typed YAML. Distributed
+evaluation is not supported by the Experiment Runner.
 
 Choosing an evaluation type
 ---------------------------
 
-- **One-off run, one setup**: use the **policy runner** (single or multi-GPU);
-  use ``--object_set`` for heterogeneous objects in one run.
-- **Many env/policy combinations in one go**: use the **sequential batch eval
-  runner** with a jobs JSON; use ``--object_set`` for heterogeneous objects in one run.
+- **Quickly inspect a registered environment**: use
+  ``experiment_runner.py --environment NAME``.
+- **Repeatable or multi-Run evaluation**: use ``experiment_runner.py`` with a
+  typed YAML Experiment Definition.
+- **Graph-spec or external environments, arbitrary policy CLI configuration,
+  or multi-GPU execution**: use ``policy_runner.py``.

--- a/docs/pages/quickstart/first_experiments/exploring_variations.rst
+++ b/docs/pages/quickstart/first_experiments/exploring_variations.rst
@@ -5,10 +5,9 @@ Arena lets you evaluate a robot policy across variations of object, lighting, an
 from a single environment definition — no task logic changes, no duplicated configuration. You
 swap one argument and get a completely different environment.
 
-The fastest way to see this is with the **policy runner** and a **zero-action policy** — a
-placeholder policy that sends zero commands to the robot every step. The robot stays still, but
-the environment loads, the scene renders, and you can verify that each variation works. No model
-weights needed.
+The fastest way to see this is with the **Experiment Runner's inline preview mode**. It builds one
+registered environment and steps it with a **zero-action policy**, so the robot stays still while
+the environment loads and renders. No model weights or Experiment YAML are needed.
 
 The four experiments below all use the same ``pick_and_place_maple_table`` environment. Each one changes
 exactly one argument from the baseline.
@@ -21,15 +20,14 @@ Your reference run — rubiks cube on the table, bowl as destination:
 
 .. code-block:: bash
 
-   python isaaclab_arena/evaluation/policy_runner.py \
+   python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --policy_type zero_action \
-     --num_steps 50 \
-     pick_and_place_maple_table \
-     --embodiment droid_rel_joint_pos \
-     --pick_up_object rubiks_cube_hot3d_robolab \
-     --destination_location bowl_ycb_robolab \
-     --hdr home_office_robolab
+     --environment pick_and_place_maple_table \
+     environment.embodiment=droid_rel_joint_pos \
+     environment.pick_up_object=rubiks_cube_hot3d_robolab \
+     environment.destination_location=bowl_ycb_robolab \
+     environment.hdr=home_office_robolab \
+     rollout_limit.num_steps=50
 
 .. figure:: ../../../images/default_srl_pnp.png
    :width: 100%
@@ -40,32 +38,31 @@ Your reference run — rubiks cube on the table, bowl as destination:
 Experiment: Swap Objects
 -------------------------
 
-Change ``--pick_up_object`` and ``--destination_location`` to swap what is on the table.
+Change ``environment.pick_up_object`` and ``environment.destination_location`` to swap what is on the table.
 Some options to try:
 
 .. code-block:: text
 
-   --pick_up_object:
+   environment.pick_up_object:
      rubiks_cube_hot3d_robolab     mustard_bottle_hot3d_robolab
      mug_hot3d_robolab             soup_can_hot3d_robolab
      ceramic_mug_hot3d_robolab     pitcher_hot3d_robolab
      mustard_ycb_robolab           sugar_box_ycb_robolab
      tomato_soup_can_ycb_robolab   mug_ycb_robolab
 
-   --destination_location:
+   environment.destination_location:
      bowl_ycb_robolab              wooden_bowl_hot3d_robolab
 
 .. code-block:: bash
 
-   python isaaclab_arena/evaluation/policy_runner.py \
+   python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --policy_type zero_action \
-     --num_steps 50 \
-     pick_and_place_maple_table \
-     --embodiment droid_rel_joint_pos \
-     --pick_up_object mustard_bottle_hot3d_robolab \
-     --destination_location wooden_bowl_hot3d_robolab \
-     --hdr home_office_robolab
+     --environment pick_and_place_maple_table \
+     environment.embodiment=droid_rel_joint_pos \
+     environment.pick_up_object=mustard_bottle_hot3d_robolab \
+     environment.destination_location=wooden_bowl_hot3d_robolab \
+     environment.hdr=home_office_robolab \
+     rollout_limit.num_steps=50
 
 .. figure:: ../../../images/swap_objects.gif
    :width: 100%
@@ -76,7 +73,7 @@ Some options to try:
 Experiment: Change Background HDR
 -----------------------------------
 
-Set ``--hdr`` to any registered HDR environment map to change the background and ambient lighting:
+Set ``environment.hdr`` to any registered HDR environment map to change the background and ambient lighting:
 
 .. code-block:: text
 
@@ -86,20 +83,19 @@ Set ``--hdr`` to any registered HDR environment map to change the background and
    kiara_interior_robolab         brown_photostudio_robolab
    carpentry_shop_robolab
 
-You can also adjust the dome light intensity independently with ``--light_intensity``:
+You can also adjust the dome light intensity independently with ``environment.light_intensity``:
 
 .. code-block:: bash
 
-   python isaaclab_arena/evaluation/policy_runner.py \
+   python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --policy_type zero_action \
-     --num_steps 50 \
-     pick_and_place_maple_table \
-     --embodiment droid_rel_joint_pos \
-     --pick_up_object rubiks_cube_hot3d_robolab \
-     --destination_location bowl_ycb_robolab \
-     --hdr billiard_hall_robolab \
-     --light_intensity 1000.0
+     --environment pick_and_place_maple_table \
+     environment.embodiment=droid_rel_joint_pos \
+     environment.pick_up_object=rubiks_cube_hot3d_robolab \
+     environment.destination_location=bowl_ycb_robolab \
+     environment.hdr=billiard_hall_robolab \
+     environment.light_intensity=1000.0 \
+     rollout_limit.num_steps=50
 
 .. figure:: ../../../images/swap_hdr.gif
    :width: 100%
@@ -110,24 +106,23 @@ You can also adjust the dome light intensity independently with ``--light_intens
 Experiment: Scale Up
 ---------------------
 
-Add ``--num_envs`` to run many environments in parallel on the GPU:
+Use ``--num_envs`` to run many environments in parallel on the GPU:
 
 .. code-block:: bash
 
-   python isaaclab_arena/evaluation/policy_runner.py \
+   python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --policy_type zero_action \
-     --num_steps 50 \
+     --environment pick_and_place_maple_table \
      --num_envs 64 \
-     pick_and_place_maple_table \
-     --embodiment droid_rel_joint_pos \
-     --pick_up_object rubiks_cube_hot3d_robolab \
-     --destination_location bowl_ycb_robolab
+     environment.embodiment=droid_rel_joint_pos \
+     environment.pick_up_object=rubiks_cube_hot3d_robolab \
+     environment.destination_location=bowl_ycb_robolab \
+     rollout_limit.num_steps=50
 
-All 64 environments share the same assets and run simultaneously on the GPU. When you swap in a
-real policy, every one of those environments runs inference in parallel — giving you 64 evaluation
-episodes at the cost of one. This is how Arena makes it practical to measure policy robustness
-across hundreds of object and scene combinations in a single run.
+All 64 environments share the same assets and run simultaneously on the GPU. In a configured Run
+with a real policy, every one of those environments runs inference in parallel — giving you 64
+evaluation episodes at the cost of one. This is how Arena makes it practical to measure policy
+robustness across hundreds of object and scene combinations in a single run.
 
 .. figure:: ../../../images/scale_up.gif
    :width: 100%
@@ -140,23 +135,23 @@ Sequential Batch Evaluation
 
 The four experiments above run one variation at a time. In practice, Arena is used to evaluate
 a policy across hundreds of object, scene, and embodiment combinations in a single run. The
-``experiment_runner.py`` script reads a JSON job config that lists any number of jobs — each with its
-own environment arguments, policy, and step count — and runs them sequentially within one Isaac
-Sim process, collecting success metrics for each. ``getting_started_jobs_config.json`` bundles
-the four experiments above into a single config:
+Experiment Runner can also load a typed YAML Experiment Definition containing any number of
+named Runs. Each Run declares its environment, policy, and rollout limit, and the Runs execute
+sequentially within one Isaac Sim process. ``getting_started_experiment.yaml`` bundles the four
+experiments above into a single definition:
 
 .. code-block:: bash
 
    python isaaclab_arena/evaluation/experiment_runner.py \
      --viz kit \
-     --eval_jobs_config isaaclab_arena_environments/eval_jobs_configs/getting_started_jobs_config.json
+     --experiment_config isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
 
 .. figure:: ../../../images/iterate_getting_started_jobs_config.gif
-   :alt: Four evaluation jobs running sequentially: baseline, swapped objects, changed HDR, and 64 parallel environments
+   :alt: Four evaluation Runs executing sequentially: baseline, swapped objects, changed HDR, and 64 parallel environments
    :align: center
 
-At the end of the run you get a per-job summary of success rates. See
-:ref:`sequential-batch-experiment-runner` for full details on the job config format and available options.
+At the end of the Experiment you get a per-Run summary of success rates. See
+:ref:`sequential-batch-experiment-runner` for details on inline previews and configured Experiments.
 
 All of the above used a zero-action policy — the robot stays still and success rates are zero.
 The next page swaps in a real pre-trained model and runs it in closed loop:

--- a/isaaclab_arena/evaluation/arena_experiment_config_loader.py
+++ b/isaaclab_arena/evaluation/arena_experiment_config_loader.py
@@ -8,18 +8,21 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
+from dataclasses import fields, replace
 from importlib import import_module
 from pathlib import Path
+from typing import Any
 
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.evaluation.legacy_eval_config import run_cfgs_from_legacy_eval_config
-from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
+from isaaclab_arena.hydra.experiment_composition import compose_arena_run, load_arena_experiment_from_yaml
 from isaaclab_arena.policy.policy_base import PolicyCfg
-from isaaclab_arena_environments.cli import ensure_environments_registered
+
+_INLINE_RUN_NAME = "preview"
+_INLINE_POLICY_TYPE = "zero_action"
 
 
 def validate_experiment_config_path(experiment_config: str | Path) -> Path:
@@ -66,6 +69,70 @@ def load_arena_experiment_from_config_file(
         overrides=overrides,
     )
 
+    return _with_process_device(experiment_cfg, device)
+
+
+def compose_inline_arena_experiment(
+    environment_name: str,
+    *,
+    device: str,
+    environment_builder_values: dict[str, Any],
+    shared_environment_values: dict[str, Any],
+    num_steps: int | None,
+    num_episodes: int | None,
+    overrides: list[str] | None = None,
+) -> ArenaExperimentCfg:
+    """Compose one zero-action preview Run from CLI-provided values.
+
+    Args:
+        environment_name: Registered environment selected for the preview.
+        device: Process-wide simulation device applied to the Run.
+        environment_builder_values: Base values for the typed environment builder config.
+        shared_environment_values: Shared CLI values copied into matching environment config fields.
+        num_steps: Step limit for the preview, or None for an episode-driven preview.
+        num_episodes: Episode limit for the preview, or None for a step-driven preview.
+        overrides: Hydra overrides relative to the implicit preview Run.
+
+    Returns:
+        A one-Run typed Arena Experiment.
+    """
+    environment_cfg_types = _registered_environment_cfg_types()
+    available_environment_names = ", ".join(sorted(environment_cfg_types))
+    assert (
+        environment_name in environment_cfg_types
+    ), f"Unknown registered environment '{environment_name}'. Available environments: {available_environment_names}"
+
+    environment_cfg_type = environment_cfg_types[environment_name]
+    environment_field_names = {config_field.name for config_field in fields(environment_cfg_type)}
+    if shared_environment_values.get("enable_cameras", False):
+        assert (
+            "enable_cameras" in environment_field_names
+        ), f"Environment '{environment_name}' does not expose camera support in its typed configuration"
+    environment_values = {
+        field_name: value
+        for field_name, value in shared_environment_values.items()
+        if field_name in environment_field_names
+    }
+    environment_values["type"] = environment_name
+
+    run_cfg = compose_arena_run(
+        _INLINE_RUN_NAME,
+        {
+            "environment": environment_values,
+            "policy": {"type": _INLINE_POLICY_TYPE},
+            "environment_builder": environment_builder_values,
+            "rollout_limit": {"num_steps": num_steps, "num_episodes": num_episodes},
+        },
+        environment_cfg_types=environment_cfg_types,
+        policy_cfg_type_resolver=_resolve_policy_cfg_type_from_name_or_class_path,
+        overrides=overrides,
+        source=f"inline environment '{environment_name}'",
+    )
+    return _with_process_device(ArenaExperimentCfg(runs={_INLINE_RUN_NAME: run_cfg}), device)
+
+
+def _with_process_device(experiment_cfg: ArenaExperimentCfg, device: str) -> ArenaExperimentCfg:
+    """Apply one process device to every Run in an Experiment."""
     # TODO(cvolk, 2026-07-09): [typed-config-migration] Make device a process-level
     # evaluation setting shared by AppLauncher and Run execution. Then remove device
     # from ArenaEnvBuilderCfg and delete this per-Run copy.
@@ -82,6 +149,8 @@ def load_arena_experiment_from_config_file(
 
 def _registered_environment_cfg_types() -> dict[str, type[ArenaEnvironmentCfg]]:
     """Return registered environment selector names and their config types."""
+    from isaaclab_arena_environments.cli import ensure_environments_registered
+
     ensure_environments_registered()
     registry = EnvironmentRegistry()
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]] = {}

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -3,11 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import os
+from dataclasses import asdict
 from pathlib import Path
 
+from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    compose_inline_arena_experiment,
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
@@ -23,6 +27,8 @@ from isaaclab_arena.metrics.metrics_logger import MetricsLogger
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 from isaaclab_arena.video.video_recording import timestamped_run_dir
 from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
+
+_SHARED_ENVIRONMENT_VALUE_NAMES = ("enable_cameras", "mimic", "auto", "num_envs")
 
 
 # TODO(cvolk): Move experiment-level variation inspection out of this CLI entry point.
@@ -54,12 +60,47 @@ def _assert_camera_support_enabled(experiment_cfg: ArenaExperimentCfg, enable_ca
     )
 
 
+def _load_selected_experiment(
+    args_cli: argparse.Namespace,
+    experiment_config_path: Path | None,
+    experiment_overrides: list[str],
+) -> ArenaExperimentCfg:
+    """Load a configured Experiment or compose one inline preview Run."""
+    if args_cli.environment is not None:
+        builder_cfg = arena_env_builder_cfg_from_argparse(args_cli)
+        shared_environment_values = {
+            name: getattr(args_cli, name) for name in _SHARED_ENVIRONMENT_VALUE_NAMES if hasattr(args_cli, name)
+        }
+        return compose_inline_arena_experiment(
+            args_cli.environment,
+            device=args_cli.device,
+            environment_builder_values=asdict(builder_cfg),
+            shared_environment_values=shared_environment_values,
+            num_steps=args_cli.num_steps,
+            num_episodes=args_cli.num_episodes,
+            overrides=experiment_overrides,
+        )
+
+    assert experiment_config_path is not None
+    return load_arena_experiment_from_config_file(
+        experiment_config_path,
+        device=args_cli.device,
+        overrides=experiment_overrides,
+    )
+
+
 def main():
     args_cli, experiment_overrides = parse_experiment_runner_args()
-    experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
-    legacy_experiment_config = load_legacy_json_experiment_config(
-        experiment_config_path,
-        experiment_overrides,
+    experiment_config_path = (
+        validate_experiment_config_path(args_cli.experiment_config) if args_cli.experiment_config is not None else None
+    )
+    legacy_experiment_config = (
+        load_legacy_json_experiment_config(
+            experiment_config_path,
+            experiment_overrides,
+        )
+        if experiment_config_path is not None
+        else None
     )
 
     if args_cli.record_camera_video or (
@@ -70,10 +111,10 @@ def main():
     # Print the variations catalogue for each run's environment and exit.
     if args_cli.list_variations:
         with SimulationAppContext(args_cli):
-            experiment_cfg = load_arena_experiment_from_config_file(
+            experiment_cfg = _load_selected_experiment(
+                args_cli,
                 experiment_config_path,
-                device=args_cli.device,
-                overrides=experiment_overrides,
+                experiment_overrides,
             )
             _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
             list_variations(experiment_cfg)
@@ -91,10 +132,10 @@ def main():
             return
 
     with SimulationAppContext(args_cli):
-        experiment_cfg = load_arena_experiment_from_config_file(
+        experiment_cfg = _load_selected_experiment(
+            args_cli,
             experiment_config_path,
-            device=args_cli.device,
-            overrides=experiment_overrides,
+            experiment_overrides,
         )
         _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
         metrics_logger = MetricsLogger()

--- a/isaaclab_arena/evaluation/experiment_runner_cli.py
+++ b/isaaclab_arena/evaluation/experiment_runner_cli.py
@@ -8,7 +8,16 @@ import argparse
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 
-_DEFAULT_EXPERIMENT_CONFIG_PATH = "isaaclab_arena_environments/eval_jobs_configs/zero_action_jobs_config.json"
+_DEFAULT_INLINE_NUM_STEPS = 100
+
+
+def _overrides_inline_rollout_limit(overrides: list[str]) -> bool:
+    """Return whether Hydra overrides provide an inline rollout limit."""
+    for override in overrides:
+        override_key = override.partition("=")[0].lstrip("+~")
+        if override_key == "rollout_limit" or override_key.startswith("rollout_limit."):
+            return True
+    return False
 
 
 def add_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
@@ -20,11 +29,33 @@ def add_experiment_runner_arguments(parser: argparse.ArgumentParser) -> None:
         "--eval_jobs_config",
         dest="experiment_config",
         type=str,
-        default=_DEFAULT_EXPERIMENT_CONFIG_PATH,
+        default=None,
         help=(
             "Path to a typed YAML Experiment or legacy JSON evaluation config. "
             "For YAML, append Hydra KEY=VALUE overrides for fields on declared Runs."
         ),
+    )
+    parser.add_argument(
+        "--environment",
+        type=str,
+        default=None,
+        help=(
+            "Registered environment to run as an inline zero-action preview. "
+            "Append Hydra overrides relative to the generated preview Run."
+        ),
+    )
+    rollout_limit_group = parser.add_mutually_exclusive_group()
+    rollout_limit_group.add_argument(
+        "--num_steps",
+        type=int,
+        default=None,
+        help=f"Inline preview step limit. Defaults to {_DEFAULT_INLINE_NUM_STEPS}.",
+    )
+    rollout_limit_group.add_argument(
+        "--num_episodes",
+        type=int,
+        default=None,
+        help="Inline preview episode limit instead of a step limit.",
     )
     parser.add_argument(
         "--record_viewport_video",
@@ -89,5 +120,20 @@ def parse_experiment_runner_args(argv: list[str] | None = None) -> tuple[argpars
     parser.allow_abbrev = False
     args_cli, experiment_overrides = parser.parse_known_args(argv)
     assert_hydra_overrides(experiment_overrides, parser)
+    if (args_cli.experiment_config is None) == (args_cli.environment is None):
+        parser.error("Specify exactly one input source: --experiment_config PATH or --environment NAME")
+    if args_cli.environment is not None and args_cli.env_graph_spec_yaml is not None:
+        parser.error("--env_graph_spec_yaml is not supported in inline preview mode; use policy_runner.py")
+    if args_cli.environment is not None and args_cli.external_environment_class_path is not None:
+        parser.error("--external_environment_class_path is not supported in inline preview mode; use policy_runner.py")
+    if args_cli.experiment_config is not None and (args_cli.num_steps is not None or args_cli.num_episodes is not None):
+        parser.error("--num_steps and --num_episodes are supported only with --environment")
+    if (
+        args_cli.environment is not None
+        and args_cli.num_steps is None
+        and args_cli.num_episodes is None
+        and not _overrides_inline_rollout_limit(experiment_overrides)
+    ):
+        args_cli.num_steps = _DEFAULT_INLINE_NUM_STEPS
     assert not args_cli.distributed, "Distributed evaluation is not supported yet"
     return args_cli, experiment_overrides

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import torch
-import tqdm
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -19,6 +17,7 @@ from isaaclab_arena.evaluation.policy_runner_cli import (
     add_policy_runner_arguments,
     build_policy_from_cli,
 )
+from isaaclab_arena.evaluation.rollout import rollout_policy
 from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -28,7 +27,6 @@ from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
 
 if TYPE_CHECKING:
-    from isaaclab_arena.metrics.metric_data import MetricsDataCollection
     from isaaclab_arena.policy.policy_base import PolicyBase
 
 
@@ -61,79 +59,6 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     return (
         "cuda" in args_cli.device and hasattr(args_cli, "distributed") and args_cli.distributed and get_world_size() > 1
     )
-
-
-def rollout_policy(
-    env,
-    policy: PolicyBase,
-    num_steps: int | None,
-    num_episodes: int | None,
-) -> MetricsDataCollection | None:
-    assert num_steps is not None or num_episodes is not None, "Either num_steps or num_episodes must be provided"
-    assert num_steps is None or num_episodes is None, "Only one of num_steps or num_episodes must be provided"
-
-    pbar = None
-    try:
-        obs, _ = env.reset()
-        policy.reset()
-        policy.set_task_description(env.unwrapped.get_language_instruction())
-
-        # Setup progress bar based on num_steps or num_episodes
-        if num_steps is not None:
-            pbar = tqdm.tqdm(total=num_steps, desc="Steps", unit="step")
-        else:
-            pbar = tqdm.tqdm(total=num_episodes, desc="Episodes", unit="episode")
-
-        num_episodes_completed = 0
-        num_steps_completed = 0
-
-        while True:
-            with torch.inference_mode():
-                actions = policy.get_action(env, obs)
-                obs, _, terminated, truncated, _ = env.step(actions)
-
-                if terminated.any() or truncated.any():
-                    # Only reset policy for those envs that are terminated or truncated
-                    print(
-                        f"Resetting policy for terminated env_ids: {terminated.nonzero().flatten()}"
-                        f" and truncated env_ids: {truncated.nonzero().flatten()}"
-                    )
-                    env_ids = (terminated | truncated).nonzero().flatten()
-                    policy.reset(env_ids=env_ids)
-                    # Break if number of episodes is reached
-                    completed_episodes = env_ids.shape[0]
-                    num_episodes_completed += completed_episodes
-                    if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-                        metrics = env.unwrapped.compute_metrics()
-                        tqdm.tqdm.write(
-                            f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
-                            f" {metrics_to_plain_python_types(metrics)}"
-                        )
-                    if num_episodes is not None:
-                        pbar.update(completed_episodes)
-                        if num_episodes_completed >= num_episodes:
-                            break
-                # Break if number of steps is reached
-                num_steps_completed += 1
-                if num_steps is not None:
-                    pbar.update(1)
-                    if num_steps_completed >= num_steps:
-                        break
-
-        pbar.close()
-
-    except Exception as e:
-        if pbar is not None:
-            pbar.close()
-        raise RuntimeError(f"Error rolling out policy: {e}")
-
-    else:
-
-        # Only compute metrics if env has non-None metrics.
-        # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
-        if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-            return env.unwrapped.compute_metrics()
-        return None
 
 
 def main():

--- a/isaaclab_arena/evaluation/rollout.py
+++ b/isaaclab_arena/evaluation/rollout.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Roll out policies in Arena environments."""
+
+from __future__ import annotations
+
+import torch
+import tqdm
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
+from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
+
+if TYPE_CHECKING:
+    from isaaclab_arena.metrics.metric_data import MetricsDataCollection
+    from isaaclab_arena.policy.policy_base import PolicyBase
+
+
+def rollout_policy(
+    env,
+    policy: PolicyBase,
+    num_steps: int | None,
+    num_episodes: int | None,
+) -> MetricsDataCollection | None:
+    """Roll out a policy until its configured step or episode limit."""
+    assert num_steps is not None or num_episodes is not None, "Either num_steps or num_episodes must be provided"
+    assert num_steps is None or num_episodes is None, "Only one of num_steps or num_episodes must be provided"
+
+    pbar = None
+    try:
+        obs, _ = env.reset()
+        policy.reset()
+        policy.set_task_description(env.unwrapped.get_language_instruction())
+
+        # Setup progress bar based on num_steps or num_episodes
+        if num_steps is not None:
+            pbar = tqdm.tqdm(total=num_steps, desc="Steps", unit="step")
+        else:
+            pbar = tqdm.tqdm(total=num_episodes, desc="Episodes", unit="episode")
+
+        num_episodes_completed = 0
+        num_steps_completed = 0
+
+        while True:
+            with torch.inference_mode():
+                actions = policy.get_action(env, obs)
+                obs, _, terminated, truncated, _ = env.step(actions)
+
+                if terminated.any() or truncated.any():
+                    # Only reset policy for those envs that are terminated or truncated
+                    print(
+                        f"Resetting policy for terminated env_ids: {terminated.nonzero().flatten()}"
+                        f" and truncated env_ids: {truncated.nonzero().flatten()}"
+                    )
+                    env_ids = (terminated | truncated).nonzero().flatten()
+                    policy.reset(env_ids=env_ids)
+                    # Break if number of episodes is reached
+                    completed_episodes = env_ids.shape[0]
+                    num_episodes_completed += completed_episodes
+                    if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
+                        metrics = env.unwrapped.compute_metrics()
+                        tqdm.tqdm.write(
+                            f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
+                            f" {metrics_to_plain_python_types(metrics)}"
+                        )
+                    if num_episodes is not None:
+                        pbar.update(completed_episodes)
+                        if num_episodes_completed >= num_episodes:
+                            break
+                # Break if number of steps is reached
+                num_steps_completed += 1
+                if num_steps is not None:
+                    pbar.update(1)
+                    if num_steps_completed >= num_steps:
+                        break
+
+        pbar.close()
+
+    except Exception as e:
+        if pbar is not None:
+            pbar.close()
+        raise RuntimeError(f"Error rolling out policy: {e}")
+
+    else:
+
+        # Only compute metrics if env has non-None metrics.
+        # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
+        if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
+            return env.unwrapped.compute_metrics()
+        return None

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -20,8 +20,8 @@ from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
     LegacyGraphEnvironmentCfg,
     build_arena_builder_from_legacy_graph,
 )
-from isaaclab_arena.evaluation.policy_runner import rollout_policy
 from isaaclab_arena.evaluation.resource_cleanup import close_run_resources
+from isaaclab_arena.evaluation.rollout import rollout_policy
 from isaaclab_arena.metrics.aggregate_metrics import aggregate_metrics
 from isaaclab_arena.variations.variations_hydra import overrides_from_dict
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video

--- a/isaaclab_arena/hydra/experiment_composition.py
+++ b/isaaclab_arena/hydra/experiment_composition.py
@@ -61,6 +61,36 @@ def load_arena_experiment_from_yaml(
         The typed Experiment Definition, preserving YAML mapping declaration order.
     """
     run_values_by_name = _read_and_validate_yaml_runs_as_values(yaml_path)
+    return compose_arena_experiment(
+        run_values_by_name,
+        environment_cfg_types=environment_cfg_types,
+        policy_cfg_type_resolver=policy_cfg_type_resolver,
+        overrides=overrides,
+        source=str(yaml_path),
+    )
+
+
+def compose_arena_experiment(
+    run_values_by_name: dict[str, dict[str, Any]],
+    *,
+    environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
+    policy_cfg_type_resolver: Callable[[str], type[PolicyCfg]],
+    overrides: list[str] | None = None,
+    source: str = "in-memory configuration",
+) -> ArenaExperimentCfg:
+    """Compose a typed Arena Experiment from source-independent Run values.
+
+    Args:
+        run_values_by_name: Unresolved Run values keyed by Run name.
+        environment_cfg_types: Environment selector names mapped to typed configuration classes.
+        policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
+        overrides: Hydra field overrides for Runs declared in ``run_values_by_name``.
+        source: Description included in composition errors.
+
+    Returns:
+        The typed Experiment Definition, preserving Run declaration order.
+    """
+    _validate_run_values_by_name(run_values_by_name)
     config_store = ConfigStore.instance()
     # Reuse these internal names so repeated loads replace their process-global ConfigStore entries.
     hydra_config_namespace = "isaaclab_arena_experiment_composition"
@@ -68,7 +98,7 @@ def load_arena_experiment_from_yaml(
     try:
         with _get_new_hydra_context_if_none_exists():
             arena_runs_by_name = {
-                run_name: _build_arena_run_cfg_from_yaml_values(
+                run_name: _build_arena_run_cfg_from_values(
                     config_store,
                     hydra_config_namespace,
                     index,
@@ -87,10 +117,49 @@ def load_arena_experiment_from_yaml(
             composed_experiment = compose(config_name=hydra_experiment_config_name, overrides=overrides or [])
             experiment_cfg = OmegaConf.to_object(composed_experiment)
     except (HydraException, OmegaConfBaseException, TypeError, ValueError) as exc:
-        raise ValueError(f"Could not compose Arena Experiment '{yaml_path}': {exc}") from exc
+        raise ValueError(f"Could not compose Arena Experiment from {source!r}: {exc}") from exc
 
     assert isinstance(experiment_cfg, ArenaExperimentCfg)
     return experiment_cfg
+
+
+def compose_arena_run(
+    run_name: str,
+    run_values: dict[str, Any],
+    *,
+    environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
+    policy_cfg_type_resolver: Callable[[str], type[PolicyCfg]],
+    overrides: list[str] | None = None,
+    source: str = "in-memory configuration",
+) -> ArenaRunCfg:
+    """Compose one typed Arena Run with Run-relative Hydra overrides.
+
+    Args:
+        run_name: Name assigned to the composed Run.
+        run_values: Unresolved values for the Run.
+        environment_cfg_types: Environment selector names mapped to typed configuration classes.
+        policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
+        overrides: Hydra field overrides relative to the Run.
+        source: Description included in composition errors.
+
+    Returns:
+        The fully composed typed Run configuration.
+    """
+    _validate_run_values_by_name({run_name: run_values})
+    try:
+        with _get_new_hydra_context_if_none_exists():
+            return _build_arena_run_cfg_from_values(
+                ConfigStore.instance(),
+                "isaaclab_arena_inline_run_composition",
+                0,
+                run_name,
+                run_values,
+                environment_cfg_types,
+                policy_cfg_type_resolver,
+                overrides=overrides,
+            )
+    except (HydraException, OmegaConfBaseException, TypeError, ValueError) as exc:
+        raise ValueError(f"Could not compose Arena Run from {source!r}: {exc}") from exc
 
 
 def _assert_run_name_is_hydra_compatible(run_name: str) -> None:
@@ -133,17 +202,25 @@ def _read_and_validate_yaml_runs_as_values(yaml_path: str | Path) -> dict[str, d
 
     runs: dict[str, dict[str, Any]] = {}
     for run_name, raw_run_config in raw_experiment_config.runs.items():
-        assert isinstance(run_name, str) and run_name, "Experiment Run names must be non-empty strings"
-        _assert_run_name_is_hydra_compatible(run_name)
         assert OmegaConf.is_dict(raw_run_config), f"Run '{run_name}' must be a mapping"
         run_values = OmegaConf.to_container(raw_run_config, resolve=False)
         assert isinstance(run_values, dict)
-        assert "name" not in run_values, f"Run '{run_name}' must not define 'name'; its mapping key is the Run name"
         runs[run_name] = run_values
+    _validate_run_values_by_name(runs)
     return runs
 
 
-def _build_arena_run_cfg_from_yaml_values(
+def _validate_run_values_by_name(run_values_by_name: dict[str, dict[str, Any]]) -> None:
+    """Validate the named-Run mapping shared by YAML and inline callers."""
+    assert isinstance(run_values_by_name, dict) and run_values_by_name, "Experiment must define at least one Run"
+    for run_name, run_values in run_values_by_name.items():
+        assert isinstance(run_name, str) and run_name, "Experiment Run names must be non-empty strings"
+        _assert_run_name_is_hydra_compatible(run_name)
+        assert isinstance(run_values, dict), f"Run '{run_name}' must be a mapping"
+        assert "name" not in run_values, f"Run '{run_name}' must not define 'name'; its mapping key is the Run name"
+
+
+def _build_arena_run_cfg_from_values(
     config_store: ConfigStore,
     hydra_config_namespace: str,
     index: int,
@@ -151,17 +228,19 @@ def _build_arena_run_cfg_from_yaml_values(
     run_values: dict[str, Any],
     environment_cfg_types: dict[str, type[ArenaEnvironmentCfg]],
     policy_cfg_type_resolver: Callable[[str], type[PolicyCfg]],
+    overrides: list[str] | None = None,
 ) -> ArenaRunCfg:
-    """Build one typed Arena Run from its unresolved YAML values.
+    """Build one typed Arena Run from its unresolved configuration values.
 
     Args:
         config_store: Hydra store used for the temporary typed schemas.
         hydra_config_namespace: Unique prefix for this Experiment's temporary Hydra configs.
-        index: Position of the Run in YAML declaration order.
-        run_name: Name declared by the Run's YAML mapping key.
+        index: Position of the Run in declaration order.
+        run_name: Name declared by the Run mapping key.
         run_values: Unresolved values declared for the Run.
         environment_cfg_types: Environment selectors mapped to typed configuration classes.
         policy_cfg_type_resolver: Function returning the PolicyCfg subclass for a policy.type value.
+        overrides: Hydra field overrides relative to this Run.
 
     Returns:
         The fully composed typed Run configuration.
@@ -173,7 +252,7 @@ def _build_arena_run_cfg_from_yaml_values(
     hydra_run_config_name = f"{hydra_config_namespace}_run_{index}"
     hydra_environment_config_name = f"{hydra_run_config_name}_environment"
     hydra_policy_config_name = f"{hydra_run_config_name}_policy"
-    environment = _compose_typed_config_from_yaml_selector(
+    environment = _compose_typed_config_from_selector(
         config_store,
         hydra_environment_config_name,
         run_name,
@@ -187,7 +266,7 @@ def _build_arena_run_cfg_from_yaml_values(
         policy_selector = policy_values.get("type")
         if isinstance(policy_selector, str) and policy_selector:
             policy_cfg_types[policy_selector] = policy_cfg_type_resolver(policy_selector)
-    policy = _compose_typed_config_from_yaml_selector(
+    policy = _compose_typed_config_from_selector(
         config_store,
         hydra_policy_config_name,
         run_name,
@@ -203,12 +282,12 @@ def _build_arena_run_cfg_from_yaml_values(
         name=hydra_run_config_name,
         node={"defaults": [hydra_run_schema_name, "_self_"], **remaining_values},
     )
-    run = OmegaConf.to_object(compose(config_name=hydra_run_config_name))
+    run = OmegaConf.to_object(compose(config_name=hydra_run_config_name, overrides=overrides or []))
     assert isinstance(run, ArenaRunCfg)
     return run
 
 
-def _compose_typed_config_from_yaml_selector(
+def _compose_typed_config_from_selector(
     config_store: ConfigStore,
     hydra_config_name: str,
     run_name: str,
@@ -217,7 +296,7 @@ def _compose_typed_config_from_yaml_selector(
     cfg_types: dict[str, type[Any]],
     expected_base_type: type[Any],
 ) -> Any:
-    """Resolve one YAML type selector into a concrete typed configuration.
+    """Resolve one type selector into a concrete typed configuration.
 
     The value under type selects a class from cfg_types. All remaining
     values are composed and validated against that class by Hydra.
@@ -227,7 +306,7 @@ def _compose_typed_config_from_yaml_selector(
         hydra_config_name: Unique name for the temporary Hydra config.
         run_name: Run containing the selected environment or policy.
         section_name: YAML section being composed, such as environment or policy.
-        section_values_with_selector: YAML field values for the section, including its type selector.
+        section_values_with_selector: Field values for the section, including its type selector.
         cfg_types: Available selector names mapped to typed configuration classes.
         expected_base_type: Base class that the selected configuration must inherit.
 

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -5,13 +5,17 @@
 
 """Test loading Arena Experiments at the evaluation boundary."""
 
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import pytest
 
+from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation import arena_experiment_config_loader, experiment_runner
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_experiment_config_loader import (
+    compose_inline_arena_experiment,
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
@@ -28,6 +32,11 @@ GETTING_STARTED_JSON_PATH = (
 GETTING_STARTED_YAML_PATH = (
     Path(TestConstants.arena_environments_dir) / "experiment_configs" / "getting_started_experiment.yaml"
 )
+
+
+@dataclass
+class _EnvironmentCfgWithNumEnvs(ArenaEnvironmentCfg):
+    num_envs: int = 1
 
 
 def _experiment_cfg(enable_cameras: bool = False) -> ArenaExperimentCfg:
@@ -69,6 +78,91 @@ def test_load_typed_yaml_experiment_applies_overrides_and_device(monkeypatch):
     assert runs["baseline"].environment.light_intensity == 750.0
     assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
     assert all(run.environment_builder.device == "cuda:1" for run in runs.values())
+
+
+def test_compose_inline_experiment_builds_zero_action_preview(monkeypatch):
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_environment_cfg_types",
+        lambda: {"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
+    )
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_resolve_policy_cfg_type_from_name_or_class_path",
+        lambda policy_name_or_class_path: {"zero_action": ZeroActionPolicyCfg}[policy_name_or_class_path],
+    )
+
+    experiment_cfg = compose_inline_arena_experiment(
+        "pick_and_place_maple_table",
+        device="cuda:1",
+        environment_builder_values=asdict(ArenaEnvBuilderCfg()),
+        shared_environment_values={"enable_cameras": True, "num_envs": 4},
+        num_steps=100,
+        num_episodes=None,
+        overrides=[
+            "environment.light_intensity=750.0",
+            "environment_builder.num_envs=8",
+            "rollout_limit.num_steps=5",
+            "+variations.light.hdr_image.enabled=true",
+        ],
+    )
+
+    assert list(experiment_cfg.runs) == ["preview"]
+    run_cfg = experiment_cfg.runs["preview"]
+    assert run_cfg.environment == PickAndPlaceMapleTableEnvironmentCfg(
+        enable_cameras=True,
+        light_intensity=750.0,
+    )
+    assert run_cfg.policy == ZeroActionPolicyCfg()
+    assert run_cfg.environment_builder.num_envs == 8
+    assert run_cfg.environment_builder.device == "cuda:1"
+    assert run_cfg.rollout_limit.num_steps == 5
+    assert run_cfg.num_rebuilds == 1
+    assert run_cfg.variations == {"light": {"hdr_image": {"enabled": True}}}
+
+
+def test_compose_inline_experiment_copies_shared_environment_fields(monkeypatch):
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_environment_cfg_types",
+        lambda: {"environment_with_num_envs": _EnvironmentCfgWithNumEnvs},
+    )
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_resolve_policy_cfg_type_from_name_or_class_path",
+        lambda policy_name_or_class_path: {"zero_action": ZeroActionPolicyCfg}[policy_name_or_class_path],
+    )
+
+    experiment_cfg = compose_inline_arena_experiment(
+        "environment_with_num_envs",
+        device="cuda:0",
+        environment_builder_values=asdict(ArenaEnvBuilderCfg(num_envs=4)),
+        shared_environment_values={"num_envs": 4},
+        num_steps=100,
+        num_episodes=None,
+    )
+
+    run_cfg = experiment_cfg.runs["preview"]
+    assert run_cfg.environment.num_envs == 4
+    assert run_cfg.environment_builder.num_envs == 4
+
+
+def test_compose_inline_experiment_rejects_cameras_for_environment_without_camera_field(monkeypatch):
+    monkeypatch.setattr(
+        arena_experiment_config_loader,
+        "_registered_environment_cfg_types",
+        lambda: {"environment_with_num_envs": _EnvironmentCfgWithNumEnvs},
+    )
+
+    with pytest.raises(AssertionError, match="does not expose camera support"):
+        compose_inline_arena_experiment(
+            "environment_with_num_envs",
+            device="cuda:0",
+            environment_builder_values=asdict(ArenaEnvBuilderCfg()),
+            shared_environment_values={"enable_cameras": True},
+            num_steps=100,
+            num_episodes=None,
+        )
 
 
 def test_policy_config_type_resolves_from_dotted_class_path():
@@ -131,6 +225,49 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
             "experiment_runner.py",
             "--experiment_config",
             str(GETTING_STARTED_YAML_PATH),
+            "--list_variations",
+        ],
+    )
+
+    experiment_runner.main()
+
+
+def test_experiment_runner_composes_inline_preview_after_simulation_starts(monkeypatch):
+    simulation_is_running = False
+
+    class _SimulationAppContext:
+        def __init__(self, args_cli):
+            self.args_cli = args_cli
+
+        def __enter__(self):
+            nonlocal simulation_is_running
+            assert self.args_cli.enable_cameras
+            simulation_is_running = True
+
+        def __exit__(self, _exception_type, _exception, _traceback):
+            nonlocal simulation_is_running
+            simulation_is_running = False
+
+    def compose_inline_after_startup(environment_name, **kwargs):
+        assert simulation_is_running
+        assert environment_name == "pick_and_place_maple_table"
+        assert kwargs["num_steps"] == 100
+        assert kwargs["environment_builder_values"]["num_envs"] == 4
+        assert kwargs["shared_environment_values"]["enable_cameras"] is True
+        return _experiment_cfg(enable_cameras=True)
+
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(experiment_runner, "compose_inline_arena_experiment", compose_inline_after_startup)
+    monkeypatch.setattr(experiment_runner, "list_variations", lambda _experiment: None)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--environment",
+            "pick_and_place_maple_table",
+            "--num_envs",
+            "4",
+            "--record_camera_video",
             "--list_variations",
         ],
     )

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -14,7 +14,7 @@ from hydra.core.config_store import ConfigStore
 from hydra.core.global_hydra import GlobalHydra
 
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
-from isaaclab_arena.hydra.experiment_composition import load_arena_experiment_from_yaml
+from isaaclab_arena.hydra.experiment_composition import compose_arena_run, load_arena_experiment_from_yaml
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
@@ -70,6 +70,51 @@ def test_getting_started_experiment_composes_typed_runs():
     assert [run.environment_builder.num_envs for run in runs.values()] == [1, 1, 1, 64]
     assert runs["parallel_envs"].environment_builder.env_spacing == 2.5
     assert [run.rollout_limit.num_steps for run in runs.values()] == [50, 50, 50, 100]
+
+
+def test_inline_run_composes_with_run_relative_overrides():
+    run = compose_arena_run(
+        "preview",
+        {
+            "environment": {"type": "pick_and_place_maple_table"},
+            "policy": {"type": "zero_action"},
+            "rollout_limit": {"num_steps": 100},
+        },
+        environment_cfg_types={"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
+        policy_cfg_type_resolver=_policy_cfg_type_for_name_or_class_path,
+        overrides=[
+            "environment.light_intensity=750.0",
+            "environment_builder.num_envs=4",
+            "rollout_limit.num_steps=5",
+            "num_rebuilds=2",
+            "+variations.light.hdr_image.enabled=true",
+        ],
+    )
+
+    assert run.name == "preview"
+    assert run.environment.light_intensity == 750.0
+    assert run.policy == ZeroActionPolicyCfg()
+    assert run.environment_builder.num_envs == 4
+    assert run.rollout_limit.num_steps == 5
+    assert run.num_rebuilds == 2
+    assert run.variations == {"light": {"hdr_image": {"enabled": True}}}
+
+
+def test_inline_run_accepts_episode_limit_override_without_step_default():
+    run = compose_arena_run(
+        "preview",
+        {
+            "environment": {"type": "pick_and_place_maple_table"},
+            "policy": {"type": "zero_action"},
+            "rollout_limit": {"num_steps": None, "num_episodes": None},
+        },
+        environment_cfg_types={"pick_and_place_maple_table": PickAndPlaceMapleTableEnvironmentCfg},
+        policy_cfg_type_resolver=_policy_cfg_type_for_name_or_class_path,
+        overrides=["rollout_limit.num_episodes=2"],
+    )
+
+    assert run.rollout_limit.num_steps is None
+    assert run.rollout_limit.num_episodes == 2
 
 
 def test_experiment_composition_preserves_caller_owned_hydra_context():

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import argparse
 import json
 import os
 import subprocess
@@ -18,6 +19,10 @@ NUM_STEPS = 2
 DEFAULT_VISUALIZER = "kit"
 
 
+def _raise_parser_error(_parser, message: str) -> None:
+    raise ValueError(message)
+
+
 def test_experiment_runner_parses_native_hydra_overrides():
     args_cli, experiment_overrides = parse_experiment_runner_args([
         "--experiment_config",
@@ -31,6 +36,94 @@ def test_experiment_runner_parses_native_hydra_overrides():
         "runs.baseline.rollout_limit.num_steps=2",
         "runs.baseline.environment.enable_cameras=true",
     ]
+
+
+def test_experiment_runner_parses_inline_preview_defaults_and_overrides():
+    args_cli, run_overrides = parse_experiment_runner_args([
+        "--environment",
+        "pick_and_place_maple_table",
+        "environment.embodiment=droid_rel_joint_pos",
+        "+variations.light.hdr_image.enabled=true",
+    ])
+
+    assert args_cli.environment == "pick_and_place_maple_table"
+    assert args_cli.experiment_config is None
+    assert args_cli.num_steps == 100
+    assert args_cli.num_episodes is None
+    assert run_overrides == [
+        "environment.embodiment=droid_rel_joint_pos",
+        "+variations.light.hdr_image.enabled=true",
+    ]
+
+
+def test_experiment_runner_does_not_add_step_default_to_inline_episode_override():
+    args_cli, run_overrides = parse_experiment_runner_args([
+        "--environment",
+        "pick_and_place_maple_table",
+        "rollout_limit.num_episodes=2",
+    ])
+
+    assert args_cli.num_steps is None
+    assert args_cli.num_episodes is None
+    assert run_overrides == ["rollout_limit.num_episodes=2"]
+
+
+def test_experiment_runner_parses_explicit_inline_episode_limit():
+    args_cli, run_overrides = parse_experiment_runner_args([
+        "--environment",
+        "pick_and_place_maple_table",
+        "--num_episodes",
+        "2",
+    ])
+
+    assert args_cli.num_steps is None
+    assert args_cli.num_episodes == 2
+    assert run_overrides == []
+
+
+def test_experiment_runner_requires_exactly_one_input_source(monkeypatch):
+    monkeypatch.setattr(argparse.ArgumentParser, "error", _raise_parser_error)
+
+    with pytest.raises(ValueError, match="Specify exactly one input source"):
+        parse_experiment_runner_args([])
+
+    with pytest.raises(ValueError, match="Specify exactly one input source"):
+        parse_experiment_runner_args([
+            "--experiment_config",
+            "experiment.yaml",
+            "--environment",
+            "pick_and_place_maple_table",
+        ])
+
+
+@pytest.mark.parametrize(
+    "unsupported_args",
+    [
+        ["--env_graph_spec_yaml", "environment.yaml"],
+        ["--external_environment_class_path", "package.Environment"],
+    ],
+)
+def test_experiment_runner_rejects_unsupported_inline_environment_sources(unsupported_args, monkeypatch):
+    monkeypatch.setattr(argparse.ArgumentParser, "error", _raise_parser_error)
+
+    with pytest.raises(ValueError, match="is not supported in inline preview mode"):
+        parse_experiment_runner_args([
+            "--environment",
+            "pick_and_place_maple_table",
+            *unsupported_args,
+        ])
+
+
+def test_experiment_runner_rejects_inline_rollout_flags_for_configured_experiment(monkeypatch):
+    monkeypatch.setattr(argparse.ArgumentParser, "error", _raise_parser_error)
+
+    with pytest.raises(ValueError, match="supported only with --environment"):
+        parse_experiment_runner_args([
+            "--experiment_config",
+            "experiment.yaml",
+            "--num_steps",
+            "2",
+        ])
 
 
 @pytest.mark.with_subprocess
@@ -122,6 +215,30 @@ runs:
     assert result is not None
     run_row = next(line for line in result.stdout.splitlines() if "yaml_baseline" in line and "pending" in line)
     run_cells = [cell.strip() for cell in run_row.split("|")[1:-1]]
+    assert run_cells[4] == "2"
+
+
+@pytest.mark.with_subprocess
+def test_experiment_runner_from_inline_environment(tmp_path):
+    """Execute the implicit zero-action preview Run without an Experiment file."""
+    result = run_subprocess(
+        [
+            TestConstants.python_path,
+            f"{TestConstants.evaluation_dir}/experiment_runner.py",
+            "--environment",
+            "pick_and_place_maple_table",
+            "--headless",
+            "--output_base_dir",
+            str(tmp_path / "output"),
+            "rollout_limit.num_steps=2",
+        ],
+        capture_output=True,
+    )
+
+    assert result is not None
+    run_row = next(line for line in result.stdout.splitlines() if "preview" in line and "pending" in line)
+    run_cells = [cell.strip() for cell in run_row.split("|")[1:-1]]
+    assert run_cells[2] == "zero_action"
     assert run_cells[4] == "2"
 
 


### PR DESCRIPTION
## Summary
Add CLI-only Experiment Runner previews

## Detailed description
- Let developers inspect registered environments without writing an Experiment YAML.
- Compose a typed preview Run with zero_action, CLI limits, shared builder flags, and Run-relative Hydra overrides.
- Keep configured YAML and legacy JSON flows intact while sharing rollout execution with policy_runner.py.
- Leave graph-spec, external, arbitrary-policy, and distributed workflows with policy_runner.py for now.
