### PR TITLE
Name pick-and-place contact sensors per object

### DIFF
--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -12,7 +12,6 @@ import isaaclab.envs.mdp as mdp_isaac_lab
 from isaaclab.envs.common import ViewerCfg
 from isaaclab.envs.mimic_env_cfg import MimicEnvCfg, SubTaskConfig
 from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
-from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_arena.assets.asset import Asset
@@ -30,6 +29,7 @@ from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.tasks.task_transition import Relocate, TaskTransition
 from isaaclab_arena.tasks.terminations import SuccessMode, check_success
 from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+from isaaclab_arena.utils.configclass import make_configclass
 
 
 @agent_ready
@@ -70,11 +70,8 @@ class PickAndPlaceTask(TaskBase):
         self.destination_object = destination_object
         self.background_scene = background_scene
         self.destination_location = destination_location
-        self.scene_config = SceneCfg(
-            pick_up_object_contact_sensor=self.pick_up_object.get_contact_sensor_cfg(
-                contact_against_object=self.destination_location,
-            ),
-        )
+        self.contact_sensor_name = self.contact_sensor_name_for_pick_up_object(pick_up_object)
+        self.scene_config = self._make_scene_cfg()
         self.force_threshold = force_threshold
         self.velocity_threshold = velocity_threshold
         if max_separation is not None:
@@ -89,6 +86,22 @@ class PickAndPlaceTask(TaskBase):
             else task_description
         )
 
+    @classmethod
+    def contact_sensor_name_for_pick_up_object(cls, pick_up_object: Asset | str) -> str:
+        """Return the scene sensor name for a pick-up object's destination contact check."""
+        object_name = pick_up_object.name if isinstance(pick_up_object, Asset) else pick_up_object
+        return f"contact_sensor_{object_name}"
+
+    def _make_scene_cfg(self):
+        contact_sensor_cfg = self.pick_up_object.get_contact_sensor_cfg(
+            contact_against_object=self.destination_location,
+        )
+        scene_cfg_type = make_configclass(
+            "SceneCfg",
+            [(self.contact_sensor_name, type(contact_sensor_cfg), contact_sensor_cfg)],
+        )
+        return scene_cfg_type()
+
     def get_scene_cfg(self):
         return self.scene_config
 
@@ -101,7 +114,7 @@ class PickAndPlaceTask(TaskBase):
                 func=object_on_destination,
                 params={
                     "object_cfg": SceneEntityCfg(self.pick_up_object.name),
-                    "contact_sensor_cfg": SceneEntityCfg("pick_up_object_contact_sensor"),
+                    "contact_sensor_cfg": SceneEntityCfg(self.contact_sensor_name),
                     "force_threshold": self.force_threshold,
                     "velocity_threshold": self.velocity_threshold,
                 },
@@ -181,7 +194,7 @@ class PickAndPlaceTask(TaskBase):
                     partial(
                         object_on_destination,
                         object_cfg=SceneEntityCfg(self.pick_up_object.name),
-                        contact_sensor_cfg=SceneEntityCfg("pick_up_object_contact_sensor"),
+                        contact_sensor_cfg=SceneEntityCfg(self.contact_sensor_name),
                         force_threshold=self.force_threshold,
                         velocity_threshold=self.velocity_threshold,
                     ),
@@ -206,13 +219,6 @@ class PickAndPlaceTask(TaskBase):
             subject=pick_up_object,
             effects=(Relocate(subject=pick_up_object, relation=relation.name, target=destination_location),),
         )
-
-
-@configclass
-class SceneCfg:
-    """Scene configuration for the pick and place task."""
-
-    pick_up_object_contact_sensor: ContactSensorCfg = MISSING
 
 
 @configclass

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -70,8 +70,8 @@ class PickAndPlaceTask(TaskBase):
         self.destination_object = destination_object
         self.background_scene = background_scene
         self.destination_location = destination_location
-        self.contact_sensor_name = self.contact_sensor_name_for_pick_up_object(pick_up_object)
-        self.scene_config = self._make_scene_cfg()
+        self.contact_sensor_name = f"contact_sensor_{pick_up_object.name}"
+        self.scene_config = self.make_scene_cfg()
         self.force_threshold = force_threshold
         self.velocity_threshold = velocity_threshold
         if max_separation is not None:
