### PR TITLE
Add SimReady search to agentic environment generation.

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -12,6 +12,15 @@ from typing import Any
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import InferenceBackend
 from isaaclab_arena.agentic_environment_generation.prim_path_inference import PrimPathInference
+from isaaclab_arena.agentic_environment_generation.prompt_normalization import (
+    PromptNormalizationInference,
+    format_normalized_prompt_block,
+)
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
+    SimReadyCandidateCatalogue,
+    SimReadySearchConfig,
+    search_simready_objects,
+)
 from isaaclab_arena.agentic_environment_generation.spec_inference import SpecInference
 from isaaclab_arena.agentic_environment_generation.spec_validation import required_task_init_param_names
 from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
@@ -34,6 +43,9 @@ class EnvironmentGenerationAgent:
         temperature: float = 0.2,
         max_tokens: int = 4096,
         max_retries: int = 3,
+        *,
+        enable_simready_search: bool = False,
+        simready_config: SimReadySearchConfig | None = None,
     ):
         """Configure the OpenAI-compatible client and validate the model.
 
@@ -51,6 +63,8 @@ class EnvironmentGenerationAgent:
             max_retries: Number of additional attempts after a recoverable failure
                 (network errors, timeouts, empty responses, malformed JSON). Each
                 retry is a fresh API call.
+            enable_simready_search: When ``True``, run SimReady search on normalized object phrases.
+            simready_config: Optional SimReady search configuration.
         """
         inference_backend = InferenceBackend(
             api_key=api_key,
@@ -60,8 +74,11 @@ class EnvironmentGenerationAgent:
             max_tokens=max_tokens,
             max_retries=max_retries,
         )
+        self.prompt_normalization = PromptNormalizationInference(inference_backend)
         self.spec_inference = SpecInference(inference_backend)
         self.prim_path_inference = PrimPathInference(inference_backend)
+        self.enable_simready_search = enable_simready_search
+        self.simready_config = simready_config or SimReadySearchConfig(enabled=enable_simready_search)
         self._traces: list[str] = []
 
     @property
@@ -75,6 +92,8 @@ class EnvironmentGenerationAgent:
         asset_catalog: AssetCatalogue | None = None,
         relation_catalog: RelationCatalogue | None = None,
         task_catalog: TaskCatalogue | None = None,
+        *,
+        enable_simready_search: bool | None = None,
     ) -> tuple[ArenaEnvGraphSpec | None, dict[str, Any] | None]:
         """Call the model with user prompt and return the parsed ArenaEnvGraphSpec.
 
@@ -86,6 +105,7 @@ class EnvironmentGenerationAgent:
                 from the live ``ObjectRelationLibraryRegistry``.
             task_catalog: Pre-built task vocabulary. When ``None``, built from
                 ``TaskRegistry`` tasks marked ``@agent_ready``.
+            enable_simready_search: Override the agent-level SimReady search flag.
 
         Returns:
             A ``(spec, data)`` tuple. On success, ``spec`` is validated and
@@ -93,6 +113,32 @@ class EnvironmentGenerationAgent:
             When validation fails, ``agent.traces`` holds the diagnostic trace.
         """
         self._traces = []
+        normalized = self.prompt_normalization.infer(prompt, self._traces)
+        if normalized is None:
+            return None, None
+
+        normalized_block = format_normalized_prompt_block(normalized)
+        self._traces.append(normalized_block)
+
+        use_simready = self.enable_simready_search if enable_simready_search is None else enable_simready_search
+        simready_catalog: SimReadyCandidateCatalogue | None = None
+        if use_simready:
+            simready_config = SimReadySearchConfig(
+                enabled=True,
+                source=self.simready_config.source,
+                s3_url=self.simready_config.s3_url,
+                service_url=self.simready_config.service_url,
+                project_config_path=self.simready_config.project_config_path,
+                indexed_path=self.simready_config.indexed_path,
+                indexed_directory_type=self.simready_config.indexed_directory_type,
+                max_results_per_object=self.simready_config.max_results_per_object,
+                use_service_fallback=self.simready_config.use_service_fallback,
+            )
+            simready_catalog = search_simready_objects(normalized.objects, simready_config, self._traces)
+            simready_block = simready_catalog.to_catalog_string()
+            if simready_block:
+                self._traces.append(simready_block)
+
         asset_catalog = asset_catalog or build_asset_catalogue()
         relation_catalog = relation_catalog or build_relation_catalogue()
         task_catalog = task_catalog or build_task_catalogue()
@@ -102,6 +148,8 @@ class EnvironmentGenerationAgent:
             asset_catalog=asset_catalog,
             relation_catalog=relation_catalog,
             task_catalog=task_catalog,
+            normalized_prompt_block=normalized_block,
+            simready_candidate_catalog=simready_catalog,
         )
         if spec is None:
             return None, data

--- a/isaaclab_arena/agentic_environment_generation/prompt_normalization.py
+++ b/isaaclab_arena/agentic_environment_generation/prompt_normalization.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""LLM inference to normalize user prompts before spec generation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ValidationError
+
+from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    InferenceBackend,
+    StructuredOutputRequest,
+    build_strict_schema,
+)
+from isaaclab_arena.agentic_environment_generation.spec_validation import format_validation_error
+
+
+class NormalizedPromptDescriptions(BaseModel):
+    """Structured descriptions for each ArenaEnvGraphSpec section."""
+
+    env_name: str = Field(
+        min_length=1,
+        description="Short snake_case label summarizing the scene and tasks.",
+    )
+    embodiment: str = Field(
+        min_length=1,
+        description="Robot/embodiment intent in plain language (family, control mode, cameras).",
+    )
+    background: str = Field(
+        min_length=1,
+        description="Static scene/background intent in plain language.",
+    )
+    object_references: str = Field(
+        default="",
+        description=(
+            "Optional surfaces or appliances inside the background that should become "
+            "object_reference nodes; empty when none are needed."
+        ),
+    )
+    objects: list[str] = Field(
+        default_factory=list,
+        description=(
+            "One short search phrase per manipulable object or distractor, e.g. 'red hammer' or 'ceramic bowl'."
+        ),
+    )
+    relations: str = Field(
+        default="",
+        description="Spatial layout intent in plain language (on/next_to/anchor).",
+    )
+    task: str = Field(
+        min_length=1,
+        description="Overall manipulation task intent in plain language.",
+    )
+
+
+def format_normalized_prompt_block(normalized: NormalizedPromptDescriptions) -> str:
+    """Format normalized descriptions for downstream LLM prompts."""
+    object_lines = "\n".join(f"- {phrase}" for phrase in normalized.objects) or "- (none)"
+    refs = normalized.object_references.strip() or "(none)"
+    relations = normalized.relations.strip() or "(none)"
+    return (
+        "NORMALIZED PROMPT:\n"
+        f"env_name: {normalized.env_name}\n"
+        f"embodiment: {normalized.embodiment}\n"
+        f"background: {normalized.background}\n"
+        f"object_references: {refs}\n"
+        f"objects:\n{object_lines}\n"
+        f"relations: {relations}\n"
+        f"task: {normalized.task}"
+    )
+
+
+class PromptNormalizationInference:
+    """Natural-language prompt -> normalized section descriptions."""
+
+    def __init__(self, inference_backend: InferenceBackend):
+        """Wire prompt normalization to a structured-output backend.
+
+        Args:
+            inference_backend: Shared LLM client for JSON-schema completion requests.
+        """
+        self._inference_backend = inference_backend
+        self._schema = build_strict_schema(NormalizedPromptDescriptions)
+
+    def infer(self, prompt: str, traces: list[str]) -> NormalizedPromptDescriptions | None:
+        """Normalize a user prompt into section descriptions for later inference passes.
+
+        Args:
+            prompt: End-user environment description.
+            traces: Accumulator for validation error lines, extended in place on failure.
+
+        Returns:
+            Validated normalized descriptions on success, otherwise ``None``.
+        """
+        data = self._inference_backend.run_json(
+            StructuredOutputRequest(
+                schema_name="NormalizedPromptDescriptions",
+                schema=self._schema,
+                system=self._system_prompt(),
+                user=f"USER PROMPT:\n{prompt.strip()}",
+                retry_label="normalize_prompt",
+            )
+        )
+        try:
+            return NormalizedPromptDescriptions.model_validate(data)
+        except ValidationError as exc:
+            traces.extend(format_validation_error(exc))
+            return None
+
+    @staticmethod
+    def _system_prompt() -> str:
+        return """\
+You normalize robot environment-generation prompts into structured descriptions.
+Do not choose registry asset names. Describe intent only.
+
+GUIDANCE:
+- ``env_name`` should be short snake_case summarizing the scene and task.
+- ``objects`` must list one short search phrase per distinct manipulable object or distractor.
+  Keep phrases compact and visual, e.g. "red hammer", "blue bowl", "spring clamp".
+- Leave ``object_references`` empty unless the prompt explicitly mentions a surface or appliance
+  inside the background (counter top, fridge door, table surface).
+- ``relations`` should capture placement intent (what sits on what, next_to sides, anchor surface).
+- ``task`` should summarize the robot's goal in one or two sentences.
+"""

