### PR TITLE
Add directional lighting to env-graph scenes

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -377,6 +377,23 @@ class LightBase(LibraryObject, ABC):
     object_type = ObjectType.BASE
     tags = ["light"]
 
+    _intensity_when_on: float | None = None
+    """Intensity stashed by :meth:`off` (while the light was lit) and restored by :meth:`on`."""
+
+    def on(self) -> None:
+        """Turn the light on, restoring the intensity it had before the last :meth:`off`.
+
+        A no-op if the light was never turned off (it is already at its configured intensity).
+        """
+        if self._intensity_when_on is not None:
+            self.set_intensity(self._intensity_when_on)
+
+    def off(self) -> None:
+        """Turn the light off (intensity 0), remembering the current intensity so :meth:`on` restores it."""
+        if self.spawner_cfg.intensity > 0.0:
+            self._intensity_when_on = self.spawner_cfg.intensity
+        self.set_intensity(0.0)
+
     def set_intensity(self, intensity: float) -> None:
         """Set the light's intensity."""
         assert intensity >= 0.0, f"Light intensity must be non-negative, got {intensity}."
@@ -423,7 +440,7 @@ class DomeLight(LightBase):
     name = "light"
     # Setting a global prim path for the dome light. Will not get repeated for each environment.
     default_prim_path = "/World/Light"
-    default_spawner_cfg = sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=500.0)
+    default_spawner_cfg = sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=1500.0)
 
     spawner_cfg: sim_utils.DomeLightCfg
     """Narrows the base-class spawner cfg type to ``DomeLightCfg`` for this asset."""
@@ -509,6 +526,14 @@ class DirectionalLight(LightBase):
         position_xyz = self.initial_pose.position_xyz if self.initial_pose is not None else (0.0, 0.0, 0.0)
         self.initial_pose = Pose(position_xyz=position_xyz, rotation_xyzw=tuple(rotation_xyzw))
         self.object_cfg = self._init_object_cfg()
+
+    def set_dome_light(self, dome_light: LightBase) -> None:
+        """Register a dome light for the direction variation to dim when it activates.
+
+        Dimming the (bright) dome while the directional light is on lets its shadows show. Forwarded
+        to the ``direction`` variation; a no-op on illumination unless that variation is enabled.
+        """
+        self.get_variation("direction").set_dome_light(dome_light)
 
 
 @register_asset

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -382,8 +382,7 @@ class LightBase(LibraryObject, ABC):
     """Intensity the light is lit at by default, and the intensity ``on()`` restores."""
 
     def __init__(self, *args, spawner_cfg: sim_utils.LightCfg, **kwargs):
-        # Copy the spawner cfg so intensity/color changes stay on this instance rather than leaking
-        # into the shared class default (which is what callers get when they don't pass one).
+        # Deep-copy here to avoid altering the shared class default.
         super().__init__(*args, spawner_cfg=copy.deepcopy(spawner_cfg), **kwargs)
 
     def on(self, intensity: float | None = None) -> None:

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import copy
 from abc import ABC
 from typing import TYPE_CHECKING, Any
 
@@ -377,21 +378,20 @@ class LightBase(LibraryObject, ABC):
     object_type = ObjectType.BASE
     tags = ["light"]
 
-    _intensity_when_on: float | None = None
-    """Intensity stashed by :meth:`off` (while the light was lit) and restored by :meth:`on`."""
+    default_intensity: float
+    """Intensity the light is lit at by default, and the intensity ``on()`` restores."""
 
-    def on(self) -> None:
-        """Turn the light on, restoring the intensity it had before the last :meth:`off`.
+    def __init__(self, *args, spawner_cfg: sim_utils.LightCfg, **kwargs):
+        # Copy the spawner cfg so intensity/color changes stay on this instance rather than leaking
+        # into the shared class default (which is what callers get when they don't pass one).
+        super().__init__(*args, spawner_cfg=copy.deepcopy(spawner_cfg), **kwargs)
 
-        A no-op if the light was never turned off (it is already at its configured intensity).
-        """
-        if self._intensity_when_on is not None:
-            self.set_intensity(self._intensity_when_on)
+    def on(self, intensity: float | None = None) -> None:
+        """Turn the light on, at ``intensity`` if given, else at the class default intensity."""
+        self.set_intensity(intensity if intensity is not None else self.default_intensity)
 
     def off(self) -> None:
