### PR TITLE
Add the Cosmos workflow

### DIFF
--- a/isaaclab_arena/tests/test_osmo_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_workflow.py
@@ -12,8 +12,9 @@ from osmo.tasks.dreamzero_policy_runner_task import DreamZeroPolicyRunnerTaskCfg
 from osmo.tasks.pi0_server_task import Pi0ServerTask, Pi0ServerTaskCfg
 from osmo.tasks.policy_runner_task import PolicyRunnerTaskCfg
 from osmo.workflows.dreamzero_split_workflows import DreamZeroPolicyRunnerWorkflow
-from osmo.workflows.server_plus_policy_runner_workflow import Pi0PlusPolicyRunnerWorkflow
+from osmo.workflows.server_plus_policy_runner_workflow import CosmosPolicyRunnerWorkflow, Pi0PlusPolicyRunnerWorkflow
 from osmo.workflows.workflow import WorkflowCfg
+from osmo.workflows.workflow_constants import POLICY_SERVER_PORT
 
 
 def test_task_name_is_a_required_keyword_argument():
@@ -43,6 +44,23 @@ def test_typed_workflow_config_renders_policy_runner_and_server():
     assert "--ping_timeout 300" in policy_runner_command
     assert "--num_envs 2" in policy_runner_command
     assert "example_environment light.hdr_image.enabled=true" in policy_runner_command
+
+
+def test_cosmos_workflow_renders_policy_runner_and_server():
+    """Pair the Cosmos policy-runner with the Cosmos server it connects to."""
+    workflow = CosmosPolicyRunnerWorkflow(
+        workflow_cfg=WorkflowCfg(),
+        task_cfg=PolicyRunnerTaskCfg(arena_env="example_environment"),
+    )
+
+    tasks = workflow.generate_workflow()["workflow"]["groups"][0]["tasks"]
+    policy_runner_command = tasks[0]["files"][0]["contents"]
+
+    assert [task["name"] for task in tasks] == ["policy_runner", "cosmos_server"]
+    assert "isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy" in policy_runner_command
+    assert "--remote_host {{host:cosmos_server}}" in policy_runner_command
+    assert f"--remote_port {POLICY_SERVER_PORT}" in policy_runner_command
+    assert "action_policy_server_robolab" in tasks[1]["files"][0]["contents"]
 
 
 def test_static_workflow_threads_declared_task_names_into_host_token():

--- a/osmo/submit_evaluation_workflow.py
+++ b/osmo/submit_evaluation_workflow.py
@@ -52,7 +52,11 @@ import sys
 
 from isaaclab_arena.cli.dataclass_cli import add_dataclass_cli_args, dataclass_from_cli
 from osmo.workflows.dreamzero_split_workflows import DreamZeroEvaluationWorkflow
-from osmo.workflows.server_plus_policy_runner_workflow import Gr00tPolicyRunnerWorkflow, Pi0PlusPolicyRunnerWorkflow
+from osmo.workflows.server_plus_policy_runner_workflow import (
+    CosmosPolicyRunnerWorkflow,
+    Gr00tPolicyRunnerWorkflow,
+    Pi0PlusPolicyRunnerWorkflow,
+)
 from osmo.workflows.workflow import SubmittableWorkflow
 from osmo.workflows.zero_action_policy_runner_workflow import ZeroActionPolicyRunnerWorkflow
 
@@ -60,6 +64,7 @@ POLICIES: dict[str, type[SubmittableWorkflow]] = {
     "zero_action": ZeroActionPolicyRunnerWorkflow,
     "pi0": Pi0PlusPolicyRunnerWorkflow,
     "gr00t": Gr00tPolicyRunnerWorkflow,
+    "cosmos": CosmosPolicyRunnerWorkflow,
     "dreamzero": DreamZeroEvaluationWorkflow,
 }
 