--- a/isaaclab_arena/agentic_environment_generation/prompt_normalization.py
+++ b/isaaclab_arena/agentic_environment_generation/prompt_normalization.py
@@ -35,8 +35,9 @@ class NormalizedPromptDescriptions(BaseModel):
     object_references: str = Field(
         default="",
         description=(
-            "Optional surfaces or appliances inside the background that should become "
-            "object_reference nodes; empty when none are needed."
+            "Optional named sub-parts inside a multi-prim background (e.g. counter top, "
+            "fridge door) that should become object_reference nodes; empty when none are needed. "
+            "Do not list the background itself (e.g. 'maple table') here."
         ),
     )
     objects: list[str] = Field(
@@ -119,8 +120,13 @@ GUIDANCE:
 - ``env_name`` should be short snake_case summarizing the scene and task.
 - ``objects`` must list one short search phrase per distinct manipulable object or distractor.
   Keep phrases compact and visual, e.g. "red hammer", "blue bowl", "spring clamp".
-- Leave ``object_references`` empty unless the prompt explicitly mentions a surface or appliance
-  inside the background (counter top, fridge door, table surface).
+- Put the scene/table/room name in ``background`` only (e.g. "maple table", "kitchen").
+  Naming the background is not an ``object_references`` cue — the background asset itself is
+  the resting surface, so leave ``object_references`` empty for prompts like
+  "on the maple table" or "from the maple table".
+- Leave ``object_references`` empty unless the prompt names a distinct sub-part or appliance
+  *inside* a multi-prim background (e.g. "counter top", "fridge door", "microwave door").
+  Do not invent a table-surface reference for a table background.
 - ``relations`` should capture placement intent (what sits on what, next_to sides, anchor surface).
 - ``task`` should summarize the robot's goal in one or two sentences.
 """

--- a/isaaclab_arena/agentic_environment_generation/simready_asset_search.py
+++ b/isaaclab_arena/agentic_environment_generation/simready_asset_search.py
@@ -160,7 +160,7 @@ async def _search_phrase_async(
 ) -> list[SimReadyObjectCandidate]:
     from simready.search import AssetLibrary, SearchFilterPhrase
 
-    matches = library.search(include_all=_phrase_path_filters(phrase))
+    matches = library.search(include_any=_phrase_path_filters(phrase))
     if not matches and use_service_phrase:
         service_library = AssetLibrary()
         service_library.add_service_source(service_url)

--- a/isaaclab_arena/agentic_environment_generation/simready_asset_search.py
+++ b/isaaclab_arena/agentic_environment_generation/simready_asset_search.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SimReady asset search for agentic environment generation."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+SIMREADY_USD_OBJECT_REGISTRY_NAME = "simready_usd_object"
+
+ISAAC_SIMREADY_GA_S3_URL = (
+    "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/SimReady"
+)
+DEFAULT_SIMREADY_SERVICE_URL = "https://search.simready.omniverse.nvidia.com/"
+
+
+class SimReadySourceKind(str, Enum):
+    """Configured SimReady search backend."""
+
+    ISAAC_SIM_GA = "isaac-sim-ga"
+    S3 = "s3"
+    SERVICE = "service"
+    CACHE = "cache"
+    INDEXED = "indexed"
+
+
+@dataclass
+class SimReadySearchConfig:
+    """Configuration for SimReady object lookup."""
+
+    enabled: bool = False
+    source: SimReadySourceKind = SimReadySourceKind.ISAAC_SIM_GA
+    s3_url: str = ISAAC_SIMREADY_GA_S3_URL
+    service_url: str = DEFAULT_SIMREADY_SERVICE_URL
+    project_config_path: str | None = None
+    indexed_path: str | None = None
+    indexed_directory_type: str = "local"
+    max_results_per_object: int = 1
+    use_service_fallback: bool = False
+
+
+@dataclass(frozen=True)
+class SimReadyObjectCandidate:
+    """One SimReady search hit exposed to spec inference."""
+
+    search_phrase: str
+    usd_path: str
+    tags: tuple[str, ...] = ("sim-ready",)
+    relevance_score: float | None = None
+
+    @property
+    def registry_name(self) -> str:
+        return SIMREADY_USD_OBJECT_REGISTRY_NAME
+
+    def params(self) -> dict[str, Any]:
+        return {"usd_path": self.usd_path, "tags": list(self.tags)}
+
+
+@dataclass
+class SimReadyCandidateCatalogue:
+    """Prompt-scoped SimReady hits for spec inference."""
+
+    candidates: list[SimReadyObjectCandidate] = field(default_factory=list)
+
+    def to_catalog_string(self) -> str:
+        """Format candidates as the SIMREADY_OBJECT_CANDIDATES prompt block."""
+        if not self.candidates:
+            return ""
+        lines = [
+            f"SIMREADY_OBJECT_CANDIDATES ({len(self.candidates)}):",
+            (
+                "When a desired object matches a candidate below, use "
+                f"registry_name={SIMREADY_USD_OBJECT_REGISTRY_NAME!r} and copy params exactly."
+            ),
+        ]
+        for index, candidate in enumerate(self.candidates, start=1):
+            tag_text = ", ".join(candidate.tags)
+            score = f" relevance={candidate.relevance_score:.2f}" if candidate.relevance_score is not None else ""
+            lines.append(
+                f"- candidate_{index}: requested_object={candidate.search_phrase!r}{score}\n"
+                f"  registry_name: {candidate.registry_name}\n"
+                "  params:\n"
+                f"    usd_path: {candidate.usd_path}\n"
+                f"    tags: [{tag_text}]"
+            )
+        return "\n".join(lines)
+
+
+def _slugify_phrase(phrase: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", phrase.strip().lower()).strip("_")
+    return slug or "object"
+
+
+def _phrase_path_filters(phrase: str) -> list[Any]:
+    from simready.search import SearchFilterPathContains
+
+    words = [word for word in re.split(r"\s+", phrase.strip().lower()) if word]
+    if not words:
+        return [SearchFilterPathContains(phrase)]
+    return [SearchFilterPathContains(word) for word in words]
+
+
+def _select_matches(matches: list[Any], max_results: int) -> list[Any]:
+    if not matches:
+        return []
+    if matches and getattr(matches[0], "relevance_score", None) is not None:
+        matches = sorted(
+            matches,
+            key=lambda match: match.relevance_score if match.relevance_score is not None else 0.0,
+            reverse=True,
+        )
+    return matches[:max_results]
+
+
+async def _configure_asset_library(config: SimReadySearchConfig, traces: list[str]) -> Any | None:
+    try:
+        from simready.search import AssetLibrary
+    except ImportError:
+        traces.append("simready-search is not installed; install with pip install 'isaaclab_arena[simready]'")
+        return None
+
+    library = AssetLibrary()
+    source = config.source
+    if source == SimReadySourceKind.ISAAC_SIM_GA:
+        await library.add_s3_source(config.s3_url or ISAAC_SIMREADY_GA_S3_URL)
+        return library
+    if source == SimReadySourceKind.S3:
+        assert config.s3_url, "simready s3 source requires s3_url"
+        await library.add_s3_source(config.s3_url)
+        return library
+    if source == SimReadySourceKind.SERVICE:
+        library.add_service_source(config.service_url or DEFAULT_SIMREADY_SERVICE_URL)
+        return library
+    if source == SimReadySourceKind.CACHE:
+        assert config.project_config_path, "simready cache source requires project_config_path"
+        await library.add_cache_source(config.project_config_path)
+        return library
+    if source == SimReadySourceKind.INDEXED:
+        assert config.indexed_path, "simready indexed source requires indexed_path"
+        await library.add_indexed_source(config.indexed_path, config.indexed_directory_type)
+        return library
+    traces.append(f"unknown simready source: {source}")
+    return None
+
+
+async def _search_phrase_async(
+    library: Any,
+    phrase: str,
+    *,
+    use_service_phrase: bool,
+    service_url: str,
+    max_results: int,
+) -> list[SimReadyObjectCandidate]:
+    from simready.search import AssetLibrary, SearchFilterPhrase
+
+    matches = library.search(include_all=_phrase_path_filters(phrase))
+    if not matches and use_service_phrase:
+        service_library = AssetLibrary()
+        service_library.add_service_source(service_url)
+        matches = service_library.search(include_all=[SearchFilterPhrase(phrase)])
+
+    candidates: list[SimReadyObjectCandidate] = []
+    for match in _select_matches(matches, max_results):
+        usd_path = str(match.asset_path)
+        tags = ("sim-ready", *_slugify_phrase(phrase).split("_"))
+        tags = tuple(dict.fromkeys(tag for tag in tags if tag))
+        candidates.append(
+            SimReadyObjectCandidate(
+                search_phrase=phrase,
+                usd_path=usd_path,
+                tags=tags,
+                relevance_score=getattr(match, "relevance_score", None),
+            )
+        )
+    return candidates
+
+
+async def search_simready_objects_async(
+    object_phrases: list[str],
+    config: SimReadySearchConfig,
+    traces: list[str],
+) -> SimReadyCandidateCatalogue:
+    """Query SimReady for each normalized object phrase."""
+    phrases = [phrase.strip() for phrase in object_phrases if phrase.strip()]
+    if not phrases:
+        return SimReadyCandidateCatalogue()
+
+    library = await _configure_asset_library(config, traces)
+    if library is None:
+        return SimReadyCandidateCatalogue()
+
+    candidates: list[SimReadyObjectCandidate] = []
+    for phrase in phrases:
+        try:
+            hits = await _search_phrase_async(
+                library,
+                phrase,
+                use_service_phrase=config.use_service_fallback or config.source == SimReadySourceKind.SERVICE,
+                service_url=config.service_url,
+                max_results=config.max_results_per_object,
+            )
+        except Exception as exc:
+            traces.append(f"simready search failed for {phrase!r}: {exc}")
+            continue
+        if not hits:
+            traces.append(f"simready search returned no matches for {phrase!r}")
+            continue
+        candidates.extend(hits)
+
+    return SimReadyCandidateCatalogue(candidates=candidates)
+
+
+def search_simready_objects(
+    object_phrases: list[str],
+    config: SimReadySearchConfig,
+    traces: list[str],
+) -> SimReadyCandidateCatalogue:
+    """Synchronous wrapper around :func:`search_simready_objects_async`."""
+    return asyncio.run(search_simready_objects_async(object_phrases, config, traces))
+
+
+def simready_search_config_from_cli(
+    *,
+    enabled: bool,
+    source: str,
+    s3_url: str | None,
+    service_url: str | None,
+    project_config_path: str | None,
+    indexed_path: str | None,
+    max_results_per_object: int,
+    use_service_fallback: bool,
+) -> SimReadySearchConfig:
+    """Build :class:`SimReadySearchConfig` from CLI/GUI arguments."""
+    return SimReadySearchConfig(
+        enabled=enabled,
+        source=SimReadySourceKind(source),
+        s3_url=s3_url or ISAAC_SIMREADY_GA_S3_URL,
+        service_url=service_url or DEFAULT_SIMREADY_SERVICE_URL,
+        project_config_path=project_config_path,
+        indexed_path=indexed_path,
+        max_results_per_object=max_results_per_object,
+        use_service_fallback=use_service_fallback,
+    )

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -133,8 +133,10 @@ GUIDANCE:
   variance of that family in EMBODIMENTS, pick the one with the default tag.
 - For multiple instances of the same registry asset, use semantic (left/right) or numerical (1/2/3)
   suffixes in ``id``.
-- Only populate ``object_references`` when the prompt explicitly mentions surfaces or appliances
-  inside the background; otherwise leave it unset.
+- Only populate ``object_references`` when the prompt (or NORMALIZED PROMPT) names a distinct
+  sub-part or appliance *inside* a multi-prim background (e.g. counter top, fridge door).
+  A background name such as "maple table" is the resting surface itself — do not add an
+  ``object_reference`` for it; anchor ``is_anchor`` on the background asset instead.
 - For each ``object_reference``, leave ``prim_path`` empty.
 - REQUIRED: include an ``is_anchor`` relation on the resting surface (background or an
   ``object_reference`` within it).

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -16,6 +16,7 @@ from isaaclab_arena.agentic_environment_generation.inference_backend import (
     StructuredOutputRequest,
     build_strict_schema,
 )
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import SIMREADY_USD_OBJECT_REGISTRY_NAME
 from isaaclab_arena.agentic_environment_generation.spec_validation import (
     collect_agent_ready_task_validation_traces,
     format_validation_error,
@@ -37,6 +38,9 @@ class SpecInference:
         asset_catalog: Any,
         relation_catalog: Any,
         task_catalog: Any,
+        *,
+        normalized_prompt_block: str | None = None,
+        simready_candidate_catalog: Any | None = None,
     ) -> tuple[ArenaEnvGraphSpec | None, dict[str, Any]]:
         """Generate an ArenaEnvGraphSpec from a natural-language prompt.
 
@@ -46,6 +50,8 @@ class SpecInference:
             asset_catalog: Embodiment, background, and object vocabulary for the user message.
             relation_catalog: Relation vocabulary for the user message.
             task_catalog: Task vocabulary for the user message.
+            normalized_prompt_block: Optional normalized section descriptions from pass 0.
+            simready_candidate_catalog: Optional SimReady hits for prompt-scoped object params.
 
         Returns:
             A ``(spec, data)`` tuple. On success, ``spec`` is validated and ``data`` is the
@@ -56,12 +62,14 @@ class SpecInference:
             StructuredOutputRequest(
                 schema_name="ArenaEnvGraphSpec",
                 schema=self._schema,
-                system=self._system_prompt(),
+                system=self._system_prompt(has_simready_candidates=bool(simready_candidate_catalog)),
                 user=self._user_message(
                     prompt,
                     asset_catalog,
                     relation_catalog,
                     task_catalog,
+                    normalized_prompt_block=normalized_prompt_block,
+                    simready_candidate_catalog=simready_candidate_catalog,
                 ),
                 retry_label="generate_spec",
             )
@@ -80,17 +88,36 @@ class SpecInference:
         asset_catalog: Any,
         relation_catalog: Any,
         task_catalog: Any,
+        *,
+        normalized_prompt_block: str | None = None,
+        simready_candidate_catalog: Any | None = None,
     ) -> str:
