### PR TITLE
Fix crashed placement when rotate around roll/pitch without disabling global random_yaw_init 

### DIFF
--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -415,8 +415,7 @@ class ObjectPlacer:
         """Sample absolute world Z-yaws for non-anchor objects without FaceTo.
 
         Marker yaw is included; random_yaw_init adds a sampled delta. Roll/pitch marker objects
-        are omitted here so their requested rotation is applied directly; their overlap footprint
-        is instead enclosed in :meth:`_bake_marker_rotation_footprints`.
+        are omitted here so their requested rotation is applied directly.
         """
         orientations: dict[ObjectBase, float] = {}
         for obj in objects:
@@ -464,15 +463,11 @@ class ObjectPlacer:
         objects: list[ObjectBase],
         candidate_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
     ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
-        """Enclose the applied footprint of roll/pitch marker objects for overlap validation.
+        """Enclose the applied footprint of roll/pitch marker objects.
 
-        Roll/pitch marker objects are excluded from the sampled-yaw path (see
-        :meth:`_generate_initial_orientations`) because :meth:`_apply_poses` writes their fixed
-        marker rotation verbatim. The yaw-only bbox pass cannot represent that out-of-plane
-        rotation, so replace each such object's box with the AABB enclosing it after the marker
-        rotation. This keeps overlap, On, and NextTo checks conservative (never a false pass)
-        instead of validating a rotated object against its unrotated footprint. The subsequent
-        yaw pass leaves these objects untouched (they carry no sampled yaw).
+        Roll/pitch marker objects are excluded from the sampled-yaw path, because the yaw-only bbox
+        pass cannot represent that out-of-plane rotation, so replace each such object's box with the AABB enclosing
+        it after the marker rotation. The subsequent yaw pass leaves these objects untouched.
 
         Returns a shallow copy with only roll/pitch objects replaced; other boxes are shared.
         """

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -244,6 +244,10 @@ class ObjectPlacer:
         num_candidates = num_envs * candidates_per_env
         env_bboxes = build_per_env_bounding_boxes(objects, num_envs)
         unrotated_candidate_bboxes = env_bboxes.get_bounding_boxes_for_solver_candidates(candidates_per_env)
+        # Roll/pitch marker objects carry a fixed out-of-plane rotation the yaw pass cannot
+        # represent; enclose that rotated footprint once so overlap checks match the rotation
+        # _apply_poses writes verbatim. The yaw pass below then leaves these objects untouched.
+        base_candidate_bboxes = self._bake_marker_rotation_footprints(objects, unrotated_candidate_bboxes)
         per_env_bboxes = env_bboxes.get_bounding_boxes_for_all_envs()
 
         initial_positions: list[dict[ObjectBase, tuple[float, float, float]]] = []
@@ -261,9 +265,7 @@ class ObjectPlacer:
             )
 
         # Bake each candidate's yaw into a conservative enclosing bbox for overlap checks.
-        candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
-        )
+        candidate_bboxes = self._rotate_candidate_bboxes(objects, base_candidate_bboxes, orientations_per_candidate)
 
         all_positions = self._solver.solve(
             objects,
@@ -274,10 +276,8 @@ class ObjectPlacer:
             collision_objects=collision_objects,
         )
         self._apply_face_to_orientations(all_positions, orientations_per_candidate)
-        # FaceTo yaw is only known after solving, so rebuild from unrotated boxes before validation.
-        candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
-        )
+        # FaceTo yaw is only known after solving, so rebuild from the base boxes before validation.
+        candidate_bboxes = self._rotate_candidate_bboxes(objects, base_candidate_bboxes, orientations_per_candidate)
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()
         all_validations = [
@@ -415,7 +415,8 @@ class ObjectPlacer:
         """Sample absolute world Z-yaws for non-anchor objects without FaceTo.
 
         Marker yaw is included; random_yaw_init adds a sampled delta. Roll/pitch marker objects
