### PR TITLE
feat(evaluation): add Evaluation v1 protocol contracts

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,3 +39,4 @@ Guidelines for modifications:
 * Rebecca Zhang <rebeccazhang0707, rebeccaz@nvidia.com> (NVIDIA)
 * Shiwei Sheng <shiweis, shiweis@nvidia.com> (NVIDIA)
 * Weihua Zhang <yami007007-weihuaz, weihuaz@nvidia.com> (NVIDIA)
+* Yifan Zhang <gary.yifan.zhang@gmail.com> (EngineAI)

--- a/isaaclab_arena/evaluation/__init__.py
+++ b/isaaclab_arena/evaluation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena evaluation workflows and protocol contracts."""

--- a/isaaclab_arena/evaluation/protocol/__init__.py
+++ b/isaaclab_arena/evaluation/protocol/__init__.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure-Python contracts for declaring and reporting task evaluation."""
+
+from .requirements import (
+    AllOf,
+    AnyOf,
+    JsonScalar,
+    JsonValue,
+    PredicateRequirement,
+    PredicateSpec,
+    RequirementSpec,
+    RoleRef,
+    evaluate_requirement,
+)
+from .result import EvaluationOutcome, EvaluationResult, RequirementResult
+from .spec import EvaluationSpec, FailureSpec, MilestoneSpec
+from .truth import TruthValue, all_truth, any_truth
+
+__all__ = [
+    "AllOf",
+    "AnyOf",
+    "EvaluationSpec",
+    "EvaluationOutcome",
+    "EvaluationResult",
+    "FailureSpec",
+    "JsonScalar",
+    "JsonValue",
+    "MilestoneSpec",
+    "PredicateRequirement",
+    "PredicateSpec",
+    "RequirementSpec",
+    "RequirementResult",
+    "RoleRef",
+    "TruthValue",
+    "all_truth",
+    "any_truth",
+    "evaluate_requirement",
+]

--- a/isaaclab_arena/evaluation/protocol/_validation.py
+++ b/isaaclab_arena/evaluation/protocol/_validation.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared validation helpers for Evaluation protocol value objects."""
+
+
+def validate_name(value: object, field_name: str) -> None:
+    """Validate a non-empty string identifier without surrounding whitespace.
+
+    Args:
+        value: Candidate identifier.
+        field_name: Public field name to include in validation errors.
+    """
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if not value or value != value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string without surrounding whitespace")

--- a/isaaclab_arena/evaluation/protocol/requirements.py
+++ b/isaaclab_arena/evaluation/protocol/requirements.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative requirements for the Evaluation protocol."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import TypeAlias
+
+from ._validation import validate_name
+from .truth import TruthValue, all_truth, any_truth
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | tuple["JsonValue", ...] | Mapping[str, "JsonValue"]
+
+
+def _freeze_json(value: object) -> JsonValue:
+    if isinstance(value, Mapping):
+        frozen_mapping: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            frozen_mapping[key] = _freeze_json(item)
+        return MappingProxyType(frozen_mapping)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    if not isinstance(value, (str, int, float, bool, type(None))):
+        raise TypeError("PredicateSpec.parameters values must be JSON-compatible")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError("PredicateSpec.parameters cannot contain non-finite floats")
+    return value
+
+
+def _json_identity(value: JsonValue):
+    if isinstance(value, Mapping):
+        return ("object", tuple(sorted((key, _json_identity(item)) for key, item in value.items())))
+    if isinstance(value, tuple):
+        return ("array", tuple(_json_identity(item) for item in value))
+    if value is None:
+        return ("null",)
+    if isinstance(value, bool):
+        return ("boolean", value)
+    if isinstance(value, int):
+        return ("integer", value)
+    if isinstance(value, float):
+        return ("number", value.hex())
+    return ("string", value)
+
+
+@dataclass(frozen=True)
+class RoleRef:
+    """Semantic task role resolved to a scene entity by a later binding stage."""
+
+    name: str
+    """Task-local semantic role name."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "RoleRef.name")
+
+
+@dataclass(frozen=True)
+class PredicateSpec:
+    """Stable predicate identity and its fully resolved declaration parameters."""
+
+    predicate_id: str
+    """Stable, namespaced predicate identifier."""
+
+    predicate_version: str
+    """Version of the predicate semantics."""
+
+    roles: Mapping[str, RoleRef] = field(default_factory=dict)
+    """Predicate argument names mapped to semantic task roles."""
+
+    parameters: Mapping[str, JsonValue] = field(default_factory=dict)
+    """Resolved JSON-compatible parameters that affect predicate semantics."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.predicate_id, "PredicateSpec.predicate_id")
+        validate_name(self.predicate_version, "PredicateSpec.predicate_version")
+
+        roles = dict(self.roles)
+        for argument, role in roles.items():
+            validate_name(argument, "PredicateSpec role argument")
+            if not isinstance(role, RoleRef):
+                raise TypeError("PredicateSpec.roles values must be RoleRef instances")
+
+        parameters: dict[str, JsonValue] = {}
+        for name, value in self.parameters.items():
+            validate_name(name, "PredicateSpec parameter name")
+            parameters[name] = _freeze_json(value)
+
+        object.__setattr__(self, "roles", MappingProxyType(roles))
+        object.__setattr__(self, "parameters", MappingProxyType(parameters))
+
+    def __hash__(self) -> int:
+        """Hash this immutable declaration independently of mapping insertion order."""
+        return hash((
+            self.predicate_id,
+            self.predicate_version,
+            tuple(sorted(self.roles.items())),
+            _json_identity(self.parameters),
+        ))
+
+    def __eq__(self, other: object) -> bool:
+        """Compare declarations using JSON type-sensitive parameter identity.
+
+        Args:
+            other: Candidate declaration to compare.
+        """
+        if not isinstance(other, PredicateSpec):
+            return NotImplemented
+        return (
+            self.predicate_id == other.predicate_id
+            and self.predicate_version == other.predicate_version
+            and self.roles == other.roles
+            and _json_identity(self.parameters) == _json_identity(other.parameters)
+        )
+
+
+@dataclass(frozen=True)
+class PredicateRequirement:
+    """Named leaf requirement backed by one predicate declaration."""
+
+    name: str
+    """Stable task-local name used to associate evidence with this requirement."""
+
+    predicate: PredicateSpec
+    """Predicate whose evidence determines this requirement."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "PredicateRequirement.name")
+        if not isinstance(self.predicate, PredicateSpec):
+            raise TypeError("PredicateRequirement.predicate must be a PredicateSpec")
+
+
+def _normalize_child_requirements(
+    requirements: tuple[RequirementSpec, ...],
+    operator_name: str,
+) -> tuple[RequirementSpec, ...]:
+    """Normalize and validate a logical operator's children.
+
+    Args:
+        requirements: Child requirement declarations.
+        operator_name: Logical operator name to include in validation errors.
+    """
+    normalized = tuple(requirements)
+    if not normalized:
+        raise ValueError(f"{operator_name} requires at least one child requirement")
+    if not all(isinstance(requirement, (PredicateRequirement, AllOf, AnyOf)) for requirement in normalized):
+        raise TypeError(f"{operator_name}.requirements must contain declarative requirements")
+    return normalized
+
+
+@dataclass(frozen=True)
+class AllOf:
+    """Requirement satisfied only when every child is true."""
+
+    requirements: tuple[RequirementSpec, ...]
+    """Child requirements."""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "requirements", _normalize_child_requirements(self.requirements, "AllOf"))
+
+
+@dataclass(frozen=True)
+class AnyOf:
+    """Requirement satisfied when at least one child is true."""
+
+    requirements: tuple[RequirementSpec, ...]
+    """Child requirements."""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "requirements", _normalize_child_requirements(self.requirements, "AnyOf"))
+
+
+RequirementSpec: TypeAlias = PredicateRequirement | AllOf | AnyOf
+
+
+def evaluate_requirement(requirement: RequirementSpec, evidence: Mapping[str, TruthValue]) -> TruthValue:
+    """Reduce named predicate evidence through a declarative requirement tree.
+
+    Missing evidence is explicitly represented as ``TruthValue.UNKNOWN``.
+
+    Args:
+        requirement: Requirement tree to reduce.
+        evidence: Truth values keyed by predicate requirement name.
+    """
+    if isinstance(requirement, PredicateRequirement):
+        value = evidence.get(requirement.name, TruthValue.UNKNOWN)
+        if not isinstance(value, TruthValue):
+            raise TypeError("Requirement evidence values must be TruthValue instances")
+        return value
+    if isinstance(requirement, AllOf):
+        return all_truth(evaluate_requirement(child, evidence) for child in requirement.requirements)
+    if isinstance(requirement, AnyOf):
+        return any_truth(evaluate_requirement(child, evidence) for child in requirement.requirements)
+    raise TypeError(f"Unsupported requirement type: {type(requirement).__name__}")

