### PR TITLE
Refactor: Fold stand-height lift into Droid initial_pose

### DIFF
--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -41,7 +41,7 @@ from isaaclab_arena.embodiments.droid.observations import arm_joint_pos, ee_pos,
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import franka_stack_events
 from isaaclab_arena.utils.cameras import ArenaCameraCfg
-from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.pose import Pose, translate_by_xyz_offset
 
 # The base stand's x/y footprint.
 _STAND_FOOTPRINT_SCALE_XY: tuple[float, float] = (1.2, 1.2)
@@ -75,13 +75,21 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         stand_unit_height = _stand_unit_height_m(self.scene_config.stand.spawn.usd_path)
         self.scene_config.stand.spawn.scale = (*_STAND_FOOTPRINT_SCALE_XY, stand_height_m / stand_unit_height)
         # Lift the robot base (and stand) so a taller/shorter stand keeps its bottom on the floor.
-        self._robot_base_z_offset = stand_height_m - _DEFAULT_STAND_HEIGHT_M
-        self.scene_config.robot.init_state.pos = self._lift_z(self.scene_config.robot.init_state.pos)
-        self.scene_config.stand.init_state.pos = self._lift_z(self.scene_config.stand.init_state.pos)
-        # Fold the same lift into an explicit ``initial_pose`` override so the stored pose matches the
-        # spawned base (``initial_pose.position_xyz == robot.init_state.pos``).
-        if self.initial_pose is not None:
-            self.initial_pose = self._lift_z_pose(self.initial_pose)
+        self._robot_base_offset = (0.0, 0.0, stand_height_m - _DEFAULT_STAND_HEIGHT_M)
+        if self.initial_pose is None:
+            # No explicit base pose: lift the default robot and stand init states so the robot sits atop
+            # the lifted stand.
+            self.scene_config.robot.init_state.pos = translate_by_xyz_offset(
+                self.scene_config.robot.init_state.pos, self._robot_base_offset
+            )
+            self.scene_config.stand.init_state.pos = translate_by_xyz_offset(
+                self.scene_config.stand.init_state.pos, self._robot_base_offset
+            )
+        else:
+            # Explicit base pose: lift it and make it the scene robot init state
+            self.initial_pose = translate_by_xyz_offset(self.initial_pose, self._robot_base_offset)
+            self.scene_config.robot.init_state.pos = self.initial_pose.position_xyz
+            self.scene_config.robot.init_state.rot = self.initial_pose.rotation_xyzw
         self.action_config = None
         self.camera_config = DroidCameraCfg()
         self.observation_config = DroidObservationsCfg()
@@ -92,17 +100,9 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         self.mimic_env = None
         self.add_camera_variations(self.camera_config)
 
-    def _lift_z(self, pos: tuple[float, float, float]) -> tuple[float, float, float]:
-        """Return ``pos`` shifted up by the stand-height-driven robot base offset."""
-        return (pos[0], pos[1], pos[2] + self._robot_base_z_offset)
-
-    def _lift_z_pose(self, pose: Pose) -> Pose:
-        """Return ``pose`` with its position shifted up by the stand-height-driven robot base offset."""
-        return Pose(position_xyz=self._lift_z(pose.position_xyz), rotation_xyzw=pose.rotation_xyzw)
-
     def set_initial_pose(self, pose: Pose) -> None:
         """Store the requested base pose, lifted by the stand-height offset to match the spawned base."""
-        super().set_initial_pose(self._lift_z_pose(pose))
+        super().set_initial_pose(translate_by_xyz_offset(pose, self._robot_base_offset))
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
         # ``pose`` is already lifted by the stand-height offset (see __init__ / set_initial_pose), so the

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -105,7 +105,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
     def _lift_by_base_offset(self, target: tuple[float, float, float]) -> tuple[float, float, float]: ...
 
     def _lift_by_base_offset(self, target: tuple[float, float, float] | Pose) -> tuple[float, float, float] | Pose:
-        """Shift ``target`` up by the stand-height offset, so the base sits atop the (re)scaled stand."""
+        """Shift ``target`` up by the stand-height offset, so the base sits atop the rescaled stand."""
         return translate_by_xyz_offset(target, (0.0, 0.0, self._robot_base_z_offset))
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -8,7 +8,7 @@ import functools
 import torch
 import warnings
 from abc import ABC
-from typing import Any
+from typing import Any, overload
 
 import isaaclab.envs.mdp as mdp_isaac_lab
 import isaaclab.sim as sim_utils
