### PR TITLE
Address SQA bug: OpenPI policy runner runs in the Arena container.

### DIFF
--- a/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
+++ b/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
@@ -45,7 +45,8 @@ Terminal 2 — arena policy runner
 
 **Run pi05 closed-loop**
 
-Open a second terminal and point the arena policy runner at the server:
+Open a second terminal, enter the Arena container with ``./docker/run_docker.sh``, and
+point the arena policy runner at the server:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Summary
Address issue that the OpenPI docs did not state that the policy runner must be run from inside the Arena container.

## Detailed description
- Terminal 2 of the OpenPI quickstart now says to enter the Arena container with `./docker/run_docker.sh`, matching the wording already used on the DreamZero page.
- Addresses [6491128](https://nvbugspro.nvidia.com/bug/6491128)