### PR TITLE
Improve env gen GUI support for kitchen envs

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/prim_path_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/prim_path_inference.py
@@ -87,9 +87,9 @@ class PrimPathInference:
 You resolve object_reference prim_path values for an ArenaEnvGraphSpec.
 
 GUIDANCE:
-- BACKGROUND PRIM TREE lists prims in nested form: each indented line shows a path suffix
-  under its parent; join ancestor suffixes with '/' to form the full relative_path for prim_path.
-- Pick prim_path only from those full relative_path values.
+- BACKGROUND PRIM TREE lists each prim on its own line as ``<relative_path> (<object_type> ...)``.
+  The ``relative_path`` before the parenthesis is the exact prim_path to return.
+- Pick prim_path only from those relative_path values (copy verbatim; do not shorten to leaf names).
 - prim_path must be a relative suffix under the parent background — never include
   {ENV_REGEX_NS} or the background registry name.
 - Respect each input object_reference object_type: pick a prim_path whose object_type in
@@ -108,19 +108,18 @@ GUIDANCE:
 def _prim_tree_catalog(prim_tree: list[UsdPrimRecord]) -> str:
     """Format the background USD prim tree for the user message.
 
-    Each line shows a parent-relative path suffix, indented under its nearest
-    retained ancestor, followed by ``object_type`` and optional joint names.
-    Join ancestor suffixes with ``/`` to recover the full ``relative_path`` for
-    ``prim_path``. Example output::
+    Each line shows the full default-prim-relative ``relative_path`` (the prim_path
+    to return), indented under ancestors for readability, followed by ``object_type``
+    and optional joint names. Example output::
 
         BACKGROUND PRIM TREE:
         counter_right_main_group/top_geometry (base)
         fridge_main_group (articulation fridge_door_joint)
         cab_1_main_group (articulation right_door_joint)
-          corpus (rigid)
-            top (base)
-            shelf_1 (base)
-          right_door (rigid)
+          cab_1_main_group/corpus (rigid)
+            cab_1_main_group/corpus/top (base)
+            cab_1_main_group/corpus/shelf_1 (base)
+          cab_1_main_group/right_door (rigid)
     """
     records = sorted(prim_tree, key=lambda record: record.relative_path)
     lines = ["BACKGROUND PRIM TREE:"]
@@ -129,13 +128,11 @@ def _prim_tree_catalog(prim_tree: list[UsdPrimRecord]) -> str:
         path = record.relative_path
         while stack and not path.startswith(stack[-1] + "/"):
             stack.pop()
-        parent = stack[-1] if stack else ""
-        suffix = path[len(parent) + 1 :] if parent else path
         indent = "  " * len(stack)
         tag = record.object_type.value
         if record.joint_names:
             tag += " " + ",".join(record.joint_names)
-        lines.append(f"{indent}{suffix} ({tag})")
+        lines.append(f"{indent}{path} ({tag})")
         stack.append(path)
     return "\n".join(lines)
 

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -211,6 +211,24 @@ def test_partial_episode_dropped_on_close(tmp_path):
         assert list(tmp_path.iterdir()) == []
 
 
+def test_partial_episode_written_on_close_when_enabled(tmp_path):
+    """Preview callers can opt into writing an unfinished episode on close()."""
+    env = _make_env()
+    with _patched_writers() as writers:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path), flush_partial_on_close=True)
+
+        _configure_step(env)
+        recorder.step(None)
+        recorder.close()
+
+        assert writers and all(writer.closed for writer in writers)
+        written_paths = [writer.filename for writer in writers]
+        for env_id in range(2):
+            for camera in CAMERAS:
+                expected = os.path.join(str(tmp_path), f"robot-cam-env{env_id}-{camera}-episode-0.mp4")
+                assert expected in written_paths
+
+
 def test_no_video_written_for_empty_episode(tmp_path):
     """An env terminating with no recorded frames writes no video; its episode index still advances."""
     env = _make_env()

--- a/isaaclab_arena/tests/test_prim_path_inference.py
+++ b/isaaclab_arena/tests/test_prim_path_inference.py
@@ -33,8 +33,21 @@ def test_prim_tree_catalog_nested_format():
     ]
     assert (
         _prim_tree_catalog(tree)
-        == "BACKGROUND PRIM TREE:\ncab_1_main_group (articulation right_door_joint)\n  corpus (rigid)\n    back (base)"
+        == "BACKGROUND PRIM TREE:\ncab_1_main_group (articulation right_door_joint)\n"
+        "  cab_1_main_group/corpus (rigid)\n"
+        "    cab_1_main_group/corpus/back (base)"
     )
+
+
+def test_prim_tree_catalog_shows_full_path_for_nested_floor():
+    tree = [
+        UsdPrimRecord("Kitchen", ObjectType.BASE),
+        UsdPrimRecord("Kitchen/Floor", ObjectType.BASE),
+        UsdPrimRecord("Counter_north_0", ObjectType.BASE),
+    ]
+    catalog = _prim_tree_catalog(tree)
+    assert "Kitchen/Floor (base)" in catalog
+    assert "\n  Floor (base)" not in catalog
 
 
 @patch("isaaclab_arena.utils.usd_prim_tree.load_usd_prim_tree")

--- a/isaaclab_arena/tests/test_viewer_cfg.py
+++ b/isaaclab_arena/tests/test_viewer_cfg.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+
+class _StubLookatObject:
+    def __init__(self, initial_pose):
+        self.name = "stub_object"
+        self.initial_pose = initial_pose
+
+    def get_initial_pose(self):
+        return self.initial_pose
+
+
+def test_get_viewer_cfg_look_at_object_pose_per_env():
+    """Relation-placed objects store PosePerEnv; viewer cfg uses env 0."""
+    obj = _StubLookatObject(PosePerEnv(poses=[Pose(position_xyz=(1.0, 2.0, 3.0))]))
+    viewer_cfg = get_viewer_cfg_look_at_object(obj, offset=np.array([-1.0, -1.0, 1.0]))
+    assert viewer_cfg.lookat == (1.0, 2.0, 3.0)
+    assert viewer_cfg.eye == (0.0, 1.0, 4.0)

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -18,7 +18,7 @@ from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.utils.configclass import make_configclass
-from isaaclab_arena.utils.pose import PoseRange
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 
 
 class ArenaCameraCfg:
@@ -144,6 +144,23 @@ def make_camera_observation_cfg(
     return WrappedCameraObsCfg()
 
 
+def _resolve_lookat_pose(lookat_object: Asset) -> Pose | None:
+    """Return a single world-frame pose for viewer targeting."""
+    initial_pose = lookat_object.get_initial_pose()
+    if initial_pose is None:
+        object_cfg = getattr(lookat_object, "object_cfg", None)
+        if object_cfg is not None and hasattr(object_cfg, "init_state"):
+            pos = getattr(object_cfg.init_state, "pos", None)
+            if pos is not None:
+                return Pose(position_xyz=tuple(float(x) for x in pos))
+        return None
+    if isinstance(initial_pose, PosePerEnv):
+        return initial_pose.poses[0] if initial_pose.poses else None
+    if isinstance(initial_pose, PoseRange):
+        return initial_pose.get_midpoint()
+    return initial_pose
+
+
 def get_viewer_cfg_look_at_object(lookat_object: Asset, offset: np.ndarray) -> ViewerCfg:
     """Create a viewer configuration that looks at a specific object with an offset.
 
@@ -162,13 +179,10 @@ def get_viewer_cfg_look_at_object(lookat_object: Asset, offset: np.ndarray) -> V
         ViewerCfg configured with the camera position and target.
         Default ViewerCfg with standard positioning if the object has no initial pose set.
     """
-    initial_pose = lookat_object.get_initial_pose()
+    initial_pose = _resolve_lookat_pose(lookat_object)
     if initial_pose is None:
         print(f"{lookat_object.name} has no initial pose set. Using default ViewerCfg.")
         return ViewerCfg()
-
-    if isinstance(initial_pose, PoseRange):
-        initial_pose = initial_pose.get_midpoint()
 
     # TODO(cvolk): Add float coercion to Pose.__post_init__ so this conversion is unnecessary.
     # Ensure we only pass primitive Python floats (not NumPy scalars) into ViewerCfg,

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -8,7 +8,7 @@
 Each frame is streamed straight to a per-(env, camera) ffmpeg encoder as it arrives, and
 the file is finalised when that environment resets (terminated or truncated), so each
 output file corresponds to exactly one complete episode. Partial episodes cut off by
-``num_steps`` are deleted on ``close()``.
+``num_steps`` are deleted on ``close()`` unless ``flush_partial_on_close`` is enabled.
 
 Output filename: ``<name_prefix>-env<N>-<camera_name>-episode-<E>.mp4``
 
@@ -115,12 +115,14 @@ class CameraObsVideoRecorder(gym.Wrapper):
         video_folder: str,
         name_prefix: str = "robot-cam",
         fps: int | None = None,
+        flush_partial_on_close: bool = False,
     ):
         super().__init__(env)
         os.makedirs(video_folder, exist_ok=True)
         self.video_folder = video_folder
         self.name_prefix = name_prefix
         self.fps = fps if fps is not None else int(env.metadata.get("render_fps", 30))
