### PR TITLE
Install OpenPI client in native uv environments

### DIFF
--- a/isaaclab_arena/tests/test_packaging.py
+++ b/isaaclab_arena/tests/test_packaging.py
@@ -12,7 +12,9 @@ bare ``--no-deps --editable`` install in the native uv job.
 """
 
 import importlib.util
+import tomllib
 from importlib import metadata
+from pathlib import Path
 
 PACKAGE_ROOTS = (
     "isaaclab_arena",
@@ -30,6 +32,8 @@ DISCOVERABLE_MODULES = (
     "isaaclab_arena.tasks.sequential_composite_tasks.franka_put_and_close_door_task",
 )
 
+REPOSITORY_ROOT = Path(__file__).parents[2]
+
 
 def test_package_roots_importable():
     for package_root in PACKAGE_ROOTS:
@@ -43,3 +47,16 @@ def test_modules_discoverable():
 
 def test_package_version_resolves():
     assert metadata.version("isaaclab_arena")
+
+
+def test_native_openpi_client_matches_server_commit():
+    """Keep the native OpenPI client wire-compatible with the separately built server."""
+    pyproject_config = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    openpi_client_source = pyproject_config["tool"]["uv"]["sources"]["openpi-client"]
+    openpi_server_commit = (
+        (REPOSITORY_ROOT / "isaaclab_arena_openpi" / "docker" / "OPENPI_COMMIT").read_text(encoding="utf-8").strip()
+    )
+
+    assert pyproject_config["dependency-groups"]["openpi"] == ["openpi-client"]
+    assert "openpi" in pyproject_config["tool"]["uv"]["default-groups"]
+    assert openpi_client_source["rev"] == openpi_server_commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,15 @@ isaacsim = [
     "torchvision==0.26.0",
     "torchaudio==2.11.0",
 ]
+openpi = [
+    "openpi-client",
+]
 
 [tool.uv]
 # Arena supports Linux x86_64 only; resolve and lock for exactly that platform.
 environments = ["sys_platform == 'linux' and platform_machine == 'x86_64'"]
-# Install the sim stack (isaaclab/isaacsim wheels) on a bare `uv sync`.
-default-groups = ["isaacsim"]
+# Install the sim stack and remote OpenPI client on a bare `uv sync`.
+default-groups = ["isaacsim", "openpi"]
 # Isaac Lab is explicitly pinned to a beta, while Isaac Sim requires a
 # transitive tinyobjloader release candidate. The exact constraint below makes
 # that RC explicit without allowing unrelated packages to float to prereleases.
@@ -114,6 +117,11 @@ mujoco-usd-converter = { index = "pypi" }
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
 torchaudio = { index = "pytorch-cu128" }
+
+[tool.uv.sources.openpi-client]
+git = "https://github.com/Physical-Intelligence/openpi"
+rev = "c23745b5ad24e98f66967ea795a07b2588ed6c79"
+subdirectory = "packages/openpi-client"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -816,6 +816,21 @@ wheels = [
 ]
 
 [[package]]
+name = "dm-tree"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "attrs", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "wrapt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/66/a3ec619d22b6baffa5ab853e8dc6ec9d0c837127948af59bb15b988d7312/dm_tree-0.1.10.tar.gz", hash = "sha256:22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a", size = 35748, upload-time = "2026-03-31T17:35:39.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/eb/1d55c679cee9a54e552480d308535753c72e2250cf720d7aa777bff2a4fe/dm_tree-0.1.10-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:012c2b376e88d3685c73a4b5c23be41fe933e14e380dcd90172971690b0e02d2", size = 186506, upload-time = "2026-03-31T17:35:17.593Z" },
+]
+
+[[package]]
 name = "dotvar"
 version = "0.1.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1420,6 +1435,9 @@ isaacsim = [
     { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
+openpi = [
+    { name = "openpi-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1451,6 +1469,7 @@ isaacsim = [
     { name = "torchaudio", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torchvision", specifier = "==0.26.0", index = "https://download.pytorch.org/whl/cu128" },
 ]
+openpi = [{ name = "openpi-client", git = "https://github.com/Physical-Intelligence/openpi?subdirectory=packages%2Fopenpi-client&rev=c23745b5ad24e98f66967ea795a07b2588ed6c79" }]
 
 [[package]]
 name = "isaacsim"
@@ -2983,6 +3002,18 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/13/af150685be342dc09bfb0824e2a280020ccf1c7fc64e15a31d9209016aa9/opencv_python_headless-4.13.0.90-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dbc1f4625e5af3a80ebdbd84380227c0f445228588f2521b11af47710caca1ba", size = 57683677, upload-time = "2026-01-18T09:10:23.588Z" },
     { url = "https://files.pythonhosted.org/packages/81/a1/facfe2801a861b424c4221d66e1281cf19735c00e07f063a337a208c11b5/opencv_python_headless-4.13.0.90-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f46b17ea0aa7e4124ca6ad71143f89233ae9557f61d2326bcdb34329a1ddf9bd", size = 62535926, upload-time = "2026-01-18T09:12:47.229Z" },
+]
+
+[[package]]
+name = "openpi-client"
+version = "0.1.0"
+source = { git = "https://github.com/Physical-Intelligence/openpi?subdirectory=packages%2Fopenpi-client&rev=c23745b5ad24e98f66967ea795a07b2588ed6c79#c23745b5ad24e98f66967ea795a07b2588ed6c79" }
+dependencies = [
+    { name = "dm-tree", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "msgpack", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "websockets", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fix failing ci nightly on main. Install OpenPI client with native uv. 


Verification: Previously failed CI test passes locally.
```
uv run --no-sync python -m pytest -sv --durations=0 \
  isaaclab_arena/tests/test_osmo_experiment_workflow.py
```


## Detailed description
- Native uv CI could not collect the OSMO experiment tests because `openpi-client` was only installed by the Docker build.
- Add the client as a default uv dependency group, pinned to the same upstream revision used by the OpenPI server.
- Refresh the lockfile and guard the shared revision so client/server compatibility cannot drift.
- Leave the existing Docker installation path unchanged.