@@ -79,17 +79,11 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         if self.initial_pose is None:
             # No explicit base pose: lift the default robot and stand init states so the robot sits atop
             # the lifted stand.
-            self.scene_config.robot.init_state.pos = translate_by_xyz_offset(
-                self.scene_config.robot.init_state.pos, self._robot_base_offset
-            )
-            self.scene_config.stand.init_state.pos = translate_by_xyz_offset(
-                self.scene_config.stand.init_state.pos, self._robot_base_offset
-            )
+            self.scene_config.robot.init_state.pos = self._lift_by_base_offset(self.scene_config.robot.init_state.pos)
+            self.scene_config.stand.init_state.pos = self._lift_by_base_offset(self.scene_config.stand.init_state.pos)
         else:
-            # Explicit base pose: lift it and make it the scene robot init state
-            self.initial_pose = translate_by_xyz_offset(self.initial_pose, self._robot_base_offset)
-            self.scene_config.robot.init_state.pos = self.initial_pose.position_xyz
-            self.scene_config.robot.init_state.rot = self.initial_pose.rotation_xyzw
+            # Explicit base pose: lift it via set_initial_pose; get_scene_cfg writes the scene config later.
+            self.set_initial_pose(self.initial_pose)
         self.action_config = None
         self.camera_config = DroidCameraCfg()
         self.observation_config = DroidObservationsCfg()
@@ -102,7 +96,17 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
 
     def set_initial_pose(self, pose: Pose) -> None:
         """Store the requested base pose, lifted by the stand-height offset to match the spawned base."""
-        super().set_initial_pose(translate_by_xyz_offset(pose, self._robot_base_offset))
+        super().set_initial_pose(self._lift_by_base_offset(pose))
+
+    @overload
+    def _lift_by_base_offset(self, target: Pose) -> Pose: ...
+
+    @overload
+    def _lift_by_base_offset(self, target: tuple[float, float, float]) -> tuple[float, float, float]: ...
+
+    def _lift_by_base_offset(self, target: tuple[float, float, float] | Pose) -> tuple[float, float, float] | Pose:
+        """Shift ``target`` up by the stand-height offset, so the base sits atop the (re)scaled stand."""
+        return translate_by_xyz_offset(target, self._robot_base_offset)
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
         # ``pose`` is already lifted by the stand-height offset (see __init__ / set_initial_pose), so the

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -8,7 +8,7 @@ import functools
 import torch
 import warnings
 from abc import ABC
-from typing import Any, overload
+from typing import Any
 
 import isaaclab.envs.mdp as mdp_isaac_lab
 import isaaclab.sim as sim_utils
@@ -75,12 +75,16 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         stand_unit_height = _stand_unit_height_m(self.scene_config.stand.spawn.usd_path)
         self.scene_config.stand.spawn.scale = (*_STAND_FOOTPRINT_SCALE_XY, stand_height_m / stand_unit_height)
         # Lift the robot base (and stand) so a taller/shorter stand keeps its bottom on the floor.
-        self._robot_base_z_offset = stand_height_m - _DEFAULT_STAND_HEIGHT_M
+        self._robot_base_offset = (0.0, 0.0, stand_height_m - _DEFAULT_STAND_HEIGHT_M)
         if self.initial_pose is None:
             # No explicit base pose: lift the default robot and stand init states so the robot sits atop
             # the lifted stand.
-            self.scene_config.robot.init_state.pos = self._lift_by_base_offset(self.scene_config.robot.init_state.pos)
-            self.scene_config.stand.init_state.pos = self._lift_by_base_offset(self.scene_config.stand.init_state.pos)
+            self.scene_config.robot.init_state.pos = translate_by_xyz_offset(
+                self.scene_config.robot.init_state.pos, self._robot_base_offset
+            )
+            self.scene_config.stand.init_state.pos = translate_by_xyz_offset(
+                self.scene_config.stand.init_state.pos, self._robot_base_offset
+            )
         else:
             # Explicit base pose: lift it via set_initial_pose; get_scene_cfg writes the scene config later.
             self.set_initial_pose(self.initial_pose)
@@ -96,17 +100,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
 
     def set_initial_pose(self, pose: Pose) -> None:
         """Store the requested base pose, lifted by the stand-height offset to match the spawned base."""