--- a/isaaclab_arena/evaluation/protocol/result.py
+++ b/isaaclab_arena/evaluation/protocol/result.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task-semantic result contracts for the Evaluation protocol."""
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+
+from ._validation import validate_name
+from .truth import TruthValue
+
+
+def _validate_sha256(value: str, field_name: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field_name} must be a lowercase SHA-256 hex digest")
+
+
+class EvaluationOutcome(StrEnum):
+    """Task-semantic outcome, independent of episode completion cause."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class RequirementResult:
+    """Observed truth value of one named predicate requirement."""
+
+    name: str
+    """Requirement name from the Evaluation specification."""
+
+    value: TruthValue
+    """Current three-valued result."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "RequirementResult.name")
+        if not isinstance(self.value, TruthValue):
+            raise TypeError("RequirementResult.value must be a TruthValue")
+
+
+@dataclass(frozen=True)
+class EvaluationResult:
+    """Pure task-semantic snapshot produced from an Evaluation specification.
+
+    This contract intentionally does not classify timeout, shutdown, or other
+    episode completion causes. A runtime integration may wrap this snapshot
+    after its lifecycle and precedence policies have been defined.
+    """
+
+    outcome: EvaluationOutcome
+    """Current task-semantic outcome."""
+
+    progress: float
+    """Normalized progress derived from declared milestones."""
+
+    spec_hash: str
+    """Canonical hash of the Evaluation specification."""
+
+    predicate_revisions: Mapping[str, str]
+    """Predicate IDs mapped to the semantic revisions used for this result."""
+
+    completion_step: int | None = None
+    """First simulation or control step at which the success requirement became true."""
+
+    binding_hash: str | None = None
+    """Hash of separately compiled role bindings, when available."""
+
+    highest_milestone: str | None = None
+    """Highest reached milestone name, when any."""
+
+    failure_code: str | None = None
+    """Selected semantic failure reason, when outcome is failure."""
+
+    failure_stage: str | None = None
+    """Task stage associated with the selected semantic failure."""
+
+    requirement_results: Mapping[str, RequirementResult] = field(default_factory=dict)
+    """Per-requirement truth values used to explain the result."""
+
+    protocol_version: str = "1"
+    """Evaluation protocol version that produced this result."""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.outcome, EvaluationOutcome):
+            raise TypeError("EvaluationResult.outcome must be an EvaluationOutcome")
+        if isinstance(self.progress, bool) or not isinstance(self.progress, (int, float)):
+            raise TypeError("EvaluationResult.progress must be a finite number")
+        if not math.isfinite(self.progress):
+            raise TypeError("EvaluationResult.progress must be a finite number")
+        if not 0.0 <= self.progress <= 1.0:
+            raise ValueError("EvaluationResult.progress must be between 0.0 and 1.0")
+        object.__setattr__(self, "progress", float(self.progress))
+        if self.completion_step is not None:
+            if isinstance(self.completion_step, bool) or not isinstance(self.completion_step, int):
+                raise TypeError("EvaluationResult.completion_step must be an integer or None")
+            if self.completion_step < 0:
+                raise ValueError("EvaluationResult.completion_step cannot be negative")
+        if self.outcome is EvaluationOutcome.SUCCESS and self.completion_step is None:
+            raise ValueError("Success outcome requires a completion_step")
+        _validate_sha256(self.spec_hash, "EvaluationResult.spec_hash")
+        if self.binding_hash is not None:
+            _validate_sha256(self.binding_hash, "EvaluationResult.binding_hash")
+        validate_name(self.protocol_version, "EvaluationResult.protocol_version")
+        if self.highest_milestone is not None:
+            validate_name(self.highest_milestone, "EvaluationResult.highest_milestone")
+        if self.failure_code is not None:
+            validate_name(self.failure_code, "EvaluationResult.failure_code")
+        if self.failure_stage is not None:
+            validate_name(self.failure_stage, "EvaluationResult.failure_stage")
+
+        if self.outcome is EvaluationOutcome.FAILURE and self.failure_code is None:
+            raise ValueError("Failure outcome requires a failure_code")
+        if self.outcome is not EvaluationOutcome.FAILURE and self.failure_code is not None:
+            raise ValueError("failure_code is only valid for a failure outcome")
+        if self.failure_stage is not None and self.failure_code is None:
+            raise ValueError("failure_stage requires a failure_code")
+
+        predicate_revisions = dict(self.predicate_revisions)
+        if not predicate_revisions:
+            raise ValueError("EvaluationResult.predicate_revisions cannot be empty")
+        for predicate_id, predicate_version in predicate_revisions.items():
+            validate_name(predicate_id, "EvaluationResult.predicate_revisions key")
+            validate_name(predicate_version, "EvaluationResult predicate revision")
+        object.__setattr__(self, "predicate_revisions", MappingProxyType(predicate_revisions))
+
+        requirement_results = dict(self.requirement_results)
+        for name, requirement_result in requirement_results.items():
+            validate_name(name, "EvaluationResult.requirement_results key")
+            if not isinstance(requirement_result, RequirementResult):
+                raise TypeError("EvaluationResult.requirement_results values must be RequirementResult instances")
+            if name != requirement_result.name:
+                raise ValueError("EvaluationResult.requirement_results keys must match RequirementResult.name")
+        object.__setattr__(self, "requirement_results", MappingProxyType(requirement_results))
+
+    def __hash__(self) -> int:
+        """Hash this immutable result independently of mapping insertion order."""
+        return hash((
+            self.outcome,
+            self.completion_step,
+            self.progress,
+            self.spec_hash,
+            tuple(sorted(self.predicate_revisions.items())),
+            self.binding_hash,
+            self.highest_milestone,
+            self.failure_code,
+            self.failure_stage,
+            tuple(sorted(self.requirement_results.items())),
+            self.protocol_version,
+        ))

--- a/isaaclab_arena/evaluation/protocol/spec.py
+++ b/isaaclab_arena/evaluation/protocol/spec.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned Evaluation specification and canonical identity."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ._validation import validate_name
+from .requirements import AllOf, AnyOf, PredicateRequirement, RequirementSpec
+
+_SPEC_HASH_DOMAIN = b"isaaclab_arena.evaluation_spec.v1\0"
+_REQUIREMENT_TYPES = (PredicateRequirement, AllOf, AnyOf)
+
+
+def _validate_requirement(requirement: RequirementSpec, field_name: str) -> None:
+    if not isinstance(requirement, _REQUIREMENT_TYPES):
+        raise TypeError(f"{field_name} must be a declarative requirement")
+
+
+@dataclass(frozen=True)
+class MilestoneSpec:
+    """Named progress milestone derived from the same evidence as success."""
+
+    name: str
+    """Stable task-local milestone name."""
+
+    requirement: RequirementSpec
+    """Condition that marks this milestone as reached."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.name, "MilestoneSpec.name")
+        _validate_requirement(self.requirement, "MilestoneSpec.requirement")
+
+
+@dataclass(frozen=True)
+class FailureSpec:
+    """Named semantic failure condition."""
+
+    code: str
+    """Stable machine-readable failure reason code."""
+
+    requirement: RequirementSpec
+    """Condition that identifies the failure."""
+
+    stage: str | None = None
+    """Optional task stage in which the failure is meaningful."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.code, "FailureSpec.code")
+        _validate_requirement(self.requirement, "FailureSpec.requirement")
+        if self.stage is not None:
+            validate_name(self.stage, "FailureSpec.stage")
+
+
+@dataclass(frozen=True)
+class EvaluationSpec:
+    """Simulator-independent declaration of task evaluation semantics."""
+
+    success: RequirementSpec
+    """Condition that defines task success."""
+
+    milestones: tuple[MilestoneSpec, ...] = ()
+    """Ordered progress conditions."""
+
+    failures: tuple[FailureSpec, ...] = ()
+    """Semantic failure conditions."""
+
+    protocol_version: str = "1"
+    """Version of the Evaluation protocol schema."""
+
+    def __post_init__(self) -> None:
+        validate_name(self.protocol_version, "EvaluationSpec.protocol_version")
+        _validate_requirement(self.success, "EvaluationSpec.success")
+
+        milestones = tuple(self.milestones)
+        failures = tuple(self.failures)
+        if not all(isinstance(milestone, MilestoneSpec) for milestone in milestones):
+            raise TypeError("EvaluationSpec.milestones must contain MilestoneSpec instances")
+        if not all(isinstance(failure, FailureSpec) for failure in failures):
+            raise TypeError("EvaluationSpec.failures must contain FailureSpec instances")
+        _validate_unique((milestone.name for milestone in milestones), "milestone name")
+        _validate_unique((failure.code for failure in failures), "failure code")
+        _validate_requirement_declarations(self.success, milestones, failures)
+
+        object.__setattr__(self, "milestones", milestones)
+        object.__setattr__(self, "failures", failures)
+
+    def to_canonical_dict(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible representation."""
+        return {
+            "failures": [
+                {
+                    "code": failure.code,
+                    "requirement": _requirement_to_dict(failure.requirement),
+                    "stage": failure.stage,
+                }
+                for failure in self.failures
+            ],
+            "milestones": [
+                {
+                    "name": milestone.name,
+                    "requirement": _requirement_to_dict(milestone.requirement),
+                }
+                for milestone in self.milestones
+            ],
+            "protocol_version": self.protocol_version,
+            "success": _requirement_to_dict(self.success),
+        }
+
+    def to_canonical_json(self) -> str:
+        """Serialize this specification to deterministic canonical JSON."""
+        return json.dumps(
+            self.to_canonical_dict(),
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def to_canonical_bytes(self) -> bytes:
+        """Serialize this specification to deterministic UTF-8 bytes."""
+        return self.to_canonical_json().encode("utf-8")
+
+    @property
+    def spec_hash(self) -> str:
+        """SHA-256 identity of evaluation semantics, excluding runtime role bindings."""
+        return hashlib.sha256(_SPEC_HASH_DOMAIN + self.to_canonical_bytes()).hexdigest()
+
+
+def _validate_unique(values, description: str) -> None:
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            raise ValueError(f"Duplicate {description}: {value!r}")
+        seen.add(value)
+
+
+def _iter_leaf_requirements(requirement: RequirementSpec):
+    if isinstance(requirement, PredicateRequirement):
+        yield requirement
+        return
+    for child in requirement.requirements:
+        yield from _iter_leaf_requirements(child)
+
+
+def _validate_requirement_declarations(
+    success: RequirementSpec,
+    milestones: tuple[MilestoneSpec, ...],
+    failures: tuple[FailureSpec, ...],
+) -> None:
+    declarations: dict[str, object] = {}
+    predicate_revisions: dict[str, str] = {}
+    roots = (
+        success,
+        *(milestone.requirement for milestone in milestones),
+        *(failure.requirement for failure in failures),
+    )
+    for root in roots:
+        for leaf in _iter_leaf_requirements(root):
+            existing = declarations.setdefault(leaf.name, leaf.predicate)
+            if existing != leaf.predicate:
+                raise ValueError(f"Requirement name {leaf.name!r} is reused with a different predicate")
+            predicate_id = leaf.predicate.predicate_id
+            predicate_version = leaf.predicate.predicate_version
+            existing_version = predicate_revisions.setdefault(predicate_id, predicate_version)
+            if existing_version != predicate_version:
+                raise ValueError(
+                    f"Predicate {predicate_id!r} uses multiple revisions: {existing_version!r} and"
+                    f" {predicate_version!r}"
+                )
+
+
+def _requirement_to_dict(requirement: RequirementSpec) -> dict[str, Any]:
+    if isinstance(requirement, PredicateRequirement):
+        return {
+            "name": requirement.name,
+            "predicate": {
+                "id": requirement.predicate.predicate_id,
+                "parameters": _json_to_builtin(requirement.predicate.parameters),
+                "roles": {name: role.name for name, role in requirement.predicate.roles.items()},
+                "version": requirement.predicate.predicate_version,
+            },
+            "type": "predicate",
+        }
+    if isinstance(requirement, AllOf):
+        return {
+            "requirements": [_requirement_to_dict(child) for child in requirement.requirements],
+            "type": "all_of",
+        }
+    if isinstance(requirement, AnyOf):
+        return {
+            "requirements": [_requirement_to_dict(child) for child in requirement.requirements],
+            "type": "any_of",
+        }
+    raise TypeError(f"Unsupported requirement type: {type(requirement).__name__}")
+
+
+def _json_to_builtin(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _json_to_builtin(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_to_builtin(item) for item in value]
+    return value

--- a/isaaclab_arena/evaluation/protocol/truth.py
+++ b/isaaclab_arena/evaluation/protocol/truth.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Three-valued truth operations used by evaluation requirements."""
+
+from collections.abc import Iterable
+from enum import StrEnum
+
+
+class TruthValue(StrEnum):
+    """Truth state of a predicate whose evidence may be unavailable."""
+
+    TRUE = "true"
+    FALSE = "false"
+    UNKNOWN = "unknown"
+
+
+def all_truth(values: Iterable[TruthValue]) -> TruthValue:
+    """Combine truth values using three-valued conjunction.
+
+    Args:
+        values: Truth values to combine.
+    """
+    saw_unknown = False
+    for value in values:
+        if not isinstance(value, TruthValue):
+            raise TypeError("all_truth values must be TruthValue instances")
+        if value is TruthValue.FALSE:
+            return TruthValue.FALSE
+        if value is TruthValue.UNKNOWN:
+            saw_unknown = True
+    return TruthValue.UNKNOWN if saw_unknown else TruthValue.TRUE
+
+
+def any_truth(values: Iterable[TruthValue]) -> TruthValue:
+    """Combine truth values using three-valued disjunction.
+
+    Args:
+        values: Truth values to combine.
+    """
+    saw_unknown = False
+    for value in values:
+        if not isinstance(value, TruthValue):
+            raise TypeError("any_truth values must be TruthValue instances")
+        if value is TruthValue.TRUE:
+            return TruthValue.TRUE
+        if value is TruthValue.UNKNOWN:
+            saw_unknown = True
+    return TruthValue.UNKNOWN if saw_unknown else TruthValue.FALSE

--- a/isaaclab_arena/tests/test_evaluation_requirements.py
+++ b/isaaclab_arena/tests/test_evaluation_requirements.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for declarative Evaluation requirements."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from isaaclab_arena.evaluation.protocol import (
+    AllOf,
+    AnyOf,
+    PredicateRequirement,
+    PredicateSpec,
+    RoleRef,
+    TruthValue,
+    evaluate_requirement,
+)
+
+
+def _predicate_requirement(name: str) -> PredicateRequirement:
+    return PredicateRequirement(
+        name=name,
+        predicate=PredicateSpec(
+            predicate_id="arena.spatial.object_in_receptacle",
+            predicate_version="1",
+            roles={"subject": RoleRef("object"), "receptacle": RoleRef("target")},
+            parameters={"xy_tolerance_m": 0.02},
+        ),
+    )
+
+
+def test_predicate_declaration_is_immutable_and_detached_from_input_mappings():
+    roles = {"subject": RoleRef("object")}
+    parameter_bounds = [0.05, 0.2]
+    parameter_options = {"axis": "z"}
+    parameters = {
+        "minimum_height_m": 0.05,
+        "bounds_m": parameter_bounds,
+        "options": parameter_options,
+    }
+    predicate = PredicateSpec(
+        predicate_id="arena.spatial.lifted",
+        predicate_version="1",
+        roles=roles,
+        parameters=parameters,
+    )
+
+    roles["subject"] = RoleRef("replacement")
+    parameters["minimum_height_m"] = 1.0
+    parameter_bounds[0] = 1.0
+    parameter_options["axis"] = "x"
+
+    assert predicate.roles["subject"] == RoleRef("object")
+    assert predicate.parameters["minimum_height_m"] == 0.05
+    assert predicate.parameters["bounds_m"] == (0.05, 0.2)
+    assert predicate.parameters["options"] == {"axis": "z"}
+    assert hash(predicate) == hash(
+        PredicateSpec(
+            predicate_id="arena.spatial.lifted",
+            predicate_version="1",
+            roles={"subject": RoleRef("object")},
+            parameters={
+                "minimum_height_m": 0.05,
+                "bounds_m": (0.05, 0.2),
+                "options": {"axis": "z"},
+            },
+        )
+    )
+    with pytest.raises(TypeError):
+        predicate.roles["subject"] = RoleRef("replacement")
+    with pytest.raises(FrozenInstanceError):
+        predicate.predicate_version = "2"
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: RoleRef(""),
+        lambda: RoleRef(1),
+        lambda: PredicateSpec("", "1"),
+        lambda: PredicateSpec("arena.spatial.lifted", ""),
+        lambda: PredicateSpec("arena.spatial.lifted", "1", roles={"subject": "object"}),
+        lambda: PredicateSpec("arena.spatial.lifted", "1", parameters={"threshold": object()}),
+        lambda: PredicateSpec("arena.spatial.lifted", "1", parameters={"nested": {1: "invalid"}}),
+        lambda: PredicateSpec("arena.spatial.lifted", "1", parameters={"threshold": float("nan")}),
+        lambda: PredicateRequirement("", PredicateSpec("arena.spatial.lifted", "1")),
+        lambda: AllOf(()),
+        lambda: AllOf((object(),)),
+        lambda: AnyOf(()),
+        lambda: AnyOf((object(),)),
+    ],
+)
+def test_invalid_declarations_fail_at_construction(factory):
+    with pytest.raises((TypeError, ValueError)):
+        factory()
+
+
+def test_requirement_reducer_evaluates_nested_expression():
+    placed = _predicate_requirement("placed")
+    released = _predicate_requirement("released")
+    stable = _predicate_requirement("stable")
+    requirement = AllOf((placed, AnyOf((released, stable))))
+
+    assert (
+        evaluate_requirement(
+            requirement,
+            {
+                "placed": TruthValue.TRUE,
+                "released": TruthValue.FALSE,
+                "stable": TruthValue.TRUE,
+            },
+        )
+        is TruthValue.TRUE
+    )
+    assert (
+        evaluate_requirement(
+            requirement,
+            {
+                "placed": TruthValue.TRUE,
+                "released": TruthValue.FALSE,
+                "stable": TruthValue.UNKNOWN,
+            },
+        )
+        is TruthValue.UNKNOWN
+    )
+    assert (
+        evaluate_requirement(
+            requirement,
+            {
+                "placed": TruthValue.FALSE,
+                "released": TruthValue.UNKNOWN,
+                "stable": TruthValue.UNKNOWN,
+            },
+        )
+        is TruthValue.FALSE
+    )
+
+
+def test_missing_predicate_evidence_is_unknown():
+    assert evaluate_requirement(_predicate_requirement("placed"), {}) is TruthValue.UNKNOWN
+
+
+def test_requirement_reducer_rejects_non_truth_evidence():
+    with pytest.raises(TypeError):
+        evaluate_requirement(_predicate_requirement("placed"), {"placed": "true"})

--- a/isaaclab_arena/tests/test_evaluation_result.py
+++ b/isaaclab_arena/tests/test_evaluation_result.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for pure-Python Evaluation result contracts."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from isaaclab_arena.evaluation.protocol import EvaluationOutcome, EvaluationResult, RequirementResult, TruthValue
+
+_SPEC_HASH = "a" * 64
+_BINDING_HASH = "b" * 64
+_PREDICATE_REVISIONS = {
+    "arena.manipulation.grasped": "1",
+    "arena.spatial.object_in_receptacle": "1",
+}
+
+
+def _success_result(**overrides) -> EvaluationResult:
+    values = {
+        "outcome": EvaluationOutcome.SUCCESS,
+        "completion_step": 42,
+        "progress": 1.0,
+        "spec_hash": _SPEC_HASH,
+        "predicate_revisions": _PREDICATE_REVISIONS,
+    }
+    values.update(overrides)
+    return EvaluationResult(**values)
+
+
+def test_success_result_carries_semantic_provenance_and_requirement_values():
+    requirement_results = {
+        "grasped": RequirementResult("grasped", TruthValue.TRUE),
+        "placed": RequirementResult("placed", TruthValue.TRUE),
+    }
+
+    result = EvaluationResult(
+        outcome=EvaluationOutcome.SUCCESS,
+        completion_step=42,
+        progress=1.0,
+        spec_hash=_SPEC_HASH,
+        predicate_revisions=_PREDICATE_REVISIONS,
+        binding_hash=_BINDING_HASH,
+        highest_milestone="grasped",
+        requirement_results=requirement_results,
+    )
+    requirement_results["stable"] = RequirementResult("stable", TruthValue.TRUE)
+
+    assert result.protocol_version == "1"
+    assert result.outcome is EvaluationOutcome.SUCCESS
+    assert result.completion_step == 42
+    assert result.predicate_revisions == _PREDICATE_REVISIONS
+    assert result.requirement_results == {
+        "grasped": RequirementResult("grasped", TruthValue.TRUE),
+        "placed": RequirementResult("placed", TruthValue.TRUE),
+    }
+    with pytest.raises(TypeError):
+        result.requirement_results["stable"] = RequirementResult("stable", TruthValue.TRUE)
+    with pytest.raises(TypeError):
+        result.predicate_revisions["arena.spatial.object_in_receptacle"] = "2"
+    with pytest.raises(FrozenInstanceError):
+        result.progress = 0.5
+
+
+def test_failure_result_carries_reason_without_defining_resolution_precedence():
+    result = EvaluationResult(
+        outcome=EvaluationOutcome.FAILURE,
+        progress=0.5,
+        spec_hash=_SPEC_HASH,
+        predicate_revisions={"arena.manipulation.dropped": "1"},
+        binding_hash=None,
+        failure_code="object_dropped",
+        failure_stage="transport",
+        requirement_results={"dropped": RequirementResult("dropped", TruthValue.TRUE)},
+    )
+
+    assert result.failure_code == "object_dropped"
+    assert result.failure_stage == "transport"
+
+
+def test_indeterminate_result_represents_missing_evidence_explicitly():
+    result = EvaluationResult(
+        outcome=EvaluationOutcome.INDETERMINATE,
+        progress=0.0,
+        spec_hash=_SPEC_HASH,
+        predicate_revisions={"arena.spatial.object_in_receptacle": "1"},
+        requirement_results={"placed": RequirementResult("placed", TruthValue.UNKNOWN)},
+    )
+
+    assert result.requirement_results["placed"].value is TruthValue.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: _success_result(completion_step=None),
+        lambda: _success_result(completion_step=-1),
+        lambda: _success_result(completion_step=True),
+        lambda: _success_result(progress=True),
+        lambda: _success_result(progress=-0.1),
+        lambda: _success_result(progress=1.1),
+        lambda: _success_result(spec_hash="not-a-sha256"),
+        lambda: _success_result(failure_code="object_dropped"),
+        lambda: _success_result(predicate_revisions={}),
+        lambda: _success_result(predicate_revisions={"arena.spatial.placed": ""}),
+        lambda: EvaluationResult(
+            outcome=EvaluationOutcome.FAILURE,
+            progress=0.5,
+            spec_hash=_SPEC_HASH,
+            predicate_revisions={"arena.manipulation.dropped": "1"},
+        ),
+        lambda: EvaluationResult(
+            outcome=EvaluationOutcome.INDETERMINATE,
+            progress=0.0,
+            spec_hash=_SPEC_HASH,
+            predicate_revisions={"arena.spatial.object_in_receptacle": "1"},
+            failure_stage="transport",
+        ),
+        lambda: _success_result(
+            requirement_results={"placed": RequirementResult("different_name", TruthValue.TRUE)},
+        ),
+    ],
+)
+def test_result_rejects_structurally_inconsistent_states(factory):
+    with pytest.raises((TypeError, ValueError)):
+        factory()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: RequirementResult("", TruthValue.TRUE),
+        lambda: RequirementResult("placed", "true"),
+    ],
+)
+def test_requirement_result_validates_its_public_contract(factory):
+    with pytest.raises((TypeError, ValueError)):
+        factory()

--- a/isaaclab_arena/tests/test_evaluation_spec.py
+++ b/isaaclab_arena/tests/test_evaluation_spec.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for EvaluationSpec validation, serialization, and identity."""
+
+import dataclasses
+import json
+
+import pytest
+
+from isaaclab_arena.evaluation.protocol import (
+    AllOf,
+    EvaluationSpec,
+    FailureSpec,
+    JsonValue,
+    MilestoneSpec,
+    PredicateRequirement,
+    PredicateSpec,
+    RoleRef,
+)
+
+
+def _requirement(
+    name: str,
+    predicate_id: str,
+    *,
+    roles: dict[str, RoleRef] | None = None,
+    parameters: dict[str, JsonValue] | None = None,
+    version: str = "1",
+) -> PredicateRequirement:
+    return PredicateRequirement(
+        name=name,
+        predicate=PredicateSpec(
+            predicate_id=predicate_id,
+            predicate_version=version,
+            roles=roles or {},
+            parameters=parameters or {},
+        ),
+    )
+
+
+def _pick_and_place_spec(*, tolerance_m: float = 0.02, predicate_version: str = "1") -> EvaluationSpec:
+    grasped = _requirement(
+        "grasped",
+        "arena.manipulation.grasped",
+        roles={"subject": RoleRef("object"), "agent": RoleRef("robot")},
+    )
+    placed = _requirement(
+        "placed",
+        "arena.spatial.object_in_receptacle",
+        roles={"receptacle": RoleRef("target"), "subject": RoleRef("object")},
+        parameters={"xy_tolerance_m": tolerance_m, "require_release": True},
+        version=predicate_version,
+    )
+    dropped = _requirement(
+        "dropped",
+        "arena.manipulation.dropped",
+        roles={"subject": RoleRef("object")},
+        parameters={"minimum_height_m": 0.4},
+    )
+    return EvaluationSpec(
+        success=AllOf((placed,)),
+        milestones=(MilestoneSpec("grasped", grasped),),
+        failures=(FailureSpec("object_dropped", dropped, stage="transport"),),
+    )
+
+
+def test_evaluation_spec_has_deterministic_canonical_serialization():
+    spec = _pick_and_place_spec()
+
+    payload = json.loads(spec.to_canonical_json())
+
+    assert payload == {
+        "failures": [{
+            "code": "object_dropped",
+            "requirement": {
+                "name": "dropped",
+                "predicate": {
+                    "id": "arena.manipulation.dropped",
+                    "parameters": {"minimum_height_m": 0.4},
+                    "roles": {"subject": "object"},
+                    "version": "1",
+                },
+                "type": "predicate",
+            },
+            "stage": "transport",
+        }],
+        "milestones": [{
+            "name": "grasped",
+            "requirement": {
+                "name": "grasped",
+                "predicate": {
+                    "id": "arena.manipulation.grasped",
+                    "parameters": {},
+                    "roles": {"agent": "robot", "subject": "object"},
+                    "version": "1",
+                },
+                "type": "predicate",
+            },
+        }],
+        "protocol_version": "1",
+        "success": {
+            "requirements": [{
+                "name": "placed",
+                "predicate": {
+                    "id": "arena.spatial.object_in_receptacle",
+                    "parameters": {"require_release": True, "xy_tolerance_m": 0.02},
+                    "roles": {"receptacle": "target", "subject": "object"},
+                    "version": "1",
+                },
+                "type": "predicate",
+            }],
+            "type": "all_of",
+        },
+    }
+    assert spec.to_canonical_bytes() == spec.to_canonical_json().encode("utf-8")
+    assert len(spec.spec_hash) == 64
+    assert all(character in "0123456789abcdef" for character in spec.spec_hash)
+
+
+def test_spec_hash_ignores_mapping_insertion_order():
+    first = _requirement(
+        "placed",
+        "arena.spatial.object_in_receptacle",
+        roles={"subject": RoleRef("object"), "receptacle": RoleRef("target")},
+        parameters={
+            "xy_tolerance_m": 0.02,
+            "require_release": True,
+            "stability": {"linear_mps": 0.01, "angular_radps": 0.1},
+            "axes": ("x", "y"),
+        },
+    )
+    second = _requirement(
+        "placed",
+        "arena.spatial.object_in_receptacle",
+        roles={"receptacle": RoleRef("target"), "subject": RoleRef("object")},
+        parameters={
+            "axes": ("x", "y"),
+            "stability": {"angular_radps": 0.1, "linear_mps": 0.01},
+            "require_release": True,
+            "xy_tolerance_m": 0.02,
+        },
+    )
+
+    assert EvaluationSpec(success=first).spec_hash == EvaluationSpec(success=second).spec_hash
+
+
+def test_spec_hash_changes_when_evaluation_semantics_change():
+    baseline = _pick_and_place_spec()
+
+    assert _pick_and_place_spec(tolerance_m=0.03).spec_hash != baseline.spec_hash
+    assert _pick_and_place_spec(predicate_version="2").spec_hash != baseline.spec_hash
+
+
+def test_spec_hash_is_independent_of_external_role_bindings():
+    spec = _pick_and_place_spec()
+    first_bindings = {"object": "red_cube", "target": "blue_bowl", "robot": "franka"}
+    second_bindings = {"object": "green_cube", "target": "tray", "robot": "ur10"}
+
+    assert first_bindings != second_bindings
+    assert spec.spec_hash == spec.spec_hash
+    assert "red_cube" not in spec.to_canonical_json()
+    assert "green_cube" not in spec.to_canonical_json()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: EvaluationSpec(
+            success=_requirement("placed", "arena.spatial.placed"),
+            milestones=(
+                MilestoneSpec("progress", _requirement("grasped", "arena.manipulation.grasped")),
+                MilestoneSpec("progress", _requirement("lifted", "arena.manipulation.lifted")),
+            ),
+        ),
+        lambda: EvaluationSpec(
+            success=_requirement("placed", "arena.spatial.placed"),
+            failures=(
+                FailureSpec("dropped", _requirement("dropped", "arena.manipulation.dropped")),
+                FailureSpec("dropped", _requirement("collision", "arena.safety.collision")),
+            ),
+        ),
+    ],
+)
+def test_spec_rejects_duplicate_milestone_names_and_failure_codes(factory):
+    with pytest.raises(ValueError):
+        factory()
+
+
+def test_spec_rejects_conflicting_reuse_of_requirement_name():
+    with pytest.raises(ValueError, match="placed"):
+        EvaluationSpec(
+            success=_requirement("placed", "arena.spatial.placed"),
+            milestones=(
+                MilestoneSpec(
+                    "placed",
+                    _requirement("placed", "arena.spatial.object_in_receptacle"),
+                ),
+            ),
+        )
+
+
+@pytest.mark.parametrize(("first_value", "second_value"), [(True, 1), (1, 1.0), (-0.0, 0.0)])
+def test_spec_rejects_type_distinct_json_values_for_one_requirement_name(first_value, second_value):
+    first = _requirement("placed", "arena.spatial.placed", parameters={"threshold": first_value})
+    second = _requirement("placed", "arena.spatial.placed", parameters={"threshold": second_value})
+
+    assert first.predicate != second.predicate
+    assert EvaluationSpec(success=first).spec_hash != EvaluationSpec(success=second).spec_hash
+    with pytest.raises(ValueError, match="placed"):
+        EvaluationSpec(success=first, milestones=(MilestoneSpec("placed", second),))
+
+
+def test_spec_rejects_multiple_revisions_of_one_predicate_id():
+    with pytest.raises(ValueError, match="arena.spatial.placed"):
+        EvaluationSpec(
+            success=_requirement("placed_v1", "arena.spatial.placed", version="1"),
+            milestones=(
+                MilestoneSpec(
+                    "placed_v2",
+                    _requirement("placed_v2", "arena.spatial.placed", version="2"),
+                ),
+            ),
+        )
+
+
+def test_evaluation_spec_is_frozen():
+    spec = _pick_and_place_spec()
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.protocol_version = "2"

