### PR TITLE
Document safe CLI exit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,9 @@ def test_foo():  # pytest-visible outer function
     assert result
 ```
 
+- **Don't** call CLI paths that may invoke `sys.exit`—such as argparse `--help`, invalid arguments, or `parser.error()`—directly inside pytest. After Isaac Sim starts, catching `SystemExit` still leaves Kit shutdown queued.
+- **Instead**, run the CLI with `subprocess.run([TestConstants.python_path, ...])` and assert the child result. Use `with_subprocess` only when the child starts Isaac Sim; the marker does not create a child process.
+
 ## Boundaries
 
 - **Never** force-push to `main` or `release/*`. **Instead**, push to a `<username>/<type>/<short-description>` branch (`<type>` ∈ `feature`, `fix`, `docs`, `refactor`, `chore`, `ci`) and open a PR against `main`.


### PR DESCRIPTION
## Summary
Document safe CLI exit testing for future agents

## Detailed description
After Isaac Sim starts, calling sys.exit both raises SystemExit and schedules the shared simulation application to stop. Catching the exception does not cancel the scheduled shutdown.
This allowed a CLI test to pass while later, unrelated simulation tests failed, making earlier CI failures  (#929 and #933) painfully hard to debug. 

