### PR TITLE
Add the simready-search dependency

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -121,8 +121,19 @@ COPY isaaclab_arena_environments ${WORKDIR}/isaaclab_arena_environments
 COPY isaaclab_arena_examples ${WORKDIR}/isaaclab_arena_examples
 COPY docs ${WORKDIR}/docs
 
-# Install IsaacLab Arena (runtime + dev deps declared in pyproject.toml)
-RUN /isaac-sim/python.sh -m pip install -e "${WORKDIR}/[dev]"
+# Install IsaacLab Arena (runtime + dev deps declared in pyproject.toml).
+# The second command applies the [tool.uv] override-dependencies by hand, because pip has no
+# override mechanism of its own: simready-search pins boto3==1.42.58, while Isaac Sim prebundles
+# boto3 1.40.61 and isaacsim-kernel pins that version. pip installs into a directory that precedes
+# the prebundle on sys.path, so without this the image would silently run its S3 asset searches
+# against an AWS stack Isaac Sim does not ship. Reinstalling the prebundled versions makes the
+# shadowing copies a no-op. pip warns that simready-search wanted the newer boto3; that warning is
+# the same assertion the uv overrides encode, and both stand or fall together.
+# --no-deps keeps the repair to these four: without it pip also reinstalls urllib3 and certifi,
+# which would shadow the prebundled ones in turn.
+RUN /isaac-sim/python.sh -m pip install -e "${WORKDIR}/[dev]" \
+    && /isaac-sim/python.sh -m pip install --force-reinstall --no-deps \
+        boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3
 
 ################################
 # Install cuRobo (optional)

--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -122,18 +122,14 @@ COPY isaaclab_arena_examples ${WORKDIR}/isaaclab_arena_examples
 COPY docs ${WORKDIR}/docs
 
 # Install IsaacLab Arena (runtime + dev deps declared in pyproject.toml).
-# The second command applies the [tool.uv] override-dependencies by hand, because pip has no
-# override mechanism of its own: simready-search pins boto3==1.42.58, while Isaac Sim prebundles
-# boto3 1.40.61 and isaacsim-kernel pins that version. pip installs into a directory that precedes
-# the prebundle on sys.path, so without this the image would silently run its S3 asset searches
-# against an AWS stack Isaac Sim does not ship. Reinstalling the prebundled versions makes the
-# shadowing copies a no-op. pip warns that simready-search wanted the newer boto3; that warning is
-# the same assertion the uv overrides encode, and both stand or fall together.
-# --no-deps keeps the repair to these four: without it pip also reinstalls urllib3 and certifi,
-# which would shadow the prebundled ones in turn.
+# The second command applies the [tool.uv] override-dependencies by hand. simready-search pins boto3==1.42.58,
+# while Isaac Sim prebundles boto3 1.40.61 and isaacsim-kernel pins that version.
+# pip installs into a directory that precedes the prebundle on sys.path, so without this the image
+# would silently run its S3 asset searches against an AWS stack Isaac Sim does not ship.
 RUN /isaac-sim/python.sh -m pip install -e "${WORKDIR}/[dev]" \
     && /isaac-sim/python.sh -m pip install --force-reinstall --no-deps \
-        boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3
+        boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3 \
+        simready-search==0.2.1
 
 ################################
 # Install cuRobo (optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ dev = [
     "tenacity",
     "streamlit>=1.56",
     "streamlit-ace>=0.1.1",
+    # Asset search for agentic environment generation. Kept here rather than behind an extra of
+    # its own: it adds one wheel, since Isaac Sim already brings everything it depends on, and an
+    # extra only bought a way to install the review GUI with its asset search missing.
+    "simready-search>=2026.4.2",
 ]
 
 # PEP 735 dependency groups for the native uv install: the sim stack the
@@ -143,11 +147,21 @@ index-strategy = "first-index"
 # Sim 6.0 with websockets 16.1.1, installed by pip alongside isaacteleop),
 # and isaacteleop[cloudxr] -- needed for teleop sessions in the
 # isaaclab-from-source flavor -- requires websockets>=14.
