### PR TITLE
Add Lightwheel kitchen graph spec with mesh placement

### DIFF
--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -36,6 +36,7 @@ from isaaclab_arena.embodiments.droid.observations import arm_joint_pos, ee_pos,
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import franka_stack_events
 from isaaclab_arena.embodiments.robot_on_stand_utils import RobotPrimSpec, StandPrimSpec, compose_on_stand_usd
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.cameras import ArenaCameraCfg
 from isaaclab_arena.utils.pose import Pose
 
@@ -66,6 +67,8 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
     which changes how far the stand extends below the root link.
     When manually placing the robot on floor, ``set_initial_pose`` z value and
     ``stand_height_m`` should be adjusted together to keep the bottom of stand fixed.
+    ``placement_bbox_stand_only`` uses the stand footprint for ``On`` / ``NextTo`` placement
+    instead of the full robot+stand USD bounds.
     """
 
     name = "droid"
@@ -79,9 +82,11 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        placement_bbox_stand_only: bool = False,
     ):
         super().__init__(enable_cameras, initial_pose, concatenate_observation_terms, arm_mode)
         self.stand_height_m = stand_height_m
+        self.placement_bbox_stand_only = placement_bbox_stand_only
         self.scene_config = DroidSceneCfg()
         self.scene_config.robot.spawn.usd_path = compose_on_stand_usd(
             _DROID_ROBOT_PRIM,
@@ -98,6 +103,15 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         self.reward_config = None
         self.mimic_env = None
         self.add_camera_variations(self.camera_config)
+
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Return root-relative placement bounds from the composed on-stand USD spawn.
+
+        When ``placement_bbox_stand_only`` is True, bounds exclude the robot arm and cover
+        the stand footprint only.
+        """
+        prim_path = _DROID_ROBOT_PRIM.stand_prim_path if self.placement_bbox_stand_only else None
+        return super().get_bounding_box(prim_path=prim_path)
 
     def set_initial_joint_pose(self, initial_joint_pose: list[float]) -> None:
         self.event_config.init_franka_arm_pose.params["default_pose"] = initial_joint_pose
@@ -124,6 +138,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        placement_bbox_stand_only: bool = False,
     ):
         super().__init__(
             enable_cameras,
@@ -132,6 +147,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms,
             arm_mode,
             stand_height_m,
+            placement_bbox_stand_only,
         )
         self.action_config = DroidDifferentialIKActionsCfg()
 
@@ -151,6 +167,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        placement_bbox_stand_only: bool = False,
     ):
         super().__init__(
             enable_cameras,
@@ -159,6 +176,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms,
             arm_mode,
             stand_height_m,
+            placement_bbox_stand_only,
         )
         self.action_config = DroidRelativeJointPositionActionsCfg()
 
@@ -179,6 +197,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        placement_bbox_stand_only: bool = False,
     ):
         super().__init__(
             enable_cameras,
@@ -187,6 +206,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms,
             arm_mode,
             stand_height_m,
+            placement_bbox_stand_only,
         )
         self.action_config = DroidAbsoluteJointPositionActionsCfg()
 

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -59,8 +59,13 @@ class EmbodimentBase(PlaceableAsset):
         self._collision_mesh: trimesh.Trimesh | None = None
         """Lazily-extracted robot collision mesh, cached so the USD is opened once."""
 
-    def get_bounding_box(self) -> AxisAlignedBoundingBox:
-        """Return root-relative bounds computed from the articulation's USD geometry."""
+    def get_bounding_box(self, prim_path: str | None = None) -> AxisAlignedBoundingBox:
+        """Return root-relative bounds computed from the articulation's USD geometry.
+
+        Args:
+            prim_path: Optional sub-prim to bound (e.g. stand only). When None, bounds the
+                full default prim.
+        """
         # Import locally because USD/pxr is available only after simulation initialization.
         from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
 
