### PR TITLE
Revert "Fix Franka assembly asset path (#919)"

### DIFF
--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -48,7 +48,7 @@ _DEFAULT_CAMERA_OFFSET = Pose(position_xyz=(0.11, -0.031, -0.074), rotation_xyzw
 # This is not ideal but currently required by the ObjectPlacementSolver to handle the robot placement correctly.
 # TODO(cvolk): Move to the IsaacLab supported FRANKA_CFG and handle the handling of the stand internally.
 _FRANKA_IK_REL_CFG = FRANKA_PANDA_HIGH_PD_CFG.copy()
-_FRANKA_IK_REL_CFG.spawn.usd_path = f"{ARENA_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
+_FRANKA_IK_REL_CFG.spawn.usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/robot_library/franka_panda_hand_on_stand.usd"
 
 # Standard-PD Franka for joint-position control.
 # Uses FRANKA_PANDA_CFG (gravity on, stiffness=80, damping=4) instead of HIGH_PD.

--- a/isaaclab_arena/tests/test_assembly_task.py
+++ b/isaaclab_arena/tests/test_assembly_task.py
@@ -379,19 +379,6 @@ def _test_gear_mesh_initialization(simulation_app) -> bool:
 
 
 # Test functions that will be called by pytest
-def test_franka_assembly_asset_override_is_still_required():
-    """Flag upstream Franka path changes that may obsolete Arena's Legacy override."""
-    from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
-    from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG
-
-    removed_upstream_path = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
-    assert FRANKA_PANDA_HIGH_PD_CFG.spawn.usd_path == removed_upstream_path, (
-        "Isaac Lab changed FRANKA_PANDA_HIGH_PD_CFG.spawn.usd_path. Verify the new asset with the assembly tests, "
-        "then remove _LEGACY_FRANKA_PANDA_USD_PATH and the FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG.spawn.usd_path "
-        "assignment from isaaclab_arena_environments/mdp/robot_configs.py and delete this tripwire test."
-    )
-
-
 def test_peg_insert_assembly_single():
     result = run_simulation_app_function(_test_peg_insert_assembly_single, headless=HEADLESS)
     assert result, f"Test {_test_peg_insert_assembly_single.__name__} failed"

--- a/isaaclab_arena_environments/mdp/robot_configs.py
+++ b/isaaclab_arena_environments/mdp/robot_configs.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG
 
 # ===========================================================================================
@@ -15,6 +16,11 @@ from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG
 # ===========================================================================================
 
 FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG = FRANKA_PANDA_HIGH_PD_CFG.copy()
+# Match Arena Franka embodiments: stock panda_instanceable.usd is missing from the Isaac 6.0
+# staging asset root, and the stand-combined USD is what ObjectPlacementSolver expects.
+FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG.spawn.usd_path = (
+    f"{ISAACLAB_NUCLEUS_DIR}/Arena/assets/robot_library/franka_panda_hand_on_stand.usd"
+)
 
 # Enable contact sensors for assembly tasks
 FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG.spawn.activate_contact_sensors = True

--- a/isaaclab_arena_environments/mdp/robot_configs.py
+++ b/isaaclab_arena_environments/mdp/robot_configs.py
@@ -8,19 +8,13 @@
 
 from __future__ import annotations
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
 from isaaclab_assets.robots.franka import FRANKA_PANDA_HIGH_PD_CFG
-
-_LEGACY_FRANKA_PANDA_USD_PATH = f"{ISAACLAB_NUCLEUS_DIR}/Robots/FrankaEmika/Legacy/panda_instanceable.usd"
 
 # ===========================================================================================
 # Franka Panda robot configuration optimized for assembly tasks (peg insert, gear mesh, etc.).
 # ===========================================================================================
 
 FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG = FRANKA_PANDA_HIGH_PD_CFG.copy()
-# Use the available Franka asset under Legacy instead of the unavailable path in the pinned Isaac Lab config.
-# test_franka_assembly_asset_override_is_still_required flags future upstream path changes.
-FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG.spawn.usd_path = _LEGACY_FRANKA_PANDA_USD_PATH
 
 # Enable contact sensors for assembly tasks
 FRANKA_PANDA_ASSEMBLY_HIGH_PD_CFG.spawn.activate_contact_sensors = True


### PR DESCRIPTION
This reverts commit fa28eb3ec4eaae73c61bab73bff7a9a51932470d.

- The Arena franka with stand USD has been fixed on staging server. Update the franka embodiment default to use it.
- Update the gear assembly tasks which uses a different cfg to also use the franka with stand.