--- a/isaaclab_arena/tests/test_evaluation_truth.py
+++ b/isaaclab_arena/tests/test_evaluation_truth.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Evaluation protocol's three-valued truth model."""
+
+import pytest
+
+from isaaclab_arena.evaluation.protocol.truth import TruthValue, all_truth, any_truth
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([], TruthValue.TRUE),
+        ([TruthValue.TRUE, TruthValue.TRUE], TruthValue.TRUE),
+        ([TruthValue.TRUE, TruthValue.UNKNOWN], TruthValue.UNKNOWN),
+        ([TruthValue.UNKNOWN, TruthValue.UNKNOWN], TruthValue.UNKNOWN),
+        ([TruthValue.TRUE, TruthValue.FALSE, TruthValue.UNKNOWN], TruthValue.FALSE),
+    ],
+)
+def test_all_truth_uses_three_valued_conjunction(values: list[TruthValue], expected: TruthValue):
+    assert all_truth(values) is expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        ([], TruthValue.FALSE),
+        ([TruthValue.FALSE, TruthValue.FALSE], TruthValue.FALSE),
+        ([TruthValue.FALSE, TruthValue.UNKNOWN], TruthValue.UNKNOWN),
+        ([TruthValue.UNKNOWN, TruthValue.UNKNOWN], TruthValue.UNKNOWN),
+        ([TruthValue.FALSE, TruthValue.TRUE, TruthValue.UNKNOWN], TruthValue.TRUE),
+    ],
+)
+def test_any_truth_uses_three_valued_disjunction(values: list[TruthValue], expected: TruthValue):
+    assert any_truth(values) is expected
+
+
+@pytest.mark.parametrize("reducer", [all_truth, any_truth])
+def test_truth_reducers_reject_boolean_values(reducer):
+    with pytest.raises(TypeError):
+        reducer([True])