+# Pin the AWS/HTTP stack to the versions Isaac Sim requires: simready-search
+# asks for boto3==1.42.58, requests>=2.32.5 and s3transfer 0.16.x, all of which
+# are over-strict. The Docker image runs its S3 asset searches against the
+# boto3 1.40.61 / requests 2.32.3 / s3transfer 0.14.0 that isaacsim-kernel
+# pins. Without these overrides simready-search cannot resolve alongside either
+# sim-stack flavor at all, leaving the asset search with no installable runtime.
 override-dependencies = [
     "numpy==2.3.1",
     "coverage==7.4.4",
     "packaging==26.0",
     "websockets==16.1.1",
+    "boto3==1.40.61",
+    "botocore==1.40.61",
+    "requests==2.32.3",
+    "s3transfer==0.14.0",
 ]
 # Isaac Lab 3.0 Beta 2 does not correctly pin its dependencies: the published
 # wheel declares these transitive deps too broadly, so we constrain them to

--- a/uv.lock
+++ b/uv.lock
@@ -20,9 +20,13 @@ constraints = [
     { name = "tinyobjloader", specifier = "==2.0.0rc13" },
 ]
 overrides = [
+    { name = "boto3", specifier = "==1.40.61" },
+    { name = "botocore", specifier = "==1.40.61" },
     { name = "coverage", specifier = "==7.4.4" },
     { name = "numpy", specifier = "==2.3.1" },
     { name = "packaging", specifier = "==26.0" },
+    { name = "requests", specifier = "==2.32.3" },
+    { name = "s3transfer", specifier = "==0.14.0" },
     { name = "websockets", specifier = "==16.1.1" },
 ]
 
@@ -501,9 +505,9 @@ name = "boto3"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jmespath", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "s3transfer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "botocore", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "jmespath", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "s3transfer", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ed/f9/6ef8feb52c3cce5ec3967a535a6114b57ac7949fd166b0f3090c2b06e4e5/boto3-1.40.61.tar.gz", hash = "sha256:d6c56277251adf6c2bdd25249feae625abe4966831676689ff23b4694dea5b12", size = 111535, upload-time = "2025-10-28T19:26:57.247Z" }
 wheels = [
@@ -515,9 +519,9 @@ name = "botocore"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jmespath", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "urllib3", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/a3/81d3a47c2dbfd76f185d3b894f2ad01a75096c006a2dd91f237dca182188/botocore-1.40.61.tar.gz", hash = "sha256:a2487ad69b090f9cccd64cf07c7021cd80ee9c0655ad974f87045b02f3ef52cd", size = 14393956, upload-time = "2025-10-28T19:26:46.108Z" }
 wheels = [
@@ -2065,6 +2069,7 @@ dependencies = [
 dev = [
     { name = "debugpy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "jupyter", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "simready-search", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "streamlit", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "streamlit-ace", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "tenacity", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
@@ -2107,8 +2112,8 @@ openpi = [
 
 [package.metadata]
 requires-dist = [
-    { name = "decorator", specifier = ">=4.0.2,<5" },
     { name = "debugpy", marker = "extra == 'dev'" },
+    { name = "decorator", specifier = ">=4.0.2,<5" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "lightwheel-sdk" },
     { name = "matplotlib" },
@@ -2119,6 +2124,7 @@ requires-dist = [
     { name = "pytest" },
     { name = "sbi" },
     { name = "scipy" },
+    { name = "simready-search", marker = "extra == 'dev'", specifier = ">=2026.4.2" },
     { name = "streamlit", marker = "extra == 'dev'", specifier = ">=1.56" },
     { name = "streamlit-ace", marker = "extra == 'dev'", specifier = ">=0.1.1" },
     { name = "tenacity", marker = "extra == 'dev'" },
@@ -5938,7 +5944,7 @@ name = "s3transfer"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "botocore", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
@@ -6064,6 +6070,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
+name = "simready-search"
+version = "2026.4.2"
+source = { registry = "https://pypi.nvidia.com/" }
+dependencies = [
+    { name = "boto3", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+]
+wheels = [
+    { url = "https://pypi.nvidia.com/simready-search/simready_search-2026.4.2-py3-none-any.whl", hash = "sha256:10193fabfe7a3cf56c93a559eb31069ccfb1d9fd6d162ffc2a2eb7318591f2e1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Add the simready-search dependency, to unblock https://github.com/isaac-sim/IsaacLab-Arena/pull/982 testing.

## Detailed description
- Override boto3, botocore, requests and s3transfer to the versions isaacsim-kernel pins. simready-search asks for boto3==1.42.58, requests>=2.32.5 and s3transfer 0.16.x, all over-strict; without the overrides it does not resolve alongside either sim-stack flavor.