-        """Turn the light off (intensity 0), remembering the current intensity so :meth:`on` restores it."""
-        if self.spawner_cfg.intensity > 0.0:
-            self._intensity_when_on = self.spawner_cfg.intensity
+        """Turn the light off (intensity 0)."""
         self.set_intensity(0.0)
 
     def set_intensity(self, intensity: float) -> None:
@@ -440,7 +440,8 @@ class DomeLight(LightBase):
     name = "light"
     # Setting a global prim path for the dome light. Will not get repeated for each environment.
     default_prim_path = "/World/Light"
-    default_spawner_cfg = sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=1500.0)
+    default_intensity = 1500.0
+    default_spawner_cfg = sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=default_intensity)
 
     spawner_cfg: sim_utils.DomeLightCfg
     """Narrows the base-class spawner cfg type to ``DomeLightCfg`` for this asset."""
@@ -493,7 +494,8 @@ class DirectionalLight(LightBase):
 
     name = "directional_light"
     default_prim_path = "/World/DirectionalLight"
-    default_spawner_cfg = sim_utils.DistantLightCfg(intensity=1000.0)
+    default_intensity = 1000.0
+    default_spawner_cfg = sim_utils.DistantLightCfg(intensity=default_intensity)
     default_initial_pose = Pose(position_xyz=(0.0, 0.0, 5.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
 
     spawner_cfg: sim_utils.DistantLightCfg
@@ -528,11 +530,7 @@ class DirectionalLight(LightBase):
         self.object_cfg = self._init_object_cfg()
 
     def set_dome_light(self, dome_light: LightBase) -> None:
-        """Register a dome light for the direction variation to dim when it activates.
-
-        Dimming the (bright) dome while the directional light is on lets its shadows show. Forwarded
-        to the ``direction`` variation; a no-op on illumination unless that variation is enabled.
-        """
+        """Register a dome light for the direction variation to dim when it activates."""
         self.get_variation("direction").set_dome_light(dome_light)
 
 

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -70,7 +70,7 @@ def _ensure_scene_lighting(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: dic
 
     Injects:
     - dome light
-    - directional light (default off). For lighting variations to act on.
+    - directional light (default turned off). For lighting variations to act on.
     """
     if _scene_already_has_light(graph_spec, assets_by_node_id):
         return

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.asset import Asset
@@ -21,6 +22,8 @@ from isaaclab_arena.utils.usd_helpers import has_light, open_stage
 
 _DEFAULT_LIGHT_ASSET_NAME = "light"
 _DEFAULT_LIGHT_NODE_ID = "auto_dome_light"
+_DIRECTIONAL_LIGHT_ASSET_NAME = "directional_light"
+_DIRECTIONAL_LIGHT_NODE_ID = "auto_directional_light"
 
 if TYPE_CHECKING:
     from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -64,13 +67,46 @@ def build_checks_for_placer_params(graph_spec: ArenaEnvGraphSpec) -> ObjectPlace
 
 
 def _ensure_scene_lighting(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: dict[str, Any]) -> None:
-    """Inject a default light when the scene would otherwise render black."""
-    if _scene_already_has_light(graph_spec, assets_by_node_id):
-        return
+    """Ensure the scene has ambient lighting plus a directional light for lighting variations.
 
-    node_id = _unique_node_id(set(assets_by_node_id), _DEFAULT_LIGHT_NODE_ID)
-    assets_by_node_id[node_id] = AssetRegistry().get_asset_by_name(_DEFAULT_LIGHT_ASSET_NAME)()
-    print(f"INFO: no light found in scene or background USD(s); injected default light '{node_id}'.")
+    A dome light is injected when the scene would otherwise render black (as before). A
+    directional light (registry ``directional_light``) is then added on top so directional-lighting
+    variations (``directional_light.direction.*`` / ``directional_light.intensity.*``) have a target.
+    The directional light is off by default and contributes no illumination unless a variation turns
+    it on at build time (see LightDirectionVariation), so scenes with no lighting variation are lit
+    only by their ambient/baked-in lighting. When the directional light is turned on, its direction
+    variation also dims the injected dome so the directional light's shadows are visible.
+    """
+    dome_light = None
+    if not _scene_already_has_light(graph_spec, assets_by_node_id):
+        dome_node_id = _unique_node_id(set(assets_by_node_id), _DEFAULT_LIGHT_NODE_ID)
+        dome_cls = AssetRegistry().get_asset_by_name(_DEFAULT_LIGHT_ASSET_NAME)
+        # Fresh per-instance spawner cfg so a direction variation dimming this dome mutates only it,
+        # never the shared class default (which would darken later, variation-free builds).
+        dome_light = dome_cls(spawner_cfg=copy.deepcopy(dome_cls.default_spawner_cfg))
+        assets_by_node_id[dome_node_id] = dome_light
+        print(f"INFO: no light found in scene or background USD(s); injected default light '{dome_node_id}'.")
+
+    if not _scene_has_asset_named(assets_by_node_id, _DIRECTIONAL_LIGHT_ASSET_NAME):
+        directional_node_id = _unique_node_id(set(assets_by_node_id), _DIRECTIONAL_LIGHT_NODE_ID)
+        light_cls = AssetRegistry().get_asset_by_name(_DIRECTIONAL_LIGHT_ASSET_NAME)
+        # Fresh per-instance spawner cfg so off()/on() mutate only this light, never the shared class
+        # default (which would otherwise light up later, variation-free builds).
+        directional_light = light_cls(spawner_cfg=copy.deepcopy(light_cls.default_spawner_cfg))
+        directional_light.off()  # a lighting-direction variation turns it back on at build time
+        if dome_light is not None:
+            # Let the direction variation dim this dome when it activates, so shadows show.
+            directional_light.set_dome_light(dome_light)
+        assets_by_node_id[directional_node_id] = directional_light
+        print(
+            f"INFO: injected directional light '{directional_node_id}'"
+            " (off unless a lighting-direction variation activates it)."
+        )
+
+
+def _scene_has_asset_named(assets_by_node_id: dict[str, Any], asset_name: str) -> bool:
+    """Return whether any instantiated asset has the given registry name."""
+    return any(getattr(asset, "name", None) == asset_name for asset in assets_by_node_id.values())
 
 
 def _unique_node_id(existing_ids: set[str], base: str) -> str:

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import copy
 from typing import TYPE_CHECKING, Any
 
 from isaaclab_arena.assets.asset import Asset
@@ -20,10 +19,10 @@ from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.usd_helpers import has_light, open_stage
 
-_DEFAULT_LIGHT_ASSET_NAME = "light"
-_DEFAULT_LIGHT_NODE_ID = "auto_dome_light"
-_DIRECTIONAL_LIGHT_ASSET_NAME = "directional_light"
-_DIRECTIONAL_LIGHT_NODE_ID = "auto_directional_light"
+_DEFAULT_DOME_LIGHT_ASSET_NAME = "light"
+_DEFAULT_DOME_LIGHT_NODE_ID = "auto_dome_light"
+_DEFAULT_DIRECTIONAL_LIGHT_ASSET_NAME = "directional_light"
+_DEFAULT_DIRECTIONAL_LIGHT_NODE_ID = "auto_directional_light"
 
 if TYPE_CHECKING:
     from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -67,46 +66,31 @@ def build_checks_for_placer_params(graph_spec: ArenaEnvGraphSpec) -> ObjectPlace
 
 
 def _ensure_scene_lighting(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: dict[str, Any]) -> None:
-    """Ensure the scene has ambient lighting plus a directional light for lighting variations.
+    """Inject default lighting setup, if no lighting already exists.
 
-    A dome light is injected when the scene would otherwise render black (as before). A
-    directional light (registry ``directional_light``) is then added on top so directional-lighting
-    variations (``directional_light.direction.*`` / ``directional_light.intensity.*``) have a target.
-    The directional light is off by default and contributes no illumination unless a variation turns
-    it on at build time (see LightDirectionVariation), so scenes with no lighting variation are lit
-    only by their ambient/baked-in lighting. When the directional light is turned on, its direction
-    variation also dims the injected dome so the directional light's shadows are visible.
+    Injects:
+    - dome light
+    - directional light (default off). For lighting variations to act on.
     """
-    dome_light = None
-    if not _scene_already_has_light(graph_spec, assets_by_node_id):
-        dome_node_id = _unique_node_id(set(assets_by_node_id), _DEFAULT_LIGHT_NODE_ID)
-        dome_cls = AssetRegistry().get_asset_by_name(_DEFAULT_LIGHT_ASSET_NAME)
-        # Fresh per-instance spawner cfg so a direction variation dimming this dome mutates only it,
-        # never the shared class default (which would darken later, variation-free builds).
-        dome_light = dome_cls(spawner_cfg=copy.deepcopy(dome_cls.default_spawner_cfg))
-        assets_by_node_id[dome_node_id] = dome_light
-        print(f"INFO: no light found in scene or background USD(s); injected default light '{dome_node_id}'.")
+    if _scene_already_has_light(graph_spec, assets_by_node_id):
+        return
 
-    if not _scene_has_asset_named(assets_by_node_id, _DIRECTIONAL_LIGHT_ASSET_NAME):
-        directional_node_id = _unique_node_id(set(assets_by_node_id), _DIRECTIONAL_LIGHT_NODE_ID)
-        light_cls = AssetRegistry().get_asset_by_name(_DIRECTIONAL_LIGHT_ASSET_NAME)
-        # Fresh per-instance spawner cfg so off()/on() mutate only this light, never the shared class
-        # default (which would otherwise light up later, variation-free builds).
-        directional_light = light_cls(spawner_cfg=copy.deepcopy(light_cls.default_spawner_cfg))
-        directional_light.off()  # a lighting-direction variation turns it back on at build time
-        if dome_light is not None:
-            # Let the direction variation dim this dome when it activates, so shadows show.
-            directional_light.set_dome_light(dome_light)
-        assets_by_node_id[directional_node_id] = directional_light
-        print(
-            f"INFO: injected directional light '{directional_node_id}'"
-            " (off unless a lighting-direction variation activates it)."
-        )
+    dome_node_id = _unique_node_id(set(assets_by_node_id), _DEFAULT_DOME_LIGHT_NODE_ID)
+    dome_light = AssetRegistry().get_asset_by_name(_DEFAULT_DOME_LIGHT_ASSET_NAME)()
+    assets_by_node_id[dome_node_id] = dome_light
 
+    directional_node_id = _unique_node_id(set(assets_by_node_id), _DEFAULT_DIRECTIONAL_LIGHT_NODE_ID)
+    directional_light = AssetRegistry().get_asset_by_name(_DEFAULT_DIRECTIONAL_LIGHT_ASSET_NAME)()
+    directional_light.off()  # a lighting-direction variation turns it back on at build time
+    # Let the direction variation dim this dome when it activates, so shadows show.
+    directional_light.set_dome_light(dome_light)
+    assets_by_node_id[directional_node_id] = directional_light
 
-def _scene_has_asset_named(assets_by_node_id: dict[str, Any], asset_name: str) -> bool:
-    """Return whether any instantiated asset has the given registry name."""
-    return any(getattr(asset, "name", None) == asset_name for asset in assets_by_node_id.values())
+    print(
+        f"INFO: no light found in scene or background USD(s); injected default light '{dome_node_id}'"
+        f" and directional light '{directional_node_id}'"
+        " (off unless a lighting-direction variation activates it)."
+    )
 
 
 def _unique_node_id(existing_ids: set[str], base: str) -> str:

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -225,7 +225,7 @@ def _test_direction_variation_lights_injected_directional_light(simulation_app):
 
 
 def test_direction_variation_lights_injected_directional_light():
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_direction_variation_lights_injected_directional_light)
+    result = run_function_with_persistent_simulation_app(_test_direction_variation_lights_injected_directional_light)
     assert result

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -158,17 +158,27 @@ def _minimal_scene_spec(*, objects: list[AssetSpec]) -> ArenaEnvGraphSpec:
     )
 
 
+def _lights_of_type(arena_env, light_cls) -> list:
+    return [asset for asset in arena_env.scene.assets.values() if isinstance(asset, light_cls)]
+
+
 def _test_default_light_is_injected_when_scene_has_none(simulation_app):
-    from isaaclab_arena.assets.object_library import DomeLight
+    from isaaclab_arena.assets.object_library import DirectionalLight, DomeLight
 
     # A single YCB object with no light asset and no light baked into its USD: the converter
     # must inject a default light so the env does not render black.
     spec = _minimal_scene_spec(objects=[AssetSpec(id="mug", registry_name="mug_ycb_robolab")])
     arena_env = spec.to_arena_env()
 
-    assert any(isinstance(asset, DomeLight) for asset in arena_env.scene.assets.values())
+    assert len(_lights_of_type(arena_env, DomeLight)) == 1
 
-    # An explicit light suppresses injection — no double-lighting.
+    # The directional light comes along so lighting variations have a target, but is off until one
+    # of its variations activates it.
+    directional_lights = _lights_of_type(arena_env, DirectionalLight)
+    assert len(directional_lights) == 1
+    assert directional_lights[0].spawner_cfg.intensity == 0.0
+
+    # An explicit light suppresses injection — no double-lighting, and no directional light either.
     explicit = _minimal_scene_spec(
         objects=[
             AssetSpec(id="mug", registry_name="mug_ycb_robolab"),
@@ -176,7 +186,12 @@ def _test_default_light_is_injected_when_scene_has_none(simulation_app):
         ]
     )
     explicit_env = explicit.to_arena_env()
-    assert sum(isinstance(asset, DomeLight) for asset in explicit_env.scene.assets.values()) == 1
+    assert len(_lights_of_type(explicit_env, DomeLight)) == 1
+    assert len(_lights_of_type(explicit_env, DirectionalLight)) == 0
+
+    # The injected lights own their spawner cfgs: turning the directional light off above must not
+    # have darkened the shared class default for later builds.
+    assert DirectionalLight.default_spawner_cfg.intensity == DirectionalLight.default_intensity
 
     return True
 
@@ -185,4 +200,30 @@ def test_default_light_is_injected_when_scene_has_none():
     from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
 
     result = run_simulation_app_function(_test_default_light_is_injected_when_scene_has_none)
+    assert result
+
+
+def _test_direction_variation_lights_injected_directional_light(simulation_app):
+    from isaaclab_arena.assets.object_library import DirectionalLight, DomeLight
+
+    spec = _minimal_scene_spec(objects=[AssetSpec(id="mug", registry_name="mug_ycb_robolab")])
+    arena_env = spec.to_arena_env()
+    dome_light = _lights_of_type(arena_env, DomeLight)[0]
+    directional_light = _lights_of_type(arena_env, DirectionalLight)[0]
+
+    direction_variation = directional_light.get_variation("direction")
+    direction_variation.enable()
+    direction_variation.configure_at_build_time()
+
+    # Enabling the variation lights the sun and dims the dome so the sun's shadows are visible.
+    assert directional_light.spawner_cfg.intensity == DirectionalLight.default_intensity
+    assert dome_light.spawner_cfg.intensity == direction_variation.cfg.dome_intensity_when_active
+
+    return True
+
+
+def test_direction_variation_lights_injected_directional_light():
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    result = run_simulation_app_function(_test_direction_variation_lights_injected_directional_light)
     assert result

--- a/isaaclab_arena/variations/light_direction_variation.py
+++ b/isaaclab_arena/variations/light_direction_variation.py
@@ -22,7 +22,7 @@ from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import BuildTimeVariationBase, VariationBaseCfg
 
 if TYPE_CHECKING:
-    from isaaclab_arena.assets.object_library import DirectionalLight, LightBase
+    from isaaclab_arena.assets.object_library import DirectionalLight, DomeLight
 
 
 def quat_xyzw_from_azimuth_elevation(azimuth_rad: float, elevation_rad: float) -> tuple[float, float, float, float]:
@@ -89,9 +89,9 @@ class LightDirectionVariation(BuildTimeVariationBase):
     ):
         super().__init__(cfg=cfg if cfg is not None else LightDirectionVariationCfg(), name=name)
         self._light = light