+        self.flush_partial_on_close = flush_partial_on_close
 
         # camera_name -> one entry per env, holding that env's open encoder for its current
         # episode, or None while no episode is in progress.
@@ -189,14 +191,13 @@ class CameraObsVideoRecorder(gym.Wrapper):
                 env_writers[env_idx] = None
 
     def close(self) -> None:
-        # Partial episodes (cut off by num_steps rather than a real reset) are discarded: the
-        # encoder is shut down and the incomplete file it was writing is removed.
+        # Partial episodes cut off by num_steps are finalised only when explicitly requested.
         for env_writers in self.writers.values():
             for env_idx, episode_writer in enumerate(env_writers):
                 if episode_writer is None:
                     continue
                 episode_writer.writer.close()
-                if os.path.exists(episode_writer.path):
+                if not self.flush_partial_on_close and os.path.exists(episode_writer.path):
                     os.remove(episode_writer.path)
                 env_writers[env_idx] = None
         self.env.close()

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -29,6 +29,9 @@ class VideoRecordingCfg:
     camera_name_prefix: str = "robot-cam"
     """Filename prefix for the per-camera mp4s written by ``CameraObsVideoRecorder``."""
 
+    flush_partial_camera_videos: bool = False
+    """Write partial camera episodes when the recorder closes."""
+
     @property
     def enabled(self) -> bool:
         """Whether any recorder is requested."""
@@ -102,6 +105,7 @@ def wrap_env_for_video(
             env,
             video_folder=video_cfg.video_base_dir,
             name_prefix=video_cfg.camera_name_prefix,
+            flush_partial_on_close=video_cfg.flush_partial_camera_videos,
         )
         print(f"Recording per-episode per-camera videos to: {video_cfg.video_base_dir}")
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/editor_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/editor_panel.py
@@ -130,6 +130,8 @@ def render_save_button(validation: SpecParseResult) -> None:
 
 def render_editor_panel(yaml_path: Path | None) -> SpecParseResult:
     """Render the ACE YAML editor; the visualization panel refreshes in its fragment."""
+    background_slot = st.empty()
+
     st.subheader("YAML editor")
     if yaml_path is not None:
         st.caption(f"Source: `{yaml_path}`")
@@ -156,6 +158,20 @@ def render_editor_panel(yaml_path: Path | None) -> SpecParseResult:
         st.session_state["edited_text"] = new_text
 
     validation = validate_yaml_text(st.session_state["edited_text"])
+    from isaaclab_arena_examples.agentic_environment_generation.review_gui.spec_visualization.visualization_widgets import (
+        render_background_prim_tree,
+    )
+    from isaaclab_arena_examples.agentic_environment_generation.review_gui.visualization_service import (
+        resolve_background_preview,
+    )
+
+    background_preview = resolve_background_preview(
+        st.session_state["edited_text"],
+        spec=validation.spec if validation.is_valid else None,
+    )
+    with background_slot.container():
+        render_background_prim_tree(background_preview.usd_path, background_preview.prim_tree)
+
     render_validation_badge(validation)
     sync_save_path_from_spec(validation)
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/sim_preview_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/sim_preview_panel.py
@@ -12,14 +12,14 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_co
 
 
 def render_sim_preview_panel(validation: SpecParseResult) -> None:
-    """Sim-preview controls and viewport frame display in the right column."""
+    """Render full-width sim-preview controls and recorded videos."""
     st.subheader("Sim preview")
     st.caption(
-        "Runs to_arena_env → relation solver, then zero-action steps. "
-        "Viewport captures use a world-frame overview of the full env grid."
+        "Runs a zero-action policy with viewport and embodiment-camera recording. "
+        "Environment spacing is the background's largest XY dimension plus 0.5 m."
     )
 
-    preview_cols = st.columns(3)
+    preview_cols = st.columns(2)
     with preview_cols[0]:
         num_envs = st.number_input(
             "Parallel envs",
@@ -32,21 +32,11 @@ def render_sim_preview_panel(validation: SpecParseResult) -> None:
     with preview_cols[1]:
         num_steps = st.number_input(
             "Zero-action steps",
-            min_value=0,
+            min_value=1,
             max_value=1000,
             step=1,
             key="sim_preview_num_steps",
-            help="Number of zero-action policy steps after reset before the second capture.",
-        )
-    with preview_cols[2]:
-        env_spacing = st.number_input(
-            "Env spacing (m)",
-            min_value=0.1,
-            max_value=50.0,
-            step=0.1,
-            format="%.1f",
-            key="sim_preview_env_spacing",
-            help="Spacing between cloned environments in the preview grid.",
+            help="Number of zero-action policy steps to record.",
         )
 
     if st.button(
@@ -56,15 +46,12 @@ def render_sim_preview_panel(validation: SpecParseResult) -> None:
         disabled=not validation.is_valid,
         help="Requires valid YAML and a healthy SimApp. This may take several minutes.",
     ):
-        with st.spinner(
-            f"Building env, solving relations, and rolling out {num_steps} steps ({num_envs} envs @ {env_spacing} m)…"
-        ):
+        with st.spinner(f"Building env, solving relations, and recording {num_steps} steps ({num_envs} envs)…"):
             ok, message = run_sim_preview_pipeline(
                 st.session_state["edited_text"],
                 validation=validation,
                 num_envs=int(num_envs),
                 num_steps=int(num_steps),
-                env_spacing=float(env_spacing),
             )
         if ok:
             st.success(message, icon="✅")
@@ -72,15 +59,22 @@ def render_sim_preview_panel(validation: SpecParseResult) -> None:
         else:
             st.error(f"Sim preview failed\n\n```\n{message}\n```", icon="🛑")
 
-    first_frame = st.session_state.get("sim_preview_first")
-    last_frame = st.session_state.get("sim_preview_last")
+    viewport_video = st.session_state.get("sim_preview_viewport_video")
+    camera_videos = st.session_state.get("sim_preview_camera_videos") or []
     run_params = st.session_state.get("sim_preview_run_params") or {}
-    displayed_steps = int(run_params.get("num_steps", num_steps))
-    if first_frame and last_frame:
-        frame_cols = st.columns(2)
-        with frame_cols[0]:
-            st.caption("Viewport — frame 1 (after reset)")
-            st.image(first_frame, width="stretch")
-        with frame_cols[1]:
-            st.caption(f"Viewport — frame 2 (after {displayed_steps} zero-action steps)")
-            st.image(last_frame, width="stretch")
+    if viewport_video:
+        st.caption(
+            f"Viewport — {run_params.get('num_steps', num_steps)} steps, "
+            f"{run_params.get('env_spacing', '?')} m auto spacing"
+        )
+        st.video(viewport_video)
+
+    if camera_videos:
+        st.caption("Embodiment cameras (per environment)")
+        video_columns = st.columns(2)
+        for index, camera_video in enumerate(
+            sorted(camera_videos, key=lambda video: (video["env_id"], video["camera_name"]))
+        ):
+            with video_columns[index % len(video_columns)]:
+                st.caption(f"Env {camera_video['env_id']} — {camera_video['camera_name']}")
+                st.video(camera_video["video"])

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/sim_preview_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/sim_preview_panel.py
@@ -10,6 +10,16 @@ import streamlit as st
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.editor_panel import SpecParseResult
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import run_sim_preview_pipeline
 
+_CAMERA_VIDEO_WIDTH_PX = 250
+
+
+def _group_camera_videos(camera_videos: list[dict]) -> dict[str, dict[int, bytes]]:
+    """Group recorded camera videos by camera name and environment."""
+    grouped: dict[str, dict[int, bytes]] = {}
+    for video in camera_videos:
+        grouped.setdefault(str(video["camera_name"]), {})[int(video["env_id"])] = video["video"]
+    return grouped
+
 
 def render_sim_preview_panel(validation: SpecParseResult) -> None:
     """Render full-width sim-preview controls and recorded videos."""
@@ -71,10 +81,35 @@ def render_sim_preview_panel(validation: SpecParseResult) -> None:
 
     if camera_videos:
         st.caption("Embodiment cameras (per environment)")
-        video_columns = st.columns(2)
-        for index, camera_video in enumerate(
-            sorted(camera_videos, key=lambda video: (video["env_id"], video["camera_name"]))
-        ):
-            with video_columns[index % len(video_columns)]:
-                st.caption(f"Env {camera_video['env_id']} — {camera_video['camera_name']}")
-                st.video(camera_video["video"])
+        st.html(f"""
+            <style>
+            div[class*="st-key-sim-preview-camera-row-"] {{
+                display: flex;
+                flex-wrap: nowrap !important;
+                overflow-x: auto;
+                align-items: flex-start;
+                padding-bottom: 0.5rem;
+            }}
+            div[class*="st-key-sim-preview-camera-row-"] > div {{
+                flex: 0 0 {_CAMERA_VIDEO_WIDTH_PX}px !important;
+                min-width: {_CAMERA_VIDEO_WIDTH_PX}px !important;
+            }}
+            </style>
+            """)
+        videos_by_camera = _group_camera_videos(camera_videos)
+        recorded_num_envs = int(run_params.get("num_envs", 0))
+        for row_index, (camera_name, videos_by_env) in enumerate(sorted(videos_by_camera.items())):
+            st.markdown(f"**{camera_name}**")
+            with st.container(
+                key=f"sim-preview-camera-row-{row_index}",
+                horizontal=True,
+                gap="small",
+            ):
+                for env_id in range(recorded_num_envs):
+                    with st.container(width=_CAMERA_VIDEO_WIDTH_PX, border=True):
+                        st.caption(f"Env {env_id}")
+                        video = videos_by_env.get(env_id)
+                        if video is None:
+                            st.caption("No recording")
+                        else:
+                            st.video(video, width="stretch")

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
@@ -70,11 +70,20 @@ class SimAppClient:
                 pass
             self._close_handles()
 
-    def render_spec(self, spec: ArenaEnvGraphSpec) -> tuple[dict[str, bytes], dict[str, tuple[float, float, float]]]:
+    def render_spec(
+        self,
+        spec: ArenaEnvGraphSpec,
+        *,
+        background_panorama: bool = False,
+    ) -> tuple[dict[str, bytes], dict[str, tuple[float, float, float]]]:
         """Ask the SimApp server to render thumbnails for ``spec``."""
         yaml_text = yaml.safe_dump(spec.to_dict(), sort_keys=False)
         with self._lock:
-            response = self._request({"cmd": "render_spec", "yaml_text": yaml_text})
+            response = self._request({
+                "cmd": "render_spec",
+                "yaml_text": yaml_text,
+                "background_panorama": background_panorama,
+            })
 
         if not response.get("ok"):
             raise SimAppError(

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/client.py
@@ -116,7 +116,6 @@ class SimAppClient:
         *,
         num_envs: int,
         num_steps: int,
-        env_spacing: float,
     ) -> dict[str, Any]:
         """Run a multi-env relation-solver rollout preview in the SimApp server."""
         with self._lock:
@@ -125,7 +124,6 @@ class SimAppClient:
                 "yaml_text": yaml_text,
                 "num_envs": num_envs,
                 "num_steps": num_steps,
-                "env_spacing": env_spacing,
             })
 
         if not response.get("ok"):

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/kit_viewport.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/kit_viewport.py
@@ -16,6 +16,7 @@ CAPTURE_DONE_TAIL_UPDATES = 3
 # Upper bound on number of frames to wait for the capture PNG to be written to disk.
 CAPTURE_WAIT_MAX_UPDATES = 60
 THUMBNAIL_CACHE_SUBDIR = "agentic_env_gen_thumbnails"
