### PR TITLE
Fix external env registration for isaaclab interop

### DIFF
--- a/isaaclab_arena/environments/isaaclab_interop.py
+++ b/isaaclab_arena/environments/isaaclab_interop.py
@@ -11,6 +11,7 @@ from isaaclab_arena_environments.cli import (
     add_environment_cli_args,
     build_environment_from_cli,
     ensure_environments_registered,
+    parse_and_return_external_environment_from_string,
 )
 
 
@@ -55,7 +56,11 @@ def environment_registration_callback() -> list[str]:
     _purge_leaked_isaaclab_assets_presets()
 
     # Imports after the simulation app is started.
-    from isaaclab_arena.cli.isaaclab_arena_cli import add_isaac_lab_cli_args, add_isaaclab_arena_cli_args
+    from isaaclab_arena.cli.isaaclab_arena_cli import (
+        add_external_environments_cli_args,
+        add_isaac_lab_cli_args,
+        add_isaaclab_arena_cli_args,
+    )
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
     # Get the requested environment from the CLI.
@@ -70,9 +75,17 @@ def environment_registration_callback() -> list[str]:
         default=None,
         help="Arena teleoperation device to configure without selecting Isaac Lab's legacy teleoperation stack.",
     )
-    environment_name = parser.parse_known_args()[0].task
+    add_external_environments_cli_args(parser)
+    initial_args = parser.parse_known_args()[0]
+    environment_name = initial_args.task
     ensure_environments_registered()
-    environment_factory_type = EnvironmentRegistry().get_component_by_name(environment_name)
+    environment_registry = EnvironmentRegistry()
+    if initial_args.external_environment_class_path is not None:
+        external_environment_name, external_environment_factory_type = (
+            parse_and_return_external_environment_from_string(initial_args.external_environment_class_path)
+        )
+        environment_registry.register(external_environment_factory_type, external_environment_name)
+    environment_factory_type = environment_registry.get_component_by_name(environment_name)
     # Get the full list of environment-specific CLI args.
     AppLauncher.add_app_launcher_args(parser)
     add_isaac_lab_cli_args(parser)

--- a/isaaclab_arena/tests/test_external_environment.py
+++ b/isaaclab_arena/tests/test_external_environment.py
@@ -3,9 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from unittest.mock import patch
+
 import pytest
 
 from isaaclab_arena.tests.utils.constants import TestConstants
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 from isaaclab_arena.tests.utils.subprocess import run_subprocess
 
 HEADLESS = True
@@ -15,6 +19,35 @@ EXTERNAL_ENV_BASIC_IMPORT_PATH = "isaaclab_arena_examples.external_environments.
 EXTERNAL_ENV_ADVANCED_IMPORT_PATH = (
     "isaaclab_arena_examples.external_environments.advanced:ExternalFrankaTableWithTaskEnvironment"
 )
+
+
+def _test_external_environment_registration_callback(_) -> bool:
+    """Verify the Isaac Lab callback registers an externally defined Arena environment."""
+    import gymnasium as gym
+
+    from isaaclab_arena.environments.isaaclab_interop import environment_registration_callback
+
+    callback_args = [
+        "external_environment_interop_test",
+        "--task",
+        "franka_table",
+        "--external_environment_class_path",
+        EXTERNAL_ENV_BASIC_IMPORT_PATH,
+        "--object",
+        "cracker_box",
+    ]
+    with patch.object(sys, "argv", callback_args):
+        remaining_args = environment_registration_callback()
+
+    assert remaining_args == []
+    assert gym.spec("franka_table").id == "franka_table"
+    return True
+
+
+def test_external_environment_registration_callback():
+    """Isaac Lab scripts can register external Arena environments through the callback."""
+    result = run_function_with_persistent_simulation_app(_test_external_environment_registration_callback)
+    assert result
 
 
 def run_policy_runner_with_external_environment(


### PR DESCRIPTION
## Summary
Isaac lab <> Arena interop callback did not support `--external_environment_class_path` causing external user envs to fail when used with Lab's IL scripts. This PR fixes it:

- Parses the external env class path in the callback and resolves the env
- Registers the external env in the callback in Arena's EnvironmentRegistry
- Adds a regression test using an external env example already present in Arena Examples.