@@ -86,13 +86,7 @@ class PickAndPlaceTask(TaskBase):
             else task_description
         )
 
-    @classmethod
-    def contact_sensor_name_for_pick_up_object(cls, pick_up_object: Asset | str) -> str:
-        """Return the scene sensor name for a pick-up object's destination contact check."""
-        object_name = pick_up_object.name if isinstance(pick_up_object, Asset) else pick_up_object
-        return f"contact_sensor_{object_name}"
-
-    def _make_scene_cfg(self):
+    def make_scene_cfg(self):
         contact_sensor_cfg = self.pick_up_object.get_contact_sensor_cfg(
             contact_against_object=self.destination_location,
         )

--- a/isaaclab_arena/tests/test_object_on_termination.py
+++ b/isaaclab_arena/tests/test_object_on_termination.py
@@ -49,11 +49,12 @@ def _test_object_on_destination_termination(simulation_app) -> bool:
 
     scene = Scene(assets=[background, cracker_box, destination_location])
 
+    task = PickAndPlaceTask(cracker_box, destination_location, background)
     isaaclab_arena_environment = IsaacLabArenaEnvironment(
         name="kitchen",
         embodiment=FrankaIKEmbodiment(),
         scene=scene,
-        task=PickAndPlaceTask(cracker_box, destination_location, background),
+        task=task,
     )
 
     # Compile an IsaacLab compatible arena environment configuration
@@ -69,8 +70,7 @@ def _test_object_on_destination_termination(simulation_app) -> bool:
         velocities_vec = []
         success_vec = []
         terminated_vec = []
-        contact_sensor_name = PickAndPlaceTask.contact_sensor_name_for_pick_up_object(cracker_box)
-        sensor = env.unwrapped.scene.sensors[contact_sensor_name]
+        sensor = env.unwrapped.scene.sensors[task.contact_sensor_name]
         for _ in tqdm.tqdm(range(NUM_STEPS)):
             with torch.inference_mode():
                 actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)

--- a/isaaclab_arena/tests/test_object_on_termination.py
+++ b/isaaclab_arena/tests/test_object_on_termination.py
@@ -69,7 +69,8 @@ def _test_object_on_destination_termination(simulation_app) -> bool:
         velocities_vec = []
         success_vec = []
         terminated_vec = []
-        sensor = env.unwrapped.scene.sensors["pick_up_object_contact_sensor"]
+        contact_sensor_name = PickAndPlaceTask.contact_sensor_name_for_pick_up_object(cracker_box)
+        sensor = env.unwrapped.scene.sensors[contact_sensor_name]
         for _ in tqdm.tqdm(range(NUM_STEPS)):
             with torch.inference_mode():
                 actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)