+PANORAMA_CACHE_SUBDIR = "agentic_env_gen_panorama_thumbnails"
 SIM_PREVIEW_CACHE_SUBDIR = "agentic_env_gen_sim_preview"
 
 
@@ -29,6 +30,11 @@ def review_gui_cache_dir(subdir: str) -> Path:
 def thumbnail_cache_dir() -> Path:
     """Cache directory for per-node USD thumbnail PNGs."""
     return review_gui_cache_dir(THUMBNAIL_CACHE_SUBDIR)
+
+
+def panorama_cache_dir() -> Path:
+    """Cache directory for background 360 panorama PNGs."""
+    return review_gui_cache_dir(PANORAMA_CACHE_SUBDIR)
 
 
 def sim_preview_cache_dir() -> Path:

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
@@ -145,7 +145,8 @@ def _handle_render_spec(
         return {"ok": False, "error": f"spec parse failed: {exc}", "traceback": traceback.format_exc()}
 
     try:
-        paths, aabb_dimensions_m = render_fn(app, spec)
+        background_panorama = bool(req.get("background_panorama", False))
+        paths, aabb_dimensions_m = render_fn(app, spec, background_panorama=background_panorama)
     except Exception as exc:
         return {"ok": False, "error": f"render failed: {exc}", "traceback": traceback.format_exc()}
 

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/server.py
@@ -169,7 +169,7 @@ def _handle_run_sim_preview(app, req: dict[str, Any]) -> dict[str, Any]:
         return {"ok": False, "error": "run_sim_preview requires string 'yaml_text'"}
 
     try:
-        num_envs, num_steps, env_spacing = parse_sim_preview_params(req)
+        num_envs, num_steps = parse_sim_preview_params(req)
     except (TypeError, ValueError, AssertionError) as exc:
         return {"ok": False, "error": f"invalid sim preview params: {exc}"}
 
@@ -179,7 +179,6 @@ def _handle_run_sim_preview(app, req: dict[str, Any]) -> dict[str, Any]:
             yaml_text,
             num_envs=num_envs,
             num_steps=num_steps,
-            env_spacing=env_spacing,
         )
     except Exception as exc:
         return {"ok": False, "error": f"sim preview failed: {exc}", "traceback": traceback.format_exc()}

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/sim_preview.py
@@ -7,14 +7,12 @@
 
 from __future__ import annotations
 
-import math
 import sys
 import time
 import uuid
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import nullcontext, suppress
+from pathlib import Path
 from typing import Any
-
-from isaaclab.envs.common import ViewerCfg
 
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
@@ -22,50 +20,33 @@ from isaaclab_arena.utils.isaaclab_utils.simulation_app import (
     collect_garbage_and_clear_cuda_cache,
     teardown_simulation_app,
 )
+from isaaclab_arena.video.camera_observation_video_recorder import parse_episode_video_filename
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.kit_viewport import (
     CAPTURE_DONE_TAIL_UPDATES,
-    PRE_CAPTURE_UPDATES,
-    capture_viewport_png,
     pump_app,
     sim_preview_cache_dir,
 )
 
 # Placement pool size when preview uses resolve_on_reset=False (see ObjectPlacerParams).
 _PREVIEW_LAYOUTS_PER_ENV = 2
+_ENV_SPACING_BUFFER_M = 0.5
 
 
-def parse_sim_preview_params(req: dict[str, Any]) -> tuple[int, int, float]:
+def parse_sim_preview_params(req: dict[str, Any]) -> tuple[int, int]:
     """Read required sim-preview rollout settings from a JSON-RPC request."""
-    missing = [key for key in ("num_envs", "num_steps", "env_spacing") if key not in req]
+    missing = [key for key in ("num_envs", "num_steps") if key not in req]
     if missing:
         raise ValueError(f"missing required sim preview params: {', '.join(missing)}")
     num_envs = int(req["num_envs"])
     num_steps = int(req["num_steps"])
-    env_spacing = float(req["env_spacing"])
     assert num_envs >= 1, f"num_envs must be >= 1, got {num_envs}"
-    assert num_steps >= 0, f"num_steps must be >= 0, got {num_steps}"
-    assert env_spacing > 0, f"env_spacing must be > 0, got {env_spacing}"
-    return num_envs, num_steps, env_spacing
+    assert num_steps >= 1, f"num_steps must be >= 1, got {num_steps}"
+    return num_envs, num_steps
 
 
 def _preview_log(started_at: float, message: str) -> None:
     elapsed = time.monotonic() - started_at
     print(f"[sim_preview] +{elapsed:.1f}s {message}", file=sys.stderr, flush=True)
-
-
-@contextmanager
-def _skip_task_viewer_cfg(arena_env):
-    """Stub task viewer cfg during compose; preview replaces it with the overview camera."""
-    task = arena_env.task
-    if task is None:
-        yield
-        return
-    original_get_viewer_cfg = task.get_viewer_cfg
-    task.get_viewer_cfg = lambda: ViewerCfg()
-    try:
-        yield
-    finally:
-        task.get_viewer_cfg = original_get_viewer_cfg
 
 
 def _preview_cfg(*, num_envs: int, env_spacing: float) -> ArenaEnvBuilderCfg:
@@ -76,28 +57,33 @@ def _preview_cfg(*, num_envs: int, env_spacing: float) -> ArenaEnvBuilderCfg:
     )
 
 