-        self._dome_light: LightBase | None = None
+        self._dome_light: DomeLight | None = None
 
-    def set_dome_light(self, dome_light: LightBase) -> None:
+    def set_dome_light(self, dome_light: DomeLight) -> None:
         """Register a dome light to dim while this variation is active, so shadows are visible."""
         self._dome_light = dome_light
 
@@ -104,6 +104,11 @@ class LightDirectionVariation(BuildTimeVariationBase):
         """
         self._light.on()
         if self._dome_light is not None:
+            print(
+                f"Warning: Dimming dome light to intensity: {self.cfg.dome_intensity_when_active} because the light"
+                " direction variation is active.This can cause issues if combined with other variations that modify"
+                " the dome light."
+            )
             self._dome_light.set_intensity(self.cfg.dome_intensity_when_active)
 
     def _realize_at_build_time(self) -> None:

--- a/isaaclab_arena/variations/light_direction_variation.py
+++ b/isaaclab_arena/variations/light_direction_variation.py
@@ -22,7 +22,7 @@ from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
 from isaaclab_arena.variations.variation_base import BuildTimeVariationBase, VariationBaseCfg
 
 if TYPE_CHECKING:
-    from isaaclab_arena.assets.object_library import DirectionalLight
+    from isaaclab_arena.assets.object_library import DirectionalLight, LightBase
 
 
 def quat_xyzw_from_azimuth_elevation(azimuth_rad: float, elevation_rad: float) -> tuple[float, float, float, float]:
@@ -62,6 +62,14 @@ class LightDirectionVariationCfg(VariationBaseCfg):
     The default range goes down to 80 degrees elevation to ensure we still cast shadows.
     """
 