-        super().set_initial_pose(self._lift_by_base_offset(pose))
-
-    @overload
-    def _lift_by_base_offset(self, target: Pose) -> Pose: ...  # noqa: E704
-
-    @overload
-    def _lift_by_base_offset(self, target: tuple[float, float, float]) -> tuple[float, float, float]: ...  # noqa: E704
-
-    def _lift_by_base_offset(self, target: tuple[float, float, float] | Pose) -> tuple[float, float, float] | Pose:
-        """Shift ``target`` up by the stand-height offset, so the base sits atop the rescaled stand."""
-        return translate_by_xyz_offset(target, (0.0, 0.0, self._robot_base_z_offset))
+        super().set_initial_pose(pose.translate(self._robot_base_offset))
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
         # ``pose`` is already lifted by the stand-height offset (see __init__ / set_initial_pose), so the

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -75,7 +75,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         stand_unit_height = _stand_unit_height_m(self.scene_config.stand.spawn.usd_path)
         self.scene_config.stand.spawn.scale = (*_STAND_FOOTPRINT_SCALE_XY, stand_height_m / stand_unit_height)
         # Lift the robot base (and stand) so a taller/shorter stand keeps its bottom on the floor.
-        self._robot_base_offset = (0.0, 0.0, stand_height_m - _DEFAULT_STAND_HEIGHT_M)
+        self._robot_base_z_offset = stand_height_m - _DEFAULT_STAND_HEIGHT_M
         if self.initial_pose is None:
             # No explicit base pose: lift the default robot and stand init states so the robot sits atop
             # the lifted stand.
@@ -106,7 +106,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
 
     def _lift_by_base_offset(self, target: tuple[float, float, float] | Pose) -> tuple[float, float, float] | Pose:
         """Shift ``target`` up by the stand-height offset, so the base sits atop the (re)scaled stand."""
-        return translate_by_xyz_offset(target, self._robot_base_offset)
+        return translate_by_xyz_offset(target, (0.0, 0.0, self._robot_base_z_offset))
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
         # ``pose`` is already lifted by the stand-height offset (see __init__ / set_initial_pose), so the

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -78,6 +78,10 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         self._robot_base_z_offset = stand_height_m - _DEFAULT_STAND_HEIGHT_M
         self.scene_config.robot.init_state.pos = self._lift_z(self.scene_config.robot.init_state.pos)
         self.scene_config.stand.init_state.pos = self._lift_z(self.scene_config.stand.init_state.pos)
+        # Fold the same lift into an explicit ``initial_pose`` override so the stored pose matches the
+        # spawned base (``initial_pose.position_xyz == robot.init_state.pos``).
+        if self.initial_pose is not None:
+            self.initial_pose = self._lift_z_pose(self.initial_pose)
         self.action_config = None
         self.camera_config = DroidCameraCfg()
         self.observation_config = DroidObservationsCfg()
@@ -92,17 +96,20 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         """Return ``pos`` shifted up by the stand-height-driven robot base offset."""
         return (pos[0], pos[1], pos[2] + self._robot_base_z_offset)
 
-    def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
-        # We override the default initial pose setting function in order to also set the initial pose
-        # of the stand, and to re-apply the stand-height lift on top of the requested pose (the base
-        # implementation overwrites init_state.pos with the raw pose).
-        scene_config = super()._update_scene_cfg_with_robot_initial_pose(scene_config, pose)
-        if scene_config is None or not hasattr(scene_config, "robot"):
-            raise RuntimeError("scene_config must be populated with a `robot` before calling `set_robot_initial_pose`.")
-        scene_config.robot.init_state.pos = self._lift_z(pose.position_xyz)
-        scene_config.stand.init_state.pos = self._lift_z(pose.position_xyz)
-        scene_config.stand.init_state.rot = pose.rotation_xyzw
+    def _lift_z_pose(self, pose: Pose) -> Pose:
+        """Return ``pose`` with its position shifted up by the stand-height-driven robot base offset."""
+        return Pose(position_xyz=self._lift_z(pose.position_xyz), rotation_xyzw=pose.rotation_xyzw)
 
+    def set_initial_pose(self, pose: Pose) -> None:
+        """Store the requested base pose, lifted by the stand-height offset to match the spawned base."""
+        super().set_initial_pose(self._lift_z_pose(pose))
+
+    def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:
+        # ``pose`` is already lifted by the stand-height offset (see __init__ / set_initial_pose), so the
+        # base implementation sets the robot base as-is; we only add the stand placement here.
+        scene_config = super()._update_scene_cfg_with_robot_initial_pose(scene_config, pose)
+        scene_config.stand.init_state.pos = pose.position_xyz
+        scene_config.stand.init_state.rot = pose.rotation_xyzw
         return scene_config
 
     def set_initial_joint_pose(self, initial_joint_pose: list[float]) -> None:

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -99,10 +99,10 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         super().set_initial_pose(self._lift_by_base_offset(pose))
 
     @overload
