### PR TITLE
Exclude relation anchors from background collision meshes

### DIFF
--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -31,8 +31,11 @@ class ObjectReference(ObjectBase):
         super().__init__(**kwargs)
         self.parent_asset = parent_asset
         self._parent_scale = parent_asset.scale
-        # Get the prim's transform pose (not geometry center - solver is origin-agnostic)
-        self.initial_pose_relative_to_parent = self._get_referenced_prim_pose_relative_to_parent(parent_asset)
+        # Resolve the path and pose together to avoid opening the parent USD stage multiple times.
+        (
+            self._prim_path_in_parent_usd,
+            self.initial_pose_relative_to_parent,
+        ) = self._get_referenced_prim_path_and_pose_relative_to_parent(parent_asset)
         self.object_cfg = self._init_object_cfg()
         self._bounding_box: AxisAlignedBoundingBox | None = None
         self._collision_mesh: trimesh.Trimesh | None = None
@@ -47,6 +50,11 @@ class ObjectReference(ObjectBase):
             T_W_P = self.parent_asset.initial_pose
             T_W_O = T_W_P.multiply(T_P_O)
         return T_W_O
+
+    @property
+    def prim_path_in_parent_usd(self) -> str:
+        """Return the referenced prim's absolute path in its parent USD stage."""
+        return self._prim_path_in_parent_usd
 
     def add_relation(self, relation: RelationBase) -> None:
         """Add a relation to this object reference.
@@ -169,8 +177,8 @@ class ObjectReference(ObjectBase):
         )
         return object_cfg
 
-    def _get_referenced_prim_pose_relative_to_parent(self, parent_asset: Object) -> Pose:
-        """Get the prim's transform pose relative to the parent's default prim.
+    def _get_referenced_prim_path_and_pose_relative_to_parent(self, parent_asset: Object) -> tuple[str, Pose]:
+        """Get the prim path and transform pose relative to the parent's default prim.
 
         The position is scaled by the parent's scale factor.
         """
@@ -186,7 +194,7 @@ class ObjectReference(ObjectBase):
                 prim_pose.position_xyz[1] * self._parent_scale[1],
                 prim_pose.position_xyz[2] * self._parent_scale[2],
             )