+    dome_intensity_when_active: float = 500.0
+    """Intensity the registered dome light (if any) is dimmed to while this variation is active.
+
+    The dome is bright by default (for shadow-free scenes); dimming it here lets the directional
+    light's shadows show through. Only applied when a dome light is registered via
+    :meth:`LightDirectionVariation.set_dome_light`.
+    """
+
 
 class LightDirectionVariation(BuildTimeVariationBase):
     """Sample a continuous orientation and apply it to a DirectionalLight.
@@ -82,6 +90,27 @@ class LightDirectionVariation(BuildTimeVariationBase):
     ):
         super().__init__(cfg=cfg if cfg is not None else LightDirectionVariationCfg(), name=name)
         self._light = light
+        self._dome_light: LightBase | None = None
+
+    def set_dome_light(self, dome_light: LightBase) -> None:
+        """Register a dome light to dim while this variation is active, so shadows are visible.
+
+        Optional: when set, :meth:`_prepare_at_build_time` lowers the dome to
+        ``cfg.dome_intensity_when_active``. When unset, the dome is left untouched.
+        """
+        self._dome_light = dome_light
+
+    def _prepare_at_build_time(self) -> None:
+        """Turn the (auto-injected, off) directional light on so the sampled direction is visible.
+
+        Also dims the registered dome light (if any) so the directional light casts visible shadows.
+        Only runs while this variation is enabled (see ``VariationBase.configure_at_build_time``), so
+        the directional light stays dark and the dome stays bright for scenes that don't vary the
+        light direction.
+        """
+        self._light.on()
+        if self._dome_light is not None:
+            self._dome_light.set_intensity(self.cfg.dome_intensity_when_active)
 
     def _realize_at_build_time(self) -> None:
         assert self.sampler is not None, "LightDirectionVariation: sampler not set."

--- a/isaaclab_arena/variations/light_direction_variation.py
+++ b/isaaclab_arena/variations/light_direction_variation.py
@@ -65,9 +65,8 @@ class LightDirectionVariationCfg(VariationBaseCfg):
     dome_intensity_when_active: float = 500.0
     """Intensity the registered dome light (if any) is dimmed to while this variation is active.
 