-        vocabulary = (
-            f"{asset_catalog.to_catalog_string()}\n\n"
-            f"{relation_catalog.to_catalog_string()}\n\n"
-            f"{task_catalog.to_catalog_string()}"
-        )
+        blocks = [
+            asset_catalog.to_catalog_string(),
+            relation_catalog.to_catalog_string(),
+            task_catalog.to_catalog_string(),
+        ]
+        if simready_candidate_catalog is not None:
+            simready_block = simready_candidate_catalog.to_catalog_string()
+            if simready_block:
+                blocks.append(simready_block)
+        if normalized_prompt_block:
+            blocks.append(normalized_prompt_block)
+        vocabulary = "\n\n".join(blocks)
         return f"{vocabulary}\n\nUSER PROMPT:\n{prompt}"
 
     @staticmethod
-    def _system_prompt() -> str:
-        return """\
+    def _system_prompt(*, has_simready_candidates: bool = False) -> str:
+        simready_rules = ""
+        if has_simready_candidates:
+            simready_rules = f"""
+- When an object matches a SIMREADY_OBJECT_CANDIDATES entry, use
+  ``registry_name: {SIMREADY_USD_OBJECT_REGISTRY_NAME!r}`` and copy that candidate's
+  ``params`` exactly (including ``usd_path`` and ``tags``).
+- Prefer a SimReady candidate over inventing a new OBJECTS registry name when the candidate
+  clearly matches the requested object phrase.
+"""
+        return f"""\
 You are an environment-generator for robot manipulation tasks.
 Convert a natural-language prompt into an ArenaEnvGraphSpec.
 
@@ -112,4 +139,4 @@ GUIDANCE:
 - REQUIRED: include an ``is_anchor`` relation on the resting surface (background or an
   ``object_reference`` within it).
 - All objects need an ``on`` relation with that anchor as ``reference``.
-"""
+{simready_rules}"""

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -98,7 +98,13 @@ class Object(ObjectBase):
         # to add the contact sensor is not yet supported for ObjectReferences and RigidObjectSet.
         # For these objects we just (try to) add the contact sensor to the root prim.
         usd_path = usd_path or self.usd_path
-        rigid_body_relative_path = find_shallowest_rigid_body(usd_path, relative_to_root=True)
+        spawn_variants = (self.spawn_cfg_addon or {}).get("variants")
+        rigid_body_relative_path = find_shallowest_rigid_body(
+            usd_path,
+            relative_to_root=True,
+            variants=spawn_variants,
+            prefer_body_when_tied=bool(spawn_variants),
+        )
         assert (
             rigid_body_relative_path is not None
         ), f"No rigid body found in {self.name} USD file: {usd_path}. Can't add contact sensor."
@@ -112,8 +118,12 @@ class Object(ObjectBase):
             assert (
                 contact_against_object.object_type == ObjectType.RIGID
             ), "Contact sensor is only supported for rigid objects"
+            against_variants = (contact_against_object.spawn_cfg_addon or {}).get("variants")
             contact_against_relative_path = find_shallowest_rigid_body(
-                contact_against_object.usd_path, relative_to_root=True
+                contact_against_object.usd_path,
+                relative_to_root=True,
+                variants=against_variants,
+                prefer_body_when_tied=bool(against_variants),
             )
             assert contact_against_relative_path is not None, (
                 f"No rigid body found in {contact_against_object.name} USD file: {contact_against_object.usd_path}."

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -375,6 +375,7 @@ def ensure_assets_registered():
         import isaaclab_arena.assets.hdr_image_library  # noqa: F401
         import isaaclab_arena.assets.object_library  # noqa: F401
         import isaaclab_arena.assets.retargeter_library  # noqa: F401
+        import isaaclab_arena.assets.simready_object_library  # noqa: F401
         import isaaclab_arena.embodiments  # noqa: F401
         import isaaclab_arena.policy  # noqa: F401
         import isaaclab_arena.relations.relations  # noqa: F401

--- a/isaaclab_arena/assets/simready_object_library.py
+++ b/isaaclab_arena/assets/simready_object_library.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic SimReady USD object registered for agent-generated environments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from isaaclab_arena.assets.object import Object
+from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.utils.pose import Pose
+
+
+@register_asset
+class SimReadyUsdObject(Object):
+    """Spawn a SimReady asset from an explicit USD path supplied in graph params."""
+
+    name = "simready_usd_object"
+    tags = ["object", "sim-ready"]
+    object_type = ObjectType.RIGID
+
+    def __init__(
+        self,
+        usd_path: str,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | None = None,
+        scale: tuple[float, float, float] | None = None,
+        **kwargs: Any,
+    ):
+        assert usd_path, "simready_usd_object requires params.usd_path"
+        kwargs.pop("tags", None)
+        super().__init__(
+            name=instance_name or self.name,
+            prim_path=prim_path,
+            tags=self.tags,
+            usd_path=usd_path,
+            object_type=self.object_type,
+            scale=scale if scale is not None else (1.0, 1.0, 1.0),
+            initial_pose=initial_pose,
+            **kwargs,
+        )

--- a/isaaclab_arena/assets/simready_object_library.py
+++ b/isaaclab_arena/assets/simready_object_library.py
@@ -14,6 +14,11 @@ from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
 
+# SimReady GA props author collision/rigid APIs under the Physics=physics variant.
+# Without this selection, Usd.Stage.Open sees geometry but no RigidBodyAPI, and
+# PickAndPlace contact sensors fail with "No rigid body found".
+SIMREADY_PHYSICS_VARIANTS: dict[str, str] = {"Physics": "physics"}
+
 
 @register_asset
 class SimReadyUsdObject(Object):
@@ -34,6 +39,8 @@ class SimReadyUsdObject(Object):
     ):
         assert usd_path, "simready_usd_object requires params.usd_path"
         kwargs.pop("tags", None)
+        spawn_cfg_addon = dict(kwargs.pop("spawn_cfg_addon", None) or {})
+        spawn_cfg_addon.setdefault("variants", dict(SIMREADY_PHYSICS_VARIANTS))
         super().__init__(
             name=instance_name or self.name,
             prim_path=prim_path,
@@ -42,5 +49,6 @@ class SimReadyUsdObject(Object):
             object_type=self.object_type,
             scale=scale if scale is not None else (1.0, 1.0, 1.0),
             initial_pose=initial_pose,
+            spawn_cfg_addon=spawn_cfg_addon,
             **kwargs,
         )

