### PR TITLE
Move RoboLab episode_length_s to composite task root

### DIFF
--- a/isaaclab_arena/environment_spec/arena_env_graph_task_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_task_conversion_utils.py
@@ -30,7 +30,10 @@ def build_task_from_spec(task_spec: CompositeTaskSpec, assets_by_node_id: dict[s
 
     if task_spec.composition is TaskCompositionType.ATOMIC:
         return _build_atomic_task_from_spec(
-            task_spec.subtasks[0], assets_by_node_id, task_description=task_spec.description
+            task_spec.subtasks[0],
+            assets_by_node_id,
+            task_description=task_spec.description,
+            episode_length_s=task_spec.episode_length_s,
         )
 
     subtasks = [_build_atomic_task_from_spec(spec, assets_by_node_id) for spec in task_spec.subtasks]
@@ -43,10 +46,12 @@ def build_task_from_spec(task_spec: CompositeTaskSpec, assets_by_node_id: dict[s
     if task_spec.composition is TaskCompositionType.PARALLEL:
         return CompositeTaskBase(
             subtasks=subtasks,
+            episode_length_s=task_spec.episode_length_s,
             task_description=task_spec.description,
         )
     return SequentialTaskBase(
         subtasks=subtasks,
+        episode_length_s=task_spec.episode_length_s,
         task_description=task_spec.description,
     )
 
@@ -56,12 +61,15 @@ def _build_atomic_task_from_spec(
     assets_by_node_id: dict[str, Any],
     *,
     task_description: str | None = None,
+    episode_length_s: float | None = None,
 ) -> Any:
     """Look up the task class by name, resolve any Asset-typed kwargs, instantiate."""
     task_class = TaskRegistry().get_task_by_name(task_spec.kind)
     task_init_kwargs = _resolve_node_refs_in_task_args(task_class, task_spec.params, assets_by_node_id)
     if task_description and "task_description" not in task_init_kwargs:
         task_init_kwargs["task_description"] = task_description
+    if episode_length_s is not None and "episode_length_s" not in task_init_kwargs:
+        task_init_kwargs["episode_length_s"] = episode_length_s
     return task_class(**task_init_kwargs)
 
 

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -131,6 +131,10 @@ class CompositeTaskSpec(BaseModel):
         min_length=1,
         description="Natural-language summary of the overall task (e.g. 'pick and place all bananas into the bin').",
     )
+    episode_length_s: float | None = Field(
+        default=None,
+        description="Maximum episode duration in seconds for the root task.",
+    )
     subtasks: list[TaskSpec] = Field(
         default_factory=list,
         description="Atomic registered tasks that compose this root task.",

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -43,6 +43,7 @@ def _test_arena_env_graph_conversion_builds_sequential_pick_and_place_task(simul
     assert arena_env.task.subtasks[1].pick_up_object.name == "mug_ycb_robolab"
     assert all(subtask.destination_location.name == "bowl_ycb_robolab" for subtask in arena_env.task.subtasks)
     assert all(subtask.background_scene.name == "maple_table_robolab" for subtask in arena_env.task.subtasks)
+    assert arena_env.task.get_episode_length_s() == 20.0
 
     return True
 

--- a/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_task_conversion.py
@@ -175,6 +175,7 @@ def test_build_task_from_spec_atomic_returns_single_task(monkeypatch):
     spec = CompositeTaskSpec(
         composition=TaskCompositionType.ATOMIC,
         description="pick up the cube",
+        episode_length_s=15.0,
         subtasks=[
             TaskSpec(
                 kind="PickAndPlaceTask",
@@ -184,21 +185,22 @@ def test_build_task_from_spec_atomic_returns_single_task(monkeypatch):
     )
     result = conversion.build_task_from_spec(spec, {})
     assert isinstance(result, FakeTask)
-    assert built == [{"task_description": "pick up the cube"}]
+    assert built == [{"task_description": "pick up the cube", "episode_length_s": 15.0}]
 
 
 def test_build_task_from_spec_sequential_wraps_multiple_tasks(monkeypatch):
     captured: dict[str, Any] = {}
 
     class FakeSequential:
-        def __init__(self, subtasks, task_description=None):
+        def __init__(self, subtasks, task_description=None, episode_length_s=None):
             captured["subtasks"] = subtasks
             captured["task_description"] = task_description
+            captured["episode_length_s"] = episode_length_s
 
     monkeypatch.setattr(
         conversion,
         "_build_atomic_task_from_spec",
-        lambda task_spec, _assets, task_description=None: task_spec.kind,
+        lambda task_spec, _assets, **kwargs: task_spec.kind,
     )
     monkeypatch.setattr(
         "isaaclab_arena.tasks.sequential_task_base.SequentialTaskBase",
@@ -210,6 +212,7 @@ def test_build_task_from_spec_sequential_wraps_multiple_tasks(monkeypatch):
     spec = CompositeTaskSpec(
         composition=TaskCompositionType.SEQUENTIAL,
         description="do two things in order",
+        episode_length_s=30.0,
         subtasks=[
             TaskSpec(kind="PickAndPlaceTask", params={}),
             TaskSpec(kind="PickAndPlaceTask", params={}),
@@ -219,6 +222,39 @@ def test_build_task_from_spec_sequential_wraps_multiple_tasks(monkeypatch):
     assert isinstance(result, FakeSequential)
     assert captured["subtasks"] == ["PickAndPlaceTask", "PickAndPlaceTask"]
     assert captured["task_description"] == "do two things in order"
+    assert captured["episode_length_s"] == 30.0
+
+
+def test_build_task_from_spec_parallel_passes_root_episode_length(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    class FakeComposite:
+        def __init__(self, subtasks, task_description=None, episode_length_s=None):
+            captured["episode_length_s"] = episode_length_s
+
+    monkeypatch.setattr(
+        conversion,
+        "_build_atomic_task_from_spec",
+        lambda task_spec, _assets, **kwargs: task_spec.kind,
+    )
+    monkeypatch.setattr(
+        "isaaclab_arena.tasks.composite_task_base.CompositeTaskBase",
+        FakeComposite,
+    )
+
+    from isaaclab_arena.environment_spec.arena_env_graph_types import CompositeTaskSpec, TaskCompositionType, TaskSpec
+
+    spec = CompositeTaskSpec(
+        composition=TaskCompositionType.PARALLEL,
+        description="do two things",
+        episode_length_s=120.0,
+        subtasks=[
+            TaskSpec(kind="PickAndPlaceTask", params={"episode_length_s": 20.0}),
+            TaskSpec(kind="PickAndPlaceTask", params={}),
+        ],
+    )
+    conversion.build_task_from_spec(spec, {})
+    assert captured["episode_length_s"] == 120.0
 
 
 def test_build_atomic_task_from_spec_params_task_description_takes_precedence(monkeypatch):

--- a/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+++ b/isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
@@ -73,16 +73,15 @@ task:
   composition: sequential
   description: pick up the rubiks cube and place it in the bowl ; pick up the mug
     and place it in the bowl
+  episode_length_s: 20.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: rubiks_cube_hot3d_robolab
       destination_location: bowl_ycb_robolab
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
   - kind: PickAndPlaceTask
     params:
       pick_up_object: mug_ycb_robolab
       destination_location: bowl_ycb_robolab
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena/tests/test_data/robolab_task_overlay.yaml
+++ b/isaaclab_arena/tests/test_data/robolab_task_overlay.yaml
@@ -8,10 +8,10 @@ external_yaml: robolab_scene_base.yaml
 task:
   composition: atomic
   description: pick up the banana and place it in the bowl
+  episode_length_s: 50.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena/tests/test_data/robolab_task_overlay.yaml
+++ b/isaaclab_arena/tests/test_data/robolab_task_overlay.yaml
@@ -8,7 +8,7 @@ external_yaml: robolab_scene_base.yaml
 task:
   composition: atomic
   description: pick up the banana and place it in the bowl
-  episode_length_s: 50.0
+  episode_length_s: 20.0
   subtasks:
   - kind: PickAndPlaceTask
     params:

--- a/isaaclab_arena_environments/robolab/tasks/apple_and_yogurt_in_bowl.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/apple_and_yogurt_in_bowl.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/workdesk_snacks.yaml
 task:
   composition: parallel
   description: Put the apple and yogurt in the bowl
+  episode_length_s: 120.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: apple
       destination_location: wooden_bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: yogurt_cup
       destination_location: wooden_bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/bagels_on_plate.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/bagels_on_plate.yaml
@@ -8,16 +8,15 @@ external_yaml: ../scenes/bagel_plate_banana_bowl.yaml
 task:
   composition: parallel
   description: Put the bagels on the plate
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bagel_1
       destination_location: plate
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bagel_2
       destination_location: plate
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/banana_bowl.yaml
 task:
   composition: atomic
   description: pick up the banana and place it in the bowl
+  episode_length_s: 50.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/banana_on_plate.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/banana_on_plate.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/bagel_plate_banana_bowl.yaml
 task:
   composition: atomic
   description: Pick up the banana and place it on the plate.
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: plate
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/banana_then_rubiks_cube.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/banana_then_rubiks_cube.yaml
@@ -8,16 +8,15 @@ external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
 task:
   composition: sequential
   description: pick up the banana and place it in the bowl ; pick up the cube and place it in the bowl
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
   - kind: PickAndPlaceTask
     params:
       pick_up_object: cube
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/bbq_sauce_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/bbq_sauce_in_bin.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/bin_condiments.yaml
 task:
   composition: parallel
   description: Put the red BBQ sauce bottles in the grey bin
+  episode_length_s: 90.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bbq_sauce_bottle_1
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bbq_sauce_bottle_2
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/big_pumpkin_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/big_pumpkin_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
 task:
   composition: atomic
   description: pick up the large pumpkin and place it into the bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_large
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/black_items_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/black_items_in_bin.yaml
@@ -8,39 +8,35 @@ external_yaml: ../scenes/workdesk_bin.yaml
 task:
   composition: parallel
   description: Put the black items in the grey bin
+  episode_length_s: 120.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: keyboard
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: remote_control
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: computer_mouse
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: smartphone
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: glasses
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/bowl_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/bowl_in_bin.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/bin_mug_mustard_marker_bowl.yaml
 task:
   composition: atomic
   description: Pick up the bowl and place it in the grey bin.
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bowl
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/butter_above_raisin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/butter_above_raisin.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/butter_raisin_box.yaml
 task:
   composition: atomic
   description: pick up the butter box and place it on top of the raisin box
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: butter_hope_robolab
       destination_location: raisin_box_hope_robolab
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/canned_food_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/canned_food_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/bin_condiments.yaml
 task:
   composition: atomic
   description: Put the canned food in the grey bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: canned_tuna
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/clamp_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/clamp_in_right_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/tools_container.yaml
 task:
   composition: atomic
   description: pick up the spring clamp and place it in the right bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: spring_clamp
       destination_location: bin_b04
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/clear_organic_objects.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/clear_organic_objects.yaml
@@ -8,81 +8,71 @@ external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
 task:
   composition: parallel
   description: Clear away the organic objects
+  episode_length_s: 240.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: lemon_1
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: lemon_2
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: lime_1
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: lime_2
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: orange_1
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: orange_2
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pomegranate
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_large
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_small
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: red_onion
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: avocado
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/clutter_plastic.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/clutter_plastic.yaml
@@ -8,25 +8,23 @@ external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
 task:
   composition: parallel
   description: Put all plastic bottles away in the bin
+  episode_length_s: 180.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: white_packer_bottle
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: milk_jug
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: utilityjug
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/clutter_pumpkin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/clutter_pumpkin.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
 task:
   composition: parallel
   description: Put all the pumpkins away in the bin
+  episode_length_s: 90.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_large
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_small
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/coffee_pot_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/coffee_pot_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/bin_condiments.yaml
 task:
   composition: atomic
   description: pick up the coffee pot and place it into the grey bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: coffee_pot
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/condiments_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/condiments_in_bin.yaml
@@ -8,32 +8,29 @@ external_yaml: ../scenes/bin_condiments.yaml
 task:
   composition: parallel
   description: Sort the sauce condiments into the grey bin
+  episode_length_s: 180.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: mustard
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: ranch_dressing
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bbq_sauce_bottle_1
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bbq_sauce_bottle_2
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/electronics_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/electronics_in_bin.yaml
@@ -8,32 +8,29 @@ external_yaml: ../scenes/workdesk_bin.yaml
 task:
   composition: parallel
   description: Put the electronic devices in the grey bin
+  episode_length_s: 180.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: smartphone
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: remote_control
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: computer_mouse
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: keyboard
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/food_packing_1_boxes.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/food_packing_1_boxes.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/foodpacking_1bin_1box_1can.yaml
 task:
   composition: atomic
   description: pick up the cheez it box and place it into the bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: cheez_it_box
       destination_location: bin_a06
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/food_packing_1_cans.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/food_packing_1_cans.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/foodpacking_1bin_1box_1can.yaml
 task:
   composition: atomic
   description: Pack canned foods into the bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: tomato_soup_can
       destination_location: bin_a06
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/hammers_in_left_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/hammers_in_left_bin.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/tools_container.yaml
 task:
   composition: parallel
   description: Put the red hammer and black hammer in the left bin
+  episode_length_s: 180.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: red_hammer
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: black_hammer
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/larger_object_raisin_box_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/larger_object_raisin_box_in_bin.yaml
@@ -8,6 +8,7 @@ external_yaml: ../scenes/butter_raisin_box_grey_bin.yaml
 task:
   composition: atomic
   description: Pick up the red raisin box and place it into the grey bin on the maple table.
+  episode_length_s: 30.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
@@ -15,4 +16,3 @@ task:
       destination_location: grey_bin
       background_scene: maple_table_robolab
       max_separation: [0.1, 0.1, 0.1]
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/marker_in_mug.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/marker_in_mug.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/workdesk.yaml
 task:
   composition: atomic
   description: Put the whiteboard marker in the mug
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: marker
       destination_location: ceramic_mug
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/mouse_on_keyboard.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/mouse_on_keyboard.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/workdesk.yaml
 task:
   composition: atomic
   description: place the computer mouse on the keyboard
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: computer_mouse
       destination_location: keyboard
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/mustard_above_raisin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/mustard_above_raisin.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/mustard_raisin_box.yaml
 task:
   composition: atomic
   description: Pick up the mustard bottle and place it on the raisin box.
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: mustard_bottle
       destination_location: raisin_box
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/mustard_in_left_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/mustard_in_left_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/two_bin.yaml
 task:
   composition: atomic
   description: put the mustard in the left bin
+  episode_length_s: 30.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: mustard
       destination_location: grey_bin_left
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/mustard_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/mustard_in_right_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/two_bin.yaml
 task:
   composition: atomic
   description: Put the mustard in the right bin
+  episode_length_s: 30.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: mustard
       destination_location: grey_bin_right
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/non_hammer_tools_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/non_hammer_tools_in_right_bin.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/tools_container.yaml
 task:
   composition: parallel
   description: Put the non-hammer tools in the right bin
+  episode_length_s: 180.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: cordless_drill
       destination_location: bin_b04
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: spring_clamp
       destination_location: bin_b04
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/rubiks_cube.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/rubiks_cube.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/rubiks_cube_bowl.yaml
 task:
   composition: atomic
   description: put the rubiks cube in the bowl
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: rubiks_cube
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/rubiks_cube_and_banana.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/rubiks_cube_and_banana.yaml
@@ -8,16 +8,15 @@ external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
 task:
   composition: parallel
   description: Put the cube and the banana in the bowl
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: cube
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/rubiks_cube_then_banana.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/rubiks_cube_then_banana.yaml
@@ -8,16 +8,15 @@ external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
 task:
   composition: sequential
   description: Put the cube then the banana in the bowl
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: cube
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
   - kind: PickAndPlaceTask
     params:
       pick_up_object: banana
       destination_location: bowl
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/sauce_bottles_crate.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/sauce_bottles_crate.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/bottles_crate.yaml
 task:
   composition: atomic
   description: place the bbq sauce bottle into the purple crate on the table
+  episode_length_s: 40.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: bbq_sauce_bottle
       destination_location: purple_crate
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/small_pumpkin_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/small_pumpkin_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
 task:
   composition: atomic
   description: Put the small pumpkin in the bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: pumpkin_small
       destination_location: container_f24
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/smaller_object_butter_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/smaller_object_butter_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/butter_raisin_box_grey_bin.yaml
 task:
   composition: atomic
   description: Place the smaller object in the grey bin.
+  episode_length_s: 30.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: butter
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/smartphone_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/smartphone_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/workdesk_bin.yaml
 task:
   composition: atomic
   description: Put the smartphone in the grey bin
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: smartphone
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/throw_away_apple.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/throw_away_apple.yaml
@@ -8,10 +8,10 @@ external_yaml: ../scenes/workdesk_snacks.yaml
 task:
   composition: atomic
   description: place the apple into the plasticpail on the table
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: apple
       destination_location: plasticpail
       background_scene: maple_table_robolab
-      episode_length_s: 20.0

--- a/isaaclab_arena_environments/robolab/tasks/throw_away_snacks.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/throw_away_snacks.yaml
@@ -8,18 +8,17 @@ external_yaml: ../scenes/workdesk_snacks.yaml
 task:
   composition: parallel
   description: Put away the snacks in the bin
+  episode_length_s: 120.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: apple
       destination_location: plasticpail
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]
   - kind: PickAndPlaceTask
     params:
       pick_up_object: yogurt_cup
       destination_location: plasticpail
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]

--- a/isaaclab_arena_environments/robolab/tasks/toy_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab/tasks/toy_in_bin.yaml
@@ -8,11 +8,11 @@ external_yaml: ../scenes/workdesk_bin.yaml
 task:
   composition: atomic
   description: place the lizard figurine into the grey bin on the table
+  episode_length_s: 60.0
   subtasks:
   - kind: PickAndPlaceTask
     params:
       pick_up_object: lizard_figurine
       destination_location: grey_bin
       background_scene: maple_table_robolab
-      episode_length_s: 20.0
       max_separation: [0.1, 0.1, 0.1]


### PR DESCRIPTION
## Summary
Set RoboLab task episode limits on the composite root and wire conversion.

## Detailed description
- Add `episode_length_s` to `CompositeTaskSpec` and pass it into composite/atomic task constructors during graph conversion
- Move `episode_length_s` out of RoboLab subtask params into each task YAML root, using upstream RoboLab benchmark durations
- Update graph-spec tests and fixtures to match the new schema