### PR TITLE
docs: remove main-branch/not-fully-tested note from release/0.1.1

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,6 @@
 ``Isaac Lab Arena`` Documentation
 =================================
 
-.. warning::
-   This is the release/0.1.1 version of Isaac Lab Arena. If you are looking for the latest development version,
-   please refer to the `main branch <https://isaac-sim.github.io/IsaacLab-Arena/main/index.html>`_.
-   This comes with the latest features but is not yet fully tested.
-
 ``Isaac Lab Arena`` is an extends `Isaac Lab <https://isaac-sim.github.io/IsaacLab/main/index.html>`_
 to simplify the creation of task/environment libraries.
 


### PR DESCRIPTION
## Summary
Remove the prominent note on the `release/0.1.1` index page that directed readers to the main branch and described the release as not fully tested (nvbug 6485479).

- The top-of-page `.. warning::` in `docs/index.rst` pointed readers to `main` and stated the version is not yet fully tested.
- Released branches should not carry this note; removed it.