--- a/isaaclab_arena/scripts/list_simready_unmatched_assets.py
+++ b/isaaclab_arena/scripts/list_simready_unmatched_assets.py
@@ -1,0 +1,295 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""List SimReady GA props with no plausible match in the Arena asset registry.
+
+Usage (inside the dev container)::
+
+    /isaac-sim/python.sh isaaclab_arena/scripts/list_simready_unmatched_assets.py \\
+        --out isaaclab_arena_environments/agent_generated/simready_unmatched_assets.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import ISAAC_SIMREADY_GA_S3_URL
+from isaaclab_arena.assets.registries import AssetRegistry, ensure_assets_registered
+
+_STOPWORDS = {
+    "a01",
+    "a02",
+    "a03",
+    "b01",
+    "robolab",
+    "ycb",
+    "hot3d",
+    "handal",
+    "physics",
+    "axis",
+    "aligned",
+    "instanceable",
+    "sm",
+    "usd",
+    "usda",
+    "usdz",
+    "isaac",
+    "simready",
+    "assets",
+    "object",
+    "objects",
+    "library",
+    "arena",
+    "srl",
+    "props",
+    "industrial",
+    "residential",
+    "equipment",
+    "warehouse",
+    "kitchen",
+    "food",
+    "dish",
+    "machine",
+    "machines",
+    "hardware",
+    "tools",
+    "vehicle",
+    "component",
+    "components",
+}
+
+
+@dataclass(frozen=True)
+class ArenaObjectRecord:
+    """One registered Arena pick-up object."""
+
+    registry_name: str
+    usd_path: str
+    basename: str
+    tokens: frozenset[str]
+
+
+@dataclass(frozen=True)
+class SimReadyRecord:
+    """One SimReady GA prop."""
+
+    usd_path: str
+    rel_path: str
+    label: str
+    tokens: frozenset[str]
+
+
+def _tokenize(text: str) -> set[str]:
+    text = unquote(text).lower()
+    text = re.sub(r"([a-z])([A-Z])", r"\1 \2", text)
+    parts = re.split(r"[^a-z0-9]+", text)
+    return {part for part in parts if len(part) >= 3 and part not in _STOPWORDS}
+
+
+def _basename(path: str) -> str:
+    return Path(unquote(path)).name.lower()
+
+
+def _resolve_usd_path(cls: type) -> str | None:
+    usd_path = getattr(cls, "usd_path", None)
+    if usd_path is None:
+        return None
+    if isinstance(usd_path, str):
+        return usd_path
+    if hasattr(usd_path, "get_path"):
+        try:
+            return str(usd_path.get_path())
+        except Exception:
+            return str(usd_path)
+    return str(usd_path)
+
+
+def _collect_arena_objects() -> list[ArenaObjectRecord]:
+    ensure_assets_registered()
+    registry = AssetRegistry()
+    records: list[ArenaObjectRecord] = []
+    for name in registry.get_all_keys():
+        cls = registry.get_asset_by_name(name)
+        tags = getattr(cls, "tags", None) or []
+        if "object" not in tags:
+            continue
+        usd_path = _resolve_usd_path(cls)
+        if not usd_path:
+            continue
+        basename = _basename(usd_path)
+        tokens = frozenset(_tokenize(f"{name} {usd_path} {basename}"))
+        records.append(
+            ArenaObjectRecord(
+                registry_name=name,
+                usd_path=usd_path,
+                basename=basename,
+                tokens=tokens,
+            )
+        )
+    return records
+
+
+def _simready_label(rel_path: str) -> str:
+    path = Path(rel_path)
+    if path.suffix.lower() in {".usd", ".usda", ".usdz"}:
+        parent = path.parent.name
+        if parent and parent not in {".", "/"}:
+            return parent
+    return path.stem
+
+
+_REGISTRY_SUFFIX_RE = re.compile(r"(_(?:robolab|ycb_robolab|hot3d_robolab|handal_robolab|fruits_veggies_robolab))+$")
+
+
+def _normalize_stem(name: str) -> str:
+    stem = Path(name).stem.lower()
+    stem = re.sub(r"^sm_", "", stem)
+    stem = re.sub(r"_[ab][0-9]{2}(_[0-9]{2})?$", "", stem)
+    stem = re.sub(r"_[0-9]+$", "", stem)
+    return stem
+
+
+def _registry_core_name(registry_name: str) -> str:
+    core = _REGISTRY_SUFFIX_RE.sub("", registry_name.lower())
+    core = re.sub(r"^[0-9]{3}_", "", core)
+    core = re.sub(r"[0-9]+$", "", core)
+    return core.strip("_")
+
+
+def _path_contains_token(path: str, token: str) -> bool:
+    if len(token) < 4:
+        return False
+    pattern = rf"(^|/|_|-){re.escape(token)}($|/|_|-|\.)"
+    return re.search(pattern, path.lower()) is not None
+
+
+def _has_arena_match(simready: SimReadyRecord, arena_objects: list[ArenaObjectRecord]) -> tuple[bool, str | None]:
+    """Return whether a SimReady asset plausibly matches any Arena registry object."""
+    simready_basename = _basename(simready.usd_path)
+    simready_stem = _normalize_stem(simready_basename)
+    simready_rel_lower = simready.rel_path.lower()
+
+    for arena in arena_objects:
+        if arena.basename == simready_basename:
+            return True, arena.registry_name
+
+        arena_stem = _normalize_stem(arena.basename)
+        if arena_stem and arena_stem == simready_stem:
+            return True, arena.registry_name
+
+        if arena_stem and len(arena_stem) >= 5:
+            if arena_stem in simready_basename or arena_stem in simready_rel_lower:
+                return True, arena.registry_name
+
+        core_name = _registry_core_name(arena.registry_name)
+        if len(core_name) >= 5 and _path_contains_token(simready_rel_lower, core_name):
+            return True, arena.registry_name
+
+        ycb_match = re.search(r"^[0-9]{3}_(.+)$", arena_stem)
+        if ycb_match:
+            ycb_object = ycb_match.group(1)
+            if ycb_object in simready_basename or ycb_object in simready_rel_lower:
+                return True, arena.registry_name
+
+    return False, None
+
+
+async def _collect_simready_assets() -> list[SimReadyRecord]:
+    from simready.search import AssetLibrary, SearchFilterPathContains
+
+    library = AssetLibrary()
+    await library.add_s3_source(ISAAC_SIMREADY_GA_S3_URL)
+    matches = library.search(include_all=[SearchFilterPathContains("SimReady")])
+    records: list[SimReadyRecord] = []
+    seen: set[str] = set()
+    prefix = "/Assets/Isaac/6.0/Isaac/SimReady/"
+    for match in matches:
+        usd_path = str(match.asset_path)
+        if usd_path in seen:
+            continue
+        seen.add(usd_path)
+        rel_path = usd_path.split(prefix, 1)[-1] if prefix in usd_path else usd_path
+        label = _simready_label(rel_path)
+        tokens = frozenset(_tokenize(f"{rel_path} {label} {usd_path}"))
+        records.append(
+            SimReadyRecord(
+                usd_path=usd_path,
+                rel_path=rel_path,
+                label=label,
+                tokens=tokens,
+            )
+        )
+    records.sort(key=lambda record: record.rel_path.lower())
+    return records
+
+
+async def main_async(out: Path) -> dict[str, Any]:
+    arena_objects = _collect_arena_objects()
+    simready_assets = await _collect_simready_assets()
+    unmatched: list[dict[str, Any]] = []
+    matched_examples: list[dict[str, str]] = []
+    for simready in simready_assets:
+        matched, registry_name = _has_arena_match(simready, arena_objects)
+        if matched:
+            if len(matched_examples) < 25:
+                matched_examples.append({
+                    "simready_label": simready.label,
+                    "simready_rel_path": simready.rel_path,
+                    "arena_registry_name": registry_name or "",
+                })
+            continue
+        unmatched.append({
+            "label": simready.label,
+            "rel_path": simready.rel_path,
+            "usd_path": simready.usd_path,
+        })
+    payload = {
+        "simready_source": ISAAC_SIMREADY_GA_S3_URL,
+        "arena_object_count": len(arena_objects),
+        "simready_asset_count": len(simready_assets),
+        "matched_count": len(simready_assets) - len(unmatched),
+        "unmatched_count": len(unmatched),
+        "matching_notes": (
+            "A SimReady asset is 'matched' only on strong signals: identical USD basename/stem, "
+            "Arena USD stem substring in the SimReady path, registry core name token in the "
+            "SimReady relative path, or YCB-style numbered object stem overlap. "
+            "Review borderline cases manually."
+        ),
+        "matched_examples": matched_examples,
+        "unmatched_assets": unmatched,
+    }
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    txt_path = out.with_suffix(".txt")
+    txt_lines = [f"{row['label']}\t{row['rel_path']}" for row in unmatched]
+    txt_path.write_text("\n".join(txt_lines) + "\n", encoding="utf-8")
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("isaaclab_arena_environments/agent_generated/simready_unmatched_assets.json"),
+        help="Output JSON path (a .txt tab-separated list is written alongside).",
+    )
+    args = parser.parse_args()
+    payload = asyncio.run(main_async(args.out))
+    print(
+        f"Wrote {payload['unmatched_count']} unmatched / {payload['simready_asset_count']} SimReady assets "
+        f"({payload['matched_count']} matched Arena registry objects) → {args.out}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -12,14 +12,20 @@ from unittest.mock import patch
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.environment_generation_agent import EnvironmentGenerationAgent
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
+    SimReadyCandidateCatalogue,
+    SimReadyObjectCandidate,
+)
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.environment_spec.arena_env_graph_types import TaskCompositionType
 from isaaclab_arena.tests.utils.agentic_environment_generation import (
     catalog,
     chat_response,
+    kitchen_normalized_dict,
     kitchen_pass1_dict,
     kitchen_prim_tree,
     kitchen_resolve_response,
+    minimal_normalized_dict,
     minimal_spec_dict,
     relation_catalog,
 )
@@ -47,7 +53,10 @@ def agent(stub_openai):
 class TestGenerateSpec:
     def test_builds_catalogues_from_singleton_registries_when_none(self, agent):
         agent_obj, client = agent
