### PR TITLE
Point the CI test image at the latest, following what's built in post merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:lab_beta_2_af1bab4dc17
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}
@@ -184,7 +184,7 @@ jobs:
     needs: [pre_commit]
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:lab_beta_2_af1bab4dc17
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}
@@ -223,7 +223,7 @@ jobs:
       GR00T_REMOTE_E2E_TIMEOUT: "900"
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:lab_beta_2_af1bab4dc17
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
 
     container:
       # The cuRobo-enabled image (built with ./docker/run_docker.sh -c / push_to_ngc.sh -c).
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:lab_beta_2_testing_curobo
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:curobo
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}


### PR DESCRIPTION
## Summary
CI test jobs were using lab_beta_2_af1bab4dc17, to enable merging https://github.com/isaac-sim/IsaacLab-Arena/pull/960. Dependencies that land in main after that never reach CI. Keep CI image up to date with main.

