### PR TITLE
Use a distinct seed per environment rebuild

### DIFF
--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -103,12 +103,13 @@ def build_and_run(
                 video_base_dir=output_dir,
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
             )
-            env = _build_environment_from_cfg(cfg, rebuild_video_cfg.render_mode)
+            rebuild_cfg = _cfg_for_rebuild(cfg, rebuild_index)
+            env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
             results_path = os.path.join(output_dir, f"episode_results_rebuild{rebuild_index}.jsonl")
             env.unwrapped.episode_recorder.set_job_name(cfg.name)
             env.unwrapped.episode_recorder.set_output_path(results_path)
 
-            policy = _build_policy_from_cfg(cfg)
+            policy = _build_policy_from_cfg(rebuild_cfg)
             num_steps, num_episodes = _resolve_rollout_limit(
                 cfg,
                 policy,
@@ -126,6 +127,19 @@ def build_and_run(
         status=RunStatus.COMPLETED,
         metrics=aggregate_metrics(metrics_per_rebuild) if metrics_per_rebuild else None,
     )
+
+
+def _cfg_for_rebuild(cfg: ArenaRunCfg, rebuild_index: int) -> ArenaRunCfg:
+    """Offset the environment-builder seed for a rebuild so each fresh construction differs.
+
+    Without this every rebuild constructs with the same seed, so build-time variations
+    (e.g. the directional-light direction) resolve to the same value on each rebuild.
+    Rebuild 0 keeps the configured seed so single-rebuild runs are unchanged.
+    """
+    if rebuild_index == 0:
+        return cfg
+    builder = replace(cfg.environment_builder, seed=cfg.environment_builder.seed + rebuild_index)
+    return replace(cfg, environment_builder=builder)
 
 
 def _build_environment_from_cfg(

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import traceback
+from copy import deepcopy
 from dataclasses import fields, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -103,7 +104,7 @@ def build_and_run(
                 video_base_dir=output_dir,
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
             )
-            rebuild_cfg = _cfg_for_rebuild(cfg, rebuild_index)
+            rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
             env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
             results_path = os.path.join(output_dir, f"episode_results_rebuild{rebuild_index}.jsonl")
             env.unwrapped.episode_recorder.set_job_name(cfg.name)
@@ -129,17 +130,16 @@ def build_and_run(
     )
 
 
-def _cfg_for_rebuild(cfg: ArenaRunCfg, rebuild_index: int) -> ArenaRunCfg:
+def _seed_cfg_for_rebuild(cfg: ArenaRunCfg, rebuild_index: int) -> ArenaRunCfg:
     """Offset the environment-builder seed for a rebuild so each fresh construction differs.
 
     Without this every rebuild constructs with the same seed, so build-time variations
     (e.g. the directional-light direction) resolve to the same value on each rebuild.
-    Rebuild 0 keeps the configured seed so single-rebuild runs are unchanged.
+    Rebuild 0 keeps the configured seed (``seed + 0``) so single-rebuild runs are unchanged.
     """
-    if rebuild_index == 0:
-        return cfg
-    builder = replace(cfg.environment_builder, seed=cfg.environment_builder.seed + rebuild_index)
-    return replace(cfg, environment_builder=builder)
+    cfg = deepcopy(cfg)
+    cfg.environment_builder.seed += rebuild_index
+    return cfg
 
 
 def _build_environment_from_cfg(

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -131,12 +131,7 @@ def build_and_run(
 
 
 def _seed_cfg_for_rebuild(cfg: ArenaRunCfg, rebuild_index: int) -> ArenaRunCfg:
-    """Offset the environment-builder seed for a rebuild so each fresh construction differs.
-
-    Without this every rebuild constructs with the same seed, so build-time variations
-    (e.g. the directional-light direction) resolve to the same value on each rebuild.
-    Rebuild 0 keeps the configured seed (``seed + 0``) so single-rebuild runs are unchanged.
-    """
+    """Offset the environment-builder seed for a rebuild so each fresh construction differs."""
     cfg = deepcopy(cfg)
     cfg.environment_builder.seed += rebuild_index
     return cfg

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -82,11 +82,27 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
         output_dir=tmp_path,
     )
 
+    base_seed = run.environment_builder.seed
     assert result.run_name == "test_run"
     assert result.status is RunStatus.COMPLETED
     assert rollout_limits == [(None, 3), (None, 2)]
-    assert received_run_cfgs == [run, run]
+    # Rebuild 0 builds the run unchanged; each later rebuild offsets the seed so its fresh
+    # construction differs (e.g. a build-time light-direction variation resolves to a new value).
+    assert received_run_cfgs[0] is run
+    assert [cfg.environment_builder.seed for cfg in received_run_cfgs] == [base_seed, base_seed + 1]
     assert run.rollout_limit == RolloutLimitCfg(num_episodes=5)
+    assert run.environment_builder.seed == base_seed
+
+
+def test_cfg_for_rebuild_offsets_seed_per_rebuild():
+    run = _run(num_rebuilds=3)
+    base_seed = run.environment_builder.seed
+
+    assert run_execution._cfg_for_rebuild(run, 0) is run
+    assert run_execution._cfg_for_rebuild(run, 1).environment_builder.seed == base_seed + 1
+    assert run_execution._cfg_for_rebuild(run, 2).environment_builder.seed == base_seed + 2
+    # The original config is never mutated.
+    assert run.environment_builder.seed == base_seed
 
 
 def test_build_and_run_raises_and_closes_resources(monkeypatch, tmp_path):

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -86,21 +86,20 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     assert result.run_name == "test_run"
     assert result.status is RunStatus.COMPLETED
     assert rollout_limits == [(None, 3), (None, 2)]
-    # Rebuild 0 builds the run unchanged; each later rebuild offsets the seed so its fresh
-    # construction differs (e.g. a build-time light-direction variation resolves to a new value).
-    assert received_run_cfgs[0] is run
+    # Each rebuild offsets the seed so its fresh construction differs (e.g. a build-time
+    # light-direction variation resolves to a new value). Rebuild 0 keeps the configured seed.
     assert [cfg.environment_builder.seed for cfg in received_run_cfgs] == [base_seed, base_seed + 1]
     assert run.rollout_limit == RolloutLimitCfg(num_episodes=5)
     assert run.environment_builder.seed == base_seed
 
 
-def test_cfg_for_rebuild_offsets_seed_per_rebuild():
+def test_seed_cfg_for_rebuild_offsets_seed_per_rebuild():
     run = _run(num_rebuilds=3)
     base_seed = run.environment_builder.seed
 
-    assert run_execution._cfg_for_rebuild(run, 0) is run
-    assert run_execution._cfg_for_rebuild(run, 1).environment_builder.seed == base_seed + 1
-    assert run_execution._cfg_for_rebuild(run, 2).environment_builder.seed == base_seed + 2
+    assert run_execution._seed_cfg_for_rebuild(run, 0).environment_builder.seed == base_seed
+    assert run_execution._seed_cfg_for_rebuild(run, 1).environment_builder.seed == base_seed + 1
+    assert run_execution._seed_cfg_for_rebuild(run, 2).environment_builder.seed == base_seed + 2
     # The original config is never mutated.
     assert run.environment_builder.seed == base_seed
 

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -83,12 +84,16 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     )
 
     base_seed = run.environment_builder.seed
+    run_seed_0 = deepcopy(run)  # Rebuild 0 keeps the configured seed.
+    run_seed_1 = deepcopy(run)
+    run_seed_1.environment_builder.seed = base_seed + 1
+
     assert result.run_name == "test_run"
     assert result.status is RunStatus.COMPLETED
     assert rollout_limits == [(None, 3), (None, 2)]
-    # Each rebuild offsets the seed so its fresh construction differs (e.g. a build-time
-    # light-direction variation resolves to a new value). Rebuild 0 keeps the configured seed.
-    assert [cfg.environment_builder.seed for cfg in received_run_cfgs] == [base_seed, base_seed + 1]
+    # Runs are the same except for their seeds.
+    assert received_run_cfgs == [run_seed_0, run_seed_1]
+    # The original config is never mutated.
     assert run.rollout_limit == RolloutLimitCfg(num_episodes=5)
     assert run.environment_builder.seed == base_seed
 


### PR DESCRIPTION
## Summary
Distinct env-builder seed per rebuild

## Detailed description
- **Reason:** Every rebuild constructed the environment with the same seed, so build-time variations (e.g. directional-light direction) resolved to the same value on each rebuild, defeating the purpose of rebuilding.
- **Change:** Added `_cfg_for_rebuild`, which offsets `environment_builder.seed` by the rebuild index. Rebuild 0 keeps the configured seed so single-rebuild runs are unchanged, and the original config is never mutated (a fresh copy via `dataclasses.replace`).
- **Impact:** Multi-rebuild runs now see genuinely different build-time variation draws across rebuilds; single-rebuild behaviour is untouched. Covered by a new unit test plus an updated budget-split test.