--- a/isaaclab_arena/tests/test_packaging.py
+++ b/isaaclab_arena/tests/test_packaging.py
@@ -27,6 +27,7 @@ PACKAGE_ROOTS = (
 
 DISCOVERABLE_MODULES = (
     "isaaclab_arena.evaluation.policy_runner",
+    "isaaclab_arena.evaluation.protocol",
     "isaaclab_arena.tasks.sequential_composite_tasks.franka_put_and_close_door_task",
 )
 


### PR DESCRIPTION
## Summary

Introduces the pure-Python protocol layer for Arena Evaluation v1.

Arena already has local termination, recorder, metric, and predicate capabilities,
but it does not yet have a unified, immutable protocol for declaring task-evaluation
semantics. This PR establishes that protocol foundation without integrating with
Isaac Lab or changing existing runtime behavior.

## Included

- Three-valued logic: `TRUE`, `FALSE`, `UNKNOWN`
- Semantic `RoleRef`
- Versioned `PredicateSpec`
- `AllOf` and `AnyOf` requirement reduction
- Evaluation goals, milestones, and failures
- Immutable recursive JSON values
- Deterministic canonical JSON serialization
- Stable `spec_hash`
- `EvaluationResult` contracts, including:
  - outcome
  - completion step
  - progress
  - failure attribution
  - requirement results
  - predicate revisions
  - spec and binding hashes
- Validation rejecting multiple revisions of the same predicate ID
- Type-sensitive JSON identity
- Packaging support for the new evaluation subpackage

## Compatibility

This PR does not modify:

- `TaskBase`
- `ArenaEnvBuilder`
- termination behavior
- recorder behavior
- metrics
- Isaac Lab runtime
- existing tasks

Importing the protocol package does not load Isaac, Omni, or Isaac Sim modules.

## Validation

- 67 pure-Python tests passed
- Full pre-commit suite passed
- Python 3.12 wheel built and installed successfully
- 3 installed-package tests passed
- DCO sign-off included

## Non-goals

This PR does not implement:

- semantic role binding
- `binding_hash` computation
- predicate execution providers
- `EvaluationManager`
- shadow recorder integration
- PickAndPlace migration
- termination authority handoff

Those are planned as separate follow-up changes after the end-to-end coverage
audit and corresponding architecture decisions.