-        are omitted so their requested rotation is applied directly.
+        are omitted here so their requested rotation is applied directly; their overlap footprint
+        is instead enclosed in :meth:`_bake_marker_rotation_footprints`.
         """
         orientations: dict[ObjectBase, float] = {}
         for obj in objects:
@@ -457,6 +458,31 @@ class ObjectPlacer:
             for candidate_idx, (yaw, direction_is_defined) in enumerate(zip(yaws, is_defined, strict=True)):
                 if direction_is_defined:
                     orientations_per_candidate[candidate_idx][obj] = yaw.item()
+
+    def _bake_marker_rotation_footprints(
+        self,
+        objects: list[ObjectBase],
+        candidate_bboxes: dict[ObjectBase, AxisAlignedBoundingBox],
+    ) -> dict[ObjectBase, AxisAlignedBoundingBox]:
+        """Enclose the applied footprint of roll/pitch marker objects for overlap validation.
+
+        Roll/pitch marker objects are excluded from the sampled-yaw path (see
+        :meth:`_generate_initial_orientations`) because :meth:`_apply_poses` writes their fixed
+        marker rotation verbatim. The yaw-only bbox pass cannot represent that out-of-plane
+        rotation, so replace each such object's box with the AABB enclosing it after the marker
+        rotation. This keeps overlap, On, and NextTo checks conservative (never a false pass)
+        instead of validating a rotated object against its unrotated footprint. The subsequent
+        yaw pass leaves these objects untouched (they carry no sampled yaw).
+
+        Returns a shallow copy with only roll/pitch objects replaced; other boxes are shared.
+        """
+        baked = dict(candidate_bboxes)
+        for obj in objects:
+            marker = self._get_relation(obj, RotateAroundSolution)
+            if marker is None or (marker.roll_rad == 0.0 and marker.pitch_rad == 0.0):
+                continue
+            baked[obj] = candidate_bboxes[obj].enclosing_after_rotation(marker.get_rotation_xyzw())
+        return baked
 
     @staticmethod
     def _rotate_candidate_bboxes(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -414,18 +414,21 @@ class ObjectPlacer:
     ) -> dict[ObjectBase, float]:
         """Sample absolute world Z-yaws for non-anchor objects without FaceTo.
 
