### PR TITLE
Address SQA bug: list variations without policy.

### DIFF
--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -136,6 +136,15 @@ def rollout_policy(
         return None
 
 
+def list_variations(args_parser: argparse.ArgumentParser) -> None:
+    """Print the Hydra-configurable variations for the selected environment."""
+    args_parser = get_isaaclab_arena_environments_cli_parser(args_parser)
+    args_cli, hydra_overrides = args_parser.parse_known_args()
+    assert_hydra_overrides(hydra_overrides, args_parser)
+    arena_builder = get_arena_builder_from_cli(args_cli, hydra_overrides=hydra_overrides)
+    print(arena_builder.get_variations_catalogue_as_string())
+
+
 def main():
     """Run an IsaacLab Arena environment with a policy.
     Use --distributed with torchrun command for one process per GPU on multi-GPU machines. AppLauncher uses LOCAL_RANK for device.
@@ -161,7 +170,13 @@ def main():
         add_policy_runner_arguments(args_parser)
         args_cli, _ = args_parser.parse_known_args()
 
+        # --list_variations only inspects the environment, so short-circuit reading other args.
+        if args_cli.list_variations:
+            list_variations(args_parser)
+            return
+
         # Get the policy class from the policy type
+        assert args_cli.policy_type is not None, "--policy_type is required."
         policy_cls = get_policy_cls(args_cli.policy_type)
         print(
             f"[Rank {local_rank}/{world_size}] Requested policy type: {args_cli.policy_type} -> Policy class:"
@@ -187,10 +202,6 @@ def main():
 
         # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
         arena_builder = get_arena_builder_from_cli(args_cli, hydra_overrides=hydra_overrides)
-
-        if args_cli.list_variations:
-            print(arena_builder.get_variations_catalogue_as_string())
-            return
 
         output_dir = timestamped_run_dir(args_cli.output_base_dir)
         video_cfg = VideoRecordingCfg(

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -71,7 +71,7 @@ def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--policy_type",
         type=str,
-        required=True,
+        default=None,
         help="Type of policy to use. This is either a registered policy name or a path to a policy class.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
Address issue that listing variations used to fail without a policy specified.

## Detailed description
- Addresses [6491076](https://nvbugspro.nvidia.com/bug/6491076)