--- a/isaaclab_arena/tests/test_object_set.py
+++ b/isaaclab_arena/tests/test_object_set.py
@@ -275,13 +275,14 @@ def _test_single_object_in_one_object_set(simulation_app):
     obj_set = RigidObjectSet(name="single_object_set", objects=[cracker_box], prim_path=OBJECT_SET_1_PRIM_PATH)
     obj_set.set_initial_pose(Pose(position_xyz=(0.1, 0.0, 0.1), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
     scene = Scene(assets=[background, obj_set])
+    task = PickAndPlaceTask(
+        pick_up_object=obj_set, destination_location=destination_location, background_scene=background
+    )
     isaaclab_arena_environment = IsaacLabArenaEnvironment(
         name="single_object_set_test",
         embodiment=embodiment,
         scene=scene,
-        task=PickAndPlaceTask(
-            pick_up_object=obj_set, destination_location=destination_location, background_scene=background
-        ),
+        task=task,
         teleop_device=None,
     )
     args_cli = get_isaaclab_arena_cli_parser().parse_args([])
@@ -303,10 +304,7 @@ def _test_single_object_in_one_object_set(simulation_app):
 
         assert env.unwrapped.scene[obj_set.name].data.root_pose_w is not None, "Root pose is None"
         assert (
-            env.unwrapped.scene.sensors[
-                PickAndPlaceTask.contact_sensor_name_for_pick_up_object(obj_set)
-            ].data.force_matrix_w
-            is not None
+            env.unwrapped.scene.sensors[task.contact_sensor_name].data.force_matrix_w is not None
         ), "Contact sensor data is None"
     except Exception as e:
         print(f"Error: {e}")
@@ -344,13 +342,14 @@ def _test_multi_objects_in_one_object_set(simulation_app):
         name="multi_object_sets", objects=[cracker_box, sugar_box], prim_path=OBJECT_SET_2_PRIM_PATH
     )
     scene = Scene(assets=[background, obj_set])
+    task = PickAndPlaceTask(
+        pick_up_object=obj_set, destination_location=destination_location, background_scene=background
+    )
     isaaclab_arena_environment = IsaacLabArenaEnvironment(
         name="multi_objects_in_one_object_set_test",
         embodiment=embodiment,
         scene=scene,
-        task=PickAndPlaceTask(
-            pick_up_object=obj_set, destination_location=destination_location, background_scene=background
-        ),
+        task=task,
         teleop_device=None,
     )
     args_cli = get_isaaclab_arena_cli_parser().parse_args([])
@@ -362,10 +361,7 @@ def _test_multi_objects_in_one_object_set(simulation_app):
 
     assert env.unwrapped.scene[obj_set.name].data.root_pose_w is not None, "Root pose is None"
     assert (
-        env.unwrapped.scene.sensors[
-            PickAndPlaceTask.contact_sensor_name_for_pick_up_object(obj_set)
-        ].data.force_matrix_w
-        is not None
+        env.unwrapped.scene.sensors[task.contact_sensor_name].data.force_matrix_w is not None
     ), "Contact sensor data is None"
 
     # replace * in OBJECT_SET_PRIM_PATH with env_index

--- a/isaaclab_arena/tests/test_object_set.py
+++ b/isaaclab_arena/tests/test_object_set.py
@@ -216,7 +216,7 @@ def _run_pick_and_place_object_set_test(
             assert obj_set.get_initial_pose() is not None, "Initial pose is None"
         assert env.unwrapped.scene[obj_set.name].data.root_pose_w is not None, "Root pose is None"
         assert (
-            env.unwrapped.scene.sensors["pick_up_object_contact_sensor"].data.force_matrix_w is not None
+            env.unwrapped.scene.sensors[task.contact_sensor_name].data.force_matrix_w is not None
         ), "Contact sensor data is None"
         return True
     except Exception as e:
@@ -303,7 +303,10 @@ def _test_single_object_in_one_object_set(simulation_app):
 
         assert env.unwrapped.scene[obj_set.name].data.root_pose_w is not None, "Root pose is None"
         assert (
-            env.unwrapped.scene.sensors["pick_up_object_contact_sensor"].data.force_matrix_w is not None
+            env.unwrapped.scene.sensors[
+                PickAndPlaceTask.contact_sensor_name_for_pick_up_object(obj_set)
+            ].data.force_matrix_w
+            is not None
         ), "Contact sensor data is None"
     except Exception as e:
         print(f"Error: {e}")
@@ -359,7 +362,10 @@ def _test_multi_objects_in_one_object_set(simulation_app):
 
     assert env.unwrapped.scene[obj_set.name].data.root_pose_w is not None, "Root pose is None"
     assert (
-        env.unwrapped.scene.sensors["pick_up_object_contact_sensor"].data.force_matrix_w is not None
+        env.unwrapped.scene.sensors[
+            PickAndPlaceTask.contact_sensor_name_for_pick_up_object(obj_set)
+        ].data.force_matrix_w
+        is not None
     ), "Contact sensor data is None"
 
     # replace * in OBJECT_SET_PRIM_PATH with env_index


### PR DESCRIPTION
## Summary
Give each pick-and-place subtask a unique contact sensor

## Detailed description
- Parallel composite tasks reused one `pick_up_object_contact_sensor`, so one placed object could mark every pick and place subtask successful
- Name sensors `contact_sensor_{pick_up_object.name}` and build scene config dynamically
- Update termination and object-set tests for the new sensor names