-    The dome is bright by default (for shadow-free scenes); dimming it here lets the directional
-    light's shadows show through. Only applied when a dome light is registered via
-    :meth:`LightDirectionVariation.set_dome_light`.
+    Dimming the dome lets the directional light's shadows show through. Only applied when a dome
+    light is registered via ``set_dome_light``.
     """
 
 
@@ -93,20 +92,15 @@ class LightDirectionVariation(BuildTimeVariationBase):
         self._dome_light: LightBase | None = None
 
     def set_dome_light(self, dome_light: LightBase) -> None:
-        """Register a dome light to dim while this variation is active, so shadows are visible.
-
-        Optional: when set, :meth:`_prepare_at_build_time` lowers the dome to
-        ``cfg.dome_intensity_when_active``. When unset, the dome is left untouched.
-        """
+        """Register a dome light to dim while this variation is active, so shadows are visible."""
         self._dome_light = dome_light
 
     def _prepare_at_build_time(self) -> None:
-        """Turn the (auto-injected, off) directional light on so the sampled direction is visible.
+        """Prepare the scene for this variation, if activated.
 
-        Also dims the registered dome light (if any) so the directional light casts visible shadows.
-        Only runs while this variation is enabled (see ``VariationBase.configure_at_build_time``), so
-        the directional light stays dark and the dome stays bright for scenes that don't vary the
-        light direction.
+        Preparation:
+        - turns on directional light
+        - (optional) dims a dome light, if registered with this variation.
         """
         self._light.on()
         if self._dome_light is not None:


### PR DESCRIPTION
## Summary
Directional light + shadows for env-graph scenes. Includes refactor for optional dimming of dome light when lighting direction variations are turned on.

## Detailed description
- **Why:** Env-graph/robolab scenes had no directional light, so `directional_light.direction` lighting variations had nothing to act on.
- **What: yaml env-graphs** 
  - We now inject a `directional_light` alongside the dome.
  - It is **off by default** (new `LightBase.on()`/`off()`)
- **What: lighting direction variation**
  - Directional light turned on when `directional_light.direction` variation is enabled
  - Optional dimming of a dome light when the variation is activated
    - Needed to be able to cast shadows
  - Default dome intensity raised 500 → 1500.