### PR TITLE
Run the native-uv tests pre-merge on uv dependency changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
     branches: [ "main" ]
   schedule:
     # Nightly at 06:00 UTC — runs the full suite (including the native-uv job;
-    # PRs run that job only when uv-managed dependency files change).
     - cron: '0 6 * * *'
   workflow_dispatch:
 
@@ -383,7 +382,7 @@ jobs:
 
   test_curobo_deps:
     name: cuRobo deps check
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, gpu-arena]
     timeout-minutes: 30
     needs: [pre_commit]
 
@@ -483,7 +482,7 @@ jobs:
 
   build_and_push_curobo_image_post_merge:
     name: Build & push cuRobo NGC image (post-merge)
-    runs-on: [self-hosted, gpu]
+    runs-on: [self-hosted, gpu-arena]
     timeout-minutes: 60
     # Separate from the base image so a cuRobo test/build failure never blocks the base :latest push.
     needs: [test, test_curobo_deps]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches: [ "main" ]
   schedule:
-    # Nightly at 06:00 UTC — runs the full suite (including the native-uv job).
+    # Nightly at 06:00 UTC — runs the full suite (including the native-uv job;
+    # PRs run that job only when uv-managed dependency files change).
     - cron: '0 6 * * *'
   workflow_dispatch:
 
@@ -98,13 +99,40 @@ jobs:
           # fresh directory owned by the current process instead.
           PRE_COMMIT_HOME: /tmp/pre-commit-cache
 
+  uv_changes:
+    name: Detect uv-related changes
+    runs-on: [self-hosted, gpu-arena]
+    timeout-minutes: 5
+    # Only meaningful on PRs; other events always run the uv tests.
+    if: github.event_name == 'pull_request'
+    outputs:
+      uv: ${{ steps.filter.outputs.uv }}
+    steps:
+      # Queries the PR's changed files via the GitHub API; no checkout needed.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            uv:
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'submodules/IsaacLab'
+              - 'submodules/IsaacLab/**'
+
   uv_test:
     name: Run tests (native uv)
     runs-on: [self-hosted, gpu-arena]
     timeout-minutes: 120
-    needs: [pre_commit]
-    # Excluded from pre-merge (pull requests); still runs nightly, on push to main, and on manual dispatch.
-    if: github.event_name != 'pull_request'
+    needs: [pre_commit, uv_changes]
+    # Runs nightly, on push to main, and on manual dispatch; on pull requests
+    # only when the PR touches the uv-managed dependency files
+    # (pyproject.toml, uv.lock, or the IsaacLab submodule). The !cancelled()
+    # guard keeps the job alive when uv_changes is skipped on non-PR events.
+    if: >-
+      !cancelled() &&
+      needs.pre_commit.result == 'success' &&
+      (github.event_name != 'pull_request' ||
+       needs.uv_changes.outputs.uv == 'true')
     env:
       # NV_API_KEY is consumed by the live-endpoint tests for agentic env gen.
       NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}


### PR DESCRIPTION
## Summary
Run the native-uv CI tests pre-merge when a PR touches uv-managed dependency files.

## Detailed description
- The `uv_test` job only ran nightly / on push to main, so a PR breaking the uv resolution (`pyproject.toml`, `uv.lock`) was only caught the next night.
- Adds a lightweight `uv_changes` job that detects PRs touching `pyproject.toml`, `uv.lock`, or the `submodules/IsaacLab` pointer, and gates `uv_test` on it; nightly/push/dispatch behavior is unchanged.