-        client.chat.completions.create.return_value = chat_response(content=json.dumps(minimal_spec_dict()))
+        client.chat.completions.create.side_effect = [
+            chat_response(content=json.dumps(minimal_normalized_dict())),
+            chat_response(content=json.dumps(minimal_spec_dict())),
+        ]
         with (
             patch(
                 "isaaclab_arena.agentic_environment_generation.environment_generation_agent.build_asset_catalogue",
@@ -74,6 +83,7 @@ class TestGenerateSpec:
         mock_resolve_usd.return_value = "/tmp/scene.usd"
         mock_load_tree.return_value = kitchen_prim_tree()
         client.chat.completions.create.side_effect = [
+            chat_response(content=json.dumps(kitchen_normalized_dict())),
             chat_response(content=json.dumps(kitchen_pass1_dict())),
             chat_response(content=json.dumps(kitchen_resolve_response())),
         ]
@@ -85,7 +95,7 @@ class TestGenerateSpec:
         )
         assert isinstance(spec, ArenaEnvGraphSpec)
         assert data is None
-        assert client.chat.completions.create.call_count == 2
+        assert client.chat.completions.create.call_count == 3
         assert spec.object_references
 
     @patch("isaaclab_arena.utils.usd_prim_tree.load_usd_prim_tree")
@@ -103,6 +113,7 @@ class TestGenerateSpec:
             }]
         }
         client.chat.completions.create.side_effect = [
+            chat_response(content=json.dumps(kitchen_normalized_dict())),
             chat_response(content=json.dumps(kitchen_pass1_dict())),
             chat_response(content=json.dumps(bad_resolve)),
         ]
@@ -114,8 +125,39 @@ class TestGenerateSpec:
         )
         assert spec is None
         assert isinstance(data, dict)
-        assert client.chat.completions.create.call_count == 2
+        assert client.chat.completions.create.call_count == 3
         assert any("is not in the background prim tree" in line for line in agent_obj.traces)
+
+    @patch("isaaclab_arena.agentic_environment_generation.environment_generation_agent.search_simready_objects")
+    def test_generate_spec_runs_normalization_then_simready_then_spec(self, mock_search, agent):
+        agent_obj, client = agent
+        mock_search.return_value = SimReadyCandidateCatalogue(
+            candidates=[
+                SimReadyObjectCandidate(
+                    search_phrase="red hammer",
+                    usd_path="s3://bucket/red_hammer.usd",
+                )
+            ]
+        )
+        agent_obj.enable_simready_search = True
+        client.chat.completions.create.side_effect = [
+            chat_response(content=json.dumps(minimal_normalized_dict())),
+            chat_response(content=json.dumps(minimal_spec_dict())),
+        ]
+        spec, data = agent_obj.generate_spec(
+            "p",
+            asset_catalog=catalog("catalog"),
+            relation_catalog=relation_catalog("RELATIONS"),
+            task_catalog=make_task_catalog("TASKS"),
+            enable_simready_search=True,
+        )
+        assert isinstance(spec, ArenaEnvGraphSpec)
+        assert data is None
+        mock_search.assert_called_once()
+        search_phrases = mock_search.call_args.args[0]
+        assert search_phrases == minimal_normalized_dict()["objects"]
+        assert any("SIMREADY_OBJECT_CANDIDATES" in line for line in agent_obj.traces)
+        assert client.chat.completions.create.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/tests/test_prompt_normalization.py
+++ b/isaaclab_arena/tests/test_prompt_normalization.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for prompt normalization inference."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from isaaclab_arena.agentic_environment_generation.prompt_normalization import (
+    NormalizedPromptDescriptions,
+    PromptNormalizationInference,
+    format_normalized_prompt_block,
+)
+from isaaclab_arena.tests.utils.agentic_environment_generation import (
+    chat_response,
+    inference_backend,
+    minimal_normalized_dict,
+)
+
+
+@pytest.fixture
+def prompt_normalization(stub_openai):
+    """A ``PromptNormalizationInference`` backed by a mocked OpenAI client."""
+    _, client = stub_openai
+    inference = PromptNormalizationInference(inference_backend(stub_openai))
+    return inference, client
+
+
+def test_infer_sets_response_format_to_json_schema(prompt_normalization):
+    inference, client = prompt_normalization
+    client.chat.completions.create.return_value = chat_response(content=json.dumps(minimal_normalized_dict()))
+    traces: list[str] = []
+    result = inference.infer("pick avocado", traces)
+    assert isinstance(result, NormalizedPromptDescriptions)
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert kwargs["response_format"]["type"] == "json_schema"
+    assert kwargs["response_format"]["json_schema"]["name"] == "NormalizedPromptDescriptions"
+    assert kwargs["response_format"]["json_schema"]["strict"] is True
+
+
+def test_infer_user_message_contains_prompt(prompt_normalization):
+    inference, client = prompt_normalization
+    client.chat.completions.create.return_value = chat_response(content=json.dumps(minimal_normalized_dict()))
+    inference.infer("user wants avocado on kitchen", [])
+    msgs = client.chat.completions.create.call_args.kwargs["messages"]
+    assert [m["role"] for m in msgs] == ["system", "user"]
+    assert "user wants avocado on kitchen" in msgs[1]["content"]
+
+
+def test_infer_returns_none_with_validation_traces_on_invalid_output(prompt_normalization):
+    inference, client = prompt_normalization
+    invalid = dict(minimal_normalized_dict())
+    invalid["env_name"] = ""
+    client.chat.completions.create.return_value = chat_response(content=json.dumps(invalid))
+    traces: list[str] = []
+    result = inference.infer("p", traces)
+    assert result is None
+    assert traces
+
+
+def test_format_normalized_prompt_block_lists_objects():
+    normalized = NormalizedPromptDescriptions.model_validate(minimal_normalized_dict())
+    block = format_normalized_prompt_block(normalized)
+    assert "NORMALIZED PROMPT:" in block
+    assert "avocado" in block
+    assert "bowl" in block

--- a/isaaclab_arena/tests/test_prompt_normalization.py
+++ b/isaaclab_arena/tests/test_prompt_normalization.py
@@ -69,3 +69,10 @@ def test_format_normalized_prompt_block_lists_objects():
     assert "NORMALIZED PROMPT:" in block
     assert "avocado" in block
     assert "bowl" in block
+
+
+def test_system_prompt_treats_maple_table_as_background_not_object_reference():
+    prompt = PromptNormalizationInference._system_prompt()
+    assert "maple table" in prompt
+    assert "background asset itself is" in prompt
+    assert "Do not invent a table-surface reference" in prompt

--- a/isaaclab_arena/tests/test_rigid_bodies.py
+++ b/isaaclab_arena/tests/test_rigid_bodies.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for rigid-body USD helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.utils.usd.rigid_bodies import find_shallowest_rigid_body, find_shallowest_rigid_body_from_stage
+
+
+def _write_physics_variant_usd(path: Path) -> None:
+    """Write a minimal USD with Physics variants and two same-depth rigid bodies."""
+    from pxr import Usd, UsdGeom, UsdPhysics
+
+    stage = Usd.Stage.CreateNew(str(path))
+    root = UsdGeom.Xform.Define(stage, "/Root")
+    stage.SetDefaultPrim(root.GetPrim())
+    variant_set = root.GetPrim().GetVariantSets().AddVariantSet("Physics")
+    variant_set.AddVariant("none")
+    variant_set.AddVariant("physics")
+    variant_set.SetVariantSelection("none")
+
+    variant_set.SetVariantSelection("physics")
+    with variant_set.GetVariantEditContext():
+        lid = UsdGeom.Xform.Define(stage, "/Root/Geometry/lid_obj")
+        UsdPhysics.RigidBodyAPI.Apply(lid.GetPrim())
+        body = UsdGeom.Xform.Define(stage, "/Root/Geometry/body_obj")
+        UsdPhysics.RigidBodyAPI.Apply(body.GetPrim())
+    variant_set.SetVariantSelection("none")
+    stage.GetRootLayer().Save()
+
+
+def test_find_shallowest_rigid_body_requires_physics_variant(tmp_path: Path):
+    usd_path = tmp_path / "prop.usda"
+    _write_physics_variant_usd(usd_path)
+
+    assert find_shallowest_rigid_body(str(usd_path)) is None
+    path = find_shallowest_rigid_body(
+        str(usd_path),
+        relative_to_root=True,
+        variants={"Physics": "physics"},
+        prefer_body_when_tied=True,
+    )
+    assert path == "/Geometry/body_obj"
+
+
+def test_find_shallowest_rigid_body_from_stage_raises_without_preference(tmp_path: Path):
+    from pxr import Usd
+
+    usd_path = tmp_path / "prop.usda"
+    _write_physics_variant_usd(usd_path)
+    stage = Usd.Stage.Open(str(usd_path))
+    stage.GetDefaultPrim().GetVariantSets().GetVariantSet("Physics").SetVariantSelection("physics")
+    with pytest.raises(ValueError, match="Expected only one"):
+        find_shallowest_rigid_body_from_stage(stage)

