### PR TITLE
Add Replicator kitchen example assets and yamls

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -221,3 +221,61 @@ class TableOakRobolab(LibraryBackground):
     tags = ["background", "robolab"]
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/table_oak.usd"
     object_min_z = -0.05
+
+
+# -----------------------------------------------------------------------------
+# Replicator kitchen backgrounds
+# -----------------------------------------------------------------------------
+
+_REPLICATOR_KITCHEN_ROOT = f"{ARENA_NUCLEUS_DIR}/Arena/assets/background_library/replicator_kitchen"
+
+
+class ReplicatorKitchenBackground(LibraryBackground):
+    """Base class for Replicator-generated kitchen floorplans."""
+
+    tags = ["background", "replicator"]
+    initial_pose = Pose.identity()
+    object_min_z = -0.2
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return ViewerCfg(eye=(0.0, -1.0, 1.35), lookat=(0.0, 0.0, 1.35))
+
+
+@register_asset
+class ReplicatorKitchenGShape(ReplicatorKitchenBackground):
+    """Replicator G-shaped kitchen."""
+
+    name = "replicator_kitchen_g_shape"
+    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_g_shape.usda"
+
+
+@register_asset
+class ReplicatorKitchenLIsland(ReplicatorKitchenBackground):
+    """Replicator L-shaped kitchen with an island."""
+
+    name = "replicator_kitchen_l_island"
+    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_l_island.usda"
+
+
+@register_asset
+class ReplicatorKitchenLShape(ReplicatorKitchenBackground):
+    """Replicator L-shaped kitchen."""
+
+    name = "replicator_kitchen_l_shape"
+    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_l_shape.usda"
+
+
+@register_asset
+class ReplicatorKitchenPeninsula(ReplicatorKitchenBackground):
+    """Replicator kitchen with a peninsula."""
+
+    name = "replicator_kitchen_peninsula"
+    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_peninsula.usda"
+
+
+@register_asset
+class ReplicatorKitchenUShape(ReplicatorKitchenBackground):
+    """Replicator U-shaped kitchen."""
+
+    name = "replicator_kitchen_u_shape"
+    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_u_shape.usda"

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_banana_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_banana_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_banana_to_bowl_kitchen_g_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_g_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: banana
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: corner_counter
+  parent_id: kitchen
+  prim_path: CornerCounter_00_0
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: corner_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: corner_counter
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: banana
+  reference: corner_counter
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: corner_counter
+  params: {}
+task:
+  composition: atomic
+  description: pick up the banana from the corner counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_bowl_sink.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_bowl_sink.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_bowl_to_sink_kitchen_g_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_g_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: sink
+  parent_id: kitchen
+  prim_path: Sink/BasinBottom
+  object_type: base
+  params: {}
+- id: sink_counter
+  parent_id: kitchen
+  prim_path: CapSurface_02
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: sink
+  params: {}
+- kind: is_anchor
+  subject: sink_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: sink
+  params:
+    side: negative_x
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 0.0
+- kind: 'on'
+  subject: bowl
+  reference: sink_counter
+  params: {}
+- kind: next_to
+  subject: bowl
+  reference: sink
+  params:
+    side: positive_y
+    distance_m: 0.1
+task:
+  composition: atomic
+  description: pick up the bowl from the sink counter and place it in the sink
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: sink
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_mustard_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_mustard_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_mustard_to_bowl_kitchen_g_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_g_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: island_top
+  parent_id: kitchen
+  prim_path: CapSurface_03
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: island_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: island_top
+  params:
+    side: positive_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: -1.57
+- kind: 'on'
+  subject: mustard_bottle
+  reference: island_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: island_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle from the kitchen island and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_banana_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_banana_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_banana_to_bowl_kitchen_l_island
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_island
+  params:
+    collision_mode: mesh
+objects:
+- id: banana
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: corner_counter
+  parent_id: kitchen
+  prim_path: CornerCounter_00_0
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: corner_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: corner_counter
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: banana
+  reference: corner_counter
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: corner_counter
+  params: {}
+task:
+  composition: atomic
+  description: pick up the banana from the corner counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_bowl_sink.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_bowl_sink.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_bowl_to_sink_kitchen_l_island
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_island
+  params:
+    collision_mode: mesh
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: sink
+  parent_id: kitchen
+  prim_path: Sink/BasinBottom
+  object_type: base
+  params: {}
+- id: sink_counter
+  parent_id: kitchen
+  prim_path: CapSurface
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: sink
+  params: {}
+- kind: is_anchor
+  subject: sink_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: sink
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: bowl
+  reference: sink_counter
+  params: {}
+- kind: next_to
+  subject: bowl
+  reference: sink
+  params:
+    side: negative_x
+    distance_m: 0.1
+task:
+  composition: atomic
+  description: pick up the bowl from the sink counter and place it in the sink
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: sink
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_mustard_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_mustard_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_mustard_to_bowl_kitchen_l_island
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_island
+  params:
+    collision_mode: mesh
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: island_top
+  parent_id: kitchen
+  prim_path: CapSurface_03
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: island_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: island_top
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: mustard_bottle
+  reference: island_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: island_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle from the kitchen island and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_banana_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_banana_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_banana_to_bowl_kitchen_l_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: banana
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: corner_counter
+  parent_id: kitchen
+  prim_path: CornerCounter_00_0
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: corner_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: corner_counter
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: banana
+  reference: corner_counter
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: corner_counter
+  params: {}
+task:
+  composition: atomic
+  description: pick up the banana from the corner counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_bowl_sink.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_bowl_sink.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_bowl_to_sink_kitchen_l_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: sink
+  parent_id: kitchen
+  prim_path: Sink/BasinBottom
+  object_type: base
+  params: {}
+- id: sink_counter
+  parent_id: kitchen
+  prim_path: CapSurface_02
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: sink
+  params: {}
+- kind: is_anchor
+  subject: sink_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: sink
+  params:
+    side: positive_x
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 3.14
+- kind: 'on'
+  subject: bowl
+  reference: sink_counter
+  params: {}
+- kind: next_to
+  subject: bowl
+  reference: sink
+  params:
+    side: negative_y
+    distance_m: 0.1
+task:
+  composition: atomic
+  description: pick up the bowl from the counter next to the sink and place it in the sink
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: sink
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_mustard_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_mustard_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_mustard_to_bowl_kitchen_l_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_l_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: CapSurface
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: mustard_bottle
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: counter_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle from the counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_bowl_sink.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_bowl_sink.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_bowl_to_sink_kitchen_peninsula
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_peninsula
+  params:
+    collision_mode: mesh
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: sink
+  parent_id: kitchen
+  prim_path: Sink/BasinBottom
+  object_type: base
+  params: {}
+- id: sink_counter
+  parent_id: kitchen
+  prim_path: CapSurface_01
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: sink
+  params: {}
+- kind: is_anchor
+  subject: sink_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: sink
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: bowl
+  reference: sink_counter
+  params: {}
+- kind: next_to
+  subject: bowl
+  reference: sink
+  params:
+    side: negative_x
+    distance_m: 0.1
+task:
+  composition: atomic
+  description: pick up the bowl from the sink counter and place it in the sink
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: sink
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_mustard_to_bowl_kitchen_peninsula
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_peninsula
+  params:
+    collision_mode: mesh
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: island_top
+  parent_id: kitchen
+  prim_path: CapSurface_02
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: island_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: island_top
+  params:
+    side: positive_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: -1.57
+- kind: 'on'
+  subject: mustard_bottle
+  reference: island_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: island_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle from the island counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_banana_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_banana_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_banana_to_bowl_kitchen_u_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_u_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: banana
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: corner_counter
+  parent_id: kitchen
+  prim_path: CornerCounter_00_0
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: corner_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: corner_counter
+  params:
+    side: negative_y
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: banana
+  reference: corner_counter
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: corner_counter
+  params: {}
+task:
+  composition: atomic
+  description: pick up the banana from the corner counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_bowl_sink.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_bowl_sink.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_bowl_to_sink_kitchen_u_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_u_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: sink
+  parent_id: kitchen
+  prim_path: Sink/BasinBottom
+  object_type: base
+  params: {}
+- id: sink_counter
+  parent_id: kitchen
+  prim_path: CapSurface_01
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: sink
+  params: {}
+- kind: is_anchor
+  subject: sink_counter
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: sink
+  params:
+    side: positive_x
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 3.14
+- kind: 'on'
+  subject: bowl
+  reference: sink_counter
+  params: {}
+- kind: next_to
+  subject: bowl
+  reference: sink
+  params:
+    side: negative_y
+    distance_m: 0.1
+task:
+  composition: atomic
+  description: pick up the bowl from the sink counter and place it in the sink
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: sink
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_mustard_bowl.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_mustard_bowl.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_mustard_to_bowl_kitchen_u_shape
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+background:
+  id: kitchen
+  registry_name: replicator_kitchen_u_shape
+  params:
+    collision_mode: mesh
+objects:
+- id: mustard_bottle
+  registry_name: mustard_bottle_hope_robolab
+  params: {}
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: KitchenRoom/Floor
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: CapSurface_03
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_x
+    distance_m: 0.15
+    tolerance_m: 0.15
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 0.0
+- kind: 'on'
+  subject: mustard_bottle
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: counter_top
+  params: {}
+task:
+  composition: atomic
+  description: pick up the mustard bottle from the counter and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: bowl
+      background_scene: kitchen


### PR DESCRIPTION
## Summary
Add Replicator kitchen environments

## Detailed description
- Register five hosted Replicator kitchen backgrounds using a staging server version to unblock internal development, while we awaits the production server version to be uploaded.
- Add 14 kitchen pick-and-place YAML configurations.
- Use mesh collision for background placement.
- New yamls are protected by existing test_kitchen_bench_yaml_env.py test.

/isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py     --viz kit     --policy_type zero_action     --num_episodes 20  --disable_fabric  --device cpu  --env_graph_spec_yaml  isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml

<img width="960" height="540" alt="penisula_mustard_mesh_short" src="https://github.com/user-attachments/assets/1909feff-a700-4e2f-bbd6-6b04a5e9e4e9" />