--- a/osmo/tasks/cosmos_policy_runner_task.py
+++ b/osmo/tasks/cosmos_policy_runner_task.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos policy-runner task for the Isaac Lab Arena OSMO workflow."""
+
+from osmo.tasks.policy_runner_task import PolicyRunnerTask, PolicyRunnerTaskCfg
+from osmo.workflows.workflow_constants import POLICY_SERVER_PORT
+
+
+class CosmosPolicyRunnerTask(PolicyRunnerTask):
+    """Policy-runner task that queries a remote Cosmos policy server."""
+
+    def __init__(
+        self,
+        task_cfg: PolicyRunnerTaskCfg,
+        remote_host: str,
+        lead: bool | None = None,
+        *,
+        task_name: str,
+    ) -> None:
+        super().__init__(task_name=task_name, task_cfg=task_cfg, lead=lead)
+        # Host of the Cosmos server this runner connects to; the workflow resolves it from the server task.
+        self.remote_host = remote_host
+
+    def _get_policy_args(self) -> list[str]:
+        return [
+            "--policy_type",
+            "isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy",
+            "--remote_host",
+            self.remote_host,
+            "--remote_port",
+            str(POLICY_SERVER_PORT),
+        ]

--- a/osmo/tasks/cosmos_server_task.py
+++ b/osmo/tasks/cosmos_server_task.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cosmos inference-server task."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+from osmo.tasks.base_task import BaseTask, TaskCfg
+from osmo.workflows.workflow_constants import POLICY_SERVER_PORT
+
+
+@dataclass
+class CosmosServerTaskCfg(TaskCfg):
+    """Config for the Cosmos inference-server task."""
+
+    image: str = "nvcr.io/nvstaging/isaac-amr/isaaclab_arena:cosmos_server"
+    """Cosmos server image (built by isaaclab_arena_cosmos/docker/build_server_image.sh)."""
+
+    checkpoint: str = "/workspace/baked_checkpoint"
+    """Checkpoint the server serves. Baked into the image at build time (see build_server_image.sh)."""
+
+
+class CosmosServerTask(BaseTask):
+    """OSMO task that serves a Cosmos policy for an eval/policy-runner task to connect to."""
+
+    def __init__(
+        self,
+        task_cfg: CosmosServerTaskCfg | None = None,
+        lead: bool | None = None,
+        *,
+        task_name: str,
+    ) -> None:
+        super().__init__(task_name=task_name, task_cfg=task_cfg or CosmosServerTaskCfg(), lead=lead)
+
+    def _get_image(self) -> str:
+        return self.task_cfg.image
+
+    def _get_inputs(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_outputs(self) -> list[dict[str, Any]]:
+        return []
+
+    def _get_run_script(self) -> str:
+        serve_command = shlex.join([
+            "python",
+            "-m",
+            "cosmos_framework.scripts.action_policy_server_robolab",
+            "--checkpoint_path",
+            self.task_cfg.checkpoint,
+            "--port",
+            str(POLICY_SERVER_PORT),
+            "--format-prompt-as-json",
+            "True",
+        ])
+        return f"set -euxo pipefail\nnvidia-smi\nexec {serve_command}\n"

--- a/osmo/workflows/server_plus_policy_runner_workflow.py
+++ b/osmo/workflows/server_plus_policy_runner_workflow.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 from osmo.tasks.base_task import BaseTask
+from osmo.tasks.cosmos_policy_runner_task import CosmosPolicyRunnerTask
+from osmo.tasks.cosmos_server_task import CosmosServerTask
 from osmo.tasks.gr00t_policy_runner_task import Gr00tPolicyRunnerTask, Gr00tPolicyRunnerTaskCfg
 from osmo.tasks.gr00t_server_task import Gr00tServerTask
 from osmo.tasks.pi0_remote_policy_runner_task import Pi0RemotePolicyRunnerTask
@@ -53,4 +55,12 @@ class Pi0PlusPolicyRunnerWorkflow(ServerPlusPolicyRunnerWorkflow):
 
     task_cls_list = [Pi0RemotePolicyRunnerTask, Pi0ServerTask]
     task_names = ["policy_runner", "policy_server"]
+    task_cfg_type = PolicyRunnerTaskCfg
+
+
+class CosmosPolicyRunnerWorkflow(ServerPlusPolicyRunnerWorkflow):
+    """Two-task workflow: a Cosmos server plus the lead policy-runner eval task."""
+
+    task_cls_list = [CosmosPolicyRunnerTask, CosmosServerTask]
+    task_names = ["policy_runner", "cosmos_server"]
     task_cfg_type = PolicyRunnerTaskCfg


### PR DESCRIPTION
## Summary
Run Cosmos policies on OSMO.

## Detailed description
- The Cosmos policy client was merged in #963.
- We now enable this in OSMO.
- Adds:
  - `CosmosServerTask` serves the checkpoint baked into the server image
  - `CosmosPolicyRunnerTask` runs the policy runner configured to point at the cosmos server.
  - `CosmosPolicyRunnerWorkflow` pairs the two.