### PR TITLE
Fix post-merge image build broken by SimReady pkg

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -122,12 +122,9 @@ COPY isaaclab_arena_examples ${WORKDIR}/isaaclab_arena_examples
 COPY docs ${WORKDIR}/docs
 
 # Install IsaacLab Arena (runtime + dev deps declared in pyproject.toml).
-# The second command applies the [tool.uv] override-dependencies by hand. simready-search pins boto3==1.42.58,
-# while Isaac Sim prebundles boto3 1.40.61 and isaacsim-kernel pins that version.
+# simready-search pins boto3==1.42.58, while Isaac Sim prebundles boto3 1.40.61 and isaacsim-kernel pins that version.
 # pip installs into a directory that precedes the prebundle on sys.path, so without this the image
 # would silently run its S3 asset searches against an AWS stack Isaac Sim does not ship.
-# Only the overridden packages are listed here -- simready-search itself comes from the [dev] extra
-# above, so its version stays declared in pyproject.toml alone.
 RUN /isaac-sim/python.sh -m pip install -e "${WORKDIR}/[dev]" \
     && /isaac-sim/python.sh -m pip install --force-reinstall --no-deps \
         boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3

--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -126,10 +126,11 @@ COPY docs ${WORKDIR}/docs
 # while Isaac Sim prebundles boto3 1.40.61 and isaacsim-kernel pins that version.
 # pip installs into a directory that precedes the prebundle on sys.path, so without this the image
 # would silently run its S3 asset searches against an AWS stack Isaac Sim does not ship.
+# Only the overridden packages are listed here -- simready-search itself comes from the [dev] extra
+# above, so its version stays declared in pyproject.toml alone.
 RUN /isaac-sim/python.sh -m pip install -e "${WORKDIR}/[dev]" \
     && /isaac-sim/python.sh -m pip install --force-reinstall --no-deps \
-        boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3 \
-        simready-search==0.2.1
+        boto3==1.40.61 botocore==1.40.61 s3transfer==0.14.0 requests==2.32.3
 
 ################################
 # Install cuRobo (optional)


### PR DESCRIPTION
## Summary

Fix post-merge image build broken by SimReady pkg pip 

## Detailed description
- #999 listed simready-search==0.2.1, but pypi.nvidia.com carries only 2026.4.2. The pin was a leftover, so the post-merge image build died at that layer.
- Fix: dropped the re-pin and used the version in [dev] as the single source of truth.