--- a/isaaclab_arena/tests/test_simready_asset_search.py
+++ b/isaaclab_arena/tests/test_simready_asset_search.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SimReady asset search."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
+    SIMREADY_USD_OBJECT_REGISTRY_NAME,
+    SimReadyCandidateCatalogue,
+    SimReadyObjectCandidate,
+    SimReadySearchConfig,
+    SimReadySourceKind,
+    search_simready_objects,
+    simready_search_config_from_cli,
+)
+
+
+class _FakeMatch:
+    def __init__(self, asset_path: str, relevance_score: float | None = None):
+        self.asset_path = asset_path
+        self.relevance_score = relevance_score
+
+
+class _FakeLibrary:
+    def __init__(self, matches: list[_FakeMatch] | None = None):
+        self._matches = matches or []
+
+    def search(self, include_all):
+        return list(self._matches)
+
+
+async def _fake_configure_library(config, traces):
+    return _FakeLibrary([_FakeMatch("s3://bucket/red_hammer.usd", relevance_score=0.95)])
+
+
+def test_simready_candidate_catalogue_to_catalog_string():
+    candidate = SimReadyObjectCandidate(
+        search_phrase="red hammer",
+        usd_path="s3://bucket/red_hammer.usd",
+        tags=("sim-ready", "red", "hammer"),
+        relevance_score=0.9,
+    )
+    block = SimReadyCandidateCatalogue(candidates=[candidate]).to_catalog_string()
+    assert "SIMREADY_OBJECT_CANDIDATES" in block
+    assert SIMREADY_USD_OBJECT_REGISTRY_NAME in block
+    assert "red hammer" in block
+    assert "s3://bucket/red_hammer.usd" in block
+
+
+def test_simready_search_config_from_cli_defaults():
+    config = simready_search_config_from_cli(
+        enabled=True,
+        source=SimReadySourceKind.ISAAC_SIM_GA.value,
+        s3_url=None,
+        service_url=None,
+        project_config_path=None,
+        indexed_path=None,
+        max_results_per_object=2,
+        use_service_fallback=False,
+    )
+    assert config.enabled is True
+    assert config.source == SimReadySourceKind.ISAAC_SIM_GA
+    assert config.max_results_per_object == 2
+
+
+@patch(
+    "isaaclab_arena.agentic_environment_generation.simready_asset_search._search_phrase_async",
+    new_callable=AsyncMock,
+)
+@patch(
+    "isaaclab_arena.agentic_environment_generation.simready_asset_search._configure_asset_library",
+    new_callable=AsyncMock,
+)
+def test_search_simready_objects_returns_candidates(mock_configure, mock_search_phrase):
+    mock_configure.return_value = _FakeLibrary()
+    mock_search_phrase.return_value = [
+        SimReadyObjectCandidate(
+            search_phrase="ceramic bowl",
+            usd_path="s3://bucket/bowl.usd",
+        )
+    ]
+    traces: list[str] = []
+    catalog = search_simready_objects(
+        ["ceramic bowl"],
+        SimReadySearchConfig(enabled=True, source=SimReadySourceKind.ISAAC_SIM_GA),
+        traces,
+    )
+    assert len(catalog.candidates) == 1
+    assert catalog.candidates[0].usd_path == "s3://bucket/bowl.usd"
+    assert catalog.candidates[0].registry_name == SIMREADY_USD_OBJECT_REGISTRY_NAME
+
+
+def test_configure_asset_library_records_missing_package():
+    import asyncio
+    import sys
+
+    from isaaclab_arena.agentic_environment_generation.simready_asset_search import _configure_asset_library
+
+    async def _run() -> tuple[object, list[str]]:
+        traces: list[str] = []
+        blocked = {
+            name: module for name, module in sys.modules.items() if name == "simready" or name.startswith("simready.")
+        }
+        for name in blocked:
+            del sys.modules[name]
+        try:
+            with patch.dict(sys.modules, {"simready": None, "simready.search": None}):
+                result = await _configure_asset_library(SimReadySearchConfig(enabled=True), traces)
+        finally:
+            sys.modules.update(blocked)
+        return result, traces
+
+    result, traces = asyncio.run(_run())
+    assert result is None
+    assert any("simready-search is not installed" in line for line in traces)
+
+
+@patch(
+    "isaaclab_arena.agentic_environment_generation.simready_asset_search._configure_asset_library",
+    new_callable=AsyncMock,
+)
+def test_search_simready_objects_returns_empty_when_library_unavailable(mock_configure):
+    mock_configure.return_value = None
+    traces: list[str] = []
+    catalog = search_simready_objects(
+        ["hammer"],
+        SimReadySearchConfig(enabled=True),
+        traces,
+    )
+    assert catalog.candidates == []
+
+
+@patch(
+    "isaaclab_arena.agentic_environment_generation.simready_asset_search._search_phrase_async",
+    new_callable=AsyncMock,
+)
+@patch(
+    "isaaclab_arena.agentic_environment_generation.simready_asset_search._configure_asset_library",
+    new_callable=AsyncMock,
+)
+def test_search_simready_objects_records_no_matches(mock_configure, mock_search_phrase):
+    mock_configure.return_value = _FakeLibrary()
+    mock_search_phrase.return_value = []
+    traces: list[str] = []
+    catalog = search_simready_objects(
+        ["missing object"],
+        SimReadySearchConfig(enabled=True),
+        traces,
+    )
+    assert catalog.candidates == []
+    assert any("no matches" in line for line in traces)

--- a/isaaclab_arena/tests/test_simready_asset_search.py
+++ b/isaaclab_arena/tests/test_simready_asset_search.py
@@ -30,7 +30,7 @@ class _FakeLibrary:
     def __init__(self, matches: list[_FakeMatch] | None = None):
         self._matches = matches or []
 
-    def search(self, include_all):
+    def search(self, include_all=None, include_any=None):
         return list(self._matches)
 
 

--- a/isaaclab_arena/tests/test_simready_object_library.py
+++ b/isaaclab_arena/tests/test_simready_object_library.py
@@ -29,3 +29,11 @@ def test_asset_spec_accepts_simready_usd_path():
     )
     assert spec.registry_name == "simready_usd_object"
     assert spec.params["usd_path"] == "https://example.com/hammer.usd"
+
+
+def test_simready_usd_object_enables_physics_variant_by_default():
+    ensure_assets_registered()
+    obj = SimReadyUsdObject(usd_path="https://example.com/kettle.usd", instance_name="kettle")
+    assert obj.spawn_cfg_addon["variants"] == {"Physics": "physics"}
+    spawn = obj._get_spawn_cfg(activate_contact_sensors=True)
+    assert spawn.variants == {"Physics": "physics"}

--- a/isaaclab_arena/tests/test_simready_object_library.py
+++ b/isaaclab_arena/tests/test_simready_object_library.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the generic SimReady USD object asset."""
+
+from __future__ import annotations
+
+from isaaclab_arena.assets.registries import AssetRegistry, ensure_assets_registered
+from isaaclab_arena.assets.simready_object_library import SimReadyUsdObject
+from isaaclab_arena.environment_spec.arena_env_graph_types import AssetSpec
+
+
+def test_simready_usd_object_registered():
+    ensure_assets_registered()
+    cls = AssetRegistry().get_asset_by_name("simready_usd_object")
+    assert cls is SimReadyUsdObject
+    assert cls.name == "simready_usd_object"
+    assert "sim-ready" in cls.tags
+
+
+def test_asset_spec_accepts_simready_usd_path():
+    ensure_assets_registered()
+    spec = AssetSpec(
+        id="hammer",
+        registry_name="simready_usd_object",
+        params={"usd_path": "https://example.com/hammer.usd", "tags": ["sim-ready", "hammer"]},
+    )
+    assert spec.registry_name == "simready_usd_object"
+    assert spec.params["usd_path"] == "https://example.com/hammer.usd"

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -12,12 +12,22 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from isaaclab_arena.agentic_environment_generation.prompt_normalization import (
+    NormalizedPromptDescriptions,
+    format_normalized_prompt_block,
+)
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
+    SIMREADY_USD_OBJECT_REGISTRY_NAME,
+    SimReadyCandidateCatalogue,
+    SimReadyObjectCandidate,
+)
 from isaaclab_arena.agentic_environment_generation.spec_inference import SpecInference
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.tests.utils.agentic_environment_generation import catalog as make_catalog
 from isaaclab_arena.tests.utils.agentic_environment_generation import (
     chat_response,
     inference_backend,
+    minimal_normalized_dict,
     minimal_spec_dict,
 )
 from isaaclab_arena.tests.utils.agentic_environment_generation import relation_catalog as make_relation_catalog
@@ -39,6 +49,8 @@ def _infer(
     asset_catalog=None,
     relation_catalog=None,
     task_catalog=None,
+    normalized_prompt_block: str | None = None,
+    simready_candidate_catalog=None,
     traces: list[str] | None = None,
 ):
     traces = traces if traces is not None else []
@@ -48,6 +60,8 @@ def _infer(
         asset_catalog=asset_catalog or make_catalog("catalog"),
         relation_catalog=relation_catalog or make_relation_catalog("RELATIONS"),
         task_catalog=task_catalog or make_task_catalog("TASKS"),
+        normalized_prompt_block=normalized_prompt_block,
+        simready_candidate_catalog=simready_candidate_catalog,
     )
 
 
@@ -105,3 +119,29 @@ def test_infer_returns_none_with_validation_traces_on_invalid_spec(spec_inferenc
     assert data["embodiment"]["registry_name"] == "not_a_real_asset"
     assert traces
     assert any("registry_name" in line for line in traces)
+
+
+def test_infer_user_message_includes_normalized_and_simready_blocks(spec_inference):
+    inference, client = spec_inference
+    client.chat.completions.create.return_value = chat_response(content=json.dumps(minimal_spec_dict()))
+    normalized = format_normalized_prompt_block(NormalizedPromptDescriptions.model_validate(minimal_normalized_dict()))
+    simready_catalog = SimReadyCandidateCatalogue(
+        candidates=[
+            SimReadyObjectCandidate(
+                search_phrase="red hammer",
+                usd_path="s3://bucket/red_hammer.usd",
+            )
+        ]
+    )
+    _infer(
+        inference,
+        client,
+        normalized_prompt_block=normalized,
+        simready_candidate_catalog=simready_catalog,
+    )
+    user_msg = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    system_msg = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+    assert "NORMALIZED PROMPT:" in user_msg
+    assert "SIMREADY_OBJECT_CANDIDATES" in user_msg
+    assert SIMREADY_USD_OBJECT_REGISTRY_NAME in user_msg
+    assert SIMREADY_USD_OBJECT_REGISTRY_NAME in system_msg

--- a/isaaclab_arena/tests/utils/agentic_environment_generation.py
+++ b/isaaclab_arena/tests/utils/agentic_environment_generation.py
@@ -80,6 +80,32 @@ def minimal_spec_dict() -> dict[str, Any]:
     return load_test_yaml("minimal_maple_table_env_graph.yaml")
 
 
+def minimal_normalized_dict() -> dict[str, Any]:
+    """Return normalized prompt descriptions aligned with ``minimal_spec_dict``."""
+    return {
+        "env_name": "pick_and_place_maple_table",
+        "embodiment": "franka robot",
+        "background": "maple table",
+        "object_references": "",
+        "objects": ["avocado", "bowl"],
+        "relations": "objects on table",
+        "task": "pick avocado and place in bowl",
+    }
+
+
+def kitchen_normalized_dict() -> dict[str, Any]:
+    """Return normalized prompt descriptions aligned with ``kitchen_pass1_dict``."""
+    return {
+        "env_name": "kitchen_pick_and_place",
+        "embodiment": "droid robot",
+        "background": "robocasa kitchen",
+        "object_references": "counter top and fridge door",
+        "objects": ["avocado", "plate", "broccoli", "sweet potato"],
+        "relations": "avocado and plate on counter; veggies as distractors",
+        "task": "pick avocado onto plate, then open fridge door",
+    }
+
+
 def kitchen_pass1_dict() -> dict[str, Any]:
     """Return the kitchen pass-1 graph spec with unresolved object references."""
     return load_test_yaml("kitchen_pass1_env_graph.yaml")

--- a/isaaclab_arena/utils/usd/rigid_bodies.py
+++ b/isaaclab_arena/utils/usd/rigid_bodies.py
@@ -40,7 +40,51 @@ def get_all_rigid_body_prim_paths(usd_path: str) -> list[str]:
     return get_all_rigid_body_prim_paths_from_stage(stage)
 
 
-def find_shallowest_rigid_body_from_stage(stage: Usd.Stage, relative_to_root: bool = False) -> str | None:
+def apply_usd_variant_selections(stage: Usd.Stage, variants: dict[str, str] | None) -> None:
+    """Select authored USD variant sets on the stage default prim when present.
+
+    Args:
+        stage: Open USD stage.
+        variants: Mapping of variant-set name to selection. Missing sets/selections are skipped.
+    """
+    if not variants:
+        return
+    root = stage.GetDefaultPrim()
+    if not root:
+        return
+    variant_sets = root.GetVariantSets()
+    for set_name, selection in variants.items():
+        if set_name not in variant_sets.GetNames():
+            continue
+        variant_set = variant_sets.GetVariantSet(set_name)
+        if selection not in variant_set.GetVariantNames():
+            continue
+        variant_set.SetVariantSelection(selection)
+
+
+def _prefer_body_rigid_body(prim_paths: list[str]) -> str:
+    """Prefer a prim whose leaf name contains ``body`` when several RBs tie on depth."""
+    body_paths = [path for path in prim_paths if "body" in path.rsplit("/", 1)[-1].lower()]
+    if body_paths:
+        return sorted(body_paths)[0]
+    return sorted(prim_paths)[0]
+
+
+def _path_relative_to_usd_root(prim_path: str) -> str:
+    """Strip the USD root prim name, returning a path suffix suitable for contact sensors."""
+    assert prim_path[0] == "/", "We expect USD paths to start with a /"
+    root_and_rest = prim_path.lstrip("/").split("/", 1)
+    if len(root_and_rest) == 1:
+        return ""
+    return "/" + root_and_rest[1]
+
+
+def find_shallowest_rigid_body_from_stage(
+    stage: Usd.Stage,
+    relative_to_root: bool = False,
+    *,
+    prefer_body_when_tied: bool = False,
+) -> str | None:
     """
     Find the shallowest (closest to root) prim that is a rigid body.
     Also verifies that there is only one rigid body at that depth level.