-        Marker yaw is always included; random_yaw_init adds a sampled delta.
+        Marker yaw is included; random_yaw_init adds a sampled delta. Roll/pitch marker objects
+        are omitted so their requested rotation is applied directly.
         """
         orientations: dict[ObjectBase, float] = {}
         for obj in objects:
-            marker_yaw = self._get_yaw_from_rotate_around_solution(obj)
+            marker = self._get_relation(obj, RotateAroundSolution)
+            has_roll_pitch = marker is not None and (marker.roll_rad != 0.0 or marker.pitch_rad != 0.0)
+            marker_yaw = marker.yaw_rad if marker is not None else 0.0
             if obj in anchor_objects:
-                assert marker_yaw == 0.0, (
-                    f"Anchor '{obj.name}' has a RotateAroundSolution (yaw={marker_yaw:.3f}). "
+                assert marker is None or (marker_yaw == 0.0 and not has_roll_pitch), (
+                    f"Anchor '{obj.name}' has a RotateAroundSolution. "
                     "Anchors are not repositioned by the placer, so any marker rotation must "
                     "already be baked into the anchor's initial_pose before calling place()."
                 )
-            elif self._get_relation(obj, FaceTo) is None:
+            elif self._get_relation(obj, FaceTo) is None and not has_roll_pitch:
                 sampled_yaw = get_random_rotation(generator) if self.params.random_yaw_init else 0.0
                 total_yaw = wrap_angle_to_pi(sampled_yaw + marker_yaw)
                 if total_yaw != 0.0:
@@ -478,22 +481,6 @@ class ObjectPlacer:
                 bbox = bbox.rotated_around_z(yaw_tensor)
             rotated[obj] = bbox
         return rotated
-
-    @staticmethod
-    def _get_yaw_from_rotate_around_solution(obj: ObjectBase) -> float:
-        """Z-yaw (radians) of obj's RotateAroundSolution marker, 0.0 if none.
-
-        Rejects roll/pitch markers: a Z-rotated box can't enclose them, so they would otherwise
-        validate a silently-wrong footprint.
-        """
-        marker = ObjectPlacer._get_relation(obj, RotateAroundSolution)
-        if marker is None:
-            return 0.0
-        assert marker.roll_rad == 0.0 and marker.pitch_rad == 0.0, (
-            f"random_yaw_init cannot enclose a roll/pitch RotateAroundSolution on '{obj.name}' "
-            f"(roll={marker.roll_rad}, pitch={marker.pitch_rad}); only yaw markers are supported."
-        )
-        return marker.yaw_rad
 
     @staticmethod
     def _get_bounding_boxes_for_candidate_index(

--- a/isaaclab_arena/tests/test_object_placer_reproducibility.py
+++ b/isaaclab_arena/tests/test_object_placer_reproducibility.py
@@ -320,16 +320,28 @@ def test_random_yaw_init_composes_marker_yaw():
     assert abs(wrap_angle_to_pi(applied - result.orientations[box1])) < 1e-5
 
 
-def test_random_yaw_init_rejects_roll_pitch_marker():
-    """A roll/pitch marker cannot be enclosed by a Z-rotated bbox, so placement must fail loudly."""
+def test_roll_pitch_marker_applied_verbatim_without_random_yaw():
+    """A roll/pitch marker is excluded from random-yaw sampling and applied verbatim.
+
+    A Z-rotated footprint bbox can't enclose a pitched object, so the object keeps its requested
+    marker rotation and is not given a sampled yaw even when random_yaw_init is on.
+    """
+    pitch_rad = math.pi / 2
     solver_params = RelationSolverParams(max_iters=5, verbose=False)
     desk, box1, box2 = _create_test_objects()
-    box1.add_relation(RotateAroundSolution(roll_rad=0.3))
+    box1.add_relation(RotateAroundSolution(pitch_rad=pitch_rad))
     placer = ObjectPlacer(
         params=ObjectPlacerParams(placement_seed=1, solver_params=solver_params, random_yaw_init=True)
     )
-    with pytest.raises(AssertionError):
-        placer.place([desk, box1, box2], num_envs=1)
+    orientations = placer._generate_initial_orientations([desk, box1, box2], {desk})
+    assert box1 not in orientations, "roll/pitch marker object must not receive a sampled yaw"
+
+    placer.place([desk, box1, box2], num_envs=1)
+    applied = box1.get_initial_pose().rotation_xyzw
+    expected = RotateAroundSolution(pitch_rad=pitch_rad).get_rotation_xyzw()
+    assert all(
+        abs(a - e) < 1e-5 for a, e in zip(applied, expected)
+    ), f"marker pitch must be applied verbatim; expected {expected}, got {applied}"
 
 
 def test_marker_yaw_applied_without_random_yaw_init():

--- a/isaaclab_arena/tests/test_validate_placement.py
+++ b/isaaclab_arena/tests/test_validate_placement.py
@@ -166,6 +166,42 @@ def test_rotate_candidate_bboxes_encloses_marker_plus_sampled_yaw():
     assert not torch.allclose(rotated[box].max_point, sampled_only.max_point, atol=1e-6)
 
 
+def test_enclosing_after_rotation_pitch_swaps_extents():
+    """A 90° pitch rotates the tall Z extent into X, so the enclosing AABB swaps X and Z half-sizes."""
+    box = AxisAlignedBoundingBox(min_point=(-0.05, -0.05, -0.3), max_point=(0.05, 0.05, 0.3))
+    quat = RotateAroundSolution(pitch_rad=math.pi / 2).get_rotation_xyzw()
+    rotated = box.enclosing_after_rotation(quat)
+    torch.testing.assert_close(rotated.max_point, torch.tensor([[0.3, 0.05, 0.05]]), atol=1e-6, rtol=0)
+    torch.testing.assert_close(rotated.min_point, torch.tensor([[-0.3, -0.05, -0.05]]), atol=1e-6, rtol=0)
+
+
+def test_bake_marker_rotation_footprints_encloses_pitched_object():
+    """A tall box pitched 90° sweeps into a neighbor that its unrotated footprint clears."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    a = _make_long_box("a", half_x=0.05, half_y=0.05, half_z=0.3)  # tall in Z
+    a.add_relation(RotateAroundSolution(pitch_rad=math.pi / 2))
+    b = _make_box("b", size=0.1)  # half-size 0.05
+    positions = {a: (0.0, 0.0, 0.0), b: (0.25, 0.0, 0.0)}
+
+    # Unrotated, a's 0.05 half-X clears b at x=0.25: overlap check passes (the latent bug).
+    axis_aligned = {a: a.get_bounding_box(), b: b.get_bounding_box()}
+    assert placer._validate_placement(positions, axis_aligned).do_all_required_validation_checks_pass() is True
+
+    # Baking the applied pitch grows a's X extent to 0.3, so it now overlaps b and is rejected.
+    baked = placer._bake_marker_rotation_footprints([a, b], axis_aligned)
+    assert placer._validate_placement(positions, baked).do_all_required_validation_checks_pass() is False
+
+
+def test_bake_marker_rotation_footprints_skips_yaw_only_marker():
+    """Yaw-only markers stay on the yaw path and are left unchanged by the roll/pitch baking."""
+    placer = ObjectPlacer(params=ObjectPlacerParams())
+    box = _make_long_box("box")
+    box.add_relation(RotateAroundSolution(yaw_rad=math.pi / 4))
+    bboxes = {box: box.get_bounding_box()}
+    baked = placer._bake_marker_rotation_footprints([box], bboxes)
+    assert baked[box] is bboxes[box]
+
+
 def test_on_relation_containment_uses_rotated_bbox():
     """Test that a child fits the parent rim axis-aligned but spills past it once yaw-inflated 90°."""
     placer = ObjectPlacer(params=ObjectPlacerParams())