-    def _lift_by_base_offset(self, target: Pose) -> Pose: ...
+    def _lift_by_base_offset(self, target: Pose) -> Pose: ...  # noqa: E704
 
     @overload
-    def _lift_by_base_offset(self, target: tuple[float, float, float]) -> tuple[float, float, float]: ...
+    def _lift_by_base_offset(self, target: tuple[float, float, float]) -> tuple[float, float, float]: ...  # noqa: E704
 
     def _lift_by_base_offset(self, target: tuple[float, float, float] | Pose) -> tuple[float, float, float] | Pose:
         """Shift ``target`` up by the stand-height offset, so the base sits atop the rescaled stand."""

--- a/isaaclab_arena/tests/test_droid_stand_height.py
+++ b/isaaclab_arena/tests/test_droid_stand_height.py
@@ -48,13 +48,16 @@ def _test_droid_stand_height(simulation_app) -> bool:
         assert abs(custom_emb.scene_config.robot.init_state.pos[2] - expected_offset) < 1e-6
         assert abs(custom_emb.scene_config.stand.init_state.pos[2] - expected_offset) < 1e-6
 
-        # The lift is re-applied on top of an explicit initial_pose (which the base class would
-        # otherwise overwrite): the requested z plus the stand-height offset.
+        # An explicit initial_pose is lifted at ingestion (set_initial_pose), so the stored override
+        # already equals the spawned base: the requested z plus the stand-height offset.
         posed_emb = DroidAbsoluteJointPositionEmbodiment(stand_height_m=_CUSTOM_STAND_HEIGHT_M)
         posed_emb.set_initial_pose(Pose(position_xyz=(0.3, 0.0, 0.5), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        assert abs(posed_emb.initial_pose.position_xyz[2] - (0.5 + expected_offset)) < 1e-6
         scene_cfg = posed_emb.get_scene_cfg()
         assert abs(scene_cfg.robot.init_state.pos[2] - (0.5 + expected_offset)) < 1e-6
         assert abs(scene_cfg.stand.init_state.pos[2] - (0.5 + expected_offset)) < 1e-6
+        # initial_pose is the single source of truth: it matches the spawned robot base exactly.
+        assert tuple(posed_emb.initial_pose.position_xyz) == tuple(scene_cfg.robot.init_state.pos)
 
         # The YAML-spec path instantiates the embodiment via asset_class(**params); a scalar
         # stand_height_m from YAML applies just the same.

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -83,13 +83,13 @@ def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:
 
 
 @overload
-def translate_by_xyz_offset(target: Pose, xyz_offset: tuple[float, float, float]) -> Pose: ...
+def translate_by_xyz_offset(target: Pose, xyz_offset: tuple[float, float, float]) -> Pose: ...  # noqa: E704
 
 
 @overload
 def translate_by_xyz_offset(
     target: tuple[float, float, float], xyz_offset: tuple[float, float, float]
-) -> tuple[float, float, float]: ...
+) -> tuple[float, float, float]: ...  # noqa: E704
 
 
 def translate_by_xyz_offset(

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -5,7 +5,6 @@
 
 import torch
 from dataclasses import dataclass
-from typing import overload
 
 
 @dataclass
@@ -52,6 +51,13 @@ class Pose:
     def multiply(self, other: "Pose") -> "Pose":
         return compose_poses(self, other)
 
+    def translate(self, xyz_offset: tuple[float, float, float]) -> "Pose":
+        """Return this pose shifted by ``xyz_offset`` (rotation unchanged)."""
+        return Pose(
+            position_xyz=translate_by_xyz_offset(self.position_xyz, xyz_offset),
+            rotation_xyzw=self.rotation_xyzw,
+        )
+
     def to_transform_matrix(self, device: torch.device) -> torch.Tensor:
         """Convert the pose to a 4x4 homogeneous transform matrix."""
         import isaaclab.utils.math as math_utils
@@ -82,30 +88,15 @@ def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:
     return Pose(position_xyz=tuple(t_C_A.tolist()), rotation_xyzw=tuple(q_C_A.tolist()))
 
 
-@overload
-def translate_by_xyz_offset(target: Pose, xyz_offset: tuple[float, float, float]) -> Pose: ...  # noqa: E704
-
-
-@overload
-def translate_by_xyz_offset(  # noqa: E704
-    target: tuple[float, float, float], xyz_offset: tuple[float, float, float]
-) -> tuple[float, float, float]: ...
-
-
 def translate_by_xyz_offset(
-    target: tuple[float, float, float] | Pose, xyz_offset: tuple[float, float, float]
-) -> tuple[float, float, float] | Pose:
-    """Return ``target`` shifted by ``xyz_offset`` (rotation, if any, unchanged).
+    target: tuple[float, float, float], xyz_offset: tuple[float, float, float]
+) -> tuple[float, float, float]:
+    """Return ``target`` shifted by ``xyz_offset``.
 
     Args:
-        target: The position tuple or Pose to shift.
+        target: The (x, y, z) position to shift.
         xyz_offset: The (x, y, z) translation to add.
     """
-    if isinstance(target, Pose):
-        return Pose(
-            position_xyz=translate_by_xyz_offset(target.position_xyz, xyz_offset),
-            rotation_xyzw=target.rotation_xyzw,
-        )
     return (target[0] + xyz_offset[0], target[1] + xyz_offset[1], target[2] + xyz_offset[2])
 
 

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -87,9 +87,9 @@ def translate_by_xyz_offset(target: Pose, xyz_offset: tuple[float, float, float]
 
 
 @overload
-def translate_by_xyz_offset(
+def translate_by_xyz_offset(  # noqa: E704
     target: tuple[float, float, float], xyz_offset: tuple[float, float, float]
-) -> tuple[float, float, float]: ...  # noqa: E704
+) -> tuple[float, float, float]: ...
 
 
 def translate_by_xyz_offset(

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -5,6 +5,7 @@
 
 import torch
 from dataclasses import dataclass
+from typing import overload
 
 
 @dataclass
@@ -79,6 +80,16 @@ def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:
     # Compose the translations
     t_C_A = R_C_B @ torch.tensor(T_B_A.position_xyz) + torch.tensor(T_C_B.position_xyz)
     return Pose(position_xyz=tuple(t_C_A.tolist()), rotation_xyzw=tuple(q_C_A.tolist()))
+
+
+@overload
+def translate_by_xyz_offset(target: Pose, xyz_offset: tuple[float, float, float]) -> Pose: ...
+
+
+@overload
+def translate_by_xyz_offset(
+    target: tuple[float, float, float], xyz_offset: tuple[float, float, float]
+) -> tuple[float, float, float]: ...
 
 
 def translate_by_xyz_offset(

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -81,6 +81,23 @@ def compose_poses(T_C_B: Pose, T_B_A: Pose) -> Pose:
     return Pose(position_xyz=tuple(t_C_A.tolist()), rotation_xyzw=tuple(q_C_A.tolist()))
 
 
+def translate_by_xyz_offset(
+    target: tuple[float, float, float] | Pose, xyz_offset: tuple[float, float, float]
+) -> tuple[float, float, float] | Pose:
+    """Return ``target`` shifted by ``xyz_offset`` (rotation, if any, unchanged).
+
+    Args:
+        target: The position tuple or Pose to shift.
+        xyz_offset: The (x, y, z) translation to add.
+    """
+    if isinstance(target, Pose):
+        return Pose(
+            position_xyz=translate_by_xyz_offset(target.position_xyz, xyz_offset),
+            rotation_xyzw=target.rotation_xyzw,
+        )
+    return (target[0] + xyz_offset[0], target[1] + xyz_offset[1], target[2] + xyz_offset[2])
+
+
 @dataclass
 class PosePerEnv:
     """Per-environment poses (one Pose per env, used for batched placement)."""


### PR DESCRIPTION
## Summary
Make the Droid robot's base pose and the scene's robot init state always match, and move the pose-shift math into one shared helper.

## Detailed description
- Add translate_by_xyz_offset as a helper func
- With no explicit nitial_pose, lift the default robot and stand init states; with an explicit pose, lift that pose and write it straight into the scene robot init state.
- Lift an explicit base pose once, at set_initial_pose time, instead of re-applying the lift later. 

## Note on how embodiment pose is set
1. Users pass a pose into the constructor — DroidEmbodiment(initial_pose=somePose)
2. Users pass nothing — DroidEmbodiment() (the default, initial_pose=None)
3. Users call set_initial_pose(...) later


