### PR TITLE
docs: remove not-fully-tested note from release/0.2.1

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,6 @@
 Welcome to Isaac Lab Arena!
 ===========================
 
-.. warning::
-   This is the latest version of IsaacLab Arena. It contains the newest features but may not be fully tested yet.
-   For the tested version, please refer to the `release/0.2.0 branch <https://isaac-sim.github.io/IsaacLab-Arena/release/0.2.0/index.html>`_.
-
 ``Isaac Lab Arena`` extends `Isaac Lab <https://isaac-sim.github.io/IsaacLab/main/index.html>`_
 to simplify the creation of task/environment libraries.
 


### PR DESCRIPTION
## Summary
Remove the "may not be fully tested" note from the `release/0.2.1` index page — it is a stable public release (nvbug 6485479).

- The top-of-page `.. warning::` in `docs/index.rst` claimed the docs may not be fully tested and pointed readers to an earlier release.
- Stable release branches should carry no such note; removed it.