-def _overview_camera(
-    num_envs: int, env_spacing: float
-) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
-    """World-frame overview camera for the env grid."""
-    cols = int(math.ceil(math.sqrt(num_envs)))
-    rows = int(math.ceil(num_envs / cols))
-    max_x = max((cols - 1) * env_spacing, 0.0)
-    max_y = max((rows - 1) * env_spacing, 0.0)
-    span = max(max_x, max_y) + env_spacing
-    target = (0.0, 0.0, 0.0)
-    height = span * 0.8 + target[2]
-    back = span * 1.1
-    side = span * 1.1
-    eye = (side, back, height)
-    return eye, target
+def _compute_env_spacing(arena_env) -> float:
+    """Return the largest background XY dimension plus a safety buffer."""
+    from isaaclab_arena.assets.background import Background
+
+    backgrounds = [asset for asset in arena_env.scene.assets.values() if isinstance(asset, Background)]
+    assert backgrounds, "Sim preview requires a background asset to compute environment spacing"
+    max_dimension_m = max(float(background.get_bounding_box().size[0, :2].max()) for background in backgrounds)
+    return max_dimension_m + _ENV_SPACING_BUFFER_M
 
 
-def _apply_overview_camera(env, app, num_envs: int, env_spacing: float) -> None:
-    """Point the Kit viewport at the full multi-env grid (world frame)."""
-    eye, target = _overview_camera(num_envs, env_spacing)
-    env.unwrapped.sim.set_camera_view(eye, target)
-    pump_app(app, count=PRE_CAPTURE_UPDATES)
+def _collect_recorded_videos(video_dir: Path) -> tuple[Path, list[dict[str, Any]]]:
+    """Return the viewport video and parsed per-env camera videos."""
+    viewport_videos: list[Path] = []
+    camera_videos: list[dict[str, Any]] = []
+    for path in sorted(video_dir.glob("*.mp4")):
+        parsed = parse_episode_video_filename(path.name)
+        if parsed is None:
+            viewport_videos.append(path)
+            continue
+        camera_videos.append({
+            "path": str(path),
+            "env_id": parsed.env_index,
+            "camera_name": parsed.camera_name,
+        })
+
+    assert viewport_videos, f"Viewport recorder produced no mp4 in {video_dir}"
+    return viewport_videos[0], camera_videos
 
 
 def _close_env_and_reset_sim(
@@ -128,14 +114,15 @@ def run_sim_preview(
     *,
     num_envs: int,
     num_steps: int,
-    env_spacing: float,
 ) -> dict[str, Any]:
-    """Run relation-solver preview and capture viewport frames."""
+    """Run a zero-action rollout and record viewport and embodiment-camera videos."""
     import gymnasium as gym
     import yaml
 
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.evaluation.policy_runner import rollout_policy
     from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicy, ZeroActionPolicyCfg
+    from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
 
     started_at = time.monotonic()
     _preview_log(started_at, "run_sim_preview started")
@@ -148,64 +135,56 @@ def run_sim_preview(
         raise ValueError(f"expected mapping, got {type(raw).__name__}")
 
     graph_spec = ArenaEnvGraphSpec.model_validate(raw)
-    arena_env = graph_spec.to_arena_env()
+    arena_env = graph_spec.to_arena_env(enable_cameras=True)
     preview_name = f"{arena_env.name}_preview_{uuid.uuid4().hex[:8]}"
     arena_env.name = preview_name
     _preview_log(started_at, f"validated spec → arena env ({preview_name})")
 
+    env_spacing = _compute_env_spacing(arena_env)
     builder_cfg = _preview_cfg(num_envs=num_envs, env_spacing=env_spacing)
     builder = ArenaEnvBuilder(arena_env, builder_cfg)
     policy = ZeroActionPolicy(ZeroActionPolicyCfg())
 
-    cache_dir = sim_preview_cache_dir()
     stamp = int(time.time() * 1000)
-    first_path = cache_dir / f"{preview_name}_{stamp}_first.png"
-    last_path = cache_dir / f"{preview_name}_{stamp}_last.png"
+    video_dir = sim_preview_cache_dir() / f"{preview_name}_{stamp}"
+    video_cfg = VideoRecordingCfg(
+        record_viewport_video=True,
+        record_camera_video=True,
+        video_base_dir=str(video_dir),
+        flush_partial_camera_videos=True,
+    )
 
     pool_layouts = builder_cfg.num_envs * _PREVIEW_LAYOUTS_PER_ENV
     env = None
     try:
-        eye, target = _overview_camera(builder_cfg.num_envs, builder_cfg.env_spacing)
         _preview_log(
             started_at,
             f"solving spatial relations ({builder_cfg.num_envs} envs, {pool_layouts} layout pool)…",
         )
         t_relations = time.monotonic()
-        with _skip_task_viewer_cfg(arena_env):
-            env_cfg, env_kwargs = builder.compose_manager_cfg()
+        env_cfg, env_kwargs = builder.compose_manager_cfg()
         _preview_log(started_at, f"relation solver finished ({time.monotonic() - t_relations:.1f}s)")
 
-        env_cfg.viewer = ViewerCfg(eye=eye, lookat=target, origin_type="world")
         _preview_log(started_at, "spawning sim scene (gym.make)…")
         t_spawn = time.monotonic()
-        env = builder.make_registered(env_cfg, env_kwargs)
+        env = builder.make_registered(env_cfg, env_kwargs, render_mode=video_cfg.render_mode)
+        env = wrap_env_for_video(env, video_cfg, num_steps=num_steps, num_episodes=None)
         _preview_log(started_at, f"sim scene ready ({time.monotonic() - t_spawn:.1f}s)")
 
-        obs, _ = env.reset()
-        _apply_overview_camera(env, app, builder_cfg.num_envs, builder_cfg.env_spacing)
-
-        if capture_viewport_png(app, first_path) is None:
-            raise RuntimeError("failed to capture first-frame viewport screenshot")
-
-        for _ in range(num_steps):
-            action = policy.get_action(env, obs)
-            obs, _, _, _, _ = env.step(action)
-
-        _apply_overview_camera(env, app, builder_cfg.num_envs, builder_cfg.env_spacing)
-
-        if capture_viewport_png(app, last_path) is None:
-            raise RuntimeError("failed to capture last-frame viewport screenshot")
+        rollout_policy(env, policy, num_steps=num_steps, num_episodes=None)
+        env.close()
+        viewport_video, camera_videos = _collect_recorded_videos(video_dir)
 
         print(
-            f"[sim_preview] captured {num_envs} envs @ {env_spacing}m spacing, {num_steps} zero-action steps "
+            f"[sim_preview] recorded {num_envs} envs @ {env_spacing}m spacing, {num_steps} zero-action steps "
             f"(total {time.monotonic() - started_at:.1f}s)",
             file=sys.stderr,
             flush=True,
         )
         return {
             "ok": True,
-            "first_frame": str(first_path),
-            "last_frame": str(last_path),
+            "viewport_video": str(viewport_video),
+            "camera_videos": camera_videos,
             "env_name": preview_name,
             "num_envs": num_envs,
             "env_spacing": env_spacing,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/thumbnail_capture.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp/thumbnail_capture.py
@@ -31,6 +31,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.as
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.kit_viewport import (
     PRE_CAPTURE_UPDATES,
     capture_viewport_png,
+    panorama_cache_dir,
     pump_app,
     set_viewport_camera_eye_lookat,
     thumbnail_cache_dir,
@@ -39,6 +40,13 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.ki
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.spec_visualization.asset_cards import (
     object_set_member_key,
 )
+
+PANORAMA_CAMERA_PRIM_PATH = "/World/_ReviewPanoramaCamera"
+PANORAMA_EYE_HEIGHT_M = 1.35
+PANORAMA_ROTATION_XYZ_DEG = (90.0, 0.0, 0.0)
+# Extra pump frames after restoring the pinhole camera so the RTX renderer drops the
+# fisheyeSpherical projection before an object_reference is captured on the same stage.
+PANORAMA_RESTORE_PUMP_UPDATES = PRE_CAPTURE_UPDATES + 5
 
 
 @dataclass
@@ -49,9 +57,15 @@ class _UsdSnapshotJob:
     viewer_cfg: object | None = None
     asset_captures: list[tuple[str, Path]] = field(default_factory=list)
     ref_captures: list[tuple[str, str, Path]] = field(default_factory=list)
+    panorama_captures: list[tuple[str, Path]] = field(default_factory=list)
 
 
-def render_thumbnails_with_app(app, spec: ArenaEnvGraphSpec) -> tuple[dict[str, Path], dict[str, AabbDimensionsM]]:
+def render_thumbnails_with_app(
+    app,
+    spec: ArenaEnvGraphSpec,
+    *,
+    background_panorama: bool = False,
+) -> tuple[dict[str, Path], dict[str, AabbDimensionsM]]:
     """Render cache-missed node thumbnails and return png paths plus AABB sizes in meters."""
     assets_by_node_id = instantiate_assets_from_spec(spec, AssetRegistry())
     # Exclude embodiment from thumbnail rendering.
@@ -65,12 +79,26 @@ def render_thumbnails_with_app(app, spec: ArenaEnvGraphSpec) -> tuple[dict[str, 
     background_viewer_cfg = assets_by_node_id[spec.background.id].get_viewer_cfg()
 
     cache_dir = thumbnail_cache_dir()
+    panorama_dir = panorama_cache_dir()
+    background_id = spec.background.id if spec.background is not None else None
 
     thumbnail_paths: dict[str, Path] = {}
     jobs_by_usd: dict[str, _UsdSnapshotJob] = {}
     asset_render_count = 0
+    panorama_render_count = 0
     ref_render_count = 0
     for node_id, usd_path in asset_paths.items():
+        use_panorama = background_panorama and node_id == background_id
+        if use_panorama:
+            cache_path = panorama_dir / f"{usd_cache_key(usd_path)}_panorama.png"
+            if cache_path.exists() and cache_path.stat().st_size > 0:
+                thumbnail_paths[node_id] = cache_path
+            else:
+                job = jobs_by_usd.setdefault(usd_path, _UsdSnapshotJob(usd_path=usd_path))
+                job.panorama_captures.append((node_id, cache_path))
+                panorama_render_count += 1
+            continue
+
         cache_path = cache_dir / f"{usd_cache_key(usd_path)}.png"
         if cache_path.exists() and cache_path.stat().st_size > 0:
             thumbnail_paths[node_id] = cache_path
@@ -105,7 +133,8 @@ def render_thumbnails_with_app(app, spec: ArenaEnvGraphSpec) -> tuple[dict[str, 
 
     if jobs:
         print(
-            f"[thumbnail_capture] rendering {asset_render_count} asset and "
+            f"[thumbnail_capture] rendering {asset_render_count} asset, "
+            f"{panorama_render_count} panorama, and "
             f"{ref_render_count} object_reference thumbnail(s) "
             f"(reusing {len(thumbnail_paths)} from cache)...",
             file=sys.stderr,
@@ -113,6 +142,7 @@ def render_thumbnails_with_app(app, spec: ArenaEnvGraphSpec) -> tuple[dict[str, 
         captured = _capture_usd_snapshot_jobs(app, jobs)
         for node_id, cache_path in [
             *((nid, cp) for job in jobs for nid, cp in job.asset_captures),
+            *((nid, cp) for job in jobs for nid, cp in job.panorama_captures),
             *((nid, cp) for job in jobs for nid, _rel, cp in job.ref_captures),
         ]:
             if node_id in captured and cache_path.exists() and cache_path.stat().st_size > 0:
@@ -184,6 +214,13 @@ def _capture_usd_snapshot_job(app, job: _UsdSnapshotJob) -> dict[str, bytes]:
             for node_id, _cache_path in job.asset_captures:
                 out[node_id] = png_bytes
 
+    if job.panorama_captures:
+        cache_path = job.panorama_captures[0][1]
+        png_bytes = _capture_background_panorama(app, stage, cache_path)
+        if png_bytes:
+            for node_id, _cache_path in job.panorama_captures:
+                out[node_id] = png_bytes
+
     if job.ref_captures:
         # Seed the camera with the background viewer_cfg orientation before framing.
         # frame_viewport_prims preserves the incoming view direction.
@@ -243,6 +280,57 @@ def _capture_stage_snapshot(
             )
 
     return capture_viewport_png(app, cache_path)
+
+
+def _capture_background_panorama(app, stage, cache_path: Path) -> bytes | None:
+    """Capture a raw fisheyeSpherical 360 panorama from the stage centroid."""
+    if stage.GetPrimAtPath(PANORAMA_CAMERA_PRIM_PATH):
+        stage.RemovePrim(Sdf.Path(PANORAMA_CAMERA_PRIM_PATH))
+
+    cache = UsdGeom.BBoxCache(0, [UsdGeom.Tokens.default_])
+    root = stage.GetDefaultPrim() or stage.GetPseudoRoot()
+    bbox = cache.ComputeWorldBound(root).ComputeAlignedBox()
+    min_pt, max_pt = bbox.GetMin(), bbox.GetMax()
+    centroid = Gf.Vec3d(
+        (min_pt[0] + max_pt[0]) * 0.5,
+        (min_pt[1] + max_pt[1]) * 0.5,
+        PANORAMA_EYE_HEIGHT_M,
+    )
+
+    camera = UsdGeom.Camera.Define(stage, Sdf.Path(PANORAMA_CAMERA_PRIM_PATH))
+    xform = UsdGeom.Xformable(camera.GetPrim())
+    xform.ClearXformOpOrder()
+    xform.AddTranslateOp().Set(centroid)
+    xform.AddRotateXYZOp().Set(Gf.Vec3f(*PANORAMA_ROTATION_XYZ_DEG))
+
+    cam_prim = camera.GetPrim()
+    cam_prim.CreateAttribute("cameraProjectionType", Sdf.ValueTypeNames.Token).Set("fisheyeSpherical")
+    for attr_name, value in (
+        ("fthetaWidth", 1024.0),
+        ("fthetaHeight", 1024.0),
+        ("fthetaMaxFov", 360.0),
+    ):
+        cam_prim.CreateAttribute(attr_name, Sdf.ValueTypeNames.Float).Set(value)
+
+    viewport = get_active_viewport()
+    # Remember the pinhole camera so we can restore it: later object_reference
+    # captures on the same stage must not inherit the fisheyeSpherical projection.
+    prior_camera_path = str(viewport.camera_path)
+    viewport.camera_path = PANORAMA_CAMERA_PRIM_PATH
+    pump_app(app, count=PRE_CAPTURE_UPDATES)
+
+    try:
+        png_bytes = capture_viewport_png(app, cache_path, pre_capture_updates=PRE_CAPTURE_UPDATES)
+        if png_bytes is None:
+            print(f"[thumbnail_capture]   panorama capture produced no file: {cache_path}", file=sys.stderr)
+        return png_bytes
+    finally:
+        # Restore the pinhole camera and drop the panorama prim before any other capture.
+        if prior_camera_path and prior_camera_path != PANORAMA_CAMERA_PRIM_PATH:
+            viewport.camera_path = prior_camera_path
+        if stage.GetPrimAtPath(PANORAMA_CAMERA_PRIM_PATH):
+            stage.RemovePrim(Sdf.Path(PANORAMA_CAMERA_PRIM_PATH))
+        pump_app(app, count=PANORAMA_RESTORE_PUMP_UPDATES)
 
 
 # Viewport and stage setup — camera, lighting, and collision-mesh overlay.

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp_connector.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/simapp_connector.py
@@ -21,8 +21,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.cl
     simapp_socket_from_env,
 )
 
-NUM_ENVS = 9
-ENV_SPACING_M = 1.5
+NUM_ENVS = 4
 NUM_STEPS = 10
 
 _SIMAPP_CLIENT_SESSION_KEY = "_simapp_client"
@@ -75,9 +74,8 @@ def run_sim_preview_pipeline(
     validation: SpecParseResult | None = None,
     num_envs: int = NUM_ENVS,
     num_steps: int = NUM_STEPS,
-    env_spacing: float = ENV_SPACING_M,
 ) -> tuple[bool, str]:
-    """Run sim preview via SimApp and store frames in session."""
+    """Run sim preview via SimApp and store recorded videos in session."""
     if validation is None or not validation.is_valid:
         validation = validate_yaml_text(yaml_text)
         if not validation.is_valid:
@@ -95,34 +93,39 @@ def run_sim_preview_pipeline(
             yaml_text,
             num_envs=num_envs,
             num_steps=num_steps,
-            env_spacing=env_spacing,
         )
     except SimAppError as exc:
-        st.session_state.pop("sim_preview_first", None)
-        st.session_state.pop("sim_preview_last", None)
+        st.session_state.pop("sim_preview_viewport_video", None)
+        st.session_state.pop("sim_preview_camera_videos", None)
         st.session_state.pop("sim_preview_run_params", None)
         return False, str(exc)
     finally:
         clear_simapp_client()
 
     try:
-        first_path = Path(response["first_frame"])
-        last_path = Path(response["last_frame"])
-        st.session_state["sim_preview_first"] = first_path.read_bytes()
-        st.session_state["sim_preview_last"] = last_path.read_bytes()
+        viewport_path = Path(response["viewport_video"])
+        st.session_state["sim_preview_viewport_video"] = viewport_path.read_bytes()
+        st.session_state["sim_preview_camera_videos"] = [
+            {
+                "video": Path(camera_video["path"]).read_bytes(),
+                "env_id": int(camera_video["env_id"]),
+                "camera_name": str(camera_video["camera_name"]),
+            }
+            for camera_video in response.get("camera_videos", [])
+        ]
         st.session_state["sim_preview_run_params"] = {
             "num_envs": response.get("num_envs", num_envs),
             "num_steps": response.get("num_steps", num_steps),
-            "env_spacing": response.get("env_spacing", env_spacing),
+            "env_spacing": response["env_spacing"],
         }
-    except OSError as exc:
-        return False, f"Failed to read preview frames: {exc}"
+    except (KeyError, OSError) as exc:
+        return False, f"Failed to read preview videos: {exc}"
 
     return (
         True,
         (
             f"Sim preview complete — {response.get('num_envs', num_envs)} envs, "
-            f"{response.get('env_spacing', env_spacing)} m spacing, "
+            f"{response['env_spacing']} m spacing, "
             f"{response.get('num_steps', num_steps)} steps."
         ),
     )

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/asset_cards.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/asset_cards.py
@@ -19,6 +19,7 @@ class AssetCard:
     role: str
     thumbnail_bytes: bytes | None = None
     aabb_dimensions_m: tuple[float, float, float] | None = None
+    is_panorama: bool = False
 
 
 def object_set_member_key(object_set_id: str, registry_name: str) -> str:
@@ -30,10 +31,12 @@ def build_asset_cards(
     spec: ArenaEnvGraphSpec,
     thumbnails: dict[str, bytes] | None = None,
     aabb_dimensions_m: dict[str, tuple[float, float, float]] | None = None,
+    panorama_node_ids: set[str] | None = None,
 ) -> list[AssetCard]:
     """Build one AssetCard per node (background, object references, objects, object-set members) for native rendering."""
     thumbnails = thumbnails or {}
     aabb_dimensions_m = aabb_dimensions_m or {}
+    panorama_node_ids = panorama_node_ids or set()
 
     entries: list[tuple[str, AssetSpec | ObjectReferenceSpec, str]] = []
     entries.append(("background", spec.background, spec.background.id))
@@ -56,6 +59,7 @@ def build_asset_cards(
             role=role,
             thumbnail_bytes=thumbnails.get(lookup_key),
             aabb_dimensions_m=aabb_dimensions_m.get(lookup_key),
+            is_panorama=asset.id in panorama_node_ids,
         )
         for role, asset, lookup_key in entries
     ]

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/visualization_widgets.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/visualization_widgets.py
@@ -63,6 +63,8 @@ def _render_asset_card(card: AssetCard) -> None:
     with st.container(border=True):
         if card.thumbnail_bytes is not None:
             st.image(card.thumbnail_bytes, width="stretch")
+            if card.is_panorama:
+                st.caption("360° panorama")
         elif is_reference and spec.prim_path is None:
             st.caption("⛔ Resolve prim_path to enable collision-mesh snapshot")
         else:
@@ -79,12 +81,26 @@ def _render_asset_card(card: AssetCard) -> None:
 
 
 def _render_asset_grid(cards: list[AssetCard]) -> None:
-    """Lay out asset cards in a grid."""
-    for start in range(0, len(cards), _ASSET_GRID_COLS):
-        columns = st.columns(_ASSET_GRID_COLS)
-        for column, card in zip(columns, cards[start : start + _ASSET_GRID_COLS]):
+    """Lay out asset cards in a grid; panorama cards span the full width on their own row."""
+    row: list[AssetCard] = []
+
+    def _flush_row() -> None:
+        if not row:
+            return
+        for column, card in zip(st.columns(_ASSET_GRID_COLS), row):
             with column:
                 _render_asset_card(card)
+        row.clear()
+
+    for card in cards:
+        if card.is_panorama:
+            _flush_row()
+            _render_asset_card(card)
+        else:
+            row.append(card)
+            if len(row) == _ASSET_GRID_COLS:
+                _flush_row()
+    _flush_row()
 
 
 def _render_prim_tree(prim_tree: list[UsdPrimRecord]) -> None:

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/visualization_widgets.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/spec_visualization/visualization_widgets.py
@@ -103,28 +103,31 @@ def _render_asset_grid(cards: list[AssetCard]) -> None:
     _flush_row()
 
 
-def _render_prim_tree(prim_tree: list[UsdPrimRecord]) -> None:
-    """Render the background prim tree in a collapsed, searchable, view-only box."""
-    if not prim_tree:
+def render_background_prim_tree(usd_path: str | None, prim_tree: list[UsdPrimRecord]) -> None:
+    """Render the background USD path and prim tree in a collapsed, searchable box."""
+    if not usd_path and not prim_tree:
         return
     with st.expander("Background prim tree", expanded=False):
-        st.iframe(
-            render_prim_tree_html(prim_tree),
-            height=estimate_prim_tree_height_px(prim_tree),
-        )
+        if usd_path:
+            st.markdown(f"`{usd_path}`")
+        if prim_tree:
+            st.iframe(
+                render_prim_tree_html(prim_tree),
+                height=estimate_prim_tree_height_px(prim_tree),
+            )
+        elif usd_path:
+            st.caption("Prim tree unavailable.")
 
 
 def render_visualization_widgets(
     spec: ArenaEnvGraphSpec,
     asset_cards: list[AssetCard],
-    prim_tree: list[UsdPrimRecord] | None = None,
 ) -> None:
     """Render the spec visualization (assets, spatial graph, tasks) as native Streamlit widgets."""
     st.markdown(f"**{spec.env_name}**")
     summary = spec.summary()
     if summary:
         st.caption(summary)
-    _render_prim_tree(prim_tree or [])
     if asset_cards:
         st.markdown("**Assets**")
         _render_asset_grid(asset_cards)

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
@@ -63,6 +63,8 @@ def initialize_state(yaml_path: Path | None, out_dir: Path) -> None:
     st.session_state.setdefault("sim_preview_num_envs", NUM_ENVS)
     st.session_state.setdefault("sim_preview_num_steps", NUM_STEPS)
     st.session_state.setdefault("sim_preview_env_spacing", ENV_SPACING_M)
+    st.session_state.setdefault("background_panorama", False)
+    st.session_state.setdefault("last_rendered_panorama", False)
     st.session_state["out_dir"] = str(out_dir.resolve())
     st.session_state.pop("_validation_text", None)
     st.session_state.pop("_validation_result", None)

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
@@ -23,11 +23,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.generatio
     render_generation_panel,
 )
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.sim_preview_panel import render_sim_preview_panel
-from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import (
-    ENV_SPACING_M,
-    NUM_ENVS,
-    NUM_STEPS,
-)
+from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import NUM_ENVS, NUM_STEPS
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.visualization_panel import (
     render_visualization_panel,
 )
@@ -62,7 +58,6 @@ def initialize_state(yaml_path: Path | None, out_dir: Path) -> None:
     st.session_state.setdefault("editor_version", 0)
     st.session_state.setdefault("sim_preview_num_envs", NUM_ENVS)
     st.session_state.setdefault("sim_preview_num_steps", NUM_STEPS)
-    st.session_state.setdefault("sim_preview_env_spacing", ENV_SPACING_M)
     st.session_state.setdefault("background_panorama", False)
     st.session_state.setdefault("last_rendered_panorama", False)
     st.session_state["out_dir"] = str(out_dir.resolve())
@@ -128,8 +123,9 @@ def main() -> None:
         validation = render_editor_panel(yaml_path)
     with right:
         render_visualization_panel(validation)
-        st.divider()
-        render_sim_preview_panel(validation)
+
+    st.divider()
+    render_sim_preview_panel(validation)
 
     # After generation, paint YAML first, then rerun to start SimApp snapshot rendering.
     if st.session_state.pop("_defer_viz_render", False):

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_panel.py
@@ -26,16 +26,27 @@ def reset_viz_render_state() -> None:
 def render_visualization_panel(validation: SpecParseResult) -> None:
     """Render the visualization panel in the right column as native Streamlit widgets."""
     st.subheader("Visualization")
-
-    if st.button(
-        "Clear cache & rerender",
-        help="Delete cached snapshot PNGs on disk and render this spec again.",
-    ):
-        removed = clear_snapshot_render_caches()
-        clear_asset_cards_cache()
-        st.session_state["last_rendered_text"] = ""
-        st.toast(f"Cleared {removed} cached snapshot(s).", icon="🗑️")
-        st.rerun()
+    st.session_state.setdefault("background_panorama", False)
+    controls_col, actions_col = st.columns([3, 1])
+    with controls_col:
+        background_panorama = st.checkbox(
+            "Background 360° panorama",
+            value=st.session_state["background_panorama"],
+            help="Render the background asset as a raw fisheyeSpherical panorama (cached separately).",
+        )
+        st.session_state["background_panorama"] = background_panorama
+    with actions_col:
+        if st.button(
+            "Clear cache & rerender",
+            help="Delete cached snapshot PNGs on disk and render this spec again.",
+            width="stretch",
+        ):
+            removed = clear_snapshot_render_caches()
+            clear_asset_cards_cache()
+            st.session_state["last_rendered_text"] = ""
+            st.session_state["last_rendered_panorama"] = not background_panorama
+            st.toast(f"Cleared {removed} cached snapshot(s).", icon="🗑️")
+            st.rerun()
 
     edited_text = st.session_state.get("edited_text", "").strip()
     if not edited_text:
@@ -47,19 +58,26 @@ def render_visualization_panel(validation: SpecParseResult) -> None:
         if pending:
             st.session_state["rendered_visualization"] = None
             st.session_state["last_rendered_text"] = st.session_state["edited_text"]
+            st.session_state["last_rendered_panorama"] = background_panorama
         st.caption("Fix YAML errors to see the visualization.")
         return
 
-    pending = st.session_state["edited_text"] != st.session_state.get("last_rendered_text", "")
+    pending = st.session_state["edited_text"] != st.session_state.get(
+        "last_rendered_text", ""
+    ) or background_panorama != st.session_state.get("last_rendered_panorama", False)
     if pending:
         if st.session_state.get("_defer_viz_render"):
             st.caption("Rendering visualization…")
         else:
             with st.spinner("Rendering node snapshots…"):
-                asset_cards, prim_tree = build_asset_cards_with_thumbnails(validation.spec)
+                asset_cards, prim_tree = build_asset_cards_with_thumbnails(
+                    validation.spec,
+                    background_panorama=background_panorama,
+                )
             st.session_state["rendered_visualization"] = asset_cards
             st.session_state["rendered_prim_tree"] = prim_tree
             st.session_state["last_rendered_text"] = st.session_state["edited_text"]
+            st.session_state["last_rendered_panorama"] = background_panorama
             st.toast("Visualization updated.", icon="🔄")
 
     asset_cards = st.session_state.get("rendered_visualization")

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_panel.py
@@ -70,12 +70,11 @@ def render_visualization_panel(validation: SpecParseResult) -> None:
             st.caption("Rendering visualization…")
         else:
             with st.spinner("Rendering node snapshots…"):
-                asset_cards, prim_tree = build_asset_cards_with_thumbnails(
+                asset_cards = build_asset_cards_with_thumbnails(
                     validation.spec,
                     background_panorama=background_panorama,
                 )
             st.session_state["rendered_visualization"] = asset_cards
-            st.session_state["rendered_prim_tree"] = prim_tree
             st.session_state["last_rendered_text"] = st.session_state["edited_text"]
             st.session_state["last_rendered_panorama"] = background_panorama
             st.toast("Visualization updated.", icon="🔄")
@@ -86,7 +85,6 @@ def render_visualization_panel(validation: SpecParseResult) -> None:
         render_visualization_widgets(
             validation.spec,
             asset_cards,
-            st.session_state.get("rendered_prim_tree", []),
         )
     elif not st.session_state.get("_defer_viz_render"):
         st.caption("Rendering visualization…")

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+import yaml
+from dataclasses import dataclass
 
 import streamlit as st
 
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import AssetSpec
 from isaaclab_arena.utils.usd_prim_tree import UsdPrimRecord
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
     SimAppError,
@@ -33,21 +36,83 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.spec_visu
 )
 
 
-def resolve_background_prim_tree(spec: ArenaEnvGraphSpec) -> list[UsdPrimRecord]:
-    """Return the background USD prim tree records, empty when unavailable."""
+@dataclass(frozen=True)
+class BackgroundPreview:
+    """Resolved background USD path and prim tree when extractable from YAML."""
+
+    usd_path: str | None
+    prim_tree: list[UsdPrimRecord]
+
+
+def _load_background_prim_tree(usd_path: str, *, registry_name: str) -> list[UsdPrimRecord]:
+    """Load prim tree records for one background USD path."""
     from isaaclab_arena.utils.usd_prim_tree import load_usd_prim_tree
 
     try:
-        usd_path = spec.background.resolve_usd_path()
-        if not usd_path:
-            return []
         return load_usd_prim_tree(usd_path)
     except Exception as exc:
         print(
-            f"[visualization_service] background prim tree lookup failed for '{spec.background.registry_name}': {exc}",
+            f"[visualization_service] background prim tree lookup failed for '{registry_name}': {exc}",
             file=sys.stderr,
         )
         return []
+
+
+def _background_asset_from_yaml_text(text: str) -> AssetSpec | None:
+    """Parse a ``background`` asset block from YAML text when the full spec is invalid."""
+    try:
+        raw = yaml.safe_load(text)
+    except Exception:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    background = raw.get("background")
+    if not isinstance(background, dict):
+        return None
+    try:
+        return AssetSpec.model_validate(background)
+    except Exception:
+        return None
+
+
+def _resolve_background_preview_from_asset(asset: AssetSpec) -> BackgroundPreview:
+    """Resolve USD path and prim tree for one background asset spec."""
+    try:
+        usd_path = asset.resolve_usd_path()
+    except Exception as exc:
+        print(
+            f"[visualization_service] background USD lookup failed for '{asset.registry_name}': {exc}",
+            file=sys.stderr,
+        )
+        return BackgroundPreview(usd_path=None, prim_tree=[])
+    prim_tree = _load_background_prim_tree(usd_path, registry_name=asset.registry_name)
+    return BackgroundPreview(usd_path=usd_path, prim_tree=prim_tree)
+
+
+def resolve_background_preview(text: str, *, spec: ArenaEnvGraphSpec | None = None) -> BackgroundPreview:
+    """Return background USD path and prim tree when extractable from YAML text.
+
+    Uses the validated spec when available; otherwise parses only the ``background`` block.
+    """
+    cached_text = st.session_state.get("_background_preview_text")
+    cached_result = st.session_state.get("_background_preview_result")
+    if cached_text == text and isinstance(cached_result, BackgroundPreview):
+        return cached_result
+
+    if spec is not None:
+        result = _resolve_background_preview_from_asset(spec.background)
+    else:
+        asset = _background_asset_from_yaml_text(text)
+        result = _resolve_background_preview_from_asset(asset) if asset is not None else BackgroundPreview(None, [])
+
+    st.session_state["_background_preview_text"] = text
+    st.session_state["_background_preview_result"] = result
+    return result
+
+
+def resolve_background_prim_tree(spec: ArenaEnvGraphSpec) -> list[UsdPrimRecord]:
+    """Return the background USD prim tree records, empty when unavailable."""
+    return _resolve_background_preview_from_asset(spec.background).prim_tree
 
 
 def _spec_render_key(spec: ArenaEnvGraphSpec, *, background_panorama: bool) -> str:
@@ -55,22 +120,19 @@ def _spec_render_key(spec: ArenaEnvGraphSpec, *, background_panorama: bool) -> s
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def _cached_asset_cards(spec_key: str) -> tuple[list[AssetCard], list[UsdPrimRecord]] | None:
+def _cached_asset_cards(spec_key: str) -> list[AssetCard] | None:
     cache = st.session_state.get("_asset_cards_cache")
     if isinstance(cache, dict) and cache.get("key") == spec_key:
         asset_cards = cache.get("asset_cards")
         if isinstance(asset_cards, list):
-            prim_tree = cache.get("prim_tree")
-            if isinstance(prim_tree, list):
-                return asset_cards, prim_tree
+            return asset_cards
     return None
 
 
-def _store_asset_cards(spec_key: str, asset_cards: list[AssetCard], prim_tree: list[UsdPrimRecord]) -> None:
+def _store_asset_cards(spec_key: str, asset_cards: list[AssetCard]) -> None:
     st.session_state["_asset_cards_cache"] = {
         "key": spec_key,
         "asset_cards": asset_cards,
-        "prim_tree": prim_tree,
     }
 
 
@@ -112,11 +174,8 @@ def build_asset_cards_with_thumbnails(
     spec: ArenaEnvGraphSpec,
     *,
     background_panorama: bool = False,
-) -> tuple[list[AssetCard], list[UsdPrimRecord]]:
-    """Build per-node asset cards plus the background prim tree records.
-
-    Loads the prim tree from the background USD directly and asks the SimApp
-    server for live USD thumbnails when available.
+) -> list[AssetCard]:
+    """Build per-node asset cards with optional SimApp thumbnails.
 
     Args:
         spec: Environment graph spec to visualize.
@@ -133,7 +192,6 @@ def build_asset_cards_with_thumbnails(
 
     thumbnails: dict[str, bytes] = {}
     aabb_dimensions_m: dict[str, tuple[float, float, float]] = {}
-    prim_tree = resolve_background_prim_tree(spec)
 
     simapp_expected = simapp_socket_from_env() is not None
     client = ensure_simapp() if simapp_expected else None
@@ -156,5 +214,5 @@ def build_asset_cards_with_thumbnails(
         aabb_dimensions_m or None,
         panorama_node_ids or None,
     )
-    _store_asset_cards(spec_key, asset_cards, prim_tree)
-    return asset_cards, prim_tree
+    _store_asset_cards(spec_key, asset_cards)
+    return asset_cards

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/visualization_service.py
@@ -19,7 +19,10 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.cl
     SimAppError,
     simapp_socket_from_env,
 )
-from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.kit_viewport import thumbnail_cache_dir
+from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.kit_viewport import (
+    panorama_cache_dir,
+    thumbnail_cache_dir,
+)
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import (
     clear_simapp_client,
     ensure_simapp,
@@ -47,8 +50,8 @@ def resolve_background_prim_tree(spec: ArenaEnvGraphSpec) -> list[UsdPrimRecord]
         return []
 
 
-def _spec_render_key(spec: ArenaEnvGraphSpec) -> str:
-    payload = json.dumps({"spec": spec.to_dict()}, sort_keys=True)
+def _spec_render_key(spec: ArenaEnvGraphSpec, *, background_panorama: bool) -> str:
+    payload = json.dumps({"spec": spec.to_dict(), "background_panorama": background_panorama}, sort_keys=True)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -73,7 +76,7 @@ def _store_asset_cards(spec_key: str, asset_cards: list[AssetCard], prim_tree: l
 
 def clear_snapshot_render_caches() -> int:
     """Delete cached review GUI snapshot PNGs and return how many files were removed."""
-    paths = list(thumbnail_cache_dir().glob("*.png"))
+    paths = [path for cache_dir in (thumbnail_cache_dir(), panorama_cache_dir()) for path in cache_dir.glob("*.png")]
     for path in paths:
         path.unlink()
     return len(paths)
@@ -105,7 +108,11 @@ def _show_simapp_render_error_once(exc: SimAppError) -> None:
     )
 
 
-def build_asset_cards_with_thumbnails(spec: ArenaEnvGraphSpec) -> tuple[list[AssetCard], list[UsdPrimRecord]]:
+def build_asset_cards_with_thumbnails(
+    spec: ArenaEnvGraphSpec,
+    *,
+    background_panorama: bool = False,
+) -> tuple[list[AssetCard], list[UsdPrimRecord]]:
     """Build per-node asset cards plus the background prim tree records.
 
     Loads the prim tree from the background USD directly and asks the SimApp
@@ -113,11 +120,16 @@ def build_asset_cards_with_thumbnails(spec: ArenaEnvGraphSpec) -> tuple[list[Ass
 
     Args:
         spec: Environment graph spec to visualize.
+        background_panorama: When True, render the background as a 360° panorama.
     """
-    spec_key = _spec_render_key(spec)
+    spec_key = _spec_render_key(spec, background_panorama=background_panorama)
     cached = _cached_asset_cards(spec_key)
     if cached is not None:
         return cached
+
+    panorama_node_ids: set[str] = set()
+    if background_panorama and spec.background is not None:
+        panorama_node_ids.add(spec.background.id)
 
     thumbnails: dict[str, bytes] = {}
     aabb_dimensions_m: dict[str, tuple[float, float, float]] = {}
@@ -130,7 +142,7 @@ def build_asset_cards_with_thumbnails(spec: ArenaEnvGraphSpec) -> tuple[list[Ass
             _warn_simapp_unavailable_once()
     else:
         try:
-            thumbnails, aabb_dimensions_m = client.render_spec(spec)
+            thumbnails, aabb_dimensions_m = client.render_spec(spec, background_panorama=background_panorama)
         except SimAppError as exc:
             _show_simapp_render_error_once(exc)
             thumbnails, aabb_dimensions_m = {}, {}
@@ -142,6 +154,7 @@ def build_asset_cards_with_thumbnails(spec: ArenaEnvGraphSpec) -> tuple[list[Ass
         spec,
         thumbnails or None,
         aabb_dimensions_m or None,
+        panorama_node_ids or None,
     )
     _store_asset_cards(spec_key, asset_cards, prim_tree)
     return asset_cards, prim_tree

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -56,6 +56,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.spec_visu
 )
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.streamlit_ui import initialize_state, parse_args
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.visualization_service import (
+    resolve_background_preview,
     resolve_background_prim_tree,
 )
 
@@ -185,6 +186,24 @@ class TestBackgroundPrimTree:
         )
         prim_tree = resolve_background_prim_tree(spec)
         assert any(record.relative_path == "fridge_main_group" for record in prim_tree)
+
+    def test_resolve_background_preview_from_invalid_spec_with_valid_background(self, monkeypatch):
+        from isaaclab_arena.tests.utils.agentic_environment_generation import kitchen_pass1_dict, kitchen_prim_tree
+
+        spec_dict = kitchen_pass1_dict()
+        spec_dict["relations"] = [{"bad": "relation"}]
+        broken_yaml = yaml.safe_dump(spec_dict, sort_keys=False)
+        monkeypatch.setattr(
+            "isaaclab_arena.environment_spec.arena_env_graph_types.AssetSpec.resolve_usd_path",
+            lambda self, *_args, **_kwargs: "/tmp/scene.usd",
+        )
+        monkeypatch.setattr(
+            "isaaclab_arena.utils.usd_prim_tree.load_usd_prim_tree",
+            lambda *_args, **_kwargs: kitchen_prim_tree(),
+        )
+        preview = resolve_background_preview(broken_yaml)
+        assert preview.usd_path == "/tmp/scene.usd"
+        assert any(record.relative_path == "fridge_main_group" for record in preview.prim_tree)
 
 
 class TestValidateYamlText:

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -27,6 +27,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.generatio
     _apply_generated_yaml,
     run_generation_pipeline,
 )
+from isaaclab_arena_examples.agentic_environment_generation.review_gui.sim_preview_panel import _group_camera_videos
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
     SimAppClient,
     spawn_simapp_process,
@@ -89,6 +90,18 @@ class TestSimPreviewParams:
     def test_parse_sim_preview_params_rejects_invalid(self):
         with pytest.raises(AssertionError):
             parse_sim_preview_params({"num_envs": 0, "num_steps": 10})
+
+    def test_groups_camera_videos_by_camera_and_env(self):
+        videos = [
+            {"camera_name": "wrist", "env_id": 1, "video": b"wrist-1"},
+            {"camera_name": "front", "env_id": 0, "video": b"front-0"},
+            {"camera_name": "wrist", "env_id": 0, "video": b"wrist-0"},
+        ]
+
+        assert _group_camera_videos(videos) == {
+            "front": {0: b"front-0"},
+            "wrist": {0: b"wrist-0", 1: b"wrist-1"},
+        }
 
 
 class TestBuildAssetCards:

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -36,11 +36,7 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.cl
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.sim_preview import (
     parse_sim_preview_params,
 )
-from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import (
-    ENV_SPACING_M,
-    NUM_ENVS,
-    NUM_STEPS,
-)
+from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp_connector import NUM_ENVS, NUM_STEPS
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.spec_visualization.asset_cards import (
     build_asset_cards,
     object_set_member_key,
@@ -88,11 +84,11 @@ class TestSimPreviewParams:
             parse_sim_preview_params({})
 
     def test_parse_sim_preview_params_custom(self):
-        assert parse_sim_preview_params({"num_envs": 8, "num_steps": 3, "env_spacing": 2.0}) == (8, 3, 2.0)
+        assert parse_sim_preview_params({"num_envs": 8, "num_steps": 3}) == (8, 3)
 
     def test_parse_sim_preview_params_rejects_invalid(self):
         with pytest.raises(AssertionError):
-            parse_sim_preview_params({"num_envs": 0, "num_steps": 10, "env_spacing": 1.5})
+            parse_sim_preview_params({"num_envs": 0, "num_steps": 10})
 
 
 class TestBuildAssetCards:
@@ -279,7 +275,6 @@ class TestInitializeState:
         assert session_state["editor_version"] == 0
         assert session_state["sim_preview_num_envs"] == NUM_ENVS
         assert session_state["sim_preview_num_steps"] == NUM_STEPS
-        assert session_state["sim_preview_env_spacing"] == ENV_SPACING_M
 
     def test_loads_yaml_from_disk(self, session_state, valid_spec_yaml: str, tmp_path: Path):
         spec_path = tmp_path / "opened.yaml"
@@ -545,17 +540,17 @@ class TestSimAppSimPreview:
             response = client.run_sim_preview(
                 yaml_text,
                 num_envs=1,
-                num_steps=0,
-                env_spacing=1.5,
+                num_steps=1,
             )
             assert response["ok"] is True
 
-            first_frame = Path(response["first_frame"])
-            last_frame = Path(response["last_frame"])
-            assert first_frame.is_file() and first_frame.stat().st_size > 0
-            assert last_frame.is_file() and last_frame.stat().st_size > 0
+            viewport_video = Path(response["viewport_video"])
+            assert viewport_video.is_file() and viewport_video.stat().st_size > 0
+            assert response["camera_videos"]
+            assert all(Path(video["path"]).is_file() for video in response["camera_videos"])
             assert response["num_envs"] == 1
-            assert response["num_steps"] == 0
+            assert response["num_steps"] == 1
+            assert response["env_spacing"] > 0.5
 
             client.shutdown()
         finally:


### PR DESCRIPTION
## Summary
Add Replicator kitchen review previews

## Detailed description
- Register Replicator kitchen backgrounds and add cached 360° panorama rendering to the review GUI.
- Show background USD and full prim paths above the editor for easier scene inspection.
- Preserve full paths during pass-2 prim inference and support relation-placed viewer targets.