-            return Pose(position_xyz=scaled_pos, rotation_xyzw=prim_pose.rotation_xyzw)
+            return prim_path_in_usd, Pose(position_xyz=scaled_pos, rotation_xyzw=prim_pose.rotation_xyzw)
 
     @staticmethod
     def isaaclab_prim_path_to_original_prim_path(

--- a/isaaclab_arena/environments/relation_solver_interface.py
+++ b/isaaclab_arena/environments/relation_solver_interface.py
@@ -26,16 +26,6 @@ if TYPE_CHECKING:
     from isaaclab_arena.relations.placement_result import PlacementResult
 
 
-def _get_passive_collision_objects(
-    assets: Iterable[Asset | RigidObjectSet],
-    include_background: bool = False,
-) -> list[CollisionObject]:
-    """Load passive collision discovery only when relation placement needs it."""
-    from isaaclab_arena.relations.passive_collision_objects import get_passive_collision_objects
-
-    return get_passive_collision_objects(assets, include_background=include_background)
-
-
 def solve_and_apply_relation_placement(
     assets: list[PlaceableAsset],
     num_envs: int,
@@ -77,12 +67,20 @@ def solve_and_apply_relation_placement(
     # mutating the caller.
     placer_params.reachability_config = copy.copy(placer_params.reachability_config)
     if collision_objects is None and scene_assets is not None:
+        # Lazy import to avoid pxr import before SimulationApp is ready.
+        from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.relations.passive_collision_objects import get_passive_collision_objects
+
         scene_assets = list(scene_assets)
-        collision_objects = _get_passive_collision_objects(
+        background_mesh_exclusions = [
+            asset for asset in get_anchor_objects(assets) if isinstance(asset, ObjectReference)
+        ]
+        collision_objects = get_passive_collision_objects(
             scene_assets,
             include_background=_should_include_background_mesh(
                 assets, scene_assets, placer_params.solver_params.collision_mode
             ),
+            background_mesh_exclusions=background_mesh_exclusions,
         )
     placement_pool = PooledObjectPlacer(
         objects=assets,

--- a/isaaclab_arena/relations/background_collision_object.py
+++ b/isaaclab_arena/relations/background_collision_object.py
@@ -128,7 +128,16 @@ def _combine_fixed_meshes(
             skipped_objects.append(obj)
             continue
         excluded_prim_paths = excluded_prim_paths_by_object.get(obj, ())
-        mesh = manager.get_collision_mesh(obj, excluded_prim_paths=excluded_prim_paths)
+        if isinstance(obj, Background):
+            try:
+                mesh = manager.get_collision_mesh_or_raise(obj, excluded_prim_paths=excluded_prim_paths)
+            except (OSError, ValueError):
+                skipped_objects.append(obj)
+                continue
+            if mesh is None:
+                continue
+        else:
+            mesh = manager.get_collision_mesh(obj, excluded_prim_paths=excluded_prim_paths)
         if mesh is None:
             skipped_objects.append(obj)
             continue

--- a/isaaclab_arena/relations/background_collision_object.py
+++ b/isaaclab_arena/relations/background_collision_object.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 import trimesh
-from collections.abc import Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.collision_mode import CollisionMode
@@ -67,15 +67,23 @@ class FixedCollisionObject:
         return self._mesh
 
 
-def make_fixed_collision_objects(objects: Sequence[CollisionObject]) -> list[CollisionObject]:
+def make_fixed_collision_objects(
+    objects: Sequence[CollisionObject],
+    excluded_prim_paths_by_object: Mapping[CollisionObject, Collection[str]] | None = None,
+) -> list[CollisionObject]:
     """Combine the objects' collision meshes into one FixedCollisionObject.
 
-    Objects in BBOX mode or without an extractable mesh are returned unchanged;
-    a whole-scene Background that cannot aggregate is an error.
+    Objects in BBOX mode or without an extractable mesh are returned unchanged.
+    Background mesh extraction failures are errors.
+
+    Args:
+        objects: Fixed collision objects to aggregate.
+        excluded_prim_paths_by_object: USD prim subtrees omitted from individual objects'
+            extracted meshes, keyed by source object.
     """
     from isaaclab_arena.assets.background import Background
 
-    mesh, skipped_objects = _combine_fixed_meshes(objects)
+    mesh, skipped_objects = _combine_fixed_meshes(objects, excluded_prim_paths_by_object)
     collision_objects: list[CollisionObject] = []
     if mesh is not None:
         collision_objects.append(FixedCollisionObject(mesh))
@@ -104,18 +112,23 @@ def make_fixed_collision_objects(objects: Sequence[CollisionObject]) -> list[Col
     return collision_objects
 
 
-def _combine_fixed_meshes(objects: Sequence[CollisionObject]) -> tuple[trimesh.Trimesh | None, list[CollisionObject]]:
+def _combine_fixed_meshes(
+    objects: Sequence[CollisionObject],
+    excluded_prim_paths_by_object: Mapping[CollisionObject, Collection[str]] | None = None,
+) -> tuple[trimesh.Trimesh | None, list[CollisionObject]]:
     from isaaclab_arena.assets.background import Background
     from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
 
     manager = WarpMeshAndSphereCache(device="cpu")
+    excluded_prim_paths_by_object = excluded_prim_paths_by_object or {}
     meshes = []
     skipped_objects = []
     for obj in objects:
         if obj.collision_mode == CollisionMode.BBOX:
             skipped_objects.append(obj)
             continue
-        mesh = manager.get_collision_mesh(obj)
+        excluded_prim_paths = excluded_prim_paths_by_object.get(obj, ())
+        mesh = manager.get_collision_mesh(obj, excluded_prim_paths=excluded_prim_paths)
         if mesh is None:
             skipped_objects.append(obj)
             continue

--- a/isaaclab_arena/relations/passive_collision_objects.py
+++ b/isaaclab_arena/relations/passive_collision_objects.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
@@ -23,7 +24,9 @@ if TYPE_CHECKING:
 
 
 def get_passive_collision_objects(
-    assets: Iterable[Asset | RigidObjectSet], include_background: bool = False
+    assets: Iterable[Asset | RigidObjectSet],
+    include_background: bool = False,
+    background_mesh_exclusions: Iterable[ObjectReference] = (),
 ) -> list[CollisionObject]:
     """Return relation-free scene assets that qualify as passive collision obstacles.
 
@@ -34,6 +37,8 @@ def get_passive_collision_objects(
         assets: Scene assets to scan for relation-free fixed objects.
         include_background: If True, include Background assets and aggregate all
             mesh-capable objects into a single FixedCollisionObject.
+        background_mesh_exclusions: Object references whose USD subtrees are omitted
+            from an aggregated parent Background mesh.
     """
     collision_objects: list[CollisionObject] = []
     for asset in assets:
@@ -76,5 +81,12 @@ def get_passive_collision_objects(
     ]
 
     if include_background:
-        return make_fixed_collision_objects(collision_objects)
-    return list(collision_objects)
+        excluded_prim_paths_by_object: defaultdict[CollisionObject, set[str]] = defaultdict(set)
+        for reference in background_mesh_exclusions:
+            if reference.parent_asset in collision_object_set:
+                excluded_prim_paths_by_object[reference.parent_asset].add(reference.prim_path_in_parent_usd)
+        return make_fixed_collision_objects(
+            collision_objects,
+            excluded_prim_paths_by_object=excluded_prim_paths_by_object,
+        )
+    return collision_objects

--- a/isaaclab_arena/relations/warp_mesh_manager.py
+++ b/isaaclab_arena/relations/warp_mesh_manager.py
@@ -11,6 +11,7 @@ import numpy as np
 import torch
 import trimesh
 from collections import defaultdict
+from collections.abc import Collection
 from heapq import heappop, heappush
 from typing import TYPE_CHECKING
 
@@ -143,20 +144,30 @@ class WarpMeshAndSphereCache:
                 "(no mesh face found). Collision detection may be incomplete for these points."
             )
 
-    def get_collision_mesh(self, obj: CollisionObject) -> trimesh.Trimesh | None:
+    def get_collision_mesh(
+        self,
+        obj: CollisionObject,
+        excluded_prim_paths: Collection[str] = (),
+    ) -> trimesh.Trimesh | None:
         """Return the cached collision mesh, extracting from USD on first access."""
         from isaaclab_arena.assets.object import Object
 
         if not isinstance(obj, Object) or obj.usd_path is None:
+            assert not excluded_prim_paths, "USD prim exclusions require an Object with a usd_path."
             return obj.get_collision_mesh()
         usd_path = obj.usd_path
-        scale = tuple(obj.scale)
-        key = (usd_path, scale)
+        scale = obj.scale
+        exclusions = tuple(sorted(excluded_prim_paths))
+        key = (usd_path, scale, exclusions)
         if key not in self._trimesh_cache:
             from isaaclab_arena.utils.usd_helpers import extract_trimesh_from_usd  # deferred: pxr import
 
             try:
-                self._trimesh_cache[key] = extract_trimesh_from_usd(usd_path, scale)
+                self._trimesh_cache[key] = extract_trimesh_from_usd(
+                    usd_path,
+                    scale,
+                    excluded_prim_paths=exclusions,
+                )
             except ValueError as e:
                 # Permanent: bad USD content, cache None to avoid re-parsing.
                 print(f"  [WarpMeshAndSphereCache] Could not extract mesh for '{obj.name}': {e}")

--- a/isaaclab_arena/relations/warp_mesh_manager.py
+++ b/isaaclab_arena/relations/warp_mesh_manager.py
@@ -124,7 +124,7 @@ class WarpMeshAndSphereCache:
         self._device = device
         self._warp_mesh_cache: dict[tuple, wp.Mesh] = {}
         self._sphere_cache: dict[tuple, torch.Tensor] = {}
-        self._trimesh_cache: dict[tuple, trimesh.Trimesh | None] = {}
+        self._trimesh_cache: dict[tuple, trimesh.Trimesh | ValueError | None] = {}
         self._sentinel_warned: bool = False
         self._raw_open_mesh_warned: set[tuple] = set()
 
@@ -149,34 +149,52 @@ class WarpMeshAndSphereCache:
         obj: CollisionObject,
         excluded_prim_paths: Collection[str] = (),
     ) -> trimesh.Trimesh | None:
-        """Return the cached collision mesh, extracting from USD on first access."""
+        """Return the collision mesh, or ``None`` when USD extraction fails."""
         from isaaclab_arena.assets.object import Object
 
         if not isinstance(obj, Object) or obj.usd_path is None:
             assert not excluded_prim_paths, "USD prim exclusions require an Object with a usd_path."
             return obj.get_collision_mesh()
-        usd_path = obj.usd_path
-        scale = obj.scale
+
+        try:
+            return self.get_collision_mesh_or_raise(obj, excluded_prim_paths)
+        except (OSError, ValueError):
+            return None
+
+    def get_collision_mesh_or_raise(
+        self,
+        obj: CollisionObject,
+        excluded_prim_paths: Collection[str] = (),
+    ) -> trimesh.Trimesh | None:
+        """Return the collision mesh while preserving USD extraction errors."""
+        from isaaclab_arena.assets.object import Object
+
+        if not isinstance(obj, Object) or obj.usd_path is None:
+            assert not excluded_prim_paths, "USD prim exclusions require an Object with a usd_path."
+            return obj.get_collision_mesh()
+
         exclusions = tuple(sorted(excluded_prim_paths))
-        key = (usd_path, scale, exclusions)
+        key = (obj.usd_path, tuple(obj.scale), exclusions)
         if key not in self._trimesh_cache:
             from isaaclab_arena.utils.usd_helpers import extract_trimesh_from_usd  # deferred: pxr import
 
             try:
                 self._trimesh_cache[key] = extract_trimesh_from_usd(
-                    usd_path,
-                    scale,
+                    obj.usd_path,
+                    obj.scale,
                     excluded_prim_paths=exclusions,
                 )
             except ValueError as e:
-                # Permanent: bad USD content, cache None to avoid re-parsing.
                 print(f"  [WarpMeshAndSphereCache] Could not extract mesh for '{obj.name}': {e}")
-                self._trimesh_cache[key] = None
+                self._trimesh_cache[key] = e
             except OSError as e:
                 # Transient: file I/O failure, don't cache so next call retries.
                 print(f"  [WarpMeshAndSphereCache] Could not extract mesh for '{obj.name}': {e}")
-                return None
-        return self._trimesh_cache[key]
+                raise
+        result = self._trimesh_cache[key]
+        if isinstance(result, ValueError):
+            raise result
+        return result
 
     @property
     def device(self) -> str:

--- a/isaaclab_arena/tests/test_reference_objects.py
+++ b/isaaclab_arena/tests/test_reference_objects.py
@@ -66,6 +66,48 @@ def test_object_reference_world_bbox_applies_parent_yaw():
     assert torch.allclose(world_bbox.max_point, torch.tensor([[8.0, 1.2, 0.05]]), atol=1e-6)
 
 
+def test_object_reference_caches_parent_usd_prim_path(monkeypatch):
+    """Resolving the initial pose also caches the parent-USD path for later use."""
+    from isaaclab_arena.assets.object_reference import ObjectReference
+
+    calls = {"open_count": 0}
+    obj_ref = ObjectReference.__new__(ObjectReference)
+    obj_ref.prim_path = "{ENV_REGEX_NS}/kitchen/counter"
+    obj_ref._parent_scale = (1.0, 1.0, 1.0)
+    parent = SimpleNamespace(usd_path="/tmp/kitchen.usd", name="kitchen")
+
+    class OpenStage:
+        def __init__(self, path):
+            assert path == parent.usd_path
+
+        def __enter__(self):
+            calls["open_count"] += 1
+            return SimpleNamespace(GetPrimAtPath=lambda path: object())
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("isaaclab_arena.assets.object_reference.open_stage", OpenStage)
+    monkeypatch.setattr(
+        ObjectReference,
+        "isaaclab_prim_path_to_original_prim_path",
+        staticmethod(lambda prim_path, parent_asset, stage: "/World/counter"),
+    )
+    monkeypatch.setattr(
+        "isaaclab_arena.assets.object_reference.get_prim_pose_in_default_prim_frame",
+        lambda prim, stage: Pose(),
+    )
+
+    (
+        obj_ref._prim_path_in_parent_usd,
+        pose,
+    ) = obj_ref._get_referenced_prim_path_and_pose_relative_to_parent(parent)
+
+    assert obj_ref.prim_path_in_parent_usd == "/World/counter"
+    assert pose == Pose()
+    assert calls["open_count"] == 1
+
+
 def test_object_reference_get_collision_mesh_extracts_referenced_prim(monkeypatch):
     """ObjectReference collision meshes are extracted from the referenced sub-prim."""
     import trimesh

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -133,17 +133,19 @@ def test_background_collision_objects_reject_failed_whole_background(monkeypatch
     from isaaclab_arena.relations.background_collision_object import make_fixed_collision_objects
     from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
     from isaaclab_arena.utils.pose import Pose
+    from isaaclab_arena.utils.usd_helpers import NoCollisionMeshError
 
     left = _mesh_box("left_cabinet", (0.2, 0.2, 0.2), (-1.0, 0.0, 0.0))
     kitchen = Background.__new__(Background)
     kitchen.name = "kitchen"
     kitchen.collision_mode = None
     kitchen.initial_pose = Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
-    monkeypatch.setattr(
-        WarpMeshAndSphereCache,
-        "get_collision_mesh",
-        lambda self, obj, excluded_prim_paths=(): left.get_collision_mesh() if obj is left else None,
-    )
+
+    def fail_strict_lookup(self, obj, excluded_prim_paths=()):
+        assert obj is kitchen
+        raise NoCollisionMeshError("No mesh geometry found")
+
+    monkeypatch.setattr(WarpMeshAndSphereCache, "get_collision_mesh_or_raise", fail_strict_lookup)
 
     with pytest.raises(AssertionError, match="whole-scene Background"):
         make_fixed_collision_objects([left, kitchen])
@@ -151,6 +153,8 @@ def test_background_collision_objects_reject_failed_whole_background(monkeypatch
 
 def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
     """Unsupported USD geometry degrades to cached meshless collision."""
+    import pytest
+
     from isaaclab_arena.assets.object import Object
     from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
@@ -159,7 +163,7 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
     obj = Object.__new__(Object)
     obj.name = "kitchen"
     obj.usd_path = "/tmp/kitchen.usd"
-    obj.scale = (1.0, 1.0, 1.0)
+    obj.scale = [1.0, 1.0, 1.0]
     obj.object_type = ObjectType.BASE
     obj.repair_collision_mesh_non_watertight = True
     calls = {"count": 0}
@@ -173,6 +177,8 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
 
     assert manager.get_collision_mesh(obj) is None
     assert manager.get_collision_mesh(obj) is None
+    with pytest.raises(UnsupportedCollisionGeometryError):
+        manager.get_collision_mesh_or_raise(obj)
     assert calls["count"] == 1
 
 
@@ -204,26 +210,24 @@ def test_warp_mesh_cache_keys_exclusions(monkeypatch):
     assert calls == [("/Kitchen/counter",), ("/Kitchen/floor",)]
 
 
-def test_background_anchor_exclusions_report_no_remaining_mesh(monkeypatch):
-    """A background with no mesh left follows the standard extraction-failure path."""
-    import pytest
-
+def test_background_anchor_exclusions_can_remove_all_meshes(monkeypatch):
+    """A background fully represented by anchors contributes no additional collision object."""
     from isaaclab_arena.relations.background_collision_object import make_fixed_collision_objects
-    from isaaclab_arena.utils.usd_helpers import NoCollisionMeshError
 
     kitchen = _make_usd_background()
 
     def fake_extract(usd_path, scale, excluded_prim_paths=()):
         assert excluded_prim_paths == ("/Kitchen",)
-        raise NoCollisionMeshError("all geometry excluded")
 
     monkeypatch.setattr("isaaclab_arena.utils.usd_helpers.extract_trimesh_from_usd", fake_extract)
 
-    with pytest.raises(AssertionError, match="whole-scene Background"):
+    assert (
         make_fixed_collision_objects(
             [kitchen],
             excluded_prim_paths_by_object={kitchen: ["/Kitchen"]},
         )
+        == []
+    )
 
 
 def test_background_exclusions_preserve_unsupported_geometry_error(monkeypatch):
@@ -301,7 +305,7 @@ def test_background_collision_objects_treat_background_none_pose_as_identity(mon
     mesh_source = _mesh_box("source", (0.2, 0.2, 0.2), (0.0, 0.0, 0.0))
     monkeypatch.setattr(
         WarpMeshAndSphereCache,
-        "get_collision_mesh",
+        "get_collision_mesh_or_raise",
         lambda self, obj, excluded_prim_paths=(): mesh_source.get_collision_mesh(),
     )
 

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -76,6 +76,23 @@ def _mesh_box(name: str, extents: tuple[float, float, float], position: tuple[fl
     return obj
 
 
+def _make_usd_background():
+    """Background stub for USD mesh extraction tests."""
+    from isaaclab_arena.assets.background import Background
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.utils.pose import Pose
+
+    background = Background.__new__(Background)
+    background.name = "kitchen"
+    background.usd_path = "/tmp/kitchen.usda"
+    background.scale = (1.0, 1.0, 1.0)
+    background.object_type = ObjectType.BASE
+    background.collision_mode = None
+    background.initial_pose = Pose.identity()
+    background.repair_collision_mesh_non_watertight = False
+    return background
+
+
 def test_background_collision_object_combines_meshes():
     """Multiple fixed background meshes are represented as one collision-only object."""
     from isaaclab_arena.relations.background_collision_object import FixedCollisionObject, make_fixed_collision_objects
@@ -125,7 +142,7 @@ def test_background_collision_objects_reject_failed_whole_background(monkeypatch
     monkeypatch.setattr(
         WarpMeshAndSphereCache,
         "get_collision_mesh",
-        lambda self, obj: left.get_collision_mesh() if obj is left else None,
+        lambda self, obj, excluded_prim_paths=(): left.get_collision_mesh() if obj is left else None,
     )
 
     with pytest.raises(AssertionError, match="whole-scene Background"):
@@ -147,7 +164,7 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
     obj.repair_collision_mesh_non_watertight = True
     calls = {"count": 0}
 
-    def fail_extract(usd_path, scale):
+    def fail_extract(usd_path, scale, excluded_prim_paths=()):
         calls["count"] += 1
         raise UnsupportedCollisionGeometryError("Unsupported non-mesh geometry in /tmp/kitchen.usd: /World/cube")
 
@@ -157,6 +174,116 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
     assert manager.get_collision_mesh(obj) is None
     assert manager.get_collision_mesh(obj) is None
     assert calls["count"] == 1
+
+
+def test_warp_mesh_cache_keys_exclusions(monkeypatch):
+    """Different anchor exclusions cannot reuse a stale whole-background mesh."""
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
+
+    obj = Object.__new__(Object)
+    obj.name = "kitchen"
+    obj.usd_path = "/tmp/kitchen.usda"
+    obj.scale = (1.0, 1.0, 1.0)
+    obj.object_type = ObjectType.BASE
+    obj.repair_collision_mesh_non_watertight = False
+    calls = []
+
+    def fake_extract(usd_path, scale, excluded_prim_paths=()):
+        calls.append(tuple(excluded_prim_paths))
+        return _mesh_box("mesh", (0.2, 0.2, 0.2), (0.0, 0.0, 0.0)).get_collision_mesh()
+
+    monkeypatch.setattr("isaaclab_arena.utils.usd_helpers.extract_trimesh_from_usd", fake_extract)
+    manager = WarpMeshAndSphereCache(device="cpu")
+
+    manager.get_collision_mesh(obj, excluded_prim_paths=["/Kitchen/counter"])
+    manager.get_collision_mesh(obj, excluded_prim_paths=["/Kitchen/counter"])
+    manager.get_collision_mesh(obj, excluded_prim_paths=["/Kitchen/floor"])
+
+    assert calls == [("/Kitchen/counter",), ("/Kitchen/floor",)]
+
+
+def test_background_anchor_exclusions_report_no_remaining_mesh(monkeypatch):
+    """A background with no mesh left follows the standard extraction-failure path."""
+    import pytest
+
+    from isaaclab_arena.relations.background_collision_object import make_fixed_collision_objects
+    from isaaclab_arena.utils.usd_helpers import NoCollisionMeshError
+
+    kitchen = _make_usd_background()
+
+    def fake_extract(usd_path, scale, excluded_prim_paths=()):
+        assert excluded_prim_paths == ("/Kitchen",)
+        raise NoCollisionMeshError("all geometry excluded")
+
+    monkeypatch.setattr("isaaclab_arena.utils.usd_helpers.extract_trimesh_from_usd", fake_extract)
+
+    with pytest.raises(AssertionError, match="whole-scene Background"):
+        make_fixed_collision_objects(
+            [kitchen],
+            excluded_prim_paths_by_object={kitchen: ["/Kitchen"]},
+        )
+
+
+def test_background_exclusions_preserve_unsupported_geometry_error(monkeypatch):
+    """Unsupported geometry outside exclusions remains a fatal background extraction failure."""
+    import pytest
+
+    from isaaclab_arena.relations.background_collision_object import make_fixed_collision_objects
+    from isaaclab_arena.utils.usd_helpers import UnsupportedCollisionGeometryError
+
+    kitchen = _make_usd_background()
+
+    def fail_extract(usd_path, scale, excluded_prim_paths=()):
+        raise UnsupportedCollisionGeometryError("unsupported geometry remains")
+
+    monkeypatch.setattr("isaaclab_arena.utils.usd_helpers.extract_trimesh_from_usd", fail_extract)
+
+    with pytest.raises(AssertionError, match="whole-scene Background"):
+        make_fixed_collision_objects(
+            [kitchen],
+            excluded_prim_paths_by_object={kitchen: ["/Kitchen/counter"]},
+        )
+
+
+def test_passive_background_excludes_relation_anchor_subtrees(monkeypatch):
+    """Background aggregation omits geometry represented separately by relation anchors."""
+    from unittest.mock import MagicMock
+
+    import isaaclab_arena.relations.passive_collision_objects as passive_module
+    from isaaclab_arena.assets.background import Background
+    from isaaclab_arena.assets.object_reference import ObjectReference
+    from isaaclab_arena.relations.passive_collision_objects import get_passive_collision_objects
+    from isaaclab_arena.utils.pose import Pose
+
+    kitchen = Background.__new__(Background)
+    kitchen.name = "kitchen"
+    kitchen.usd_path = "/tmp/kitchen.usda"
+    kitchen.initial_pose = Pose.identity()
+    kitchen.relations = []
+
+    counter = MagicMock(spec=ObjectReference)
+    counter.parent_asset = kitchen
+    counter.prim_path_in_parent_usd = "/Kitchen/counter"
+    calls = {}
+
+    def fake_make_fixed(objects, excluded_prim_paths_by_object=None):
+        calls["objects"] = list(objects)
+        calls["exclusions"] = excluded_prim_paths_by_object
+        return list(objects)
+
+    monkeypatch.setattr(passive_module, "make_fixed_collision_objects", fake_make_fixed)
+
+    result = get_passive_collision_objects(
+        [kitchen],
+        include_background=True,
+        background_mesh_exclusions=[counter, counter],
+    )
+
+    assert result == [kitchen]
+    assert calls["objects"] == [kitchen]
+    assert calls["exclusions"] == {kitchen: {"/Kitchen/counter"}}
 
 
 def test_background_collision_objects_treat_background_none_pose_as_identity(monkeypatch):
@@ -173,7 +300,9 @@ def test_background_collision_objects_treat_background_none_pose_as_identity(mon
     kitchen.initial_pose = None
     mesh_source = _mesh_box("source", (0.2, 0.2, 0.2), (0.0, 0.0, 0.0))
     monkeypatch.setattr(
-        WarpMeshAndSphereCache, "get_collision_mesh", lambda self, obj: mesh_source.get_collision_mesh()
+        WarpMeshAndSphereCache,
+        "get_collision_mesh",
+        lambda self, obj, excluded_prim_paths=(): mesh_source.get_collision_mesh(),
     )
 
     collision_objects = make_fixed_collision_objects([kitchen])
@@ -392,7 +521,9 @@ def _test_get_passive_collision_objects_filters(simulation_app) -> bool:
     }
 
     original = passive_collision_module.make_fixed_collision_objects
-    passive_collision_module.make_fixed_collision_objects = lambda objects: list(objects)
+    passive_collision_module.make_fixed_collision_objects = lambda objects, excluded_prim_paths_by_object=None: list(
+        objects
+    )
     try:
         no_combine = passive_collision_module.get_passive_collision_objects(scene.assets.values())
         combined = passive_collision_module.get_passive_collision_objects(
@@ -644,27 +775,28 @@ def test_arena_env_builder_includes_embodiment_relations(monkeypatch):
     assert calls["objects"] == [embodiment]
 
 
-def test_relation_placement_includes_background_mesh_for_object_mesh_override(monkeypatch):
-    """Object-level MESH override enables aggregate background meshes."""
+def test_relation_placement_forwards_anchor_background_mesh_exclusions(monkeypatch):
+    """Anchored object references are excluded from their background mesh."""
+    from unittest.mock import MagicMock
+
     import isaaclab_arena.environments.relation_solver_interface as interface_module
+    from isaaclab_arena.assets.object_reference import ObjectReference
     from isaaclab_arena.environments.relation_solver_interface import solve_and_apply_relation_placement
     from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
     from isaaclab_arena.relations.relation_solver_params import CollisionMode, RelationSolverParams
     from isaaclab_arena.relations.relations import IsAnchor
-    from isaaclab_arena.tests.dummy_object import DummyObject
-    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
-    mesh_object = DummyObject(
-        "mesh_object",
-        bounding_box=AxisAlignedBoundingBox(min_point=(-0.1, -0.1, -0.1), max_point=(0.1, 0.1, 0.1)),
-    )
-    mesh_object.add_relation(IsAnchor())
-    mesh_object.collision_mode = CollisionMode.MESH
+    reference = MagicMock(spec=ObjectReference)
+    reference.name = "counter"
+    reference.collision_mode = CollisionMode.MESH
+    reference.get_scene_key.return_value = "counter"
+    reference.get_relations.return_value = [IsAnchor()]
     calls = {}
 
-    def fake_get_passive_collision_objects(assets, include_background: bool = False):
+    def fake_get_passive_collision_objects(assets, include_background: bool = False, background_mesh_exclusions=()):
         calls["assets"] = list(assets)
         calls["include_background"] = include_background
+        calls["background_mesh_exclusions"] = list(background_mesh_exclusions)
         return []
 
     class FakePooledObjectPlacer:
@@ -674,15 +806,19 @@ def test_relation_placement_includes_background_mesh_for_object_mesh_override(mo
             calls["objects"] = objects
             calls["collision_objects"] = collision_objects
 
-    monkeypatch.setattr(interface_module, "_get_passive_collision_objects", fake_get_passive_collision_objects)
+    monkeypatch.setattr(
+        "isaaclab_arena.relations.passive_collision_objects.get_passive_collision_objects",
+        fake_get_passive_collision_objects,
+    )
     monkeypatch.setattr(interface_module, "PooledObjectPlacer", FakePooledObjectPlacer)
     placer_params = ObjectPlacerParams(solver_params=RelationSolverParams(collision_mode=CollisionMode.BBOX))
 
-    solve_and_apply_relation_placement([mesh_object], num_envs=1, placer_params=placer_params, scene_assets=[])
+    solve_and_apply_relation_placement([reference], num_envs=1, placer_params=placer_params, scene_assets=[])
 
     assert calls["assets"] == []
     assert calls["include_background"] is True
-    assert calls["objects"] == [mesh_object]
+    assert calls["background_mesh_exclusions"] == [reference]
+    assert calls["objects"] == [reference]
     assert calls["collision_objects"] == []
 
 
@@ -706,7 +842,7 @@ def test_relation_placement_includes_background_mesh_for_background_override(mon
     placed_object.add_relation(IsAnchor())
     calls = {}
 
-    def fake_get_passive_collision_objects(assets, include_background: bool = False):
+    def fake_get_passive_collision_objects(assets, include_background: bool = False, background_mesh_exclusions=()):
         calls["assets"] = list(assets)
         calls["include_background"] = include_background
         return []
@@ -718,7 +854,10 @@ def test_relation_placement_includes_background_mesh_for_background_override(mon
             calls["objects"] = objects
             calls["collision_objects"] = collision_objects
 
-    monkeypatch.setattr(interface_module, "_get_passive_collision_objects", fake_get_passive_collision_objects)
+    monkeypatch.setattr(
+        "isaaclab_arena.relations.passive_collision_objects.get_passive_collision_objects",
+        fake_get_passive_collision_objects,
+    )
     monkeypatch.setattr(interface_module, "PooledObjectPlacer", FakePooledObjectPlacer)
     placer_params = ObjectPlacerParams(solver_params=RelationSolverParams(collision_mode=CollisionMode.BBOX))
 
@@ -752,7 +891,7 @@ def test_relation_placement_skips_background_mesh_for_default_bbox(monkeypatch):
     placed_object.add_relation(IsAnchor())
     calls = {}
 
-    def fake_get_passive_collision_objects(assets, include_background: bool = False):
+    def fake_get_passive_collision_objects(assets, include_background: bool = False, background_mesh_exclusions=()):
         calls["assets"] = list(assets)
         calls["include_background"] = include_background
         return []
@@ -764,7 +903,10 @@ def test_relation_placement_skips_background_mesh_for_default_bbox(monkeypatch):
             calls["objects"] = objects
             calls["collision_objects"] = collision_objects
 
-    monkeypatch.setattr(interface_module, "_get_passive_collision_objects", fake_get_passive_collision_objects)
+    monkeypatch.setattr(
+        "isaaclab_arena.relations.passive_collision_objects.get_passive_collision_objects",
+        fake_get_passive_collision_objects,
+    )
     monkeypatch.setattr(interface_module, "PooledObjectPlacer", FakePooledObjectPlacer)
     placer_params = ObjectPlacerParams(solver_params=RelationSolverParams(collision_mode=CollisionMode.BBOX))
 

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -132,8 +132,7 @@ def _test_mesh_exclusion_errors(simulation_app, asset_dir: pathlib.Path) -> bool
     excluded_mesh.GetFaceVertexIndicesAttr().Set([0, 1, 2])
     stage.GetRootLayer().Save()
 
-    with pytest.raises(NoCollisionMeshError, match="All mesh geometry excluded"):
-        extract_trimesh_from_usd(usd_path.as_posix(), excluded_prim_paths=["/Root/Excluded"])
+    assert extract_trimesh_from_usd(usd_path.as_posix(), excluded_prim_paths=["/Root/Excluded"]) is None
 
     UsdGeom.Mesh.Define(stage, "/Root/Malformed")
     stage.GetRootLayer().Save()

--- a/isaaclab_arena/tests/test_usd_helpers.py
+++ b/isaaclab_arena/tests/test_usd_helpers.py
@@ -115,6 +115,34 @@ def _test_compute_local_bounding_box_from_usd_prim_path(simulation_app, asset_di
     return True
 
 
+def _test_mesh_exclusion_errors(simulation_app, asset_dir: pathlib.Path) -> bool:
+    """Distinguish fully excluded meshes from malformed included meshes."""
+    import pytest
+    from pxr import Gf, Usd, UsdGeom
+
+    from isaaclab_arena.utils.usd_helpers import NoCollisionMeshError, extract_trimesh_from_usd
+
+    usd_path = asset_dir / "mesh_exclusions.usda"
+    stage = Usd.Stage.CreateNew(usd_path.as_posix())
+    root = UsdGeom.Xform.Define(stage, "/Root")
+    stage.SetDefaultPrim(root.GetPrim())
+    excluded_mesh = UsdGeom.Mesh.Define(stage, "/Root/Excluded")
+    excluded_mesh.GetPointsAttr().Set([Gf.Vec3f(0, 0, 0), Gf.Vec3f(1, 0, 0), Gf.Vec3f(0, 1, 0)])
+    excluded_mesh.GetFaceVertexCountsAttr().Set([3])
+    excluded_mesh.GetFaceVertexIndicesAttr().Set([0, 1, 2])
+    stage.GetRootLayer().Save()
+
+    with pytest.raises(NoCollisionMeshError, match="All mesh geometry excluded"):
+        extract_trimesh_from_usd(usd_path.as_posix(), excluded_prim_paths=["/Root/Excluded"])
+
+    UsdGeom.Mesh.Define(stage, "/Root/Malformed")
+    stage.GetRootLayer().Save()
+    with pytest.raises(NoCollisionMeshError) as error:
+        extract_trimesh_from_usd(usd_path.as_posix(), excluded_prim_paths=["/Root/Excluded"])
+    assert type(error.value) is NoCollisionMeshError
+    return True
+
+
 def test_compute_local_bounding_box_from_usd(tmp_path: pathlib.Path):
     result = run_function_with_persistent_simulation_app(
         _test_compute_local_bounding_box_from_usd,
@@ -131,3 +159,11 @@ def test_compute_local_bounding_box_from_usd_prim_path(tmp_path: pathlib.Path):
         asset_dir=tmp_path,
     )
     assert result, "Test failed"
+
+
+def test_mesh_exclusion_errors(tmp_path: pathlib.Path):
+    assert run_function_with_persistent_simulation_app(
+        _test_mesh_exclusion_errors,
+        headless=HEADLESS,
+        asset_dir=tmp_path,
+    )

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -298,7 +298,7 @@ def extract_trimesh_from_usd(
     usd_path: str,
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
     excluded_prim_paths: Sequence[str] = (),
-) -> trimesh.Trimesh:
+) -> trimesh.Trimesh | None:
     """Extract all UsdGeom.Mesh prims from a USD into a single trimesh.
 
     Scale is applied per-vertex in local frame before the prim-to-world transform.
@@ -311,7 +311,8 @@ def extract_trimesh_from_usd(
         excluded_prim_paths: Absolute USD prim paths whose complete subtrees are omitted.
 
     Returns:
-        Combined trimesh with per-prim world transforms baked in.
+        Combined trimesh with per-prim world transforms baked in, or ``None`` when exclusions
+        remove every mesh.
     """
     assert all(
         s > 0 for s in scale
@@ -380,7 +381,7 @@ def extract_trimesh_from_usd(
             f"Unsupported non-mesh geometry in {usd_path}: {', '.join(skipped_gprims)}"
         )
     if excluded_mesh_count and not included_mesh_count:
-        raise NoCollisionMeshError(f"All mesh geometry excluded from {usd_path}")
+        return None
     raise NoCollisionMeshError(f"No mesh geometry found in {usd_path}")
 
 

--- a/isaaclab_arena/utils/usd_helpers.py
+++ b/isaaclab_arena/utils/usd_helpers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import functools
 import numpy as np
 import trimesh
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 
 from pxr import Gf, Usd, UsdGeom, UsdLux, UsdPhysics
@@ -297,6 +297,7 @@ def compute_local_bounding_box_from_prim(
 def extract_trimesh_from_usd(
     usd_path: str,
     scale: tuple[float, float, float] = (1.0, 1.0, 1.0),
+    excluded_prim_paths: Sequence[str] = (),
 ) -> trimesh.Trimesh:
     """Extract all UsdGeom.Mesh prims from a USD into a single trimesh.
 
@@ -307,6 +308,7 @@ def extract_trimesh_from_usd(
     Args:
         usd_path: Path to the .usd/.usda/.usdc file.
         scale: (sx, sy, sz) per-axis scale factors applied in local frame.
+        excluded_prim_paths: Absolute USD prim paths whose complete subtrees are omitted.
 
     Returns:
         Combined trimesh with per-prim world transforms baked in.
@@ -314,6 +316,10 @@ def extract_trimesh_from_usd(
     assert all(
         s > 0 for s in scale
     ), f"All scale components must be positive (negative scale flips winding/SDF sign), got {scale}"
+    excluded_paths = tuple(path.rstrip("/") for path in excluded_prim_paths)
+    assert all(
+        path.startswith("/") for path in excluded_paths
+    ), f"excluded_prim_paths must be absolute USD paths, got {excluded_paths}"
 
     stage = Usd.Stage.Open(usd_path)
     if stage is None:
@@ -322,13 +328,20 @@ def extract_trimesh_from_usd(
     all_verts: list[np.ndarray] = []
     all_faces: list[list[int]] = []
     skipped_gprims: list[str] = []
+    excluded_mesh_count = 0
+    included_mesh_count = 0
     offset = 0
 
     for prim in stage.Traverse():
+        prim_path = str(prim.GetPath())
+        if any(prim_path == path or prim_path.startswith(f"{path}/") for path in excluded_paths):
+            excluded_mesh_count += int(prim.IsA(UsdGeom.Mesh))
+            continue
         if not prim.IsA(UsdGeom.Mesh):
             if prim.IsA(UsdGeom.Gprim):
                 skipped_gprims.append(str(prim.GetPath()))
             continue
+        included_mesh_count += 1
         mesh_prim = UsdGeom.Mesh(prim)
         points = mesh_prim.GetPointsAttr().Get()
         face_vertex_counts = mesh_prim.GetFaceVertexCountsAttr().Get()
@@ -366,6 +379,8 @@ def extract_trimesh_from_usd(
         raise UnsupportedCollisionGeometryError(
             f"Unsupported non-mesh geometry in {usd_path}: {', '.join(skipped_gprims)}"
         )
+    if excluded_mesh_count and not included_mesh_count:
+        raise NoCollisionMeshError(f"All mesh geometry excluded from {usd_path}")
     raise NoCollisionMeshError(f"No mesh geometry found in {usd_path}")
 
 


### PR DESCRIPTION
## Summary
Exclude anchored references from background meshes

## Detailed description
- Prevent conflicting relation and mesh-collision constraints for anchored object references.
- Exclude referenced USD prim subtrees when aggregating their parent background mesh.
- Include exclusions in mesh-cache keys and handle fully excluded geometry.
- Add coverage for exclusion propagation, extraction, and cache behavior.

Command to run:
 /isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py     --viz kit     --policy_type zero_action     --num_episodes 20  --disable_fabric  --device cpu  --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yam
 
Before:
[RelationSolver] solve: 3635.3 ms | batch=50 | objects=3 optimizable + 2 anchors | no-overlap pairs=9 | iters=600 (6.06 ms/iter)
[placement] Validated 50 candidate layout(s); passed per check: on_relation=0/50, next_to=34/50, not_next_to=50/50, face_to=50/50, no_overlap=34/50

After:
[RelationSolver] solve: 3392.7 ms | batch=50 | objects=3 optimizable + 2 anchors | no-overlap pairs=9 | iters=600 (5.65 ms/iter)
[placement] Validated 50 candidate layout(s); passed per check: on_relation=35/50, next_to=35/50, not_next_to=50/50, face_to=50/50, no_overlap=47/50