### PR TITLE
Sort version switcher entries in descending order

### DIFF
--- a/docs/_templates/version-badge.html
+++ b/docs/_templates/version-badge.html
@@ -20,11 +20,7 @@ sphinx-multiversion's git-derived `current_version`.
   </button>
   <div class="version-switcher__menu dropdown-menu list-group-flush py-0" role="listbox">
     {%- if versions %}
-    {%- for item in versions.branches %}
-    <a class="list-group-item list-group-item-action py-1{% if item == current_version %} active{% endif %}"
-       href="{{ item.url }}" role="option"{% if item == current_version %} aria-current="true"{% endif %}>{{ version_label(item.name) }}</a>
-    {%- endfor %}
-    {%- for item in versions.tags|reverse %}
+    {%- for item in (versions.branches + versions.tags) | version_sort %}
     <a class="list-group-item list-group-item-action py-1{% if item == current_version %} active{% endif %}"
        href="{{ item.url }}" role="option"{% if item == current_version %} aria-current="true"{% endif %}>{{ version_label(item.name) }}</a>
     {%- endfor %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import sys
 
 # Modify PYTHONPATH so we can import the helpers module.
 sys.path.insert(0, os.path.abspath("."))
-from helpers import TemporaryLinkcheckIgnore, to_datetime, is_expired
+from helpers import TemporaryLinkcheckIgnore, to_datetime, is_expired, version_sort
 
 # NOTE(alexmillane, 2025-04-24): This file is in a separate folder to avoid
 # duplicate configuration errors coming from mypy. The only way I could find
@@ -168,3 +168,12 @@ isaaclab_arena_docs_config = {
     "internal_code_link_base_url": "https://github.com/isaac-sim/IsaacLab-Arena",
     "external_code_link_base_url": "UNDECIDED",
 }
+
+
+def setup(app):
+    """Expose the version_sort filter to the version-switcher template."""
+
+    def register_filters(app):
+        app.builder.templates.environment.filters["version_sort"] = version_sort
+
+    app.connect("builder-inited", register_filters)

--- a/docs/helpers.py
+++ b/docs/helpers.py
@@ -15,6 +15,26 @@
 #
 import dataclasses
 import datetime
+import re
+
+
+def version_sort(versions: list) -> list:
+    """Order sphinx-multiversion version objects for the header switcher.
+
+    Non-numeric refs (e.g. ``main``) come first, then semantic versions descending, with
+    a bare release ranked above its own prereleases (``0.3.0`` before ``0.3.0-prerelease``).
+    """
+
+    def key(version):
+        label = version.name.removeprefix("release/")
+        match = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?(.*)", label)
+        if not match:
+            return (0,)  # non-numeric refs (e.g. main) sort first
+        major, minor, patch, suffix = match.groups()
+        is_release = 1 if not suffix else 0  # a bare version outranks its prereleases
+        return (1, -int(major), -int(minor), -int(patch or 0), -is_release)
+
+    return sorted(versions, key=key)
 
 
 def to_datetime(date_str: str) -> datetime.datetime:


### PR DESCRIPTION
## Summary
- Sort the docs version-switcher dropdown strictly by version, descending.

## Details
- Adds a version-aware `version_sort` Jinja filter (main first, then semantic versions descending).