@@ -71,7 +76,7 @@ class EmbodimentBase(PlaceableAsset):
         assert spawn.usd_path is not None, "scene_config.robot must use a USD spawn for placement"
         scale = tuple(spawn.scale or (1.0, 1.0, 1.0))
         # TODO(zihaox): Account for configured initial joint positions in bounds and collision meshes.
-        return compute_local_bounding_box_from_usd(spawn.usd_path, scale)
+        return compute_local_bounding_box_from_usd(spawn.usd_path, scale, prim_path=prim_path)
 
     def get_collision_mesh(self) -> trimesh.Trimesh | None:
         """Return the robot's collision mesh from its USD default prim, in the default joint pose."""

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -29,6 +29,28 @@ def _write_cube_asset_usd(
     stage.GetRootLayer().Save()
 
 
+def _write_root_with_translated_child_cube(
+    path: pathlib.Path,
+    cube_size: float,
+    child_translate: tuple[float, float, float],
+    root_scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> None:
+    """USD with default-prim root and a translated child cube (stand-like sub-prim)."""
+    from pxr import Gf, Usd, UsdGeom
+
+    stage = Usd.Stage.CreateNew(path.as_posix())
+    root = UsdGeom.Xform.Define(stage, "/Root")
+    stage.SetDefaultPrim(root.GetPrim())
+    if root_scale != (1.0, 1.0, 1.0):
+        root.AddScaleOp(UsdGeom.XformOp.PrecisionDouble).Set(Gf.Vec3d(*root_scale))
+
+    child = UsdGeom.Xform.Define(stage, "/Root/Child")
+    child.AddTranslateOp(UsdGeom.XformOp.PrecisionDouble).Set(Gf.Vec3d(*child_translate))
+    cube = UsdGeom.Cube.Define(stage, "/Root/Child/Cube")
+    cube.GetSizeAttr().Set(cube_size)
+    stage.GetRootLayer().Save()
+
+
 def _bbox_size(path: pathlib.Path, scale: tuple[float, float, float]) -> tuple[float, float, float]:
     from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
 
@@ -63,9 +85,48 @@ def _test_compute_local_bounding_box_from_usd(simulation_app, asset_dir: pathlib
     return True
 
 
+def _test_compute_local_bounding_box_from_usd_prim_path(simulation_app, asset_dir: pathlib.Path) -> bool:
+    """Optional prim_path returns that sub-prim's AABB in the default-prim frame, with scale unbaking."""
+    from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
+
+    child_usd = asset_dir / "root_with_child_cube.usd"
+    translate = (0.5, -0.25, -1.0)
+    spawn_scale = (2.0, 2.0, 2.0)
+    _write_root_with_translated_child_cube(
+        child_usd, cube_size=1.0, child_translate=translate, root_scale=(0.5, 0.5, 0.5)
+    )
+
+    # Root-scale is baked into world bounds then unbaked via composed spawn/root scale.
+    # Child translate under a scaled default prim therefore ends up at spawn_scale * translate.
+    bbox = compute_local_bounding_box_from_usd(child_usd.as_posix(), scale=spawn_scale, prim_path="/Root/Child")
+    half = 0.5 * spawn_scale[0]
+    tx, ty, tz = (c * spawn_scale[0] for c in translate)
+    min_pt = bbox.min_point[0].tolist()
+    max_pt = bbox.max_point[0].tolist()
+    expected_min = [tx - half, ty - half, tz - half]
+    expected_max = [tx + half, ty + half, tz + half]
+    assert all(abs(a - b) < EPS for a, b in zip(min_pt, expected_min)), (min_pt, expected_min)
+    assert all(abs(a - b) < EPS for a, b in zip(max_pt, expected_max)), (max_pt, expected_max)
+
+    # Full default-prim bounds must be at least as large as the child-only bounds.
+    full = compute_local_bounding_box_from_usd(child_usd.as_posix(), scale=spawn_scale)
+    assert (full.min_point <= bbox.min_point).all()
+    assert (full.max_point >= bbox.max_point).all()
+    return True
+
+
 def test_compute_local_bounding_box_from_usd(tmp_path: pathlib.Path):
     result = run_simulation_app_function(
         _test_compute_local_bounding_box_from_usd,
+        headless=HEADLESS,
+        asset_dir=tmp_path,
+    )
+    assert result, "Test failed"
+
+
+def test_compute_local_bounding_box_from_usd_prim_path(tmp_path: pathlib.Path):
+    result = run_simulation_app_function(
+        _test_compute_local_bounding_box_from_usd_prim_path,
         headless=HEADLESS,
         asset_dir=tmp_path,
     )

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -172,6 +172,7 @@ def _read_default_prim_scale(prim: Usd.Prim) -> tuple[float, float, float]:
 def compute_local_bounding_box_from_usd(
     usd_path: str,
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    prim_path: str | None = None,
 ) -> AxisAlignedBoundingBox:
     """Compute the local bounding box matching Isaac Lab ``UsdFileCfg`` spawn size.
 
@@ -185,6 +186,9 @@ def compute_local_bounding_box_from_usd(
     Args:
         usd_path: Path to the USD file.
         scale: Spawn-time scale passed to ``UsdFileCfg`` / ``Object.scale``.
+        prim_path: Optional sub-prim to bound. When set, returns that prim's AABB
+            expressed in the default prim's frame (root-relative). When None,
+            bounds the default prim itself.
 
     Returns:
         AxisAlignedBoundingBox containing local min and max points.
@@ -197,7 +201,21 @@ def compute_local_bounding_box_from_usd(
     if not default_prim:
         default_prim = stage.GetPseudoRoot()
 
-    bbox = compute_local_bounding_box_from_prim(stage, default_prim.GetPath().pathString)
+    if prim_path is None:
+        bbox = compute_local_bounding_box_from_prim(stage, default_prim.GetPath().pathString)
+    else:
+        # Sub-prim bounds expressed in the default-prim (root) frame.
+        sub_prim = stage.GetPrimAtPath(prim_path)
+        assert sub_prim, f"No prim found at path {prim_path}"
+        bbox = compute_local_bounding_box_from_prim(stage, prim_path)
+        time_code = Usd.TimeCode.Default()
+        sub_world = UsdGeom.Xformable(sub_prim).ComputeLocalToWorldTransform(time_code).ExtractTranslation()
+        root_world = UsdGeom.Xformable(default_prim).ComputeLocalToWorldTransform(time_code).ExtractTranslation()
+        bbox = bbox.translated((
+            float(sub_world[0] - root_world[0]),
+            float(sub_world[1] - root_world[1]),
+            float(sub_world[2] - root_world[2]),
+        ))
 
     usd_scale = _read_default_prim_scale(default_prim)
     assert not any(

--- a/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_pick_mustard_to_bowl
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+background:
+  id: kitchen
+  registry_name: lightwheel_robocasa_kitchen
+  params: {}
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: right_counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry_right
+  object_type: base
+  params: {}
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: right_counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: right_counter_top
+  params:
+    side: negative_y
+    distance_m: 0.1
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: mustard_bottle
+  reference: right_counter_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: right_counter_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
@@ -9,6 +9,7 @@ embodiment:
   registry_name: droid_abs_joint_pos
   params:
     stand_height_m: 0.8
+    placement_bbox_stand_only: true
 background:
   id: kitchen
   registry_name: lightwheel_robocasa_kitchen


### PR DESCRIPTION
## Summary
Lightwheel kitchen pick and place YAML 

## Detailed description
- Add `droid_pick_and_place_lightwheel_kitchen.yaml` with relation-placed Droid, mustard, and bowl on the Lightwheel Robocasa kitchen
- Use stand-only placement bbox for Droid until full robot+stand mesh extraction is supported

Baseline:
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/2b1e6b81-2372-41ef-86a4-0965fc1b3d49" />

Droid bbox for stand only:
<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/5035e348-2483-491a-bbe2-1cfc9a848ba2" />

