### PR TITLE
Update kitchen p&p yaml configs to avoid collision

### DIFF
--- a/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
@@ -32,12 +32,20 @@ object_references:
   prim_path: floor_room/geometry
   object_type: base
   params: {}
+- id: paper_towel
+  parent_id: kitchen
+  prim_path: paper_towel_main_group
+  object_type: base
+  params: {}
 relations:
 - kind: is_anchor
   subject: floor
   params: {}
 - kind: is_anchor
   subject: right_counter_top
+  params: {}
+- kind: is_anchor
+  subject: paper_towel
   params: {}
 - kind: 'on'
   subject: droid
@@ -48,7 +56,7 @@ relations:
   reference: right_counter_top
   params:
     side: negative_y
-    distance_m: 0.1
+    distance_m: 0.15
 - kind: rotate_around_solution
   subject: droid
   params:


### PR DESCRIPTION
- Add paper roll objet reference to avoid collision with foreground objects on spawn
- Increase robot to counter distance