@@ -48,6 +92,8 @@ def find_shallowest_rigid_body_from_stage(stage: Usd.Stage, relative_to_root: bo
     Args:
         stage: The stage to analyze
         relative_to_root: Whether to return the path relative to the root of the USD file
+        prefer_body_when_tied: When several rigid bodies share the shallowest depth, prefer a
+            prim whose leaf name contains ``body`` instead of raising.
 
     Returns:
         Prim path for the shallowest rigid body. None if no rigid bodies are found.
@@ -55,7 +101,8 @@ def find_shallowest_rigid_body_from_stage(stage: Usd.Stage, relative_to_root: bo
         relative_to_root is True.
 
     Raises:
-        ValueError: If multiple rigid bodies exist at the shallowest level
+        ValueError: If multiple rigid bodies exist at the shallowest level and
+            ``prefer_body_when_tied`` is False
     """
     rigid_body_prim_paths = get_all_rigid_body_prim_paths_from_stage(stage)
 
@@ -80,23 +127,28 @@ def find_shallowest_rigid_body_from_stage(stage: Usd.Stage, relative_to_root: bo
 
         # Check if there's only one rigid body at the shallowest level
         if len(shallowest_rigid_bodies) > 1:
-            raise ValueError(
-                f"Found {len(shallowest_rigid_bodies)} rigid bodies at depth {min_depth}. "
-                f"Expected only one. Rigid bodies at this level: {shallowest_rigid_bodies}"
-            )
-        shallowest_rigid_body = shallowest_rigid_bodies[0]
+            if prefer_body_when_tied:
+                shallowest_rigid_body = _prefer_body_rigid_body(shallowest_rigid_bodies)
+            else:
+                raise ValueError(
+                    f"Found {len(shallowest_rigid_bodies)} rigid bodies at depth {min_depth}. "
+                    f"Expected only one. Rigid bodies at this level: {shallowest_rigid_bodies}"
+                )
+        else:
+            shallowest_rigid_body = shallowest_rigid_bodies[0]
 
     if relative_to_root:
-        assert shallowest_rigid_body[0] == "/", "We expect USD paths to start with a /"
-        root_and_rest = shallowest_rigid_body.lstrip("/").split("/", 1)
-        if len(root_and_rest) == 1:
-            shallowest_rigid_body = ""
-        else:
-            shallowest_rigid_body = "/" + root_and_rest[1]
+        shallowest_rigid_body = _path_relative_to_usd_root(shallowest_rigid_body)
     return shallowest_rigid_body
 
 
-def find_shallowest_rigid_body(usd_path: str, relative_to_root: bool = False) -> str | None:
+def find_shallowest_rigid_body(
+    usd_path: str,
+    relative_to_root: bool = False,
+    *,
+    variants: dict[str, str] | None = None,
+    prefer_body_when_tied: bool = False,
+) -> str | None:
     """
     Find the shallowest (closest to root) prim that is a rigid body.
     Also verifies that there is only one rigid body at that depth level.
@@ -104,6 +156,10 @@ def find_shallowest_rigid_body(usd_path: str, relative_to_root: bool = False) ->
     Args:
         usd_path: Path to the USD file to analyze
         relative_to_root: Whether to return the path relative to the root of the USD file
+        variants: Optional USD variant selections applied before searching (e.g. SimReady
+            ``{\"Physics\": \"physics\"}``).
+        prefer_body_when_tied: When several rigid bodies share the shallowest depth, prefer a
+            prim whose leaf name contains ``body`` instead of raising.
 
     Returns:
         Prim path for the shallowest rigid body. None if no rigid bodies are found.
@@ -111,9 +167,15 @@ def find_shallowest_rigid_body(usd_path: str, relative_to_root: bool = False) ->
         relative_to_root is True.
 
     Raises:
-        ValueError: If multiple rigid bodies exist at the shallowest level
+        ValueError: If multiple rigid bodies exist at the shallowest level and
+            ``prefer_body_when_tied`` is False
     """
     stage = Usd.Stage.Open(usd_path)
     if not stage:
         raise ValueError(f"Error: Could not open USD file at {usd_path}")
-    return find_shallowest_rigid_body_from_stage(stage, relative_to_root)
+    apply_usd_variant_selections(stage, variants)
+    return find_shallowest_rigid_body_from_stage(
+        stage,
+        relative_to_root,
+        prefer_body_when_tied=prefer_body_when_tied,
+    )

--- a/isaaclab_arena_environments/droid_disinfectant_into_grey_bin.yaml
+++ b/isaaclab_arena_environments/droid_disinfectant_into_grey_bin.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_disinfectant_into_grey_bin
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: maple_table
+  registry_name: maple_table_robolab
+  params: {}
+objects:
+- id: disinfectant_bottle
+  registry_name: simready_usd_object
+  params:
+    usd_path: https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/SimReady/Hospital/Cleaners/Disinfectant_B01/sm_disinfectant_b01_01.usd
+    tags:
+    - sim-ready
+    - disinfectant
+    - bottle
+- id: grey_bin
+  registry_name: simready_usd_object
+  params:
+    usd_path: https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/SimReady/Residential/Kitchen/Cabinets/Cabinet_D01/sm_fixture_cabinet_d01_01.usd
+    tags:
+    - sim-ready
+    - grey
+    - bin
+relations:
+- kind: is_anchor
+  subject: maple_table
+  params: {}
+- kind: 'on'
+  subject: disinfectant_bottle
+  reference: maple_table
+  params: {}
+- kind: 'on'
+  subject: grey_bin
+  reference: maple_table
+  params: {}
+- kind: next_to
+  subject: disinfectant_bottle
+  reference: grey_bin
+  params: {}
+task:
+  composition: atomic
+  description: Pick up the disinfectant bottle from the maple table and place it into
+    the grey bin on the table.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: disinfectant_bottle
+      destination_location: grey_bin
+      background_scene: maple_table

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -49,6 +49,8 @@ DEFAULT_PROMPT = "Franka picks up a cube from the maple table and places it into
 
 
 def add_agentic_env_gen_runner_cli_args(parser: argparse.ArgumentParser) -> None:
+    from isaaclab_arena.agentic_environment_generation.simready_asset_search import SimReadySourceKind
+
     group = parser.add_argument_group("Agentic Environment Generation Runner")
     group.add_argument(
         "--mode",
@@ -92,6 +94,53 @@ def add_agentic_env_gen_runner_cli_args(parser: argparse.ArgumentParser) -> None
         default=DEFAULT_AGENTIC_OUTPUT_DIR,
         help="Directory for the generated YAML files (default: isaaclab_arena_environments/agent_generated).",
     )
+    group.add_argument(
+        "--enable_simready_search",
+        action="store_true",
+        help="Run SimReady search on normalized object phrases before spec inference.",
+    )
+    group.add_argument(
+        "--simready_source",
+        type=str,
+        choices=tuple(kind.value for kind in SimReadySourceKind),
+        default="isaac-sim-ga",
+        help="SimReady search backend (default: isaac-sim-ga Isaac Sim 6.0 GA props).",
+    )
+    group.add_argument(
+        "--simready_s3_url",
+        type=str,
+        default=None,
+        help="Override S3 root for simready s3/isaac-sim-ga sources.",
+    )
+    group.add_argument(
+        "--simready_service_url",
+        type=str,
+        default=None,
+        help="Override hosted USD Search service URL for simready service fallback.",
+    )
+    group.add_argument(
+        "--simready_project_config",
+        type=str,
+        default=None,
+        help="Local project_config.toml path for simready cache source.",
+    )
+    group.add_argument(
+        "--simready_indexed_dir",
+        type=str,
+        default=None,
+        help="Directory or S3 prefix for simready indexed source.",
+    )
+    group.add_argument(
+        "--simready_max_results_per_object",
+        type=int,
+        default=1,
+        help="Maximum SimReady hits to keep per normalized object phrase (default: 1).",
+    )
+    group.add_argument(
+        "--simready_service_fallback",
+        action="store_true",
+        help="Fall back to hosted phrase search when the primary SimReady source returns no hits.",
+    )
 
 
 def resolve_env_spec(args_cli: argparse.Namespace) -> Path:
@@ -102,6 +151,7 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path:
         build_relation_catalogue,
         build_task_catalogue,
     )
+    from isaaclab_arena.agentic_environment_generation.simready_asset_search import simready_search_config_from_cli
 
     print(f"\n[runner] prompt: {args_cli.prompt!r}", flush=True)
 
@@ -109,7 +159,21 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path:
     relation_catalog = build_relation_catalogue()
     task_catalog = build_task_catalogue()
 
-    agent_kwargs: dict = {"temperature": args_cli.temperature}
+    simready_config = simready_search_config_from_cli(
+        enabled=args_cli.enable_simready_search,
+        source=args_cli.simready_source,
+        s3_url=args_cli.simready_s3_url,
+        service_url=args_cli.simready_service_url,
+        project_config_path=args_cli.simready_project_config,
+        indexed_path=args_cli.simready_indexed_dir,
+        max_results_per_object=args_cli.simready_max_results_per_object,
+        use_service_fallback=args_cli.simready_service_fallback,
+    )
+    agent_kwargs: dict = {
+        "temperature": args_cli.temperature,
+        "enable_simready_search": args_cli.enable_simready_search,
+        "simready_config": simready_config,
+    }
     if args_cli.model:
         agent_kwargs["model"] = args_cli.model
     agent = EnvironmentGenerationAgent(**agent_kwargs)
@@ -118,6 +182,7 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path:
         asset_catalog=asset_catalog,
         relation_catalog=relation_catalog,
         task_catalog=task_catalog,
+        enable_simready_search=args_cli.enable_simready_search,
     )
     # agent.traces holds one line per failure, e.g.
     #   "embodiment.registry_name: Unknown asset registry_name 'not_a_real_asset'"
@@ -126,9 +191,14 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path:
         print("\n[runner] validation traces:", flush=True)
         for line in agent.traces:
             print(f"  {line}", flush=True)
-        invalid_path = write_env_graph_dict(data, args_cli.out_dir)
-        print(f"[runner] wrote invalid spec YAML to {invalid_path}", flush=True)
+        if data is not None:
+            invalid_path = write_env_graph_dict(data, args_cli.out_dir)
+            print(f"[runner] wrote invalid spec YAML to {invalid_path}", flush=True)
         assert False, f"Agent returned an invalid spec. Validation traces: {agent.traces}"
+    if args_cli.enable_simready_search and agent.traces:
+        print("\n[runner] generation traces:", flush=True)
+        for line in agent.traces:
+            print(f"  {line}", flush=True)
     print_env_graph(env_graph_spec)
     print(
         f"[runner] generated → {env_graph_spec.summary()}, env_name={env_graph_spec.env_name!r}",

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -21,6 +21,10 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
     build_relation_catalogue,
     build_task_catalogue,
 )
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
+    SimReadySourceKind,
+    simready_search_config_from_cli,
+)
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.editor_panel import (
     SpecParseResult,
@@ -53,22 +57,53 @@ def get_catalogue_bundle() -> CatalogueBundle:
     )
 
 
+def _simready_config_from_session() -> tuple[bool, object]:
+    """Read SimReady GUI settings from Streamlit session state."""
+    enabled = bool(st.session_state.get("enable_simready_search", False))
+    config = simready_search_config_from_cli(
+        enabled=enabled,
+        source=st.session_state.get("simready_source", SimReadySourceKind.ISAAC_SIM_GA.value),
+        s3_url=st.session_state.get("simready_s3_url") or None,
+        service_url=st.session_state.get("simready_service_url") or None,
+        project_config_path=st.session_state.get("simready_project_config") or None,
+        indexed_path=st.session_state.get("simready_indexed_dir") or None,
+        max_results_per_object=int(st.session_state.get("simready_max_results_per_object", 1)),
+        use_service_fallback=bool(st.session_state.get("simready_service_fallback", False)),
+    )
+    return enabled, config
+
+
 def _get_generation_agent() -> EnvironmentGenerationAgent | None:
     """Lazy-init the LLM agent when ``NV_API_KEY`` is available."""
     if st.session_state.get("generation_agent_error"):
         return None
-    agent = st.session_state.get("generation_agent")
+    simready_enabled, simready_config = _simready_config_from_session()
+    agent_key = (
+        "generation_agent",
+        simready_enabled,
+        simready_config.source.value,
+        simready_config.s3_url,
+        simready_config.service_url,
+        simready_config.project_config_path,
+        simready_config.indexed_path,
+        simready_config.max_results_per_object,
+        simready_config.use_service_fallback,
+    )
+    agent = st.session_state.get(agent_key)
     if agent is not None:
         return agent
     try:
-        agent = EnvironmentGenerationAgent()
+        agent = EnvironmentGenerationAgent(
+            enable_simready_search=simready_enabled,
+            simready_config=simready_config,
+        )
     except AssertionError as exc:
         st.session_state["generation_agent_error"] = str(exc)
         return None
     except Exception as exc:
         st.session_state["generation_agent_error"] = f"{type(exc).__name__}: {exc}"
         return None
-    st.session_state["generation_agent"] = agent
+    st.session_state[agent_key] = agent
     st.session_state.pop("generation_agent_error", None)
     return agent
 
@@ -117,18 +152,20 @@ def run_generation_pipeline(prompt: str) -> tuple[bool, str]:
         return False, traceback.format_exc()
 
     try:
+        simready_enabled, _ = _simready_config_from_session()
         spec, data = agent.generate_spec(
             prompt,
             asset_catalog=catalogues.asset_catalogue,
             relation_catalog=catalogues.relation_catalogue,
             task_catalog=catalogues.task_catalogue,
+            enable_simready_search=simready_enabled,
         )
     except Exception:
         return False, traceback.format_exc()
 
     try:
         yaml_text = yaml.safe_dump(
-            spec.to_dict() if spec is not None else data,
+            spec.to_dict() if spec is not None else (data or {}),
             sort_keys=False,
         )
     except Exception:
@@ -144,11 +181,14 @@ def run_generation_pipeline(prompt: str) -> tuple[bool, str]:
 
     out_dir = Path(st.session_state["out_dir"])
     path, error = try_save_env_graph_spec(spec, out_dir)
+    trace_suffix = ""
+    if simready_enabled and agent.traces:
+        trace_suffix = "\n\nGeneration traces:\n" + "\n".join(agent.traces)
     if error is not None:
-        return True, f"Spec generated and loaded into the YAML editor, but save failed: {error}"
+        return True, f"Spec generated and loaded into the YAML editor, but save failed: {error}{trace_suffix}"
 
     st.session_state["save_path"] = str(path)
-    return True, f"Spec generated, loaded into the YAML editor, and saved to {path}."
+    return True, f"Spec generated, loaded into the YAML editor, and saved to {path}.{trace_suffix}"
 
 
 def render_generation_panel() -> None:
@@ -167,6 +207,42 @@ def render_generation_panel() -> None:
     agent_error = st.session_state.get("generation_agent_error")
     if agent_error:
         st.info(f"LLM agent unavailable: {agent_error}", icon="ℹ️")
+
+    with st.expander("SimReady search", expanded=bool(st.session_state.get("enable_simready_search", False))):
+        st.session_state["enable_simready_search"] = st.checkbox(
+            "Enable SimReady search",
+            value=bool(st.session_state.get("enable_simready_search", False)),
+            help="Search Isaac Sim GA SimReady props for normalized object phrases before spec inference.",
+        )
+        source_options = [kind.value for kind in SimReadySourceKind]
+        st.session_state["simready_source"] = st.selectbox(
+            "SimReady source",
+            options=source_options,
+            index=source_options.index(st.session_state.get("simready_source", SimReadySourceKind.ISAAC_SIM_GA.value)),
+        )
+        st.session_state["simready_max_results_per_object"] = st.number_input(
+            "Max results per object",
+            min_value=1,
+            max_value=10,
+            value=int(st.session_state.get("simready_max_results_per_object", 1)),
+        )
+        st.session_state["simready_service_fallback"] = st.checkbox(
+            "Use hosted phrase-search fallback",
+            value=bool(st.session_state.get("simready_service_fallback", False)),
+        )
+        st.session_state["simready_s3_url"] = st.text_input(
+            "S3 URL override",
+            value=st.session_state.get("simready_s3_url", ""),
+            placeholder="Leave empty for Isaac Sim 6.0 GA SimReady default",
+        )
+        st.session_state["simready_project_config"] = st.text_input(
+            "project_config.toml path",
+            value=st.session_state.get("simready_project_config", ""),
+        )
+        st.session_state["simready_indexed_dir"] = st.text_input(
+            "Indexed directory or S3 prefix",
+            value=st.session_state.get("simready_indexed_dir", ""),
+        )
 
     if st.button("Generate spec", type="primary", use_container_width=True):
         with st.spinner("Generating spec (LLM call)…"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev = [
     "streamlit>=1.30",
     "streamlit-ace>=0.1.1",
 ]
+simready = [
+    "simready-search>=2026.4.2",
+]
 
 # PEP 735 dependency groups for the native uv install: the sim stack the
 # Docker build does not want. pip (used by the Docker build) ignores PEP 735


### PR DESCRIPTION
## Summary
Add SimReady search to agentic env generation

## Detailed description
- Agentic env gen can search Isaac Sim 6.0 SimReady props and spawn them via `simready_usd_object` when Arena registry assets are missing
- Select SimReady `Physics=physics` on spawn/contact so rigid bodies resolve for PickAndPlace sensors

/isaac-sim/python.sh isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py   --mode resolve   --enable_simready_search   --prompt "Droid picks up a disinfectant from the maple table and places it into a grey bin on the table."

Previous generated yaml:  isaaclab_arena_environments/droid_disinfectant_into_grey_bin.yaml