### PR TITLE
Support OpenDoorTask in Lightwheel kitchen YAMLs

### DIFF
--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.assets.object_reference import ObjectReference, OpenableObjectReference
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry
 from isaaclab_arena.environment_spec.arena_env_graph_task_conversion_utils import build_task_from_spec
 from isaaclab_arena.environment_spec.arena_env_graph_types import SpatialRelationSpec
@@ -137,9 +138,14 @@ def instantiate_assets_from_spec(
             **ref_params,
         }
         if openable_joint_name is not None:
+            # OpenableObjectReference always sets object_type=ARTICULATION; omit the YAML value.
+            assert (
+                ref.object_type == ObjectType.ARTICULATION
+            ), f"Openable reference '{ref.id}' must use object_type=articulation, got {ref.object_type}"
+            openable_kwargs = {k: v for k, v in common_kwargs.items() if k != "object_type"}
             assets_by_node_id[ref.id] = OpenableObjectReference(
                 openable_joint_name=openable_joint_name,
-                **common_kwargs,
+                **openable_kwargs,
             )
         else:
             assets_by_node_id[ref.id] = ObjectReference(**common_kwargs)

--- a/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
+++ b/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests: kitchen_bench graph-spec YAMLs build and reset in sim."""
+
+from __future__ import annotations
+
+import traceback
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+_KITCHEN_BENCH_DIR = Path(__file__).resolve().parents[2] / "isaaclab_arena_environments" / "kitchen_bench"
+_KITCHEN_BENCH_YAMLS = sorted(_KITCHEN_BENCH_DIR.glob("*.yaml"))
+
+
+def _test_kitchen_bench_yaml_env_bringup(simulation_app, *, yaml_path: Path) -> bool:
+    """Build an env from a kitchen_bench YAML and reset once."""
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    env = None
+    try:
+        spec = ArenaEnvGraphSpec.from_yaml(yaml_path)
+        arena_env = spec.to_arena_env()
+        args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+        env = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli)).make_registered()
+        env.reset()
+
+        assert env.unwrapped.cfg is not None
+        assert arena_env.name == spec.env_name
+        assert "robot" in env.unwrapped.scene.keys(), f"robot missing from scene for {yaml_path.name}"
+    except Exception as exc:
+        print(f"Error bringing up {yaml_path}: {exc}")
+        traceback.print_exc()
+        return False
+    finally:
+        if env is not None:
+            env.close()
+
+    return True
+
+
+@pytest.mark.parametrize(
+    "yaml_path",
+    _KITCHEN_BENCH_YAMLS,
+    ids=[path.stem for path in _KITCHEN_BENCH_YAMLS],
+)
+def test_kitchen_bench_yaml_env_bringup(yaml_path: Path):
+    """Each kitchen_bench YAML must parse and produce a resettable Arena env."""
+    assert yaml_path.is_file(), f"missing kitchen_bench YAML: {yaml_path}"
+    result = run_simulation_app_function(
+        _test_kitchen_bench_yaml_env_bringup,
+        headless=True,
+        yaml_path=yaml_path,
+    )
+    assert result, f"kitchen_bench bring-up failed for {yaml_path.name}"
+
+
+if __name__ == "__main__":
+    for path in _KITCHEN_BENCH_YAMLS:
+        test_kitchen_bench_yaml_env_bringup(path)

--- a/isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_open_kitchen_fridge
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+background:
+  id: kitchen
+  registry_name: lightwheel_robocasa_kitchen
+  params: {}
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: fridge
+  parent_id: kitchen
+  prim_path: fridge_main_group
+  object_type: articulation
+  params:
+    openable_joint_name: fridge_door_joint
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: fridge
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: fridge
+  params:
+    side: negative_y
+    distance_m: 0.6
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+task:
+  composition: atomic
+  description: open the fridge door
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: fridge
+      openness_threshold: 0.2
+      reset_openness: 0.0

--- a/isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
@@ -42,7 +42,7 @@ relations:
   reference: fridge
   params:
     side: negative_y
-    distance_m: 0.6
+    distance_m: 0.1
 - kind: rotate_around_solution
   subject: droid
   params:

--- a/isaaclab_arena_environments/kitchen_bench/droid_open_microwave_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_open_microwave_lightwheel_kitchen.yaml
@@ -42,7 +42,7 @@ relations:
   reference: microwave
   params:
     side: negative_y
-    distance_m: 0.6
+    distance_m: 0.1
 - kind: rotate_around_solution
   subject: droid
   params:

--- a/isaaclab_arena_environments/kitchen_bench/droid_open_microwave_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_open_microwave_lightwheel_kitchen.yaml
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_open_kitchen_microwave
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+background:
+  id: kitchen
+  registry_name: lightwheel_robocasa_kitchen
+  params: {}
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: microwave
+  parent_id: kitchen
+  prim_path: microwave_main_group
+  object_type: articulation
+  params:
+    openable_joint_name: microjoint
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: microwave
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: microwave
+  params:
+    side: negative_y
+    distance_m: 0.6
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+task:
+  composition: atomic
+  description: open the microwave door
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: microwave
+      openness_threshold: 0.1
+      reset_openness: 0.0


### PR DESCRIPTION
## Summary
Support OpenDoorTask in Lightwheel kitchen YAMLs

## Detailed description
- Graph-spec conversion omitted double-passing `object_type` for openable articulations so OpenDoorTask kitchen specs build cleanly
- Add Droid open-microwave and open-fridge Lightwheel kitchen env graph YAMLs. These are placed under a new kitchen_bench subforlder as we plan to add more kitchen based tasks to make a small scale robolab-style benchmark.

Command to run:
 /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py --viz kit --policy_type isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy --num_episodes 2 --enable_cameras --record_viewport_video --output_base_dir output/kitchen_task --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
 
 
<img width="480" height="270" alt="droid_kitchen_open_door (1)" src="https://github.com/user-attachments/assets/fb36ad35-dd7b-488c-a9a8-9b215c911b79" />