--- a/isaaclab_arena/utils/bounding_box.py
+++ b/isaaclab_arena/utils/bounding_box.py
@@ -218,6 +218,42 @@ class AxisAlignedBoundingBox:
                 max_point=torch.stack([max_y, -min_x, max_z], dim=1),
             )
 
+    def enclosing_after_rotation(
+        self, rotation_xyzw: tuple[float, float, float, float] | torch.Tensor
+    ) -> "AxisAlignedBoundingBox":
+        """Refit to the axis-aligned box enclosing this box under an arbitrary rotation.
+
+        Rotates the eight corners about the object origin by ``rotation_xyzw`` and returns the
+        tightest AABB containing them. Conservative (larger than the true rotated box) for any
+        non-axis-aligned rotation. Unlike :meth:`rotated_around_z`, roll and pitch tilt the box
+        out of plane, so the Z extent may grow as well.
+
+        Args:
+            rotation_xyzw: Quaternion ``(x, y, z, w)`` applied about the object origin. A single
+                quaternion rotates every stacked box equally.
+
+        Returns:
+            New AxisAlignedBoundingBox enclosing the rotated corners.
+        """
+        device = self._min_point.device
+        quat = torch.as_tensor(rotation_xyzw, dtype=torch.float32, device=device).reshape(-1)
+        assert quat.shape == (
+            4,
+        ), f"enclosing_after_rotation expects a single (x, y, z, w) quaternion, got {tuple(quat.shape)}."
+        qx, qy, qz, qw = quat.unbind(0)
+        # Rotation matrix from the (x, y, z, w) quaternion.
+        rot = torch.stack([
+            torch.stack([1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw)]),
+            torch.stack([2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw)]),
+            torch.stack([2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)]),
+        ])  # (3, 3)
+        corners = self.get_corners_at()  # (N, 8, 3)
+        rotated = corners @ rot.transpose(0, 1)  # (N, 8, 3): each corner mapped by rot
+        return AxisAlignedBoundingBox(
+            min_point=rotated.min(dim=1).values,
+            max_point=rotated.max(dim=1).values,
+        )
+
     def rotated_around_z(self, angle_rad: float | torch.Tensor) -> "AxisAlignedBoundingBox":
         """Refit to the axis-aligned box enclosing this box rotated by angle_rad around Z.
 


### PR DESCRIPTION
## Summary
Fix crashed placement when rotate around roll/pitch without disabling global random_yaw_init 

## Detailed description
  - Reason: A rotate_around_solution marker carrying roll/pitch hit an `assertError` in `_get_yaw_from_rotate_around_solution` and crashed placement. `radom_yaw_init` is baked into Placement param, and users do not have control over it thru args cli.
  - Change: Objects with a roll/pitch marker are now excluded from the returned yaw map — they get no random_yaw_init sampled delta.
  - Impact: Scenes can request a fixed pitch/roll on a placed object without disabling random_yaw_init globally. The placer just doesn't sample yaw for roll/pitch-marker objects.
 
Before this change

>   File "/workspaces/isaaclab_arena/isaaclab_arena/relations/object_placer.py", line 260, in _place_ranked
>     self._generate_initial_orientations(objects, anchor_objects_set, generator)
>   File "/workspaces/isaaclab_arena/isaaclab_arena/relations/object_placer.py", line 421, in _generate_initial_orientations
>     marker_yaw = self._get_yaw_from_rotate_around_solution(obj)
>                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/workspaces/isaaclab_arena/isaaclab_arena/relations/object_placer.py", line 492, in _get_yaw_from_rotate_around_solution
>     assert marker.roll_rad == 0.0 and marker.pitch_rad == 0.0, (
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> AssertionError: random_yaw_init cannot enclose a roll/pitch RotateAroundSolution on 'raisin_box' (roll=0.0, pitch=1.57); only yaw markers are supported.


After: some robolab envs are working again

`python isaaclab_arena/evaluation/policy_runner.py       --viz kit     --policy_type zero_action       --enable_cameras       --num_steps 100  --num_envs 10  --env_graph_spec_yaml isaaclab_arena_environments/robolab/tasks/butter_above_raisin.yaml`

