### PR TITLE
Clarify persistent SimulationApp run_simulation_app_function()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ def _test_foo(simulation_app):  # runs inside SimulationApp
     return True  # indicates pass
 
 def test_foo():  # pytest-visible outer function
-    result = run_simulation_app_function(_test_foo)
+    result = run_function_with_persistent_simulation_app(_test_foo)
     assert result
 ```
 

--- a/isaaclab_arena/tests/conftest.py
+++ b/isaaclab_arena/tests/conftest.py
@@ -7,7 +7,8 @@
 # terminate the surrounding pytest process with exit code 0, regardless
 # of whether the tests passed or failed.
 # To work around this, we stash the session object and set a flag
-# when a test fails. This flag is checked in isaaclab_arena.tests.utils.subprocess.py
+# when a test fails. This flag is checked in
+# isaaclab_arena.tests.utils.persistent_simulation_app.py
 # prior to closing the simulation app, in order to generate the correct exit code.
 
 from __future__ import annotations

--- a/isaaclab_arena/tests/test_achieve_cube_goal_pose.py
+++ b/isaaclab_arena/tests/test_achieve_cube_goal_pose.py
@@ -8,7 +8,7 @@ import traceback
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -233,7 +233,7 @@ def _test_achieve_cube_goal_pose_multiple_envs(simulation_app) -> bool:
 
 
 def test_achieve_cube_goal_pose_initial_state():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_achieve_cube_goal_pose_initial_state,
         headless=HEADLESS,
     )
@@ -241,7 +241,7 @@ def test_achieve_cube_goal_pose_initial_state():
 
 
 def test_achieve_cube_goal_pose_success():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_achieve_cube_goal_pose_success,
         headless=HEADLESS,
     )
@@ -249,7 +249,7 @@ def test_achieve_cube_goal_pose_success():
 
 
 def test_achieve_cube_goal_pose_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_achieve_cube_goal_pose_multiple_envs,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_affordance_base.py
+++ b/isaaclab_arena/tests/test_affordance_base.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -41,7 +41,7 @@ def _test_affordance_base(simulation_app):
 
 
 def test_affordance_base():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_affordance_base,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -49,9 +49,11 @@ def _test_arena_env_graph_conversion_builds_sequential_pick_and_place_task(simul
 
 def test_arena_env_graph_conversion_builds_sequential_pick_and_place_task():
 
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_arena_env_graph_conversion_builds_sequential_pick_and_place_task)
+    result = run_function_with_persistent_simulation_app(
+        _test_arena_env_graph_conversion_builds_sequential_pick_and_place_task
+    )
     assert result
 
 
@@ -102,9 +104,9 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
 
 def test_get_arena_builder_from_cli_builds_env_from_graph_yaml():
 
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_get_arena_builder_from_cli_builds_env_from_graph_yaml)
+    result = run_function_with_persistent_simulation_app(_test_get_arena_builder_from_cli_builds_env_from_graph_yaml)
     assert result
 
 
@@ -129,9 +131,9 @@ def _test_arena_env_graph_conversion_builds_object_set_node(simulation_app):
 
 
 def test_arena_env_graph_conversion_builds_object_set_node():
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_arena_env_graph_conversion_builds_object_set_node)
+    result = run_function_with_persistent_simulation_app(_test_arena_env_graph_conversion_builds_object_set_node)
     assert result
 
 
@@ -182,7 +184,7 @@ def _test_default_light_is_injected_when_scene_has_none(simulation_app):
 
 
 def test_default_light_is_injected_when_scene_has_none():
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_default_light_is_injected_when_scene_has_none)
+    result = run_function_with_persistent_simulation_app(_test_default_light_is_injected_when_scene_has_none)
     assert result

--- a/isaaclab_arena/tests/test_assembly_task.py
+++ b/isaaclab_arena/tests/test_assembly_task.py
@@ -8,7 +8,7 @@ import gymnasium as gym
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -380,32 +380,32 @@ def _test_gear_mesh_initialization(simulation_app) -> bool:
 
 # Test functions that will be called by pytest
 def test_peg_insert_assembly_single():
-    result = run_simulation_app_function(_test_peg_insert_assembly_single, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_peg_insert_assembly_single, headless=HEADLESS)
     assert result, f"Test {_test_peg_insert_assembly_single.__name__} failed"
 
 
 def test_gear_mesh_assembly_single():
-    result = run_simulation_app_function(_test_gear_mesh_assembly_single, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_gear_mesh_assembly_single, headless=HEADLESS)
     assert result, f"Test {_test_gear_mesh_assembly_single.__name__} failed"
 
 
 def test_peg_insert_assembly_multi():
-    result = run_simulation_app_function(_test_peg_insert_assembly_multi, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_peg_insert_assembly_multi, headless=HEADLESS)
     assert result, f"Test {_test_peg_insert_assembly_multi.__name__} failed"
 
 
 def test_gear_mesh_assembly_multi():
-    result = run_simulation_app_function(_test_gear_mesh_assembly_multi, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_gear_mesh_assembly_multi, headless=HEADLESS)
     assert result, f"Test {_test_gear_mesh_assembly_multi.__name__} failed"
 
 
 def test_peg_insert_initialization():
-    result = run_simulation_app_function(_test_peg_insert_initialization, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_peg_insert_initialization, headless=HEADLESS)
     assert result, f"Test {_test_peg_insert_initialization.__name__} failed"
 
 
 def test_gear_mesh_initialization():
-    result = run_simulation_app_function(_test_gear_mesh_initialization, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_gear_mesh_initialization, headless=HEADLESS)
     assert result, f"Test {_test_gear_mesh_initialization.__name__} failed"
 
 

--- a/isaaclab_arena/tests/test_asset_registry.py
+++ b/isaaclab_arena/tests/test_asset_registry.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 
 from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.utils.pose import Pose
 
 NUM_STEPS = 2
@@ -37,7 +37,7 @@ def _test_default_assets_registered(simulation_app):
 
 def test_default_assets_registered():
     # Basic test that just adds all our pick-up objects to the scene and checks that nothing crashes.
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_default_assets_registered,
     )
     assert result, "Test failed"
@@ -123,7 +123,7 @@ def _test_all_assets_in_registry(simulation_app):
 
 def test_all_assets_in_registry():
     # Basic test that just adds all our pick-up objects to the scene and checks that nothing crashes.
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_all_assets_in_registry,
         headless=HEADLESS,
     )
@@ -154,7 +154,7 @@ def _test_hdr_images_registered(simulation_app):
 
 
 def test_hdr_images_registered():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_hdr_images_registered,
     )
     assert result, "Test failed"
@@ -213,7 +213,7 @@ def _test_hdr_image_spawn(simulation_app):
 
 def test_hdr_image_spawn():
     # Test that spawns a DomeLight with an HDR image and runs the simulation.
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_hdr_image_spawn,
         headless=HEADLESS,
     )
@@ -262,7 +262,7 @@ def _test_multi_light_in_scene(simulation_app):
 
 
 def test_multi_light_in_scene():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_multi_light_in_scene,
         headless=HEADLESS,
     )
@@ -298,7 +298,7 @@ def _test_get_assets_with_all_tags(simulation_app):
 
 
 def test_get_assets_with_all_tags():
-    result = run_simulation_app_function(_test_get_assets_with_all_tags)
+    result = run_function_with_persistent_simulation_app(_test_get_assets_with_all_tags)
     assert result, "Test failed"
 
 

--- a/isaaclab_arena/tests/test_build_time_variations.py
+++ b/isaaclab_arena/tests/test_build_time_variations.py
@@ -8,7 +8,7 @@ from dataclasses import field
 import pytest
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import BuildTimeVariationBase, VariationBaseCfg
 
@@ -101,14 +101,14 @@ def _test_enabled_build_time_variation_applied(simulation_app):
 
 
 def test_disabled_build_time_variation_not_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_build_time_variation_not_applied,
         headless=HEADLESS,
     )
 
 
 def test_enabled_build_time_variation_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_build_time_variation_applied,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_camera_extrinsics_variation.py
+++ b/isaaclab_arena/tests/test_camera_extrinsics_variation.py
@@ -7,7 +7,7 @@ import torch
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 ENABLE_CAMERAS = True
@@ -126,7 +126,7 @@ def _test_camera_extrinsics_variation_realized_at_runtime(simulation_app):
 
 @pytest.mark.with_cameras
 def test_disabled_camera_extrinsics_variation_not_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_camera_extrinsics_variation_not_in_events_cfg,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -135,7 +135,7 @@ def test_disabled_camera_extrinsics_variation_not_in_events_cfg():
 
 @pytest.mark.with_cameras
 def test_enabled_camera_extrinsics_variation_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_camera_extrinsics_variation_in_events_cfg,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -144,7 +144,7 @@ def test_enabled_camera_extrinsics_variation_in_events_cfg():
 
 @pytest.mark.with_cameras
 def test_camera_extrinsics_variation_realized_at_runtime():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_camera_extrinsics_variation_realized_at_runtime,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_camera_intrinsics_variation.py
+++ b/isaaclab_arena/tests/test_camera_intrinsics_variation.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 ENABLE_CAMERAS = True
@@ -133,7 +133,7 @@ def _test_camera_intrinsics_variation_realized_at_runtime(simulation_app):
 
 @pytest.mark.with_cameras
 def test_disabled_camera_intrinsics_variation_not_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_camera_intrinsics_variation_not_in_events_cfg,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -142,7 +142,7 @@ def test_disabled_camera_intrinsics_variation_not_in_events_cfg():
 
 @pytest.mark.with_cameras
 def test_enabled_camera_intrinsics_variation_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_camera_intrinsics_variation_in_events_cfg,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -151,7 +151,7 @@ def test_enabled_camera_intrinsics_variation_in_events_cfg():
 
 @pytest.mark.with_cameras
 def test_disabled_camera_intrinsics_variation_keeps_tiled_camera():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_camera_intrinsics_variation_keeps_tiled_camera,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -160,7 +160,7 @@ def test_disabled_camera_intrinsics_variation_keeps_tiled_camera():
 
 @pytest.mark.with_cameras
 def test_enabled_camera_intrinsics_variation_forces_untiled_camera():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_camera_intrinsics_variation_forces_untiled_camera,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -169,7 +169,7 @@ def test_enabled_camera_intrinsics_variation_forces_untiled_camera():
 
 @pytest.mark.with_cameras
 def test_camera_intrinsics_variation_realized_at_runtime():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_camera_intrinsics_variation_realized_at_runtime,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_camera_observation.py
+++ b/isaaclab_arena/tests/test_camera_observation.py
@@ -8,7 +8,7 @@ import tqdm
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 2
 HEADLESS = True
@@ -70,7 +70,7 @@ def _test_camera_observation(simulation_app) -> bool:
 @pytest.mark.with_cameras
 def test_camera_observation():
 
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_camera_observation,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_close_door.py
+++ b/isaaclab_arena/tests/test_close_door.py
@@ -7,7 +7,7 @@ import gymnasium as gym
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -236,15 +236,15 @@ def _test_close_door_with_reset(simulation_app) -> bool:
 
 # Test functions that will be called by pytest
 def test_close_door_microwave():
-    run_simulation_app_function(_test_close_door_microwave, headless=HEADLESS)
+    run_function_with_persistent_simulation_app(_test_close_door_microwave, headless=HEADLESS)
 
 
 def test_close_door_microwave_multiple_envs():
-    run_simulation_app_function(_test_close_door_microwave_multiple_envs, headless=HEADLESS)
+    run_function_with_persistent_simulation_app(_test_close_door_microwave_multiple_envs, headless=HEADLESS)
 
 
 def test_close_door_with_reset():
-    run_simulation_app_function(_test_close_door_with_reset, headless=HEADLESS)
+    run_function_with_persistent_simulation_app(_test_close_door_with_reset, headless=HEADLESS)
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_collection_import_hygiene.py
+++ b/isaaclab_arena/tests/test_collection_import_hygiene.py
@@ -12,7 +12,7 @@ delete/restore hack later mints a duplicate ``ArticulationCfg`` during Kit
 startup, and every robot-building test collected afterwards fails
 ``isinstance`` checks with "Unknown asset config type" (see IsaacLab #6514).
 Keep such imports inside the inner functions run via
-``run_simulation_app_function``.
+``run_function_with_persistent_simulation_app``.
 
 TODO(alexmillane, 2026-07-15): Remove this test once Isaac Lab #6514 is fixed.
 """
@@ -53,5 +53,5 @@ def test_no_isaaclab_cfg_imports_at_collection_time():
     assert not offenders, (
         "These test modules import Isaac Lab cfg modules at collection (module) time, which duplicates "
         f"ArticulationCfg once the SimulationApp launches: {offenders}. "
-        "Defer the imports into the inner function run via run_simulation_app_function."
+        "Defer the imports into the inner function run via run_function_with_persistent_simulation_app."
     )

--- a/isaaclab_arena/tests/test_composite_open_door.py
+++ b/isaaclab_arena/tests/test_composite_open_door.py
@@ -7,7 +7,7 @@ import gymnasium as gym
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -315,7 +315,7 @@ def _test_composite_open_door_microwave_reset_condition(simulation_app) -> bool:
 
 
 def test_composite_open_door_microwave():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_composite_open_door_microwave,
         headless=HEADLESS,
     )
@@ -323,7 +323,7 @@ def test_composite_open_door_microwave():
 
 
 def test_reverse_order_composite_open_door_microwave():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_reverse_order_composite_open_door_microwave,
         headless=HEADLESS,
     )
@@ -331,7 +331,7 @@ def test_reverse_order_composite_open_door_microwave():
 
 
 def test_composite_open_door_microwave_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_composite_open_door_microwave_multiple_envs,
         headless=HEADLESS,
     )
@@ -339,7 +339,7 @@ def test_composite_open_door_microwave_multiple_envs():
 
 
 def test_reverse_order_composite_open_door_microwave_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_reverse_order_composite_open_door_microwave_multiple_envs,
         headless=HEADLESS,
     )
@@ -347,7 +347,7 @@ def test_reverse_order_composite_open_door_microwave_multiple_envs():
 
 
 def test_composite_open_door_microwave_reset_condition():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_composite_open_door_microwave_reset_condition,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_composite_task_base.py
+++ b/isaaclab_arena/tests/test_composite_task_base.py
@@ -5,7 +5,7 @@
 
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -243,7 +243,7 @@ def _test_composite_desired_subtask_success_state_with_none(simulation_app) -> b
 
 
 def test_composite_desired_subtask_success_state_with_none():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_composite_desired_subtask_success_state_with_none,
         headless=HEADLESS,
     )
@@ -251,7 +251,7 @@ def test_composite_desired_subtask_success_state_with_none():
 
 
 def test_add_suffix_configclass_transform():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_add_suffix_configclass_transform,
         headless=HEADLESS,
     )
@@ -259,7 +259,7 @@ def test_add_suffix_configclass_transform():
 
 
 def test_remove_configclass_transform():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_remove_configclass_transform,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_contact_sensor_not_at_root.py
+++ b/isaaclab_arena/tests/test_contact_sensor_not_at_root.py
@@ -6,7 +6,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -105,7 +105,7 @@ def _test_contact_sensor_not_at_root(simulation_app) -> bool:
 
 
 def test_contact_sensor_not_at_root():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_contact_sensor_not_at_root,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_detect_object_type.py
+++ b/isaaclab_arena/tests/test_detect_object_type.py
@@ -9,7 +9,7 @@ import traceback
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 NUM_STEPS = 10
@@ -154,7 +154,7 @@ def _test_auto_object_type(simulation_app):
 
 
 def test_detect_object_type():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_detect_object_type,
         headless=HEADLESS,
     )
@@ -162,7 +162,7 @@ def test_detect_object_type():
 
 
 def test_detect_object_type_for_all_objects():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_detect_object_type_for_all_objects,
         headless=HEADLESS,
     )
@@ -170,7 +170,7 @@ def test_detect_object_type_for_all_objects():
 
 
 def test_auto_object_type():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_auto_object_type,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_device_and_retargeter_registry.py
+++ b/isaaclab_arena/tests/test_device_and_retargeter_registry.py
@@ -8,7 +8,7 @@ import torch
 import tqdm
 
 from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import teardown_simulation_app
 
 NUM_STEPS = 2
@@ -75,7 +75,7 @@ def _test_all_devices_and_retargeters_in_registry(simulation_app):
 
 def test_all_devices_and_retargeters_in_registry():
     # Basic test that just adds all our pick-up objects to the scene and checks that nothing crashes.
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_all_devices_and_retargeters_in_registry,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_duplicate_asset.py
+++ b/isaaclab_arena/tests/test_duplicate_asset.py
@@ -6,7 +6,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -129,7 +129,7 @@ def _test_duplicate_asset(simulation_app) -> bool:
 
 
 def test_duplicate_asset():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_duplicate_asset,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_embodiment_collision_mesh.py
+++ b/isaaclab_arena/tests/test_embodiment_collision_mesh.py
@@ -5,7 +5,7 @@
 
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 
 def _test_embodiment_provides_robot_collision_mesh(simulation_app) -> bool:
@@ -50,7 +50,7 @@ def _test_embodiment_provides_robot_collision_mesh(simulation_app) -> bool:
 
 def test_embodiment_provides_robot_collision_mesh():
     """Pytest entry point for the embodiment collision-mesh test."""
-    result = run_simulation_app_function(_test_embodiment_provides_robot_collision_mesh, headless=True)
+    result = run_function_with_persistent_simulation_app(_test_embodiment_provides_robot_collision_mesh, headless=True)
     assert result, f"Test {test_embodiment_provides_robot_collision_mesh.__name__} failed"
 
 

--- a/isaaclab_arena/tests/test_episode_recorder.py
+++ b/isaaclab_arena/tests/test_episode_recorder.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import RunTimeVariationBase, VariationBaseCfg
 
@@ -249,19 +249,19 @@ def _test_custom_term(simulation_app, output_dir):  # noqa: ARG001
 
 
 def test_core_terms(tmp_path):
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_core_terms, headless=HEADLESS, output_dir=tmp_path
     ), "core recorder terms test failed"
 
 
 def test_variations_recorded(tmp_path):
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_variations_recorded, headless=HEADLESS, output_dir=tmp_path
     ), "variation recording test failed"
 
 
 def test_custom_term(tmp_path):
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_custom_term, headless=HEADLESS, output_dir=tmp_path
     ), "custom recorder term test failed"
 

--- a/isaaclab_arena/tests/test_events.py
+++ b/isaaclab_arena/tests/test_events.py
@@ -9,7 +9,7 @@ import traceback
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -193,7 +193,7 @@ def _test_object_moves_with_initial_velocity(simulation_app):
 
 
 def test_set_object_post_per_env_event():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_set_object_pose_per_env_event,
         headless=HEADLESS,
     )
@@ -201,7 +201,7 @@ def test_set_object_post_per_env_event():
 
 
 def test_object_moves_with_initial_velocity():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_moves_with_initial_velocity,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -19,7 +19,7 @@ from isaaclab_arena.hydra.typed_experiment_loader import load_arena_experiment_f
 from isaaclab_arena.hydra.typed_experiment_serializer import serialize_arena_experiment_to_yaml
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
 from isaaclab_arena.tests.utils.constants import TestConstants
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena_environments.pick_and_place_maple_table_environment import PickAndPlaceMapleTableEnvironmentCfg
 
 GETTING_STARTED_EXPERIMENT_PATH = (
@@ -138,7 +138,7 @@ def _test_getting_started_experiment_executes_baseline_run(simulation_app, outpu
 
 
 def test_getting_started_experiment_executes_baseline_run(tmp_path):
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_getting_started_experiment_executes_baseline_run,
         headless=True,
         output_dir=tmp_path,

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -11,7 +11,8 @@ import pytest
 
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
 from isaaclab_arena.tests.utils.constants import TestConstants
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function, run_subprocess
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+from isaaclab_arena.tests.utils.subprocess import run_subprocess
 
 HEADLESS = True
 NUM_STEPS = 2
@@ -418,7 +419,7 @@ def _test_eval_config_variation_lands_in_events_cfg(simulation_app):
 
 @pytest.mark.with_cameras
 def test_eval_config_variation_lands_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_eval_config_variation_lands_in_events_cfg,
         headless=HEADLESS,
         enable_cameras=True,

--- a/isaaclab_arena/tests/test_g1_locomanip_apple_to_plate.py
+++ b/isaaclab_arena/tests/test_g1_locomanip_apple_to_plate.py
@@ -9,7 +9,7 @@ import traceback
 import pytest
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 WARMUP_STEPS = 50
@@ -399,7 +399,7 @@ def _test_mimic_cfg_brown_box_non_default_destination_is_not_legacy(simulation_a
 
 @pytest.mark.with_cameras
 def test_initial_state_not_terminated():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_initial_state_not_terminated,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -409,7 +409,7 @@ def test_initial_state_not_terminated():
 
 @pytest.mark.with_cameras
 def test_apple_on_plate_succeeds():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_apple_on_plate_succeeds,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -418,7 +418,7 @@ def test_apple_on_plate_succeeds():
 
 
 def test_mimic_cfg_uses_object_and_destination_names():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_mimic_cfg_uses_object_and_destination_names,
         headless=HEADLESS,
         enable_cameras=False,
@@ -427,7 +427,7 @@ def test_mimic_cfg_uses_object_and_destination_names():
 
 
 def test_mimic_cfg_brown_box_preserves_legacy_datagen_name():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_mimic_cfg_brown_box_preserves_legacy_datagen_name,
         headless=HEADLESS,
         enable_cameras=False,
@@ -436,7 +436,7 @@ def test_mimic_cfg_brown_box_preserves_legacy_datagen_name():
 
 
 def test_mimic_cfg_brown_box_non_default_destination_is_not_legacy():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_mimic_cfg_brown_box_non_default_destination_is_not_legacy,
         headless=HEADLESS,
         enable_cameras=False,

--- a/isaaclab_arena/tests/test_g1_static_pick_and_place.py
+++ b/isaaclab_arena/tests/test_g1_static_pick_and_place.py
@@ -18,7 +18,7 @@ import traceback
 import pytest
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 WARMUP_STEPS = 50
@@ -220,7 +220,7 @@ def _test_apple_on_plate_succeeds(simulation_app) -> bool:
 
 @pytest.mark.with_cameras
 def test_initial_state_not_terminated():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_initial_state_not_terminated,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -230,7 +230,7 @@ def test_initial_state_not_terminated():
 
 @pytest.mark.with_cameras
 def test_apple_on_plate_succeeds():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_apple_on_plate_succeeds,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_g1_wbc_embodiment.py
+++ b/isaaclab_arena/tests/test_g1_wbc_embodiment.py
@@ -11,7 +11,7 @@ import traceback
 import pytest
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -127,7 +127,7 @@ def _test_wbc_joint_standing_idle_actions(simulation_app) -> bool:
 
 @pytest.mark.with_cameras
 def test_wbc_joint_standing_idle_actions_single_env():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_wbc_joint_standing_idle_actions,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
@@ -165,7 +165,7 @@ def _test_wbc_pink_standing_idle_actions(simulation_app) -> bool:
 
 @pytest.mark.with_cameras
 def test_wbc_pink_standing_idle_actions_single_env():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_wbc_pink_standing_idle_actions,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_galbot_embodiment.py
+++ b/isaaclab_arena/tests/test_galbot_embodiment.py
@@ -9,7 +9,7 @@ import tqdm
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -180,7 +180,7 @@ def _test_galbot_observation_config(simulation_app) -> bool:
 
 def test_galbot_initial_position():
     """Pytest entry point for Galbot initial position test."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_galbot_initial_position,
         headless=HEADLESS,
     )
@@ -189,7 +189,7 @@ def test_galbot_initial_position():
 
 def test_galbot_action_space():
     """Pytest entry point for Galbot action space test."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_galbot_action_space,
         headless=HEADLESS,
     )
@@ -198,7 +198,7 @@ def test_galbot_action_space():
 
 def test_galbot_observation_config():
     """Pytest entry point for Galbot observation configuration test."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_galbot_observation_config,
         headless=HEADLESS,
     )
@@ -272,7 +272,7 @@ def _test_galbot_arm_reaches_goal(simulation_app) -> bool:
 
 def test_galbot_arm_reaches_goal():
     """Pytest entry point for Galbot arm reaching goal test."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_galbot_arm_reaches_goal,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_hdr_image_variation.py
+++ b/isaaclab_arena/tests/test_hdr_image_variation.py
@@ -5,7 +5,7 @@
 
 """Tests for :class:`HDRImageVariation` wired through :class:`ArenaEnvBuilder`."""
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.hdr_image_variation import HDRImageVariationCfg
 
 HEADLESS = True
@@ -54,7 +54,7 @@ def _test_enabled_hdr_variation_in_compiled_scene(simulation_app):
 
 
 def test_enabled_hdr_variation_in_compiled_scene():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_hdr_variation_in_compiled_scene,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_isaac_sim_debug_draw.py
+++ b/isaaclab_arena/tests/test_isaac_sim_debug_draw.py
@@ -5,7 +5,7 @@
 
 """Smoke tests for IsaacSimDebugDraw."""
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 
 def smoke_test_debug_draw(simulation_app) -> bool:
@@ -29,5 +29,5 @@ def smoke_test_debug_draw(simulation_app) -> bool:
 
 def test_isaac_sim_debug_draw_smoke():
     """Smoke test: IsaacSimDebugDraw initializes and runs without errors."""
-    result = run_simulation_app_function(smoke_test_debug_draw)
+    result = run_function_with_persistent_simulation_app(smoke_test_debug_draw)
     assert result, "IsaacSimDebugDraw smoke test failed"

--- a/isaaclab_arena/tests/test_isaaclab_bug_get_local_poses.py
+++ b/isaaclab_arena/tests/test_isaaclab_bug_get_local_poses.py
@@ -14,7 +14,7 @@ import torch
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.utils.pose import Pose
 
 HEADLESS = True
@@ -70,7 +70,7 @@ def _test_get_local_poses_matches_camera_offset_cfg(simulation_app) -> bool:
 
 @pytest.mark.with_cameras
 def test_get_local_poses_matches_camera_offset_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_get_local_poses_matches_camera_offset_cfg,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,

--- a/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
+++ b/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 _KITCHEN_BENCH_DIR = Path(__file__).resolve().parents[2] / "isaaclab_arena_environments" / "kitchen_bench"
 _KITCHEN_BENCH_YAMLS = sorted(_KITCHEN_BENCH_DIR.glob("*.yaml"))
@@ -54,7 +54,7 @@ def _test_kitchen_bench_yaml_env_bringup(simulation_app, *, yaml_path: Path) -> 
 def test_kitchen_bench_yaml_env_bringup(yaml_path: Path):
     """Each kitchen_bench YAML must parse and produce a resettable Arena env."""
     assert yaml_path.is_file(), f"missing kitchen_bench YAML: {yaml_path}"
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_kitchen_bench_yaml_env_bringup,
         headless=True,
         yaml_path=yaml_path,

--- a/isaaclab_arena/tests/test_light_color_temperature_variation.py
+++ b/isaaclab_arena/tests/test_light_color_temperature_variation.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
 HEADLESS = True
@@ -87,8 +87,12 @@ def _test_enabled_light_color_temperature_variation_applied(simulation_app):
 
 
 def test_disabled_light_color_temperature_variation_not_applied():
-    assert run_simulation_app_function(_test_disabled_light_color_temperature_variation_not_applied, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_disabled_light_color_temperature_variation_not_applied, headless=HEADLESS
+    )
 
 
 def test_enabled_light_color_temperature_variation_applied():
-    assert run_simulation_app_function(_test_enabled_light_color_temperature_variation_applied, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_enabled_light_color_temperature_variation_applied, headless=HEADLESS
+    )

--- a/isaaclab_arena/tests/test_light_color_variation.py
+++ b/isaaclab_arena/tests/test_light_color_variation.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
 HEADLESS = True
@@ -76,8 +76,10 @@ def _test_enabled_light_color_variation_applied(simulation_app):
 
 
 def test_disabled_light_color_variation_not_applied():
-    assert run_simulation_app_function(_test_disabled_light_color_variation_not_applied, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_disabled_light_color_variation_not_applied, headless=HEADLESS
+    )
 
 
 def test_enabled_light_color_variation_applied():
-    assert run_simulation_app_function(_test_enabled_light_color_variation_applied, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_enabled_light_color_variation_applied, headless=HEADLESS)

--- a/isaaclab_arena/tests/test_light_direction_variation.py
+++ b/isaaclab_arena/tests/test_light_direction_variation.py
@@ -9,7 +9,7 @@ import torch
 import pytest
 from isaaclab.utils.math import quat_apply
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.light_direction_variation import quat_xyzw_from_azimuth_elevation
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
@@ -127,14 +127,14 @@ def _test_enabled_light_direction_variation_applied(simulation_app):
 
 
 def test_disabled_light_direction_variation_not_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_light_direction_variation_not_applied,
         headless=HEADLESS,
     )
 
 
 def test_enabled_light_direction_variation_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_light_direction_variation_applied,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_light_intensity_variation.py
+++ b/isaaclab_arena/tests/test_light_intensity_variation.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
 HEADLESS = True
@@ -75,14 +75,14 @@ def _test_enabled_light_intensity_variation_applied(simulation_app):
 
 
 def test_disabled_light_intensity_variation_not_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_light_intensity_variation_not_applied,
         headless=HEADLESS,
     )
 
 
 def test_enabled_light_intensity_variation_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_light_intensity_variation_applied,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_locomanip_object_on_termination.py
+++ b/isaaclab_arena/tests/test_locomanip_object_on_termination.py
@@ -6,7 +6,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 50
 HEADLESS = True
@@ -101,7 +101,7 @@ def _test_g1_locomanip_object_on_destination_termination(simulation_app) -> bool
 
 
 def test_g1_locomanip_object_on_destination_termination():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_g1_locomanip_object_on_destination_termination,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_configuration.py
+++ b/isaaclab_arena/tests/test_object_configuration.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -31,7 +31,7 @@ def _test_object_initial_pose_update(simulation_app):
 
 
 def test_object_configuration():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_initial_pose_update,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_mass_variation.py
+++ b/isaaclab_arena/tests/test_object_mass_variation.py
@@ -7,7 +7,7 @@ import torch
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.object_mass_variation import ObjectMassVariationCfg
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 
@@ -344,56 +344,56 @@ def _test_object_mass_sample_below_floor_fails(simulation_app):
 
 
 def test_object_mass_variation_registration():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_object_mass_variation_registration,
         headless=HEADLESS,
     )
 
 
 def test_disabled_object_mass_variation_not_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_object_mass_variation_not_in_events_cfg,
         headless=HEADLESS,
     )
 
 
 def test_enabled_object_mass_variation_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_object_mass_variation_in_events_cfg,
         headless=HEADLESS,
     )
 
 
 def test_object_mass_variation_realized_and_recorded():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_object_mass_variation_realized_and_recorded,
         headless=HEADLESS,
     )
 
 
 def test_object_mass_variation_scales_inertia():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_object_mass_variation_scales_inertia,
         headless=HEADLESS,
     )
 
 
 def test_hydra_override_applies_object_mass_variation():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_hydra_override_applies_object_mass_variation,
         headless=HEADLESS,
     )
 
 
 def test_object_mass_variation_partial_reset_accepts_sequence_env_ids():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_object_mass_variation_partial_reset_accepts_sequence_env_ids,
         headless=HEADLESS,
     )
 
 
 def test_object_mass_sample_below_floor_fails():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_object_mass_sample_below_floor_fails,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_of_type_base.py
+++ b/isaaclab_arena/tests/test_object_of_type_base.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 100
 HEADLESS = True
@@ -88,7 +88,7 @@ def _test_object_of_type_base(simulation_app):
 
 
 def test_object_of_type_base():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_of_type_base,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_on_microwave_tray.py
+++ b/isaaclab_arena/tests/test_object_on_microwave_tray.py
@@ -8,7 +8,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 120
 HEADLESS = True
@@ -96,7 +96,7 @@ def _test_object_on_microwave_tray_termination(simulation_app) -> bool:
 
 
 def test_object_on_microwave_tray_termination():
-    result = run_simulation_app_function(_test_object_on_microwave_tray_termination, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_object_on_microwave_tray_termination, headless=HEADLESS)
     assert result, "Test failed"
 
 

--- a/isaaclab_arena/tests/test_object_on_termination.py
+++ b/isaaclab_arena/tests/test_object_on_termination.py
@@ -10,7 +10,7 @@ import traceback
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 50
 HEADLESS = True
@@ -139,7 +139,7 @@ def _test_object_on_destination_termination(simulation_app) -> bool:
 
 
 def test_object_on_destination_termination():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_on_destination_termination,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_pose_randomization.py
+++ b/isaaclab_arena/tests/test_object_pose_randomization.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_RESETS = 10
 NUM_STEPS_PER_RESET = 1
@@ -101,7 +101,7 @@ def _test_object_pose_randomization(simulation_app):
 
 
 def test_object_pose_randomization():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_pose_randomization,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_scale.py
+++ b/isaaclab_arena/tests/test_object_scale.py
@@ -5,7 +5,7 @@
 
 """Tests for object scale parameter (LibraryObject and subclasses)."""
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -38,7 +38,7 @@ def _test_object_scale_default_and_override(simulation_app):
 
 
 def test_object_scale_default_and_override():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_scale_default_and_override,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_set.py
+++ b/isaaclab_arena/tests/test_object_set.py
@@ -7,7 +7,7 @@ import os
 import traceback
 from unittest.mock import patch
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 NUM_ENVS = 10
@@ -476,7 +476,7 @@ def _test_multi_object_sets(simulation_app):
 
 
 def test_empty_object_set():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_empty_object_set,
         headless=HEADLESS,
     )
@@ -484,7 +484,7 @@ def test_empty_object_set():
 
 
 def test_object_set_samples_and_stores_variant_indices():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_set_samples_and_stores_variant_indices,
         headless=HEADLESS,
     )
@@ -492,7 +492,7 @@ def test_object_set_samples_and_stores_variant_indices():
 
 
 def test_object_set_default_variant_indices_follow_member_order():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_set_default_variant_indices_follow_member_order,
         headless=HEADLESS,
     )
@@ -500,7 +500,7 @@ def test_object_set_default_variant_indices_follow_member_order():
 
 
 def test_object_set_random_variant_indices_use_placement_seed():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_set_random_variant_indices_use_placement_seed,
         headless=HEADLESS,
     )
@@ -508,7 +508,7 @@ def test_object_set_random_variant_indices_use_placement_seed():
 
 
 def test_object_set_regenerates_variants_with_different_num_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_set_regenerates_variants_with_different_num_envs,
         headless=HEADLESS,
     )
@@ -516,7 +516,7 @@ def test_object_set_regenerates_variants_with_different_num_envs():
 
 
 def test_articulation_object_set():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_articulation_object_set,
         headless=HEADLESS,
     )
@@ -524,7 +524,7 @@ def test_articulation_object_set():
 
 
 def test_single_object_in_one_object_set():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_single_object_in_one_object_set,
         headless=HEADLESS,
     )
@@ -532,7 +532,7 @@ def test_single_object_in_one_object_set():
 
 
 def test_multi_objects_in_one_object_set():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_multi_objects_in_one_object_set,
         headless=HEADLESS,
     )
@@ -540,7 +540,7 @@ def test_multi_objects_in_one_object_set():
 
 
 def test_multi_object_sets():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_multi_object_sets,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_set_on_termination.py
+++ b/isaaclab_arena/tests/test_object_set_on_termination.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 # Turned this up to 200 to ensure all objects fall below the velocity threshold.
 NUM_STEPS = 100
@@ -115,7 +115,7 @@ def _test_object_set_on_destination_termination(simulation_app) -> bool:
 
 
 def test_object_set_on_destination_termination():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_set_on_destination_termination,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_set_utils.py
+++ b/isaaclab_arena/tests/test_object_set_utils.py
@@ -7,7 +7,7 @@ import contextlib
 import os
 import tempfile
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -182,7 +182,7 @@ def _test_cache_pipeline_unifies_mixed_rigid_body_depths(simulation_app):
 
 
 def test_rescale_rename_rigid_body_and_save_to_cache_depth0():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_rescale_rename_rigid_body_and_save_to_cache_depth0,
         headless=HEADLESS,
     )
@@ -190,7 +190,7 @@ def test_rescale_rename_rigid_body_and_save_to_cache_depth0():
 
 
 def test_rescale_rename_rigid_body_and_save_to_cache_depth1():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_rescale_rename_rigid_body_and_save_to_cache_depth1,
         headless=HEADLESS,
     )
@@ -198,7 +198,7 @@ def test_rescale_rename_rigid_body_and_save_to_cache_depth1():
 
 
 def test_cache_pipeline_unifies_mixed_rigid_body_depths():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_cache_pipeline_unifies_mixed_rigid_body_depths,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_object_with_cfg_addons.py
+++ b/isaaclab_arena/tests/test_object_with_cfg_addons.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -41,7 +41,7 @@ def _test_object_with_cfg_addons(simulation_app):
 
 
 def test_object_with_cfg_addons():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_with_cfg_addons,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_open_door.py
+++ b/isaaclab_arena/tests/test_open_door.py
@@ -7,7 +7,7 @@ import gymnasium as gym
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -213,7 +213,7 @@ def _test_open_door_microwave_reset_condition(simulation_app) -> bool:
 
 
 def test_open_door_microwave():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_open_door_microwave,
         headless=HEADLESS,
     )
@@ -221,7 +221,7 @@ def test_open_door_microwave():
 
 
 def test_open_door_microwave_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_open_door_microwave_multiple_envs,
         headless=HEADLESS,
     )
@@ -229,7 +229,7 @@ def test_open_door_microwave_multiple_envs():
 
 
 def test_open_door_microwave_reset_condition():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_open_door_microwave_reset_condition,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_physics_presets.py
+++ b/isaaclab_arena/tests/test_physics_presets.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -101,23 +101,23 @@ def _test_builder_unknown_preset_raises(simulation_app) -> bool:
 
 
 def test_arena_physics_cfg_presets():
-    assert run_simulation_app_function(_test_arena_physics_cfg_presets, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_arena_physics_cfg_presets, headless=HEADLESS)
 
 
 def test_builder_no_presets_defaults_to_physx():
-    assert run_simulation_app_function(_test_builder_no_presets_defaults_to_physx, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_builder_no_presets_defaults_to_physx, headless=HEADLESS)
 
 
 def test_builder_physx_preset():
-    assert run_simulation_app_function(_test_builder_physx_preset, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_builder_physx_preset, headless=HEADLESS)
 
 
 def test_builder_newton_preset():
-    assert run_simulation_app_function(_test_builder_newton_preset, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_builder_newton_preset, headless=HEADLESS)
 
 
 def test_builder_unknown_preset_raises():
-    assert run_simulation_app_function(_test_builder_unknown_preset_raises, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_builder_unknown_preset_raises, headless=HEADLESS)
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_physics_settle.py
+++ b/isaaclab_arena/tests/test_physics_settle.py
@@ -14,7 +14,7 @@ Each scenario runs end to end against a live SimulationApp:
 
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 SETTLE_STEPS = 30
@@ -336,22 +336,24 @@ def _test_validate_pool_layouts_grades_each_layout(simulation_app):
 
 
 def test_objects_settled_when_at_rest():
-    result = run_simulation_app_function(_test_objects_settled_when_at_rest, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_objects_settled_when_at_rest, headless=HEADLESS)
     assert result, f"Test {test_objects_settled_when_at_rest.__name__} failed"
 
 
 def test_objects_not_settled_when_colliding():
-    result = run_simulation_app_function(_test_objects_not_settled_when_colliding, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_objects_not_settled_when_colliding, headless=HEADLESS)
     assert result, f"Test {test_objects_not_settled_when_colliding.__name__} failed"
 
 
 def test_parallel_layout_validation_per_env():
-    result = run_simulation_app_function(_test_parallel_layout_validation_per_env, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_parallel_layout_validation_per_env, headless=HEADLESS)
     assert result, f"Test {test_parallel_layout_validation_per_env.__name__} failed"
 
 
 def test_validate_pool_layouts_grades_each_layout():
-    result = run_simulation_app_function(_test_validate_pool_layouts_grades_each_layout, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(
+        _test_validate_pool_layouts_grades_each_layout, headless=HEADLESS
+    )
     assert result, f"Test {test_validate_pool_layouts_grades_each_layout.__name__} failed"
 
 

--- a/isaaclab_arena/tests/test_place_upright_task.py
+++ b/isaaclab_arena/tests/test_place_upright_task.py
@@ -6,7 +6,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 5
 HEADLESS = True
@@ -181,7 +181,7 @@ def _test_place_upright_mug_condition(simulation_app) -> bool:
 
 
 def test_place_upright_mug_single():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_place_upright_mug_single,
         headless=HEADLESS,
     )
@@ -189,7 +189,7 @@ def test_place_upright_mug_single():
 
 
 def test_place_upright_mug_multi():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_place_upright_mug_multi,
         headless=HEADLESS,
     )
@@ -197,7 +197,7 @@ def test_place_upright_mug_multi():
 
 
 def test_place_upright_mug_condition():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_place_upright_mug_condition,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_press_coffee_machine_button.py
+++ b/isaaclab_arena/tests/test_press_coffee_machine_button.py
@@ -6,7 +6,7 @@
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 1
 HEADLESS = True
@@ -165,7 +165,7 @@ def _test_press_button_coffee_machine_multiple_envs(simulation_app) -> bool:
 
 
 def test_press_button_coffee_machine():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_press_button_coffee_machine,
         headless=HEADLESS,
     )
@@ -173,7 +173,7 @@ def test_press_button_coffee_machine():
 
 
 def test_press_button_coffee_machine_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_press_button_coffee_machine_multiple_envs,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_progress_objective_tracking.py
+++ b/isaaclab_arena/tests/test_progress_objective_tracking.py
@@ -5,7 +5,7 @@
 
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -721,75 +721,85 @@ def _test_task_base_progress_objective_hooks(simulation_app) -> bool:
 
 
 def test_predicate_groups_single_callable():
-    assert run_simulation_app_function(_test_predicate_groups_single_callable, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_predicate_groups_single_callable, headless=HEADLESS)
 
 
 def test_rest_pose_recorder_is_owned_by_env():
-    assert run_simulation_app_function(_test_rest_pose_recorder_is_owned_by_env, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_rest_pose_recorder_is_owned_by_env, headless=HEADLESS)
 
 
 def test_predicate_groups_list_of_callables():
-    assert run_simulation_app_function(_test_predicate_groups_list_of_callables, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_predicate_groups_list_of_callables, headless=HEADLESS)
 
 
 def test_predicate_groups_weighted_tuples():
-    assert run_simulation_app_function(_test_predicate_groups_weighted_tuples, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_predicate_groups_weighted_tuples, headless=HEADLESS)
 
 
 def test_predicate_groups_dict_groups():
-    assert run_simulation_app_function(_test_predicate_groups_dict_groups, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_predicate_groups_dict_groups, headless=HEADLESS)
 
 
 def test_predicate_groups_rejects_invalid_inputs():
-    assert run_simulation_app_function(_test_predicate_groups_rejects_invalid_inputs, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_predicate_groups_rejects_invalid_inputs, headless=HEADLESS)
 
 
 def test_state_machine_advances_sequentially():
-    assert run_simulation_app_function(_test_state_machine_advances_sequentially, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_state_machine_advances_sequentially, headless=HEADLESS)
 
 
 def test_state_machine_ignores_out_of_order_success():
-    assert run_simulation_app_function(_test_state_machine_ignores_out_of_order_success, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_state_machine_ignores_out_of_order_success, headless=HEADLESS
+    )
 
 
 def test_state_machine_logical_any():
-    assert run_simulation_app_function(_test_state_machine_logical_any, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_state_machine_logical_any, headless=HEADLESS)
 
 
 def test_state_machine_logical_all():
-    assert run_simulation_app_function(_test_state_machine_logical_all, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_state_machine_logical_all, headless=HEADLESS)
 
 
 def test_state_machine_logical_choose():
-    assert run_simulation_app_function(_test_state_machine_logical_choose, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_state_machine_logical_choose, headless=HEADLESS)
 
 
 def test_state_machine_reset_clears_state():
-    assert run_simulation_app_function(_test_state_machine_reset_clears_state, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_state_machine_reset_clears_state, headless=HEADLESS)
 
 
 def test_gating_advance_when_parent_subtask_idx_matches():
-    assert run_simulation_app_function(_test_gating_advance_when_parent_subtask_idx_matches, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_gating_advance_when_parent_subtask_idx_matches, headless=HEADLESS
+    )
 
 
 def test_gating_blocked_when_parent_subtask_idx_mismatches():
-    assert run_simulation_app_function(_test_gating_blocked_when_parent_subtask_idx_mismatches, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_gating_blocked_when_parent_subtask_idx_mismatches, headless=HEADLESS
+    )
 
 
 def test_gating_noop_when_env_has_no_current_subtask_idx():
-    assert run_simulation_app_function(_test_gating_noop_when_env_has_no_current_subtask_idx, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_gating_noop_when_env_has_no_current_subtask_idx, headless=HEADLESS
+    )
 
 
 def test_gating_sequential_task_end_to_end():
-    assert run_simulation_app_function(_test_gating_sequential_task_end_to_end, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_gating_sequential_task_end_to_end, headless=HEADLESS)
 
 
 def test_recorder_publishes_to_extras_and_records_nothing():
-    assert run_simulation_app_function(_test_recorder_publishes_to_extras_and_records_nothing, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(
+        _test_recorder_publishes_to_extras_and_records_nothing, headless=HEADLESS
+    )
 
 
 def test_task_base_progress_objective_hooks():
-    assert run_simulation_app_function(_test_task_base_progress_objective_hooks, headless=HEADLESS)
+    assert run_function_with_persistent_simulation_app(_test_task_base_progress_objective_hooks, headless=HEADLESS)
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_reference_objects.py
+++ b/isaaclab_arena/tests/test_reference_objects.py
@@ -10,7 +10,7 @@ import tqdm
 import traceback
 from types import SimpleNamespace
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose
 
@@ -412,7 +412,7 @@ def _test_reference_objects_with_transform(simulation_app, tmp_path: pathlib.Pat
 
 def test_reference_objects(tmp_path: pathlib.Path):
     tmp_path = tmp_path / "reference_objects.usd"
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_reference_objects,
         headless=HEADLESS,
         tmp_path=tmp_path,
@@ -425,7 +425,7 @@ def test_reference_objects_with_transform(tmp_path: pathlib.Path):
     # the test still works if the whole environment is translated and rotated.
     # This relies on the reference objects relative poses being correct.
     tmp_path = tmp_path / "reference_objects_with_transform.usd"
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_reference_objects_with_transform,
         headless=HEADLESS,
         tmp_path=tmp_path,

--- a/isaaclab_arena/tests/test_relation_placement_from_yaml.py
+++ b/isaaclab_arena/tests/test_relation_placement_from_yaml.py
@@ -8,7 +8,7 @@
 import traceback
 from pathlib import Path
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 _GRAPH = Path(__file__).parent / "test_data" / "pick_and_place_maple_table_env_graph.yaml"
 
@@ -71,7 +71,7 @@ def _test_yaml_spec_placement_satisfies_relations(simulation_app) -> bool:
 
 def test_yaml_spec_placement_satisfies_relations():
     """Pytest entry point: YAML spec -> built env -> solved placement honors relations."""
-    result = run_simulation_app_function(_test_yaml_spec_placement_satisfies_relations, headless=True)
+    result = run_function_with_persistent_simulation_app(_test_yaml_spec_placement_satisfies_relations, headless=True)
     assert result, f"Test {test_yaml_spec_placement_satisfies_relations.__name__} failed"
 
 

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -9,7 +9,7 @@ Background obstacles carry no relations (so they are absent from the relation gr
 but should still be avoided by placed objects.
 """
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -405,7 +405,7 @@ def _test_get_passive_collision_objects_filters(simulation_app) -> bool:
 
 
 def test_get_passive_collision_objects_filters():
-    result = run_simulation_app_function(_test_get_passive_collision_objects_filters, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_get_passive_collision_objects_filters, headless=HEADLESS)
     assert result, "get_passive_collision_objects() returned the wrong subset"
 
 

--- a/isaaclab_arena/tests/test_revolute_joint_moved_rate_metric.py
+++ b/isaaclab_arena/tests/test_revolute_joint_moved_rate_metric.py
@@ -9,7 +9,7 @@ import tqdm
 import traceback
 
 from isaaclab_arena.metrics.metric_data import MetricsDataCollection
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 100
 HEADLESS = True
@@ -102,7 +102,7 @@ def _test_revolute_joint_moved_rate(simulation_app):
 
 
 def test_revolute_joint_moved_rate_metric():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_revolute_joint_moved_rate,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_robot_initial_position.py
+++ b/isaaclab_arena/tests/test_robot_initial_position.py
@@ -10,7 +10,7 @@ import traceback
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -83,7 +83,7 @@ def _test_robot_initial_position(simulation_app):
 
 
 def test_robot_initial_position():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_robot_initial_position,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_robot_on_stand_utils.py
+++ b/isaaclab_arena/tests/test_robot_on_stand_utils.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 _HEIGHT_ATOL = 1e-3
 _ROOT_WRITE_ATOL = 5e-3
@@ -220,16 +220,18 @@ def _test_droid_stand_and_externals_under_link0(simulation_app) -> bool:
 
 
 def test_droid_on_stand_usd_compose():
-    result = run_simulation_app_function(_test_droid_on_stand_usd_compose)
+    result = run_function_with_persistent_simulation_app(_test_droid_on_stand_usd_compose)
     assert result, f"Test {test_droid_on_stand_usd_compose.__name__} failed"
 
 
 def test_franka_on_stand_usd_compose():
-    result = run_simulation_app_function(_test_franka_on_stand_usd_compose)
+    result = run_function_with_persistent_simulation_app(_test_franka_on_stand_usd_compose)
     assert result, f"Test {test_franka_on_stand_usd_compose.__name__} failed"
 
 
 @pytest.mark.with_cameras
 def test_droid_stand_and_externals_under_link0():
-    result = run_simulation_app_function(_test_droid_stand_and_externals_under_link0, enable_cameras=True)
+    result = run_function_with_persistent_simulation_app(
+        _test_droid_stand_and_externals_under_link0, enable_cameras=True
+    )
     assert result, f"Test {test_droid_stand_and_externals_under_link0.__name__} failed"

--- a/isaaclab_arena/tests/test_run_time_variations.py
+++ b/isaaclab_arena/tests/test_run_time_variations.py
@@ -9,7 +9,7 @@ import pytest
 from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import RunTimeVariationBase, VariationBaseCfg
 
@@ -171,21 +171,21 @@ def _test_runtime_variation_build_time_effects_applied(simulation_app):
 
 
 def test_disabled_runtime_variation_not_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_disabled_runtime_variation_not_in_events_cfg,
         headless=HEADLESS,
     )
 
 
 def test_enabled_runtime_variation_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_enabled_runtime_variation_in_events_cfg,
         headless=HEADLESS,
     )
 
 
 def test_runtime_variation_build_time_effects_applied():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_runtime_variation_build_time_effects_applied,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_scene_add_assets_ordering.py
+++ b/isaaclab_arena/tests/test_scene_add_assets_ordering.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -54,7 +54,7 @@ def _test_object_reference_without_parent_raises(simulation_app) -> bool:
 
 
 def test_object_references_added_before_parents():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_references_added_before_parents,
         headless=HEADLESS,
     )
@@ -62,7 +62,7 @@ def test_object_references_added_before_parents():
 
 
 def test_object_reference_without_parent_raises():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_object_reference_without_parent_raises,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_scene_to_usd.py
+++ b/isaaclab_arena/tests/test_scene_to_usd.py
@@ -6,7 +6,7 @@
 import numpy as np
 import pathlib
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 EPS = 1e-6
@@ -74,7 +74,7 @@ def _test_scene_to_usd(simulation_app, output_path: pathlib.Path) -> bool:
 def test_scene_to_usd(tmp_path: pathlib.Path):
     # The passed tmp_path is a directory.
     output_path = tmp_path / "saved_kitchen_with_cracker_box_for_test.usd"
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_scene_to_usd,
         headless=HEADLESS,
         output_path=output_path,

--- a/isaaclab_arena/tests/test_sequential_open_door.py
+++ b/isaaclab_arena/tests/test_sequential_open_door.py
@@ -7,7 +7,7 @@ import gymnasium as gym
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -336,7 +336,7 @@ def _test_sequential_open_door_microwave_reset_condition(simulation_app) -> bool
 
 
 def test_sequential_open_door_microwave():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_open_door_microwave,
         headless=HEADLESS,
     )
@@ -344,7 +344,7 @@ def test_sequential_open_door_microwave():
 
 
 def test_out_of_order_sequential_open_door_microwave():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_out_of_order_sequential_open_door_microwave,
         headless=HEADLESS,
     )
@@ -352,7 +352,7 @@ def test_out_of_order_sequential_open_door_microwave():
 
 
 def test_sequential_open_door_microwave_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_open_door_microwave_multiple_envs,
         headless=HEADLESS,
     )
@@ -360,7 +360,7 @@ def test_sequential_open_door_microwave_multiple_envs():
 
 
 def test_out_of_order_sequential_open_door_microwave_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_out_of_order_sequential_open_door_microwave_multiple_envs,
         headless=HEADLESS,
     )
@@ -368,7 +368,7 @@ def test_out_of_order_sequential_open_door_microwave_multiple_envs():
 
 
 def test_sequential_open_door_microwave_reset_condition():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_open_door_microwave_reset_condition,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_sequential_task_base.py
+++ b/isaaclab_arena/tests/test_sequential_task_base.py
@@ -5,7 +5,7 @@
 
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -280,7 +280,7 @@ def _test_sequential_reset_clears_state_and_index(simulation_app) -> bool:
 
 
 def test_sequential_success_advances_in_order():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_success_advances_in_order,
         headless=HEADLESS,
     )
@@ -288,7 +288,7 @@ def test_sequential_success_advances_in_order():
 
 
 def test_sequential_success_latches():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_success_latches,
         headless=HEADLESS,
     )
@@ -296,7 +296,7 @@ def test_sequential_success_latches():
 
 
 def test_sequential_desired_subtask_success_state():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_desired_subtask_success_state,
         headless=HEADLESS,
     )
@@ -304,7 +304,7 @@ def test_sequential_desired_subtask_success_state():
 
 
 def test_sequential_desired_subtask_success_state_with_none():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_desired_subtask_success_state_with_none,
         headless=HEADLESS,
     )
@@ -312,7 +312,7 @@ def test_sequential_desired_subtask_success_state_with_none():
 
 
 def test_sequential_reset_clears_state_and_index():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sequential_reset_clears_state_and_index,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_simulation_app_context.py
+++ b/isaaclab_arena/tests/test_simulation_app_context.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 TEST_ARG = 123
 
@@ -15,7 +15,7 @@ def simulation_app_running(simulation_app) -> bool:
 
 def test_simulation_app_context():
     # Run a function which returns True if the simulation app is running.
-    test_passed = run_simulation_app_function(
+    test_passed = run_function_with_persistent_simulation_app(
         simulation_app_running,
     )
     assert test_passed, "Tested function returned False"
@@ -26,9 +26,9 @@ def got_argument(_, test_arg: int) -> bool:
     return test_arg == TEST_ARG
 
 
-def test_run_simulation_app_function_with_arg():
+def test_run_function_with_persistent_simulation_app_with_arg():
     # Run a function which returns True if the simulation app is running.
-    test_passed = run_simulation_app_function(
+    test_passed = run_function_with_persistent_simulation_app(
         got_argument,
         test_arg=TEST_ARG,
     )

--- a/isaaclab_arena/tests/test_sorting_task.py
+++ b/isaaclab_arena/tests/test_sorting_task.py
@@ -8,7 +8,7 @@ import traceback
 
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -321,7 +321,7 @@ def _test_sorting_task_multiple_envs(simulation_app) -> bool:
 
 
 def test_sorting_task_initial_state():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sorting_task_initial_state,
         headless=HEADLESS,
     )
@@ -329,7 +329,7 @@ def test_sorting_task_initial_state():
 
 
 def test_sorting_task_success():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sorting_task_success,
         headless=HEADLESS,
     )
@@ -337,7 +337,7 @@ def test_sorting_task_success():
 
 
 def test_sorting_task_partial_success():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sorting_task_partial_success,
         headless=HEADLESS,
     )
@@ -345,7 +345,7 @@ def test_sorting_task_partial_success():
 
 
 def test_sorting_task_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_sorting_task_multiple_envs,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_success_rate_metric.py
+++ b/isaaclab_arena/tests/test_success_rate_metric.py
@@ -7,7 +7,7 @@ import torch
 import tqdm
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 100
 HEADLESS = True
@@ -123,7 +123,7 @@ def _test_success_rate_metric(simulation_app):
 
 
 def test_success_rate_metric():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_success_rate_metric,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_task_base.py
+++ b/isaaclab_arena/tests/test_task_base.py
@@ -5,7 +5,7 @@
 
 """Regression tests for TaskBase episode-length defaults."""
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 
 def _test_episode_length_defaults(simulation_app) -> bool:
@@ -41,5 +41,5 @@ def _test_episode_length_defaults(simulation_app) -> bool:
 
 
 def test_episode_length_defaults():
-    result = run_simulation_app_function(_test_episode_length_defaults)
+    result = run_function_with_persistent_simulation_app(_test_episode_length_defaults)
     assert result

--- a/isaaclab_arena/tests/test_task_registry.py
+++ b/isaaclab_arena/tests/test_task_registry.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 
 def _test_task_registry_resolves_concrete_tasks(simulation_app):
@@ -33,5 +33,5 @@ def _test_task_registry_resolves_concrete_tasks(simulation_app):
 
 
 def test_task_registry_resolves_concrete_tasks():
-    result = run_simulation_app_function(_test_task_registry_resolves_concrete_tasks)
+    result = run_function_with_persistent_simulation_app(_test_task_registry_resolves_concrete_tasks)
     assert result

--- a/isaaclab_arena/tests/test_turn_stand_mixer_knob.py
+++ b/isaaclab_arena/tests/test_turn_stand_mixer_knob.py
@@ -8,7 +8,7 @@ import random
 import torch
 import traceback
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 10
 HEADLESS = True
@@ -177,7 +177,7 @@ def _test_turn_stand_mixer_knob_reset_condition(simulation_app):
 
 
 def test_turn_stand_mixer_knob_to_desired_levels_single_env():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_turn_stand_mixer_knob_to_desired_levels_single_env,
         headless=HEADLESS,
     )
@@ -185,7 +185,7 @@ def test_turn_stand_mixer_knob_to_desired_levels_single_env():
 
 
 def test_turn_stand_mixer_knob_multiple_envs():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_turn_stand_mixer_knob_multiple_envs,
         headless=HEADLESS,
     )
@@ -193,7 +193,7 @@ def test_turn_stand_mixer_knob_multiple_envs():
 
 
 def test_turn_stand_mixer_knob_reset_condition():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_turn_stand_mixer_knob_reset_condition,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -5,7 +5,7 @@
 
 import pathlib
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 EPS = 1e-4
@@ -116,7 +116,7 @@ def _test_compute_local_bounding_box_from_usd_prim_path(simulation_app, asset_di
 
 
 def test_compute_local_bounding_box_from_usd(tmp_path: pathlib.Path):
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_compute_local_bounding_box_from_usd,
         headless=HEADLESS,
         asset_dir=tmp_path,
@@ -125,7 +125,7 @@ def test_compute_local_bounding_box_from_usd(tmp_path: pathlib.Path):
 
 
 def test_compute_local_bounding_box_from_usd_prim_path(tmp_path: pathlib.Path):
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_compute_local_bounding_box_from_usd_prim_path,
         headless=HEADLESS,
         asset_dir=tmp_path,

--- a/isaaclab_arena/tests/test_usd_pose_helpers.py
+++ b/isaaclab_arena/tests/test_usd_pose_helpers.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 EPS = 1e-6
@@ -48,7 +48,7 @@ def _test_get_prim_pose_in_default_prim_frame(simulation_app):
 
 def test_get_prim_pose_in_default_prim_frame():
     # Basic test that just adds all our pick-up objects to the scene and checks that nothing crashes.
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_get_prim_pose_in_default_prim_frame,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_usd_scale_helpers.py
+++ b/isaaclab_arena/tests/test_usd_scale_helpers.py
@@ -14,7 +14,7 @@ import tempfile
 
 import pytest
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -428,48 +428,54 @@ def _test_both_paths_agree_origin_prim(simulation_app):
 
 
 def test_extract_trimesh_translated_child_nonuniform_scale():
-    result = run_simulation_app_function(_test_extract_trimesh_translated_child_nonuniform_scale, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(
+        _test_extract_trimesh_translated_child_nonuniform_scale, headless=HEADLESS
+    )
     assert result
 
 
 def test_extract_trimesh_from_prim_scales_in_root_frame():
-    result = run_simulation_app_function(_test_extract_trimesh_from_prim_scales_in_root_frame, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(
+        _test_extract_trimesh_from_prim_scales_in_root_frame, headless=HEADLESS
+    )
     assert result
 
 
 def test_extract_trimesh_from_prim_keeps_mesh_with_unsupported_geometry():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_extract_trimesh_from_prim_keeps_mesh_with_unsupported_geometry, headless=HEADLESS
     )
     assert result
 
 
 def test_extract_trimesh_from_prim_rejects_analytic_only_geometry():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_extract_trimesh_from_prim_rejects_analytic_only_geometry, headless=HEADLESS
     )
     assert result
 
 
 def test_extract_trimesh_from_usd_keeps_mesh_with_unsupported_geometry():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_extract_trimesh_from_usd_keeps_mesh_with_unsupported_geometry, headless=HEADLESS
     )
     assert result
 
 
 def test_extract_trimesh_from_usd_rejects_analytic_only_geometry():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_extract_trimesh_from_usd_rejects_analytic_only_geometry, headless=HEADLESS
     )
     assert result
 
 
 def test_bbox_translated_child_nonuniform_scale():
-    result = run_simulation_app_function(_test_bbox_translated_child_nonuniform_scale, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(
+        _test_bbox_translated_child_nonuniform_scale, headless=HEADLESS
+    )
     assert result
 
 
 def test_both_paths_agree_origin_prim():
-    result = run_simulation_app_function(_test_both_paths_agree_origin_prim, headless=HEADLESS)
+    result = run_function_with_persistent_simulation_app(_test_both_paths_agree_origin_prim, headless=HEADLESS)
     assert result

--- a/isaaclab_arena/tests/test_variation_recorder.py
+++ b/isaaclab_arena/tests/test_variation_recorder.py
@@ -6,7 +6,7 @@
 """Tests for sample listeners and ``VariationRecorder``.
 
 Listener and recorder mechanics are plain Python (no SimulationApp). The end-to-end test that
-records a real HDR draw runs inside ``run_simulation_app_function`` because constructing a dome
+records a real HDR draw runs inside ``run_function_with_persistent_simulation_app`` because constructing a dome
 light via the registry pulls in ``isaaclab.sim``.
 """
 
@@ -16,7 +16,7 @@ from dataclasses import field
 import pytest
 from isaaclab.utils.configclass import configclass
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations.choice_sampler import ChoiceSampler
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import BuildTimeVariationBase, VariationBaseCfg
@@ -213,7 +213,7 @@ def _test_hdr_variation_recorder_captures_chosen_hdr_name(simulation_app):
 
 
 def test_hdr_variation_recorder_captures_chosen_hdr_name():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_hdr_variation_recorder_captures_chosen_hdr_name,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_variations_hydra.py
+++ b/isaaclab_arena/tests/test_variations_hydra.py
@@ -11,7 +11,7 @@ from isaaclab_arena.tests.test_build_time_variations import TestBuildTimeVariati
 from isaaclab_arena.tests.test_run_time_variations import TEST_EVENT_NAME
 from isaaclab_arena.tests.test_run_time_variations import get_test_environment as get_runtime_test_environment
 from isaaclab_arena.tests.test_run_time_variations import noop_test_variation_event
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.variations import variations_hydra
 
 HEADLESS = True
@@ -69,7 +69,7 @@ def _test_hydra_override_applies_build_time_variation(simulation_app):
 
 
 def test_hydra_override_applies_build_time_variation():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_hydra_override_applies_build_time_variation,
         headless=HEADLESS,
     )
@@ -103,7 +103,7 @@ def _test_hydra_override_enables_runtime_variation_in_events_cfg(simulation_app)
 
 
 def test_hydra_override_enables_runtime_variation_in_events_cfg():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_hydra_override_enables_runtime_variation_in_events_cfg,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_xr_anchor_pose.py
+++ b/isaaclab_arena/tests/test_xr_anchor_pose.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 
@@ -77,7 +77,7 @@ def _test_g1_wbc_pink_xr_anchor(simulation_app) -> bool:
 
 def test_gr1_pink_xr_anchor_pose():
     """GR1T2 Pink uses a fixed pelvis-relative XR anchor."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_gr1_pink_xr_anchor,
         headless=HEADLESS,
     )
@@ -86,7 +86,7 @@ def test_gr1_pink_xr_anchor_pose():
 
 def test_g1_wbc_pink_xr_anchor_pose():
     """G1 WBC Pink uses the same pelvis-relative XR anchor pattern as GR1T2."""
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_g1_wbc_pink_xr_anchor,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/utils/persistent_simulation_app.py
+++ b/isaaclab_arena/tests/utils/persistent_simulation_app.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import atexit
+import os
+import sys
+import traceback
+from collections.abc import Callable
+
+from isaaclab.app import AppLauncher
+from isaacsim import SimulationApp
+
+from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.tests.conftest import PYTEST_SESSION
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import get_app_launcher, teardown_simulation_app
+
+# NOTE(alexmillane): Isaac Sim makes testing complicated. During shutdown Isaac Sim will
+# terminate the surrounding pytest process with exit code 0, regardless
+# of whether the tests passed or failed.
+# To work around this, we track the failure state of the tests in two ways:
+# 1. We stash the pytest session object and set a flag when a test fails.
+# 2. We set a flag when a test fails.
+# These flags are checked before closing the persistent simulation app, and we
+# manually exit the process with exit code 1 if tests have failed.
+
+_PERSISTENT_SIM_APP_LAUNCHER: AppLauncher | None = None
+_PERSISTENT_INIT_ARGS = None  # store (headless, enable_cameras) used at first init
+_AT_LEAST_ONE_TEST_FAILED = False
+
+
+class _IsolatedArgv:
+    """Temporarily replace sys.argv so Kit doesn't see pytest flags like '-m'."""
+
+    def __init__(self, argv=None):
+        # Keep program name; drop the rest (or use provided list)
+        self._new = [sys.argv[0]] + (argv or [])
+        self._old = None
+
+    def __enter__(self):
+        self._old = sys.argv[:]
+        sys.argv = self._new
+
+    def __exit__(self, exc_type, exc, tb):
+        sys.argv = self._old
+
+
+def _close_persistent_simulation_app():
+    global _PERSISTENT_SIM_APP_LAUNCHER
+    global _AT_LEAST_ONE_TEST_FAILED
+    if _PERSISTENT_SIM_APP_LAUNCHER is not None:
+        tests_failed = PYTEST_SESSION.tests_failed or _AT_LEAST_ONE_TEST_FAILED
+        print(f"Closing persistent simulation app. Tests failed: {tests_failed}")
+        if tests_failed:
+            # If any test failed, exit the process with exit code 1
+            # to prevent Isaac Sim from terminating the pytest process with exit code 0.
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(1)
+        else:
+            _PERSISTENT_SIM_APP_LAUNCHER.app.close()
+
+
+def get_persistent_simulation_app(headless: bool, enable_cameras: bool = False) -> SimulationApp:
+    """Create once, reuse forever (until process exit)."""
+    global _PERSISTENT_SIM_APP_LAUNCHER, _PERSISTENT_INIT_ARGS
+    # Create a new simulation app if it doesn't exist
+    if _PERSISTENT_SIM_APP_LAUNCHER is None:
+        parser = get_isaaclab_arena_cli_parser()
+        simulation_app_args = parser.parse_args([])
+        simulation_app_args.headless = headless
+        simulation_app_args.enable_cameras = enable_cameras
+        if not headless:
+            simulation_app_args.visualizer = ["kit"]
+        with _IsolatedArgv([]):
+
+            app_launcher = get_app_launcher(simulation_app_args)
+
+        _PERSISTENT_SIM_APP_LAUNCHER = app_launcher
+        _PERSISTENT_INIT_ARGS = (headless, enable_cameras)
+        atexit.register(_close_persistent_simulation_app)
+    else:
+        # sanity-check mismatched flags after first init
+        first_headless, first_enable_cameras = _PERSISTENT_INIT_ARGS
+        if (headless != first_headless) or (enable_cameras != first_enable_cameras):
+            print(
+                "[isaaclab-arena] Warning: persistent SimulationApp already initialized with "
+                f"headless={first_headless}, enable_cameras={first_enable_cameras}. "
+                "Ignoring new values."
+            )
+    return _PERSISTENT_SIM_APP_LAUNCHER.app
+
+
+def run_function_with_persistent_simulation_app(
+    function: Callable[..., bool],
+    headless: bool = True,
+    enable_cameras: bool = False,
+    **kwargs,
+) -> bool:
+    """Run a function with the persistent SimulationApp in the current pytest process.
+
+    The SimulationApp is created on first use and reused until pytest exits. The
+    simulation context and stage are reset after each function call.
+
+    Args:
+        function: Function that receives the SimulationApp as its first argument
+            and returns whether the test passed.
+        headless: Whether to create the SimulationApp without a GUI.
+        enable_cameras: Whether to enable camera rendering.
+        **kwargs: Additional keyword arguments forwarded to the function.
+
+    Returns:
+        Whether the function returned a truthy value.
+    """
+    global _AT_LEAST_ONE_TEST_FAILED
+    try:
+        simulation_app = get_persistent_simulation_app(headless=headless, enable_cameras=enable_cameras)
+        test_result = bool(function(simulation_app, **kwargs))
+        if not test_result:
+            _AT_LEAST_ONE_TEST_FAILED = True
+        return test_result
+    except Exception as exception:
+        print(f"Exception occurred while running the function with the persistent SimulationApp: {exception}")
+        traceback.print_exc()
+        return False
+    finally:
+        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)

--- a/isaaclab_arena/tests/utils/persistent_simulation_app.py
+++ b/isaaclab_arena/tests/utils/persistent_simulation_app.py
@@ -14,6 +14,7 @@ from isaacsim import SimulationApp
 
 from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
 from isaaclab_arena.tests.conftest import PYTEST_SESSION
+from isaaclab_arena.tests.utils import subprocess as subprocess_utils
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import get_app_launcher, teardown_simulation_app
 
 # NOTE(alexmillane): Isaac Sim makes testing complicated. During shutdown Isaac Sim will
@@ -22,12 +23,11 @@ from isaaclab_arena.utils.isaaclab_utils.simulation_app import get_app_launcher,
 # To work around this, we track the failure state of the tests in two ways:
 # 1. We stash the pytest session object and set a flag when a test fails.
 # 2. We set a flag when a test fails.
-# These flags are checked before closing the persistent simulation app, and we
-# manually exit the process with exit code 1 if tests have failed.
+# These flags are checked in prior to closing the simulation app in _close_persistent(),
+# and we manually exit the process with the exit code 1 if tests have failed.
 
 _PERSISTENT_SIM_APP_LAUNCHER: AppLauncher | None = None
 _PERSISTENT_INIT_ARGS = None  # store (headless, enable_cameras) used at first init
-_AT_LEAST_ONE_TEST_FAILED = False
 
 
 class _IsolatedArgv:
@@ -46,11 +46,10 @@ class _IsolatedArgv:
         sys.argv = self._old
 
 
-def _close_persistent_simulation_app():
+def _close_persistent():
     global _PERSISTENT_SIM_APP_LAUNCHER
-    global _AT_LEAST_ONE_TEST_FAILED
     if _PERSISTENT_SIM_APP_LAUNCHER is not None:
-        tests_failed = PYTEST_SESSION.tests_failed or _AT_LEAST_ONE_TEST_FAILED
+        tests_failed = PYTEST_SESSION.tests_failed or subprocess_utils._AT_LEAST_ONE_TEST_FAILED
         print(f"Closing persistent simulation app. Tests failed: {tests_failed}")
         if tests_failed:
             # If any test failed, exit the process with exit code 1
@@ -79,7 +78,7 @@ def get_persistent_simulation_app(headless: bool, enable_cameras: bool = False) 
 
         _PERSISTENT_SIM_APP_LAUNCHER = app_launcher
         _PERSISTENT_INIT_ARGS = (headless, enable_cameras)
-        atexit.register(_close_persistent_simulation_app)
+        atexit.register(_close_persistent)
     else:
         # sanity-check mismatched flags after first init
         first_headless, first_enable_cameras = _PERSISTENT_INIT_ARGS
@@ -113,16 +112,17 @@ def run_function_with_persistent_simulation_app(
     Returns:
         Whether the function returned a truthy value.
     """
-    global _AT_LEAST_ONE_TEST_FAILED
+    # Get a persistent simulation app
     try:
         simulation_app = get_persistent_simulation_app(headless=headless, enable_cameras=enable_cameras)
         test_result = bool(function(simulation_app, **kwargs))
         if not test_result:
-            _AT_LEAST_ONE_TEST_FAILED = True
+            subprocess_utils._AT_LEAST_ONE_TEST_FAILED = True
         return test_result
-    except Exception as exception:
-        print(f"Exception occurred while running the function with the persistent SimulationApp: {exception}")
+    except Exception as e:
+        print(f"Exception occurred while running the function (persistent mode): {e}")
         traceback.print_exc()
         return False
     finally:
+        # **Always** clean up the SimulationContext/timeline between tests
         teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)

--- a/isaaclab_arena/tests/utils/subprocess.py
+++ b/isaaclab_arena/tests/utils/subprocess.py
@@ -3,33 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import atexit
 import os
 import subprocess
 import sys
-import traceback
-from collections.abc import Callable
-
-from isaaclab.app import AppLauncher
-from isaacsim import SimulationApp
-
-from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
-from isaaclab_arena.tests.conftest import PYTEST_SESSION
-from isaaclab_arena.utils.isaaclab_utils.simulation_app import get_app_launcher, teardown_simulation_app
-
-# NOTE(alexmillane): Isaac Sim makes testing complicated. During shutdown Isaac Sim will
-# terminate the surrounding pytest process with exit code 0, regardless
-# of whether the tests passed or failed.
-# To work around this, we track the failure state of the tests in two ways:
-# 1. We stash the pytest session object and set a flag when a test fails.
-# 2. We set a flag when a test fails.
-# These flags are checked in prior to closing the simulation app in _close_persistent(),
-# and we manually exit the process with the exit code 1 if tests have failed.
-
-_PERSISTENT_SIM_APP_LAUNCHER: AppLauncher | None = None
-_PERSISTENT_INIT_ARGS = None  # store (headless, enable_cameras) used at first init
-_AT_LEAST_ONE_TEST_FAILED = False
-
 
 _SUBPROCESS_TIMEOUT_SEC = int(os.environ.get("ISAACLAB_ARENA_SUBPROCESS_TIMEOUT", "900"))
 
@@ -64,7 +40,6 @@ def run_subprocess(
         timeout_sec = _SUBPROCESS_TIMEOUT_SEC
 
     print(f"Running command (timeout={timeout_sec}s): {cmd}")
-    global _AT_LEAST_ONE_TEST_FAILED
 
     if env is None:
         env = os.environ.copy()
@@ -81,7 +56,6 @@ def run_subprocess(
         )
     except subprocess.TimeoutExpired:
         sys.stderr.write(f"\n[isaaclab-arena] Subprocess timed out after {timeout_sec}s\n")
-        _AT_LEAST_ONE_TEST_FAILED = True
         raise subprocess.SubprocessError(f"Subprocess timed out after {timeout_sec}s: {cmd}")
 
     print(f"Command completed with return code: {result.returncode}")
@@ -89,108 +63,8 @@ def run_subprocess(
         sys.stderr.write(f"Command failed with return code {result.returncode}\n")
         if capture_output and result.stderr:
             sys.stderr.write(result.stderr)
-        _AT_LEAST_ONE_TEST_FAILED = True
         raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
 
     if capture_output:
         return result
     return None
-
-
-class _IsolatedArgv:
-    """Temporarily replace sys.argv so Kit doesn't see pytest flags like '-m'."""
-
-    def __init__(self, argv=None):
-        # Keep program name; drop the rest (or use provided list)
-        self._new = [sys.argv[0]] + (argv or [])
-        self._old = None
-
-    def __enter__(self):
-        self._old = sys.argv[:]
-        sys.argv = self._new
-
-    def __exit__(self, exc_type, exc, tb):
-        sys.argv = self._old
-
-
-def _close_persistent():
-    global _PERSISTENT_SIM_APP_LAUNCHER
-    global _AT_LEAST_ONE_TEST_FAILED
-    if _PERSISTENT_SIM_APP_LAUNCHER is not None:
-        tests_failed = PYTEST_SESSION.tests_failed or _AT_LEAST_ONE_TEST_FAILED
-        print(f"Closing persistent simulation app. Tests failed: {tests_failed}")
-        if tests_failed:
-            # If any test failed, exit the process with exit code 1
-            # to prevent Isaac Sim from terminating the pytest process with exit code 0.
-            sys.stdout.flush()
-            sys.stderr.flush()
-            os._exit(1)
-        else:
-            _PERSISTENT_SIM_APP_LAUNCHER.app.close()
-
-
-def get_persistent_simulation_app(headless: bool, enable_cameras: bool = False) -> SimulationApp:
-    """Create once, reuse forever (until process exit)."""
-    global _PERSISTENT_SIM_APP_LAUNCHER, _PERSISTENT_INIT_ARGS
-    # Create a new simulation app if it doesn't exist
-    if _PERSISTENT_SIM_APP_LAUNCHER is None:
-        parser = get_isaaclab_arena_cli_parser()
-        simulation_app_args = parser.parse_args([])
-        simulation_app_args.headless = headless
-        simulation_app_args.enable_cameras = enable_cameras
-        if not headless:
-            simulation_app_args.visualizer = ["kit"]
-        with _IsolatedArgv([]):
-
-            app_launcher = get_app_launcher(simulation_app_args)
-
-        _PERSISTENT_SIM_APP_LAUNCHER = app_launcher
-        _PERSISTENT_INIT_ARGS = (headless, enable_cameras)
-        atexit.register(_close_persistent)
-    else:
-        # sanity-check mismatched flags after first init
-        first_headless, first_enable_cameras = _PERSISTENT_INIT_ARGS
-        if (headless != first_headless) or (enable_cameras != first_enable_cameras):
-            print(
-                "[isaaclab-arena] Warning: persistent SimulationApp already initialized with "
-                f"headless={first_headless}, enable_cameras={first_enable_cameras}. "
-                "Ignoring new values."
-            )
-    return _PERSISTENT_SIM_APP_LAUNCHER.app
-
-
-def run_simulation_app_function(
-    function: Callable[..., bool],
-    headless: bool = True,
-    enable_cameras: bool = False,
-    **kwargs,
-) -> bool:
-    """Run a simulation app in a separate process.
-
-    This is sometimes required to prevent simulation app shutdown interrupting pytest.
-
-    Args:
-        function: The function to run in the simulation app.
-            - The function should take a SimulationAppContext instance as its first argument,
-            and then a variable number of additional arguments.
-            - The function should return a boolean indicating whether the test passed.
-        *args: The arguments to pass to the function (after the SimulationAppContext instance).
-
-    Returns:
-        The boolean result of the function.
-    """
-    # Get a persistent simulation app
-    global _AT_LEAST_ONE_TEST_FAILED
-    try:
-        simulation_app = get_persistent_simulation_app(headless=headless, enable_cameras=enable_cameras)
-        test_result = bool(function(simulation_app, **kwargs))
-        if not test_result:
-            _AT_LEAST_ONE_TEST_FAILED = True
-        return test_result
-    except Exception as e:
-        print(f"Exception occurred while running the function (persistent mode): {e}")
-        traceback.print_exc()
-        return False
-    finally:
-        # **Always** clean up the SimulationContext/timeline between tests
-        teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)

--- a/isaaclab_arena/tests/utils/subprocess.py
+++ b/isaaclab_arena/tests/utils/subprocess.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 import sys
 
+_AT_LEAST_ONE_TEST_FAILED = False
+
 _SUBPROCESS_TIMEOUT_SEC = int(os.environ.get("ISAACLAB_ARENA_SUBPROCESS_TIMEOUT", "900"))
 
 
@@ -40,6 +42,7 @@ def run_subprocess(
         timeout_sec = _SUBPROCESS_TIMEOUT_SEC
 
     print(f"Running command (timeout={timeout_sec}s): {cmd}")
+    global _AT_LEAST_ONE_TEST_FAILED
 
     if env is None:
         env = os.environ.copy()
@@ -56,6 +59,7 @@ def run_subprocess(
         )
     except subprocess.TimeoutExpired:
         sys.stderr.write(f"\n[isaaclab-arena] Subprocess timed out after {timeout_sec}s\n")
+        _AT_LEAST_ONE_TEST_FAILED = True
         raise subprocess.SubprocessError(f"Subprocess timed out after {timeout_sec}s: {cmd}")
 
     print(f"Command completed with return code: {result.returncode}")
@@ -63,6 +67,7 @@ def run_subprocess(
         sys.stderr.write(f"Command failed with return code {result.returncode}\n")
         if capture_output and result.stderr:
             sys.stderr.write(result.stderr)
+        _AT_LEAST_ONE_TEST_FAILED = True
         raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
 
     if capture_output:

--- a/isaaclab_arena_examples/tests/test_relation_solver_examples.py
+++ b/isaaclab_arena_examples/tests/test_relation_solver_examples.py
@@ -30,28 +30,28 @@ def test_dummy_object_placer_notebook_runs():
 
 def test_isaac_sim_object_placer_smoke():
     """Smoke test: verify the Isaac Sim object placer notebook runs without errors."""
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
     from isaaclab_arena_examples.relations.isaac_sim_object_placer_notebook import smoke_test_isaac_sim_object_placer
 
-    result = run_simulation_app_function(smoke_test_isaac_sim_object_placer)
+    result = run_function_with_persistent_simulation_app(smoke_test_isaac_sim_object_placer)
     assert result, "Isaac Sim object placer smoke test failed"
 
 
 def test_isaac_sim_no_collision_smoke():
     """Smoke test: verify the Isaac Sim no-overlap notebook runs without errors."""
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
     from isaaclab_arena_examples.relations.isaac_sim_no_collision_notebook import smoke_test_isaac_sim_no_collision
 
-    result = run_simulation_app_function(smoke_test_isaac_sim_no_collision)
+    result = run_function_with_persistent_simulation_app(smoke_test_isaac_sim_no_collision)
     assert result, "Isaac Sim no-overlap smoke test failed"
 
 
 def test_isaac_sim_kitchen_background_collision_smoke():
     """Smoke test: verify the kitchen background-collision notebook runs without errors."""
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
     from isaaclab_arena_examples.relations.isaac_sim_kitchen_background_collision_notebook import (
         smoke_test_kitchen_background_collision,
     )
 
-    result = run_simulation_app_function(smoke_test_kitchen_background_collision)
+    result = run_function_with_persistent_simulation_app(smoke_test_kitchen_background_collision)
     assert result, "Kitchen background-collision smoke test failed"

--- a/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/tests/test_g1_agile_policy.py
+++ b/isaaclab_arena_g1/g1_whole_body_controller/wbc_policy/tests/test_g1_agile_policy.py
@@ -16,7 +16,7 @@ import traceback
 import pytest
 import warp as wp
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 NUM_STEPS = 500
 WARMUP_STEPS = 50
@@ -82,7 +82,7 @@ def _test_agile_standing(simulation_app) -> bool:
 
 @pytest.mark.with_cameras
 def test_agile_standing():
-    result = run_simulation_app_function(
+    result = run_function_with_persistent_simulation_app(
         _test_agile_standing,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,


### PR DESCRIPTION
## Why

Greptile and local coding agents (repeatedly) mistook `run_simulation_app_function()` for a helper that starts a separate process because it lived in subprocess.py and had incorrect documentation. 
Renames and moves it to make clear that it reuses Isaac Sim in the current test process. Apart from the module move, helper rename, and corrected documentation, this PR does not change test behavior.

## What changed

- Move the _persistent_ `SimulationApp` lifecycle into `tests/utils/persistent_simulation_app.py`.
- Rename `run_simulation_app_function()` to `run_function_with_persistent_simulation_app` so its behavior is clear at each call site.
- Leave the real `run_subprocess` helper and the `with_subprocess` marker unchanged.