### PR TITLE
Integrate physics-settled clutter placement for Isaac-cap

### DIFF
--- a/docs/pages/concepts/concept_object_placement.rst
+++ b/docs/pages/concepts/concept_object_placement.rst
@@ -239,6 +239,57 @@ Parameters:
 For backward compatibility, ``PositionLimits`` and YAML kind ``position_limits``
 remain aliases for ``PositionLimitsBox``.
 
+**ClutteredOn**
+
+Places a group of objects as a settled pile on a support surface. Unlike the relations
+above, members are not positioned by the solver: they are released above the support and
+allowed to fall, and where they come to rest is the placement.
+
+.. code-block:: python
+
+   table.add_relation(IsAnchor())
+   for tool in tools:
+       tool.add_relation(ClutteredOn(table, group="tools"))
+
+The equivalent YAML:
+
+.. code-block:: yaml
+
+   relations:
+     - kind: cluttered_on
+       subject: mug
+       reference: table
+       params:
+         group: tools
+         spread: 0.8
+
+Objects sharing a ``reference`` and a ``group`` form one pile. A support may hold several
+groups, and each is poured separately.
+
+Parameters:
+
+- ``group`` (default ``"clutter"``) — ties members of one pile together
+- ``spread`` (default ``1.0``) — fraction of the support footprint to use, shrunk about
+  its centre; must be in ``(0, 1]``
+- ``gap_m`` (default ``0.03``) — vertical gap left between stacked release poses
+- ``clearance_m`` (default ``0.01``) — height above the surface at which the lowest
+  layer starts
+- ``random_yaw`` (default ``True``) — sample a yaw per object before dropping
+
+Because a pile is produced by simulation rather than optimisation, it differs from the
+other relations in ways worth knowing:
+
+- **The support must be collidable.** Objects fall through a background asset that has no
+  rigid-body properties, and the pile ends up on the ground.
+- **The support must have a readable USD.** The drop region is derived from its bounding
+  box, so a procedurally spawned support without geometry cannot be used.
+- **A placement seed is required.** Clutter refuses to pour without one, since a pile that
+  cannot be reproduced defeats the purpose of seeding a layout.
+- **Members are excluded from overlap checking against each other.** A settled pile has
+  objects in contact by definition. They are still checked against everything else.
+- **Members do not participate in the solver.** They carry no loss term, so a clutter
+  group neither constrains nor is constrained by the optimised layout beyond its support.
+
 Anchors
 ~~~~~~~
 

--- a/docs/pages/concepts/object_placement/relations.rst
+++ b/docs/pages/concepts/object_placement/relations.rst
@@ -130,6 +130,40 @@ Most environments can be described with a small set of relations:
   XY offsets.
 - The subject and target must have different XY positions.
 
+``ClutteredOn(parent)``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Places a group of objects as a settled pile on a support surface. Members are
+released above the support and allowed to fall rather than being positioned by
+the solver.
+
+.. code-block:: python
+
+   table.add_relation(IsAnchor())
+   for tool in tools:
+       tool.add_relation(ClutteredOn(table, group="tools"))
+
+Objects that share a parent and ``group`` form one pile. ``spread`` selects the
+fraction of the support footprint used for release, ``gap_m`` separates stacked
+release poses, ``clearance_m`` offsets the lowest layer, and ``random_yaw``
+controls per-object yaw sampling.
+
+The support must be collidable and have readable geometry. A placement seed is
+required so the pour is reproducible. Clutter members do not participate in the
+solver; their settled contact and tilt are the resulting placement.
+
+The equivalent environment-spec relation is:
+
+.. code-block:: yaml
+
+   relations:
+     - kind: cluttered_on
+       subject: mug
+       reference: table
+       params:
+         group: tools
+         spread: 0.8
+
 Combining Relations
 -------------------
 

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -52,6 +52,12 @@ def add_isaac_lab_cli_args(parser: argparse.ArgumentParser) -> None:
     isaac_lab_group.add_argument("--seed", type=int, default=42, help="Optional seed for the random number generator.")
     isaac_lab_group.add_argument("--num_envs", type=int, default=1, help="Number of environments to simulate.")
     isaac_lab_group.add_argument("--env_spacing", type=float, default=30.0, help="Spacing between environments.")
+    isaac_lab_group.add_argument(
+        "--num_rerenders_on_reset",
+        type=int,
+        default=0,
+        help="Number of extra render steps after reset so sensor observations reflect reset state.",
+    )
     isaac_lab_group.add_argument("--mimic", action="store_true", default=False, help="Enable mimic environment.")
 
     # TODO(cvolk, 2026-07-06): [typed-config-migration] Move --distributed into a typed runner or simulation-app
@@ -85,6 +91,15 @@ def add_isaaclab_arena_cli_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=None,
         help="Seed for object placement. If set, objects are placed at the same positions across runs.",
+    )
+    arena_group.add_argument(
+        "--placement_clearance_m",
+        type=float,
+        default=None,
+        help=(
+            "Override the default relation-solver collision clearance in metres. "
+            "When omitted, RelationSolverParams keeps its 0.01 m default."
+        ),
     )
     arena_group.add_argument(
         "--presets",

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -121,11 +121,11 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
     return False
 
 
-def _prim_path_for_relative(registry_name: str, prim_path: str) -> str:
-    """Expand a relative prim suffix to the Isaac Lab runtime prim path."""
+def _prim_path_for_relative(parent_prim_path: str, prim_path: str) -> str:
+    """Expand a relative prim suffix below its parent asset's runtime path."""
     if prim_path.startswith("{ENV_REGEX_NS}/"):
         return prim_path
-    return f"{{ENV_REGEX_NS}}/{registry_name}/{prim_path.lstrip('/')}"
+    return f"{parent_prim_path.rstrip('/')}/{prim_path.lstrip('/')}"
 
 
 def instantiate_assets_from_spec(
@@ -162,11 +162,12 @@ def instantiate_assets_from_spec(
         assert ref.prim_path is not None, "Object reference must have a prim path"
         ref_params = dict(ref.params)
         openable_joint_name = ref_params.pop("openable_joint_name", None)
-        prim_path = _prim_path_for_relative(graph_spec.background.registry_name, ref.prim_path)
+        parent_asset = assets_by_node_id[ref.parent_id]
+        prim_path = _prim_path_for_relative(parent_asset.get_prim_path(), ref.prim_path)
         common_kwargs = {
             "name": ref.id,
             "prim_path": prim_path,
-            "parent_asset": assets_by_node_id[ref.parent_id],
+            "parent_asset": parent_asset,
             "object_type": ref.object_type,
             **ref_params,
         }

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -117,11 +117,11 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
     return False
 
 
-def _prim_path_for_relative(registry_name: str, prim_path: str) -> str:
-    """Expand a relative prim suffix to the Isaac Lab runtime prim path."""
+def _prim_path_for_relative(parent_prim_path: str, prim_path: str) -> str:
+    """Expand a relative prim suffix below its parent asset's runtime path."""
     if prim_path.startswith("{ENV_REGEX_NS}/"):
         return prim_path
-    return f"{{ENV_REGEX_NS}}/{registry_name}/{prim_path.lstrip('/')}"
+    return f"{parent_prim_path.rstrip('/')}/{prim_path.lstrip('/')}"
 
 
 def instantiate_assets_from_spec(
@@ -158,11 +158,12 @@ def instantiate_assets_from_spec(
         assert ref.prim_path is not None, "Object reference must have a prim path"
         ref_params = dict(ref.params)
         openable_joint_name = ref_params.pop("openable_joint_name", None)
-        prim_path = _prim_path_for_relative(graph_spec.background.registry_name, ref.prim_path)
+        parent_asset = assets_by_node_id[ref.parent_id]
+        prim_path = _prim_path_for_relative(parent_asset.get_prim_path(), ref.prim_path)
         common_kwargs = {
             "name": ref.id,
             "prim_path": prim_path,
-            "parent_asset": assets_by_node_id[ref.parent_id],
+            "parent_asset": parent_asset,
             "object_type": ref.object_type,
             **ref_params,
         }

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -12,7 +12,7 @@ from typing import Any
 from isaaclab.devices.device_base import DeviceCfg, DevicesCfg
 from isaaclab.envs import ManagerBasedRLMimicEnv
 from isaaclab.envs.manager_based_env import ManagerBasedEnv
-from isaaclab.managers import EventTermCfg
+from isaaclab.managers import EventTermCfg, TerminationTermCfg
 from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab_tasks.utils import parse_env_cfg
@@ -23,6 +23,7 @@ from isaaclab_arena.assets.registries import DeviceRegistry
 from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+from isaaclab_arena.environments.isaaclab_arena_manager_based_env import external_policy_termination
 from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import (
     IsaacArenaManagerBasedMimicEnvCfg,
     IsaacLabArenaManagerBasedRLEnvCfg,
@@ -42,6 +43,7 @@ from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_events import PLACEMENT_RESET_EVENT_NAME
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.tasks.no_task import NoTask
+from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.configclass import combine_configclass_instances, make_configclass
 from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import reapply_viewer_cfg
@@ -100,6 +102,10 @@ class ArenaEnvBuilder:
             placer_params = ObjectPlacerParams(
                 solver_params=RelationSolverParams(verbose=False, save_position_history=False),
             )
+        # ObjectPlacer injects these shared parameters into every registered placement validator,
+        # so one override governs both solver losses and the pluggable validation gate.
+        if self.cfg.placement_clearance_m is not None:
+            placer_params.solver_params.clearance_m = self.cfg.placement_clearance_m
         if self.cfg.placement_seed is not None:
             placer_params.placement_seed = self.cfg.placement_seed
         if self.cfg.resolve_on_reset is not None:
@@ -184,6 +190,19 @@ class ArenaEnvBuilder:
         fields = [(m.name, MetricTermCfg, m.get_metric_term_cfg()) for m in metrics]
         return make_configclass("MetricsCfg", fields)()
 
+    def _collect_episode_recorder_terms(
+        self,
+        task: TaskBase,
+    ) -> dict[str, EpisodeRecorderTermCfg]:
+        terms = dict(self.arena_env.episode_recorder_terms)
+        for name, term_cfg in task.get_episode_recorder_terms(self.arena_env).items():
+            if name in terms:
+                raise ValueError(
+                    f"duplicate episode recorder term {name!r} contributed by both the environment and task"
+                )
+            terms[name] = term_cfg
+        return terms
+
     def _compose_episode_recorders_cfg(self, extra_terms: dict[str, EpisodeRecorderTermCfg] | None = None) -> object:
         """Build a configclass container with one EpisodeRecorderTermCfg field per episode recorder term.
 
@@ -196,11 +215,8 @@ class ArenaEnvBuilder:
             ("progress", EpisodeRecorderTermCfg, ProgressEpisodeRecorderTermCfg()),
         ]
         for name, term_cfg in (extra_terms or {}).items():
-            assert name not in (
-                "core",
-                "variations",
-                "progress",
-            ), f"Episode recorder term name '{name}' collides with a built-in term."
+            if name in {"core", "variations", "progress"}:
+                raise ValueError(f"episode recorder term name {name!r} collides with a built-in term")
             fields.append((name, EpisodeRecorderTermCfg, term_cfg))
         return make_configclass("EpisodeRecorderManagerCfg", fields)()
 
@@ -266,11 +282,22 @@ class ArenaEnvBuilder:
             variations_event_cfg,
             progress_tracking_events_cfg,
         )
+        external_policy_termination_cfg = None
+        if not self.cfg.mimic:
+            external_policy_termination_cfg = make_configclass(
+                "ExternalPolicyTerminationCfg",
+                [(
+                    "external_policy_termination",
+                    TerminationTermCfg,
+                    TerminationTermCfg(func=external_policy_termination, time_out=False),
+                )],
+            )()
         termination_cfg = combine_configclass_instances(
             "TerminationCfg",
             task.get_termination_cfg(),
             self.arena_env.scene.get_termination_cfg(),
             embodiment.get_termination_cfg(),
+            external_policy_termination_cfg,
         )
         actions_cfg = embodiment.get_action_cfg()
         xr_cfg = embodiment.get_xr_cfg()
@@ -322,7 +349,7 @@ class ArenaEnvBuilder:
             task.get_commands_cfg(),
         )
 
-        episode_recorders_cfg = self._compose_episode_recorders_cfg(self.arena_env.episode_recorder_terms)
+        episode_recorders_cfg = self._compose_episode_recorders_cfg(self._collect_episode_recorder_terms(task))
 
         viewer_cfg = task.get_viewer_cfg()
 
@@ -387,6 +414,10 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
+
+        env_cfg.num_rerenders_on_reset = self.cfg.num_rerenders_on_reset
+        env_cfg.placement_seed = self.cfg.placement_seed
+        env_cfg.placement_clearance_m = self.cfg.placement_clearance_m
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -12,7 +12,7 @@ from typing import Any
 from isaaclab.devices.device_base import DeviceCfg, DevicesCfg
 from isaaclab.envs import ManagerBasedRLMimicEnv
 from isaaclab.envs.manager_based_env import ManagerBasedEnv
-from isaaclab.managers import EventTermCfg
+from isaaclab.managers import EventTermCfg, TerminationTermCfg
 from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
 from isaaclab.scene import InteractiveSceneCfg
 from isaaclab_tasks.utils import parse_env_cfg
@@ -23,6 +23,7 @@ from isaaclab_arena.assets.registries import DeviceRegistry
 from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
 from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+from isaaclab_arena.environments.isaaclab_arena_manager_based_env import external_policy_termination
 from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import (
     IsaacArenaManagerBasedMimicEnvCfg,
     IsaacLabArenaManagerBasedRLEnvCfg,
@@ -42,6 +43,7 @@ from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_events import PLACEMENT_RESET_EVENT_NAME
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.tasks.no_task import NoTask
+from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.utils.configclass import combine_configclass_instances, make_configclass
 from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
 from isaaclab_arena.utils.isaaclab_utils.resolve_clone_plan_source_patch import patch_resolve_clone_plan_source
@@ -101,6 +103,10 @@ class ArenaEnvBuilder:
             placer_params = ObjectPlacerParams(
                 solver_params=RelationSolverParams(verbose=False, save_position_history=False),
             )
+        # ObjectPlacer injects these shared parameters into every registered placement validator,
+        # so one override governs both solver losses and the pluggable validation gate.
+        if self.cfg.placement_clearance_m is not None:
+            placer_params.solver_params.clearance_m = self.cfg.placement_clearance_m
         if self.cfg.placement_seed is not None:
             placer_params.placement_seed = self.cfg.placement_seed
         if self.cfg.resolve_on_reset is not None:
@@ -185,6 +191,19 @@ class ArenaEnvBuilder:
         fields = [(m.name, MetricTermCfg, m.get_metric_term_cfg()) for m in metrics]
         return make_configclass("MetricsCfg", fields)()
 
+    def _collect_episode_recorder_terms(
+        self,
+        task: TaskBase,
+    ) -> dict[str, EpisodeRecorderTermCfg]:
+        terms = dict(self.arena_env.episode_recorder_terms)
+        for name, term_cfg in task.get_episode_recorder_terms(self.arena_env).items():
+            if name in terms:
+                raise ValueError(
+                    f"duplicate episode recorder term {name!r} contributed by both the environment and task"
+                )
+            terms[name] = term_cfg
+        return terms
+
     def _compose_episode_recorders_cfg(self, extra_terms: dict[str, EpisodeRecorderTermCfg] | None = None) -> object:
         """Build a configclass container with one EpisodeRecorderTermCfg field per episode recorder term.
 
@@ -197,11 +216,8 @@ class ArenaEnvBuilder:
             ("progress", EpisodeRecorderTermCfg, ProgressEpisodeRecorderTermCfg()),
         ]
         for name, term_cfg in (extra_terms or {}).items():
-            assert name not in (
-                "core",
-                "variations",
-                "progress",
-            ), f"Episode recorder term name '{name}' collides with a built-in term."
+            if name in {"core", "variations", "progress"}:
+                raise ValueError(f"episode recorder term name {name!r} collides with a built-in term")
             fields.append((name, EpisodeRecorderTermCfg, term_cfg))
         return make_configclass("EpisodeRecorderManagerCfg", fields)()
 
@@ -267,11 +283,22 @@ class ArenaEnvBuilder:
             variations_event_cfg,
             progress_tracking_events_cfg,
         )
+        external_policy_termination_cfg = None
+        if not self.cfg.mimic:
+            external_policy_termination_cfg = make_configclass(
+                "ExternalPolicyTerminationCfg",
+                [(
+                    "external_policy_termination",
+                    TerminationTermCfg,
+                    TerminationTermCfg(func=external_policy_termination, time_out=False),
+                )],
+            )()
         termination_cfg = combine_configclass_instances(
             "TerminationCfg",
             task.get_termination_cfg(),
             self.arena_env.scene.get_termination_cfg(),
             embodiment.get_termination_cfg(),
+            external_policy_termination_cfg,
         )
         actions_cfg = embodiment.get_action_cfg()
         xr_cfg = embodiment.get_xr_cfg()
@@ -323,7 +350,7 @@ class ArenaEnvBuilder:
             task.get_commands_cfg(),
         )
 
-        episode_recorders_cfg = self._compose_episode_recorders_cfg(self.arena_env.episode_recorder_terms)
+        episode_recorders_cfg = self._compose_episode_recorders_cfg(self._collect_episode_recorder_terms(task))
 
         viewer_cfg = task.get_viewer_cfg()
 
@@ -388,6 +415,10 @@ class ArenaEnvBuilder:
                 task_description=task_description,
                 viewer=viewer_cfg,
             )
+
+        env_cfg.num_rerenders_on_reset = self.cfg.num_rerenders_on_reset
+        env_cfg.placement_seed = self.cfg.placement_seed
+        env_cfg.placement_clearance_m = self.cfg.placement_clearance_m
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.

--- a/isaaclab_arena/environments/arena_env_builder_cfg.py
+++ b/isaaclab_arena/environments/arena_env_builder_cfg.py
@@ -5,6 +5,7 @@
 
 """Typed configuration for compiling an Arena environment."""
 
+import math
 from dataclasses import dataclass
 
 
@@ -17,9 +18,15 @@ class ArenaEnvBuilderCfg:
 
     num_envs: int = 1
     env_spacing: float = 30.0
+    num_rerenders_on_reset: int = 0
+    """Number of extra render steps after reset. Defaults to 0.
+
+    Positive values refresh sensor observations after reset at the cost of additional rendering.
+    """
     seed: int = 42
     solve_relations: bool = True
     placement_seed: int | None = None
+    placement_clearance_m: float | None = None
     resolve_on_reset: bool | None = None
     disable_fabric: bool = False
     mimic: bool = False
@@ -29,3 +36,11 @@ class ArenaEnvBuilderCfg:
 
     def __post_init__(self) -> None:
         assert self.num_envs > 0, "num_envs must be greater than zero"
+        if isinstance(self.num_rerenders_on_reset, bool) or not isinstance(self.num_rerenders_on_reset, int):
+            raise TypeError("num_rerenders_on_reset must be an integer")
+        if self.num_rerenders_on_reset < 0:
+            raise ValueError("num_rerenders_on_reset must be non-negative")
+        if self.placement_clearance_m is not None and (
+            not math.isfinite(self.placement_clearance_m) or self.placement_clearance_m < 0.0
+        ):
+            raise ValueError("placement_clearance_m must be finite and non-negative")

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import torch
 from collections.abc import Sequence
 
 from isaaclab.envs import ManagerBasedRLEnv
@@ -21,6 +22,11 @@ from isaaclab_arena.variations.variation_recorder import VariationRecorder
 # quiet, so these bound the wait rather than always being spent.
 _MIN_CLUTTER_SETTLE_STEPS = 400
 _CLUTTER_SETTLE_STEPS_PER_MEMBER = 30
+
+
+def external_policy_termination(env: IsaacLabArenaManagerBasedRLEnv) -> torch.Tensor:
+    """Return environments whose policy requested non-timeout episode termination."""
+    return env.external_policy_termination_buf
 
 
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
@@ -47,6 +53,7 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         # The initial reset touches every env before any episode has run; skip it.
         self._first_reset = True
         super().__init__(cfg=cfg, render_mode=render_mode, **kwargs)
+        self._external_policy_termination_buf = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
         self._settle_clutter_layouts()
 
     def _settle_clutter_layouts(self) -> None:
@@ -119,6 +126,20 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         """Return the index of the current episode in ``env_id``."""
         return self._episode_counts.get(env_id, 0)
 
+    @property
+    def external_policy_termination_buf(self) -> torch.Tensor:
+        """Boolean per-environment policy termination requests for the current step."""
+        return self._external_policy_termination_buf
+
+    def request_external_policy_termination(self, termination_mask: torch.Tensor) -> None:
+        """Request non-timeout episode termination for environments selected by ``termination_mask``."""
+        assert isinstance(termination_mask, torch.Tensor), "termination_mask must be a torch.Tensor"
+        assert termination_mask.dtype == torch.bool, "termination_mask must have dtype torch.bool"
+        assert termination_mask.shape == (
+            self.num_envs,
+        ), f"termination_mask must have shape ({self.num_envs},), got {tuple(termination_mask.shape)}"
+        self._external_policy_termination_buf |= termination_mask.to(device=self.device)
+
     def _advance_episode_indices(self, env_ids: Sequence[int]) -> None:
         """Advance the per-env episode counter for each episode in ``env_ids``."""
         for env_id in env_ids:
@@ -130,12 +151,16 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         if self._first_reset:
             self._first_reset = False
             super()._reset_idx(env_ids)
+            self.episode_recorder_manager.record_post_reset(env_ids)
             return
         # Runs recorder before super() so the just-finished episode is still intact.
         self.episode_recorder_manager.record_pre_reset(env_ids)
+        # Preserve the signal through recording, then clear it before the next episode starts.
+        self._external_policy_termination_buf[env_ids] = False
         # Advance before super() so reset-mode variation draws are tagged with the episode they begin.
         self._advance_episode_indices(env_ids)
         super()._reset_idx(env_ids)
+        self.episode_recorder_manager.record_post_reset(env_ids)
 
     def compute_metrics(self) -> MetricsDataCollection:
         """Compute all registered metrics.

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -95,6 +95,10 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
             pose_settle_params=ClutterSettleParams(),
         )
         self._reject_spilled_clutter_layouts(placement_pool, groups)
+        # Settling steps physics, which a reset cannot do, so an exhausted queue must rewind
+        # rather than solve fresh layouts this pass would never see. Without this, every reset
+        # past the cached set writes the poses the pile was released from and the pile falls.
+        placement_pool.recycle_layouts = True
 
     def _reject_spilled_clutter_layouts(self, placement_pool, groups) -> None:
         """Drop cached layouts whose pile did not stay on its support.

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -16,6 +16,12 @@ from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderMan
 from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
 from isaaclab_arena.variations.variation_recorder import VariationRecorder
 
+# Physics-step ceiling for settling a clutter pile, measured on piles of 8 to 80 objects:
+# 8 settle by ~250 steps, 40 by ~1000, 80 by ~2000. Settling returns as soon as the poses go
+# quiet, so these bound the wait rather than always being spent.
+_MIN_CLUTTER_SETTLE_STEPS = 400
+_CLUTTER_SETTLE_STEPS_PER_MEMBER = 30
+
 
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
     """Arena extension to ManagerBasedRLEnv that adds additional Arena-specific functionality."""
@@ -41,6 +47,44 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         # The initial reset touches every env before any episode has run; skip it.
         self._first_reset = True
         super().__init__(cfg=cfg, render_mode=render_mode, **kwargs)
+        self._settle_clutter_layouts()
+
+    def _settle_clutter_layouts(self) -> None:
+        """Replace pooled clutter drop poses with the poses the pile settles into.
+
+        A pour only describes where objects are released. Writing those poses at reset would
+        start every episode with the pile in mid-air, so the pool is settled once here and
+        each layout keeps its resting arrangement for every reset that draws it.
+        """
+        import math
+
+        from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+        from isaaclab_arena.relations.clutter_validation import ClutterSettleParams
+        from isaaclab_arena.relations.physics_settle_params import PhysicsSettleParams
+        from isaaclab_arena.relations.placement_events import get_placement_pool
+        from isaaclab_arena.relations.placement_pool_validation import validate_pool_layouts
+
+        placement_pool = get_placement_pool(self)
+        if placement_pool is None:
+            return
+        groups = get_clutter_groups(placement_pool.objects)
+        if not groups:
+            return
+
+        # The default settle budget is sized for a couple of objects nudging into place; a pile
+        # needs orders of magnitude more, growing with how deep it stacks. Settling returns as
+        # soon as the poses go quiet, so a generous ceiling costs nothing on an easy pile.
+        member_count = sum(len(group.members) for group in groups)
+        physics_steps = max(_MIN_CLUTTER_SETTLE_STEPS, _CLUTTER_SETTLE_STEPS_PER_MEMBER * member_count)
+        settle_params = PhysicsSettleParams(num_steps=math.ceil(physics_steps / self.cfg.decimation))
+
+        validate_pool_layouts(
+            self,
+            placement_pool=placement_pool,
+            settle_params=settle_params,
+            capture_settled_poses=True,
+            pose_settle_params=ClutterSettleParams(),
+        )
 
     @property
     def variation_recorder(self) -> VariationRecorder | None:

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -71,6 +71,8 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         from isaaclab_arena.relations.placement_events import get_placement_pool
         from isaaclab_arena.relations.placement_pool_validation import validate_pool_layouts
 
+        if not self.cfg.settle_clutter_on_build:
+            return
         placement_pool = get_placement_pool(self)
         if placement_pool is None:
             return

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -94,6 +94,45 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
             capture_settled_poses=True,
             pose_settle_params=ClutterSettleParams(),
         )
+        self._reject_spilled_clutter_layouts(placement_pool, groups)
+
+    def _reject_spilled_clutter_layouts(self, placement_pool, groups) -> None:
+        """Drop cached layouts whose pile did not stay on its support.
+
+        Whether a pour spills is only knowable after settling it, so the pool is filtered
+        afterwards rather than constrained up front. An env keeps its rejects when too few
+        layouts survive, since a spilled pile still beats having nothing to draw.
+        """
+        import torch
+
+        from isaaclab_arena.relations.bounding_box_helpers import build_per_env_bounding_boxes
+        from isaaclab_arena.relations.clutter_pour import region_above_support
+        from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, check_resting_poses
+
+        per_env_bboxes = build_per_env_bounding_boxes(
+            placement_pool.objects, self.num_envs
+        ).get_bounding_boxes_for_all_envs()
+        params = ClutterSettleParams(containment_margin_m=self.cfg.clutter_containment_margin_m)
+
+        def keep(env_id: int, layout) -> bool:
+            bboxes = per_env_bboxes[env_id]
+            for group in groups:
+                support = group.support
+                position = layout.positions.get(support) or support.get_initial_pose().position_xyz
+                # Judge against the whole support, not the shrunk region the pile was poured
+                # into: a tight pour is meant to relax outward as it settles.
+                region = region_above_support(tuple(float(value) for value in position), bboxes[support])
+                positions = torch.tensor(
+                    [layout.positions[member] for member in group.members if member in layout.positions],
+                    dtype=torch.float32,
+                )
+                if positions.numel() and not check_resting_poses(positions, region, params).ok:
+                    return False
+            return True
+
+        kept, rejected = placement_pool.retain_layouts(keep)
+        if rejected:
+            print(f"[clutter] rejected {rejected} spilled layout(s); {kept} cached")
 
     @property
     def variation_recorder(self) -> VariationRecorder | None:

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -76,6 +76,10 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     # Task language description
     task_description: str | None = None
 
+    # Placement provenance
+    placement_seed: int | None = None
+    placement_clearance_m: float | None = None
+
     # Override the RTX renderer's built-in scene ambient (carb /rtx/sceneDb/ambientLightIntensity, default 1.0 with
     # color [0.1, 0.1, 0.1]) so that USD light prims fully control scene illumination.
     sim: SimulationCfg = SimulationCfg(

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -80,6 +80,13 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     placement_seed: int | None = None
     placement_clearance_m: float | None = None
 
+    settle_clutter_on_build: bool = True
+    """Whether to settle poured clutter into the placement pool once the env is built.
+
+    On by default, so a reset places the resting pile rather than the poses it was released
+    from. Turn it off to observe the pour itself, which then happens on the caller's steps.
+    """
+
     # Override the RTX renderer's built-in scene ambient (carb /rtx/sceneDb/ambientLightIntensity, default 1.0 with
     # color [0.1, 0.1, 0.1]) so that USD light prims fully control scene illumination.
     sim: SimulationCfg = SimulationCfg(

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -80,6 +80,13 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     placement_seed: int | None = None
     placement_clearance_m: float | None = None
 
+    clutter_containment_margin_m: float = 0.02
+    """How far past its support a settled clutter member may rest before its layout is rejected.
+
+    Only applied when clutter is settled at build time, where a spilled layout can be dropped
+    from the cache and another drawn instead.
+    """
+
     settle_clutter_on_build: bool = True
     """Whether to settle poured clutter into the placement pool once the env is built.
 

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -80,6 +80,13 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     placement_seed: int | None = None
     placement_clearance_m: float | None = None
 
+    settle_clutter_on_build: bool = True
+    """Whether to settle poured clutter into the placement pool once the env is built.
+
+    On by default, so a reset places the resting pile rather than the poses it was released
+    from. Turn it off to observe the pour itself, which then happens on the caller's steps.
+    """
+
     # Override the RTX renderer's built-in scene ambient (carb /rtx/sceneDb/ambientLightIntensity, default 1.0 with
     # color [0.1, 0.1, 0.1]) so that USD light prims fully control scene illumination.
     # Control rate: sim.dt (1/120 s) x decimation (8) = 15 Hz

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -76,6 +76,10 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     # Task language description
     task_description: str | None = None
 
+    # Placement provenance
+    placement_seed: int | None = None
+    placement_clearance_m: float | None = None
+
     # Override the RTX renderer's built-in scene ambient (carb /rtx/sceneDb/ambientLightIntensity, default 1.0 with
     # color [0.1, 0.1, 0.1]) so that USD light prims fully control scene illumination.
     # Control rate: sim.dt (1/120 s) x decimation (8) = 15 Hz

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from pathlib import Path
 
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
@@ -68,13 +69,16 @@ def _assert_exact_experiment_output_directory_is_available(experiment_output_dir
         )
 
 
-def main():
+def main(runtime_initializer: Callable[[], None] | None = None) -> None:
     args_cli, experiment_overrides = parse_experiment_runner_args()
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
     legacy_experiment_config = load_legacy_json_experiment_config(
         experiment_config_path,
         experiment_overrides,
     )
+
+    if runtime_initializer is not None and args_cli.chunk_size is not None:
+        raise ValueError("runtime_initializer is not supported with --chunk_size subprocess dispatch")
 
     # AppLauncher must enable camera support before SimulationApp starts. Check if this is required.
     if args_cli.record_camera_video or _experiment_requires_cameras(
@@ -85,6 +89,8 @@ def main():
     # Print the variations catalogue for each run's environment and exit.
     if args_cli.list_variations:
         with SimulationAppContext(args_cli):
+            if runtime_initializer is not None:
+                runtime_initializer()
             experiment_cfg = load_arena_experiment_from_config_file(
                 experiment_config_path,
                 device=args_cli.device,
@@ -119,6 +125,8 @@ def main():
     experiment_output_directory.mkdir(parents=True, exist_ok=True)
 
     with SimulationAppContext(args_cli):
+        if runtime_initializer is not None:
+            runtime_initializer()
         experiment_cfg = load_arena_experiment_from_config_file(
             experiment_config_path,
             device=args_cli.device,

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from pathlib import Path
 
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
@@ -90,13 +91,16 @@ def _write_arena_experiment_result(
     return ArenaExperimentResult(experiment_output_directory, run_metadata_by_name).write()
 
 
-def main():
+def main(runtime_initializer: Callable[[], None] | None = None) -> None:
     args_cli, experiment_overrides = parse_experiment_runner_args()
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
     legacy_experiment_config = load_legacy_json_experiment_config(
         experiment_config_path,
         experiment_overrides,
     )
+
+    if runtime_initializer is not None and args_cli.chunk_size is not None:
+        raise ValueError("runtime_initializer is not supported with --chunk_size subprocess dispatch")
 
     # AppLauncher must enable camera support before SimulationApp starts. Check if this is required.
     if args_cli.record_camera_video or _experiment_requires_cameras(
@@ -107,6 +111,8 @@ def main():
     # Print the variations catalogue for each run's environment and exit.
     if args_cli.list_variations:
         with SimulationAppContext(args_cli):
+            if runtime_initializer is not None:
+                runtime_initializer()
             experiment_cfg = load_arena_experiment_from_config_file(
                 experiment_config_path,
                 device=args_cli.device,
@@ -141,6 +147,8 @@ def main():
     experiment_output_directory.mkdir(parents=True, exist_ok=True)
 
     with SimulationAppContext(args_cli):
+        if runtime_initializer is not None:
+            runtime_initializer()
         experiment_cfg = load_arena_experiment_from_config_file(
             experiment_config_path,
             device=args_cli.device,

--- a/isaaclab_arena/evaluation/legacy_environment_cli_args.py
+++ b/isaaclab_arena/evaluation/legacy_environment_cli_args.py
@@ -10,6 +10,8 @@ from typing import Any
 # TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this module with the JSON evaluation-job
 # frontend once experiment_runner loads typed YAML experiments directly.
 
+_BOOLEAN_OPTIONAL_KEYS = frozenset({"resolve_on_reset"})
+
 
 def legacy_environment_args_to_cli_args(args: dict[str, Any]) -> list[str]:
     """Convert legacy environment arguments into the existing parser's token order."""
@@ -21,8 +23,11 @@ def legacy_environment_args_to_cli_args(args: dict[str, Any]) -> list[str]:
         if key not in args:
             continue
         value = args[key]
-        if isinstance(value, bool) and value:
-            cli_args.append(f"--{key}")
+        if isinstance(value, bool):
+            if value:
+                cli_args.append(f"--{key}")
+            elif key in _BOOLEAN_OPTIONAL_KEYS:
+                cli_args.append(f"--no-{key}")
         elif not isinstance(value, bool) and value is not None:
             cli_args.extend((f"--{key}", str(value)))
 
@@ -35,8 +40,11 @@ def legacy_environment_args_to_cli_args(args: dict[str, Any]) -> list[str]:
     for key, value in args.items():
         if key in priority_keys or key == "environment":
             continue
-        if isinstance(value, bool) and value:
-            cli_args.append(f"--{key}")
+        if isinstance(value, bool):
+            if value:
+                cli_args.append(f"--{key}")
+            elif key in _BOOLEAN_OPTIONAL_KEYS:
+                cli_args.append(f"--no-{key}")
         elif not isinstance(value, bool) and value is not None:
             cli_args.extend((f"--{key}", str(value)))
     return cli_args

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -63,6 +63,24 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     )
 
 
+def _forward_policy_episode_terminations(env, policy: PolicyBase) -> None:
+    """Forward an optional policy termination mask to an Arena environment."""
+    termination_mask = policy.get_episode_termination_mask()
+    if termination_mask is None:
+        return
+
+    assert isinstance(termination_mask, torch.Tensor), "Policy termination mask must be a torch.Tensor or None"
+    assert termination_mask.dtype == torch.bool, "Policy termination mask must have dtype torch.bool"
+    assert (
+        termination_mask.ndim == 1 and termination_mask.shape[0] == env.unwrapped.num_envs
+    ), f"Policy termination mask must have shape ({env.unwrapped.num_envs},), got {tuple(termination_mask.shape)}"
+
+    request_termination = getattr(env.unwrapped, "request_external_policy_termination", None)
+    if request_termination is None:
+        raise RuntimeError("This environment does not support external policy termination")
+    request_termination(termination_mask)
+
+
 def rollout_policy(
     env,
     policy: PolicyBase,
@@ -90,6 +108,7 @@ def rollout_policy(
         while True:
             with torch.inference_mode():
                 actions = policy.get_action(env, obs)
+                _forward_policy_episode_terminations(env, policy)
                 obs, _, terminated, truncated, _ = env.step(actions)
 
                 if terminated.any() or truncated.any():

--- a/isaaclab_arena/policy/policy_base.py
+++ b/isaaclab_arena/policy/policy_base.py
@@ -47,6 +47,10 @@ class PolicyBase(ABC, Generic[PolicyCfgT]):
         """
         pass
 
+    def get_episode_termination_mask(self) -> torch.Tensor | None:
+        """Return a boolean mask of environments the policy requests to terminate."""
+        pass
+
     def close(self) -> None:
         """Release resources held by the policy."""
         pass

--- a/isaaclab_arena/recording/episode_recorder_manager.py
+++ b/isaaclab_arena/recording/episode_recorder_manager.py
@@ -102,6 +102,21 @@ class EpisodeRecorderManager(ManagerBase):
                 record.update(fields)
             self._append_record(record)
 
+    def record_post_reset(self, env_ids: Sequence[int] | torch.Tensor | None) -> None:
+        """Notify stateful recorder terms after environments have been reset.
+
+        Plain function terms require no lifecycle notification and are skipped. Callable term objects
+        may implement ``record_post_reset(env_ids)`` to capture state that only exists after reset.
+
+        Args:
+            env_ids: The env ids that were reset (tensor, sequence, or ``None`` for all envs).
+        """
+        normalized_env_ids = self._normalize_env_ids(env_ids)
+        for term_cfg in self._term_cfgs:
+            record_post_reset = getattr(term_cfg.func, "record_post_reset", None)
+            if record_post_reset is not None:
+                record_post_reset(normalized_env_ids)
+
     def _append_record(self, record: dict[str, Any]) -> None:
         """Append one record to the output JSONL (one object per line); no-op if no path was set."""
         if self._output_path is None:

--- a/isaaclab_arena/relations/clutter_drop_poses.py
+++ b/isaaclab_arena/relations/clutter_drop_poses.py
@@ -123,10 +123,35 @@ def _yaw_to_quat_xyzw(yaw: float) -> tuple[float, float, float, float]:
     return (0.0, 0.0, math.sin(half), math.cos(half))
 
 
-def _footprint_half_extents(bbox: AxisAlignedBoundingBox) -> tuple[float, float]:
-    """Half-width and half-depth of a bounding box's XY footprint."""
-    size = bbox.size[0]
-    return float(size[0]) * 0.5, float(size[1]) * 0.5
+@dataclass(frozen=True)
+class _Footprint:
+    """A bounding box's XY footprint, described relative to the object origin.
+
+    Local boxes are not centred on the origin -- USD pivots sit wherever the asset author
+    put them -- so the footprint's own centre has to be carried separately from its size.
+    Treating the origin as the centre would let an object hang off the region by its offset.
+    """
+
+    half_x: float
+    half_y: float
+    offset_x: float
+    offset_y: float
+    """XY of the footprint centre in the object's local frame."""
+
+    def centre_at(self, x: float, y: float) -> tuple[float, float]:
+        """Return the footprint centre when the origin is placed at ``(x, y)``."""
+        return x + self.offset_x, y + self.offset_y
+
+
+def _footprint_of(bbox: AxisAlignedBoundingBox) -> _Footprint:
+    """Half-extents and origin offset of a bounding box's XY footprint."""
+    minimum, maximum = bbox.min_point[0], bbox.max_point[0]
+    return _Footprint(
+        half_x=float(maximum[0] - minimum[0]) * 0.5,
+        half_y=float(maximum[1] - minimum[1]) * 0.5,
+        offset_x=float(maximum[0] + minimum[0]) * 0.5,
+        offset_y=float(maximum[1] + minimum[1]) * 0.5,
+    )
 
 
 def _resolve_order(
@@ -167,9 +192,12 @@ def _grid_cell_centres(
     return [centres[int(i)] for i in permutation]
 
 
-def _footprint_fits(half_x: float, half_y: float, region: ClutterRegion) -> bool:
+def _footprint_fits(footprint: _Footprint, region: ClutterRegion) -> bool:
     """Whether a footprint of these half-extents can sit wholly inside ``region``."""
-    return region.min_x + half_x <= region.max_x - half_x and region.min_y + half_y <= region.max_y - half_y
+    return (
+        region.min_x + footprint.half_x <= region.max_x - footprint.half_x
+        and region.min_y + footprint.half_y <= region.max_y - footprint.half_y
+    )
 
 
 def _sample_orientation_that_fits(
@@ -177,7 +205,7 @@ def _sample_orientation_that_fits(
     region: ClutterRegion,
     params: ClutterDropParams,
     generator: torch.Generator | None,
-) -> tuple[tuple[float, float, float, float], AxisAlignedBoundingBox, float, float]:
+) -> tuple[tuple[float, float, float, float], AxisAlignedBoundingBox, _Footprint]:
     """Sample a yaw whose rotated footprint fits the region, retrying unlucky draws.
 
     Yaw changes an elongated object's footprint substantially -- a long object turned
@@ -186,18 +214,21 @@ def _sample_orientation_that_fits(
     and only fail when no sampled orientation fits.
     """
     attempts = params.max_yaw_attempts if params.random_yaw else 1
-    widest = None
+    widest: _Footprint | None = None
     for _ in range(attempts):
         yaw = get_random_rotation(generator) if params.random_yaw else 0.0
         rotation = _yaw_to_quat_xyzw(yaw)
         # Refit the box to the sampled yaw so footprint and height match the placed object.
         rotated = bbox.rotated_by_quat(torch.tensor([rotation], dtype=torch.float32))
-        half_x, half_y = _footprint_half_extents(rotated)
-        if _footprint_fits(half_x, half_y, region):
-            return rotation, rotated, half_x, half_y
-        widest = (half_x, half_y) if widest is None else widest
+        footprint = _footprint_of(rotated)
+        if _footprint_fits(footprint, region):
+            return rotation, rotated, footprint
+        # Report the draw that came closest to needing the whole region, not the first miss.
+        if widest is None or max(footprint.half_x, footprint.half_y) > max(widest.half_x, widest.half_y):
+            widest = footprint
 
-    half_x, half_y = widest if widest is not None else (0.0, 0.0)
+    half_x = widest.half_x if widest is not None else 0.0
+    half_y = widest.half_y if widest is not None else 0.0
     raise AssertionError(
         f"object footprint {2 * half_x:.3f}x{2 * half_y:.3f} m does not fit in region "
         f"{region.max_x - region.min_x:.3f}x{region.max_y - region.min_y:.3f} m "
@@ -207,27 +238,29 @@ def _sample_orientation_that_fits(
 
 def _sample_xy(
     centre: tuple[float, float] | None,
-    half_x: float,
-    half_y: float,
+    footprint: _Footprint,
     region: ClutterRegion,
     generator: torch.Generator | None,
 ) -> tuple[float, float]:
-    """Sample an XY whose footprint stays inside ``region``.
+    """Sample an object origin whose footprint stays inside ``region``.
 
-    The admissible box is the region inset by the object's own half-extents, so the whole
-    footprint lands inside rather than just the origin. When a cell centre is given the
-    sample is drawn around it and then clamped into that admissible box.
+    The admissible box is the region inset by the object's own half-extents and then shifted
+    by its origin offset, so the whole footprint lands inside rather than just the origin.
+    When a cell centre is given it names where the footprint should sit, and the origin is
+    offset accordingly before jittering and clamping.
     """
-    min_x, max_x = region.min_x + half_x, region.max_x - half_x
-    min_y, max_y = region.min_y + half_y, region.max_y - half_y
+    min_x = region.min_x + footprint.half_x - footprint.offset_x
+    max_x = region.max_x - footprint.half_x - footprint.offset_x
+    min_y = region.min_y + footprint.half_y - footprint.offset_y
+    max_y = region.max_y - footprint.half_y - footprint.offset_y
     unit = torch.rand(2, generator=generator)
     if centre is None:
         x = min_x + float(unit[0]) * (max_x - min_x)
         y = min_y + float(unit[1]) * (max_y - min_y)
     else:
         # Jitter by half a footprint so cell-mates stay distinguishable without escaping.
-        x = centre[0] + (float(unit[0]) - 0.5) * half_x
-        y = centre[1] + (float(unit[1]) - 0.5) * half_y
+        x = centre[0] - footprint.offset_x + (float(unit[0]) - 0.5) * footprint.half_x
+        y = centre[1] - footprint.offset_y + (float(unit[1]) - 0.5) * footprint.half_y
     return min(max(x, min_x), max_x), min(max(y, min_y), max_y)
 
 
@@ -237,7 +270,7 @@ def _footprints_overlap(
     b_centre: tuple[float, float],
     b_half: tuple[float, float],
 ) -> bool:
-    """Whether two axis-aligned XY footprints overlap."""
+    """Whether two axis-aligned XY footprints overlap. Centres, not origins."""
     return (
         abs(a_centre[0] - b_centre[0]) < a_half[0] + b_half[0]
         and abs(a_centre[1] - b_centre[1]) < a_half[1] + b_half[1]
@@ -282,20 +315,22 @@ def compute_drop_poses(
     placed: list[tuple[tuple[float, float], tuple[float, float], float]] = []
 
     for drop_index, (object_index, centre) in enumerate(zip(order, centres)):
-        rotation, rotated, half_x, half_y = _sample_orientation_that_fits(
+        rotation, rotated, footprint = _sample_orientation_that_fits(
             bounding_boxes[object_index], usable, params, generator
         )
-        x, y = _sample_xy(centre, half_x, half_y, usable, generator)
+        x, y = _sample_xy(centre, footprint, usable, generator)
+        footprint_centre = footprint.centre_at(x, y)
+        half_extents = (footprint.half_x, footprint.half_y)
 
         # Lift only over the footprints actually overlapped, not over everything placed so far.
         support_z = region.floor_z + params.clearance_m
         for other_centre, other_half, other_top_z in placed:
-            if _footprints_overlap((x, y), (half_x, half_y), other_centre, other_half):
+            if _footprints_overlap(footprint_centre, half_extents, other_centre, other_half):
                 support_z = max(support_z, other_top_z + params.gap_m)
 
         # Offset the origin so the object's lowest point sits at support_z.
         z = support_z - float(rotated.bottom_surface_z[0])
-        placed.append(((x, y), (half_x, half_y), z + float(rotated.top_surface_z[0])))
+        placed.append((footprint_centre, half_extents, z + float(rotated.top_surface_z[0])))
         poses[object_index] = DropPose(position=(x, y, z), rotation_xyzw=rotation, drop_index=drop_index)
 
     assert all(pose is not None for pose in poses), "every object must receive a drop pose"

--- a/isaaclab_arena/relations/clutter_drop_poses.py
+++ b/isaaclab_arena/relations/clutter_drop_poses.py
@@ -108,6 +108,20 @@ class ClutterDropParams:
 
 
 @dataclass(frozen=True)
+class OccupiedFootprint:
+    """Something already standing in the region that clutter must not be dropped into."""
+
+    centre: tuple[float, float]
+    """XY centre of the footprint, in the region's frame."""
+
+    half_extents: tuple[float, float]
+    """Half-width and half-depth of the footprint."""
+
+    top_z: float
+    """Height of its highest point, which clutter above it must clear."""
+
+
+@dataclass(frozen=True)
 class DropPose:
     """A pre-settle pose for one object."""
 
@@ -282,6 +296,7 @@ def compute_drop_poses(
     region: ClutterRegion,
     params: ClutterDropParams | None = None,
     generator: torch.Generator | None = None,
+    occupied: list[OccupiedFootprint] | None = None,
 ) -> list[DropPose]:
     """Compute pre-settle drop poses for one pile.
 
@@ -294,6 +309,8 @@ def compute_drop_poses(
         region: Where objects may land, in the frame the returned poses use.
         params: Tuning; defaults to :class:`ClutterDropParams`.
         generator: Seeded RNG for reproducible layouts.
+        occupied: Footprints already standing in the region, such as objects the solver placed
+            on the same surface. Clutter is released above them rather than inside them.
 
     Returns:
         One :class:`DropPose` per input object, in input order.
@@ -312,7 +329,10 @@ def compute_drop_poses(
     )
 
     poses: list[DropPose | None] = [None] * len(bounding_boxes)
-    placed: list[tuple[tuple[float, float], tuple[float, float], float]] = []
+    # Seed the ladder with what is already standing here, so the first drop clears it too.
+    placed: list[tuple[tuple[float, float], tuple[float, float], float]] = [
+        (item.centre, item.half_extents, item.top_z) for item in (occupied or [])
+    ]
 
     for drop_index, (object_index, centre) in enumerate(zip(order, centres)):
         rotation, rotated, footprint = _sample_orientation_that_fits(

--- a/isaaclab_arena/relations/clutter_drop_poses.py
+++ b/isaaclab_arena/relations/clutter_drop_poses.py
@@ -101,6 +101,11 @@ class ClutterDropParams:
     random_yaw: bool = True
     """Sample a random Z-yaw per object. Disable for reproducible axis-aligned layouts."""
 
+    max_yaw_attempts: int = 8
+    """How many yaws to try before declaring an object unplaceable. A long object turned
+    diagonally needs much more room than the same object axis-aligned, so an unlucky draw
+    should be resampled rather than failing the whole layout."""
+
 
 @dataclass(frozen=True)
 class DropPose:
@@ -162,6 +167,44 @@ def _grid_cell_centres(
     return [centres[int(i)] for i in permutation]
 
 
+def _footprint_fits(half_x: float, half_y: float, region: ClutterRegion) -> bool:
+    """Whether a footprint of these half-extents can sit wholly inside ``region``."""
+    return region.min_x + half_x <= region.max_x - half_x and region.min_y + half_y <= region.max_y - half_y
+
+
+def _sample_orientation_that_fits(
+    bbox: AxisAlignedBoundingBox,
+    region: ClutterRegion,
+    params: ClutterDropParams,
+    generator: torch.Generator | None,
+) -> tuple[tuple[float, float, float, float], AxisAlignedBoundingBox, float, float]:
+    """Sample a yaw whose rotated footprint fits the region, retrying unlucky draws.
+
+    Yaw changes an elongated object's footprint substantially -- a long object turned
+    diagonally can need far more room than the same object axis-aligned -- so a single
+    unlucky draw is not evidence that the object cannot be placed. Retry before giving up,
+    and only fail when no sampled orientation fits.
+    """
+    attempts = params.max_yaw_attempts if params.random_yaw else 1
+    widest = None
+    for _ in range(attempts):
+        yaw = get_random_rotation(generator) if params.random_yaw else 0.0
+        rotation = _yaw_to_quat_xyzw(yaw)
+        # Refit the box to the sampled yaw so footprint and height match the placed object.
+        rotated = bbox.rotated_by_quat(torch.tensor([rotation], dtype=torch.float32))
+        half_x, half_y = _footprint_half_extents(rotated)
+        if _footprint_fits(half_x, half_y, region):
+            return rotation, rotated, half_x, half_y
+        widest = (half_x, half_y) if widest is None else widest
+
+    half_x, half_y = widest if widest is not None else (0.0, 0.0)
+    raise AssertionError(
+        f"object footprint {2 * half_x:.3f}x{2 * half_y:.3f} m does not fit in region "
+        f"{region.max_x - region.min_x:.3f}x{region.max_y - region.min_y:.3f} m "
+        f"after {attempts} orientation attempt(s)"
+    )
+
+
 def _sample_xy(
     centre: tuple[float, float] | None,
     half_x: float,
@@ -177,11 +220,6 @@ def _sample_xy(
     """
     min_x, max_x = region.min_x + half_x, region.max_x - half_x
     min_y, max_y = region.min_y + half_y, region.max_y - half_y
-    assert min_x <= max_x and min_y <= max_y, (
-        f"object footprint {2 * half_x:.3f}x{2 * half_y:.3f} m does not fit in region "
-        f"{region.max_x - region.min_x:.3f}x{region.max_y - region.min_y:.3f} m"
-    )
-
     unit = torch.rand(2, generator=generator)
     if centre is None:
         x = min_x + float(unit[0]) * (max_x - min_x)
@@ -244,12 +282,9 @@ def compute_drop_poses(
     placed: list[tuple[tuple[float, float], tuple[float, float], float]] = []
 
     for drop_index, (object_index, centre) in enumerate(zip(order, centres)):
-        yaw = get_random_rotation(generator) if params.random_yaw else 0.0
-        rotation = _yaw_to_quat_xyzw(yaw)
-        # Refit the box to the sampled yaw so the footprint and height match the placed object.
-        rotated = bounding_boxes[object_index].rotated_by_quat(torch.tensor([rotation], dtype=torch.float32))
-
-        half_x, half_y = _footprint_half_extents(rotated)
+        rotation, rotated, half_x, half_y = _sample_orientation_that_fits(
+            bounding_boxes[object_index], usable, params, generator
+        )
         x, y = _sample_xy(centre, half_x, half_y, usable, generator)
 
         # Lift only over the footprints actually overlapped, not over everything placed so far.

--- a/isaaclab_arena/relations/clutter_drop_poses.py
+++ b/isaaclab_arena/relations/clutter_drop_poses.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop-pose generation for clutter placement.
+
+A pile cannot be produced by the relation solver: ``On`` requires each child's whole
+footprint to rest on one Z plane and a global pairwise no-overlap loss forbids contact,
+whereas a pile is defined by objects touching and resting on one another. Clutter is
+therefore placed by dropping objects into a region and letting the simulator settle them.
+
+This module computes the *drop* poses only -- the pre-settle layout. It is pure geometry
+with no simulator dependency, so it is cheap and directly testable. Poses are guaranteed
+free of mutual penetration at spawn, which lets them double as the scene's spawn poses.
+
+The two properties that make the layout safe:
+
+* Each object's sampled XY is constrained so its yaw-rotated footprint lies inside the
+  region, rather than only its origin.
+* Objects are lifted only over the footprints they actually overlap (a per-column ladder),
+  so an object with a clear column starts just above the floor instead of above the whole
+  pile. This keeps drop heights -- and therefore impact energy and scatter -- small.
+"""
+
+from __future__ import annotations
+
+import math
+import torch
+from dataclasses import dataclass
+from enum import Enum
+
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.random import get_random_rotation
+
+
+class XySampling(str, Enum):
+    """How XY positions are drawn from the region."""
+
+    UNIFORM = "uniform"
+    """Sample each object independently. Objects may co-locate and occlude one another."""
+
+    GRID_CELLS = "grid_cells"
+    """Give each object its own jittered cell, so the group spreads across the region."""
+
+
+class DropOrder(str, Enum):
+    """Order in which objects are dropped, which decides what ends up underneath."""
+
+    AS_LISTED = "as_listed"
+    """Keep the caller's order."""
+
+    FLATTEST_FIRST = "flattest_first"
+    """Shortest object first. Flat objects reach the floor before the region gets lumpy,
+    which keeps them lying flat instead of coming to rest on an edge."""
+
+    SHUFFLE = "shuffle"
+    """Randomise, so no object is systematically at the bottom across layouts."""
+
+
+@dataclass(frozen=True)
+class ClutterRegion:
+    """Axis-aligned XY region with a floor, in the frame drop poses are returned in."""
+
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+    floor_z: float
+    """Z of the surface objects are dropped onto."""
+
+    def __post_init__(self) -> None:
+        assert self.max_x > self.min_x, f"region needs max_x > min_x, got {self.min_x}, {self.max_x}"
+        assert self.max_y > self.min_y, f"region needs max_y > min_y, got {self.min_y}, {self.max_y}"
+
+    def scaled(self, factor: float) -> ClutterRegion:
+        """Return this region scaled about its centre. Lower factors heap the pile tighter."""
+        assert factor > 0.0, f"scale factor must be positive, got {factor}"
+        cx, cy = (self.min_x + self.max_x) * 0.5, (self.min_y + self.max_y) * 0.5
+        half_x = (self.max_x - self.min_x) * 0.5 * factor
+        half_y = (self.max_y - self.min_y) * 0.5 * factor
+        return ClutterRegion(cx - half_x, cy - half_y, cx + half_x, cy + half_y, self.floor_z)
+
+
+@dataclass(frozen=True)
+class ClutterDropParams:
+    """Tuning for :func:`compute_drop_poses`."""
+
+    clutter_spread: float = 1.0
+    """Scales the usable region about its centre; below 1.0 concentrates the pile."""
+
+    xy_sampling: XySampling = XySampling.GRID_CELLS
+    drop_order: DropOrder = DropOrder.AS_LISTED
+
+    clearance_m: float = 0.01
+    """Gap between an object's lowest point and the surface it is dropped onto."""
+
+    gap_m: float = 0.03
+    """Extra vertical gap when an object must clear one already placed below it."""
+
+    random_yaw: bool = True
+    """Sample a random Z-yaw per object. Disable for reproducible axis-aligned layouts."""
+
+
+@dataclass(frozen=True)
+class DropPose:
+    """A pre-settle pose for one object."""
+
+    position: tuple[float, float, float]
+    rotation_xyzw: tuple[float, float, float, float]
+    drop_index: int
+    """Position in the drop sequence; 0 is dropped first and tends to end up lowest."""
+
+
+def _yaw_to_quat_xyzw(yaw: float) -> tuple[float, float, float, float]:
+    """Z-axis yaw (radians) as an ``(x, y, z, w)`` quaternion."""
+    half = yaw * 0.5
+    return (0.0, 0.0, math.sin(half), math.cos(half))
+
+
+def _footprint_half_extents(bbox: AxisAlignedBoundingBox) -> tuple[float, float]:
+    """Half-width and half-depth of a bounding box's XY footprint."""
+    size = bbox.size[0]
+    return float(size[0]) * 0.5, float(size[1]) * 0.5
+
+
+def _resolve_order(
+    bounding_boxes: list[AxisAlignedBoundingBox],
+    drop_order: DropOrder,
+    generator: torch.Generator | None,
+) -> list[int]:
+    """Return indices into ``bounding_boxes`` in the order they should be dropped."""
+    indices = list(range(len(bounding_boxes)))
+    if drop_order is DropOrder.AS_LISTED:
+        return indices
+    if drop_order is DropOrder.FLATTEST_FIRST:
+        return sorted(indices, key=lambda i: float(bounding_boxes[i].size[0][2]))
+    permutation = torch.randperm(len(indices), generator=generator)
+    return [indices[int(i)] for i in permutation]
+
+
+def _grid_cell_centres(
+    count: int, region: ClutterRegion, generator: torch.Generator | None
+) -> list[tuple[float, float]]:
+    """One cell centre per object, tiling the region and shuffled.
+
+    The grid is chosen to keep cells as square as the region allows, so neither axis is
+    over-subdivided. Shuffling stops objects listed together from landing side by side.
+    """
+    width, depth = region.max_x - region.min_x, region.max_y - region.min_y
+    num_cols = max(1, min(count, round(math.sqrt(count * width / depth)))) if depth > 0.0 else count
+    num_rows = math.ceil(count / num_cols)
+
+    centres = []
+    for i in range(count):
+        row, col = divmod(i, num_cols)
+        centres.append((
+            region.min_x + width * (col + 0.5) / num_cols,
+            region.min_y + depth * (row + 0.5) / num_rows,
+        ))
+    permutation = torch.randperm(count, generator=generator)
+    return [centres[int(i)] for i in permutation]
+
+
+def _sample_xy(
+    centre: tuple[float, float] | None,
+    half_x: float,
+    half_y: float,
+    region: ClutterRegion,
+    generator: torch.Generator | None,
+) -> tuple[float, float]:
+    """Sample an XY whose footprint stays inside ``region``.
+
+    The admissible box is the region inset by the object's own half-extents, so the whole
+    footprint lands inside rather than just the origin. When a cell centre is given the
+    sample is drawn around it and then clamped into that admissible box.
+    """
+    min_x, max_x = region.min_x + half_x, region.max_x - half_x
+    min_y, max_y = region.min_y + half_y, region.max_y - half_y
+    assert min_x <= max_x and min_y <= max_y, (
+        f"object footprint {2 * half_x:.3f}x{2 * half_y:.3f} m does not fit in region "
+        f"{region.max_x - region.min_x:.3f}x{region.max_y - region.min_y:.3f} m"
+    )
+
+    unit = torch.rand(2, generator=generator)
+    if centre is None:
+        x = min_x + float(unit[0]) * (max_x - min_x)
+        y = min_y + float(unit[1]) * (max_y - min_y)
+    else:
+        # Jitter by half a footprint so cell-mates stay distinguishable without escaping.
+        x = centre[0] + (float(unit[0]) - 0.5) * half_x
+        y = centre[1] + (float(unit[1]) - 0.5) * half_y
+    return min(max(x, min_x), max_x), min(max(y, min_y), max_y)
+
+
+def _footprints_overlap(
+    a_centre: tuple[float, float],
+    a_half: tuple[float, float],
+    b_centre: tuple[float, float],
+    b_half: tuple[float, float],
+) -> bool:
+    """Whether two axis-aligned XY footprints overlap."""
+    return (
+        abs(a_centre[0] - b_centre[0]) < a_half[0] + b_half[0]
+        and abs(a_centre[1] - b_centre[1]) < a_half[1] + b_half[1]
+    )
+
+
+def compute_drop_poses(
+    bounding_boxes: list[AxisAlignedBoundingBox],
+    region: ClutterRegion,
+    params: ClutterDropParams | None = None,
+    generator: torch.Generator | None = None,
+) -> list[DropPose]:
+    """Compute pre-settle drop poses for one pile.
+
+    Objects are placed so that no two overlap in 3D: an object whose footprint is clear
+    starts just above the floor, and one that would sit over an already-placed object is
+    lifted to clear it. The simulator turns this layout into a pile by settling it.
+
+    Args:
+        bounding_boxes: Object-local bounding box per object, single-environment (``N=1``).
+        region: Where objects may land, in the frame the returned poses use.
+        params: Tuning; defaults to :class:`ClutterDropParams`.
+        generator: Seeded RNG for reproducible layouts.
+
+    Returns:
+        One :class:`DropPose` per input object, in input order.
+    """
+    assert bounding_boxes, "compute_drop_poses needs at least one bounding box"
+    for i, bbox in enumerate(bounding_boxes):
+        assert bbox.num_envs == 1, f"bounding_boxes[{i}] must be single-env (N=1), got N={bbox.num_envs}"
+    params = params or ClutterDropParams()
+
+    usable = region.scaled(params.clutter_spread)
+    order = _resolve_order(bounding_boxes, params.drop_order, generator)
+    centres = (
+        _grid_cell_centres(len(order), usable, generator)
+        if params.xy_sampling is XySampling.GRID_CELLS
+        else [None] * len(order)
+    )
+
+    poses: list[DropPose | None] = [None] * len(bounding_boxes)
+    placed: list[tuple[tuple[float, float], tuple[float, float], float]] = []
+
+    for drop_index, (object_index, centre) in enumerate(zip(order, centres)):
+        yaw = get_random_rotation(generator) if params.random_yaw else 0.0
+        rotation = _yaw_to_quat_xyzw(yaw)
+        # Refit the box to the sampled yaw so the footprint and height match the placed object.
+        rotated = bounding_boxes[object_index].rotated_by_quat(torch.tensor([rotation], dtype=torch.float32))
+
+        half_x, half_y = _footprint_half_extents(rotated)
+        x, y = _sample_xy(centre, half_x, half_y, usable, generator)
+
+        # Lift only over the footprints actually overlapped, not over everything placed so far.
+        support_z = region.floor_z + params.clearance_m
+        for other_centre, other_half, other_top_z in placed:
+            if _footprints_overlap((x, y), (half_x, half_y), other_centre, other_half):
+                support_z = max(support_z, other_top_z + params.gap_m)
+
+        # Offset the origin so the object's lowest point sits at support_z.
+        z = support_z - float(rotated.bottom_surface_z[0])
+        placed.append(((x, y), (half_x, half_y), z + float(rotated.top_surface_z[0])))
+        poses[object_index] = DropPose(position=(x, y, z), rotation_xyzw=rotation, drop_index=drop_index)
+
+    assert all(pose is not None for pose in poses), "every object must receive a drop pose"
+    return [pose for pose in poses if pose is not None]

--- a/isaaclab_arena/relations/clutter_drop_poses.py
+++ b/isaaclab_arena/relations/clutter_drop_poses.py
@@ -32,6 +32,7 @@ from enum import Enum
 
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.random import get_random_rotation
+from isaaclab_arena.utils.yaw import rotate_quat_by_yaw
 
 
 class XySampling(str, Enum):
@@ -131,12 +132,6 @@ class DropPose:
     """Position in the drop sequence; 0 is dropped first and tends to end up lowest."""
 
 
-def _yaw_to_quat_xyzw(yaw: float) -> tuple[float, float, float, float]:
-    """Z-axis yaw (radians) as an ``(x, y, z, w)`` quaternion."""
-    half = yaw * 0.5
-    return (0.0, 0.0, math.sin(half), math.cos(half))
-
-
 @dataclass(frozen=True)
 class _Footprint:
     """A bounding box's XY footprint, described relative to the object origin.
@@ -219,6 +214,7 @@ def _sample_orientation_that_fits(
     region: ClutterRegion,
     params: ClutterDropParams,
     generator: torch.Generator | None,
+    base_rotation_xyzw: tuple[float, float, float, float],
 ) -> tuple[tuple[float, float, float, float], AxisAlignedBoundingBox, _Footprint]:
     """Sample a yaw whose rotated footprint fits the region, retrying unlucky draws.
 
@@ -231,7 +227,7 @@ def _sample_orientation_that_fits(
     widest: _Footprint | None = None
     for _ in range(attempts):
         yaw = get_random_rotation(generator) if params.random_yaw else 0.0
-        rotation = _yaw_to_quat_xyzw(yaw)
+        rotation = rotate_quat_by_yaw(base_rotation_xyzw, yaw)
         # Refit the box to the sampled yaw so footprint and height match the placed object.
         rotated = bbox.rotated_by_quat(torch.tensor([rotation], dtype=torch.float32))
         footprint = _footprint_of(rotated)
@@ -297,6 +293,7 @@ def compute_drop_poses(
     params: ClutterDropParams | None = None,
     generator: torch.Generator | None = None,
     occupied: list[OccupiedFootprint] | None = None,
+    base_rotations_xyzw: list[tuple[float, float, float, float]] | None = None,
 ) -> list[DropPose]:
     """Compute pre-settle drop poses for one pile.
 
@@ -311,6 +308,8 @@ def compute_drop_poses(
         generator: Seeded RNG for reproducible layouts.
         occupied: Footprints already standing in the region, such as objects the solver placed
             on the same surface. Clutter is released above them rather than inside them.
+        base_rotations_xyzw: Source-authored rotation per object. Sampled yaw is composed on
+            top of each rotation. Defaults to identity for every object.
 
     Returns:
         One :class:`DropPose` per input object, in input order.
@@ -319,6 +318,11 @@ def compute_drop_poses(
     for i, bbox in enumerate(bounding_boxes):
         assert bbox.num_envs == 1, f"bounding_boxes[{i}] must be single-env (N=1), got N={bbox.num_envs}"
     params = params or ClutterDropParams()
+    if base_rotations_xyzw is None:
+        base_rotations_xyzw = [(0.0, 0.0, 0.0, 1.0) for _ in bounding_boxes]
+    assert len(base_rotations_xyzw) == len(
+        bounding_boxes
+    ), "base_rotations_xyzw must contain one rotation per bounding box"
 
     usable = region.scaled(params.clutter_spread)
     order = _resolve_order(bounding_boxes, params.drop_order, generator)
@@ -336,7 +340,11 @@ def compute_drop_poses(
 
     for drop_index, (object_index, centre) in enumerate(zip(order, centres)):
         rotation, rotated, footprint = _sample_orientation_that_fits(
-            bounding_boxes[object_index], usable, params, generator
+            bounding_boxes[object_index],
+            usable,
+            params,
+            generator,
+            base_rotations_xyzw[object_index],
         )
         x, y = _sample_xy(centre, footprint, usable, generator)
         footprint_centre = footprint.centre_at(x, y)

--- a/isaaclab_arena/relations/clutter_groups.py
+++ b/isaaclab_arena/relations/clutter_groups.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolution of clutter members into the piles they belong to."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.relations.relations import ClutteredOn
+
+if TYPE_CHECKING:
+    from isaaclab_arena.relations.placement_asset import PlaceableAsset
+
+
+@dataclass(frozen=True)
+class ClutterGroup:
+    """One pile: the members that settle together on a shared support."""
+
+    support: PlaceableAsset
+    """The asset the pile comes to rest on."""
+
+    name: str
+    """Group name shared by every member."""
+
+    members: tuple[PlaceableAsset, ...]
+    """Members in declaration order, which is also the order they are dropped in."""
+
+    relation: ClutteredOn
+    """The relation of the first member, carrying the pile's shared parameters."""
+
+
+def is_clutter_member(asset: PlaceableAsset) -> bool:
+    """Whether an asset is placed by a clutter pour rather than by the solver."""
+    return any(isinstance(relation, ClutteredOn) for relation in asset.get_relations())
+
+
+def get_clutter_groups(assets: list[PlaceableAsset]) -> list[ClutterGroup]:
+    """Group clutter members by the support and group name they declare.
+
+    Members keep declaration order within a group, and groups keep the order of their
+    first member, so a fixed asset list always yields the same pours in the same order.
+
+    Args:
+        assets: The assets participating in placement.
+    """
+    order: list[tuple[int, str]] = []
+    members: dict[tuple[int, str], list[PlaceableAsset]] = {}
+    relations: dict[tuple[int, str], ClutteredOn] = {}
+    supports: dict[tuple[int, str], PlaceableAsset] = {}
+
+    for asset in assets:
+        for relation in asset.get_relations():
+            if not isinstance(relation, ClutteredOn):
+                continue
+            # Identity, not equality: two distinct supports may compare equal but are separate piles.
+            key = (id(relation.parent), relation.group)
+            if key not in members:
+                order.append(key)
+                members[key] = []
+                relations[key] = relation
+                supports[key] = relation.parent
+            members[key].append(asset)
+
+    return [
+        ClutterGroup(support=supports[key], name=key[1], members=tuple(members[key]), relation=relations[key])
+        for key in order
+    ]
+
+
+def assert_group_parameters_agree(group: ClutterGroup) -> None:
+    """Reject a group whose members disagree about the pile's shared parameters.
+
+    Every member carries its own relation, but spread, gaps and clearance describe the
+    pile as a whole, so conflicting values would silently resolve to whichever member
+    happened to be first.
+    """
+    shared = group.relation
+    for member in group.members:
+        for relation in member.get_relations():
+            if not isinstance(relation, ClutteredOn) or relation is shared:
+                continue
+            for field_name in ("spread", "gap_m", "clearance_m", "random_yaw"):
+                declared = getattr(relation, field_name)
+                expected = getattr(shared, field_name)
+                assert declared == expected, (
+                    f"Clutter group '{group.name}' on '{group.support.name}' has conflicting "
+                    f"{field_name}: '{member.name}' declares {declared}, expected {expected}. "
+                    "Group parameters describe the whole pile and must match across members."
+                )

--- a/isaaclab_arena/relations/clutter_pour.py
+++ b/isaaclab_arena/relations/clutter_pour.py
@@ -12,6 +12,7 @@ settling and the capture of resting poses are done by the existing in-sim valida
 
 from __future__ import annotations
 
+import math
 import torch
 from typing import TYPE_CHECKING
 
@@ -29,30 +30,66 @@ if TYPE_CHECKING:
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
+_QUARTER_TURN_TOLERANCE_RAD = 1e-3
+
+
 def region_above_support(
     support_position: tuple[float, float, float],
     support_bbox: AxisAlignedBoundingBox,
     spread: float = 1.0,
     env_index: int = 0,
+    support_rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0),
 ) -> ClutterRegion:
     """Return the drop region covering a support's top face.
 
     Bounding boxes hold extents local to the object origin, so the support's world position
-    offsets them. The floor of the region is the support's top surface.
+    offsets them and its yaw turns them. The floor of the region is the support's top surface.
+
+    A region is axis-aligned, so a support turned off-axis cannot be covered exactly. Its
+    enclosing box would be larger than the support itself and would drop clutter past the
+    real edge, so an off-axis support instead gets the largest axis-aligned square that fits
+    inside the footprint's inscribed circle. That is conservative in the safe direction and
+    rotation-invariant. Quarter turns are exact, since they only swap the extents.
 
     Args:
         support_position: World position of the support, in the environment-local frame.
         support_bbox: The support's bounding box, batched per environment.
         spread: Fraction of the footprint to use, shrunk about the centre.
         env_index: Which environment's extents to read.
+        support_rotation_xyzw: The support's world rotation. Must be a yaw-only rotation, since
+            a tilted support has no single top surface height.
     """
+    x, y, z, w = support_rotation_xyzw
+    assert abs(x) < 1e-3 and abs(y) < 1e-3, (
+        f"Clutter support rotation must be yaw-only, got (x={x:.4f}, y={y:.4f}). A tilted "
+        "support has no single top-surface height for a pile to rest on."
+    )
+    yaw = 2.0 * math.atan2(z, w)
+
     minimum = support_bbox.min_point[env_index]
     maximum = support_bbox.max_point[env_index]
+    half_x = float(maximum[0] - minimum[0]) * 0.5
+    half_y = float(maximum[1] - minimum[1]) * 0.5
+    local_centre_x = float(maximum[0] + minimum[0]) * 0.5
+    local_centre_y = float(maximum[1] + minimum[1]) * 0.5
+
+    # The footprint centre orbits the origin with the support.
+    cos_yaw, sin_yaw = math.cos(yaw), math.sin(yaw)
+    centre_x = support_position[0] + local_centre_x * cos_yaw - local_centre_y * sin_yaw
+    centre_y = support_position[1] + local_centre_x * sin_yaw + local_centre_y * cos_yaw
+
+    quarter_turns = round(yaw / (math.pi / 2.0))
+    if abs(yaw - quarter_turns * (math.pi / 2.0)) <= _QUARTER_TURN_TOLERANCE_RAD:
+        if quarter_turns % 2:
+            half_x, half_y = half_y, half_x
+    else:
+        half_x = half_y = min(half_x, half_y) / math.sqrt(2.0)
+
     region = ClutterRegion(
-        min_x=support_position[0] + float(minimum[0]),
-        min_y=support_position[1] + float(minimum[1]),
-        max_x=support_position[0] + float(maximum[0]),
-        max_y=support_position[1] + float(maximum[1]),
+        min_x=centre_x - half_x,
+        min_y=centre_y - half_y,
+        max_x=centre_x + half_x,
+        max_y=centre_y + half_y,
         floor_z=support_position[2] + float(support_bbox.top_surface_z[env_index]),
     )
     return region.scaled(spread) if spread != 1.0 else region
@@ -106,6 +143,7 @@ def plan_group_drops_into_layout(
     generator: torch.Generator,
     env_index: int = 0,
     occupied: list[OccupiedFootprint] | None = None,
+    support_rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0),
 ) -> None:
     """Write one group's drop poses into a solved layout.
 
@@ -127,7 +165,7 @@ def plan_group_drops_into_layout(
     assert_group_parameters_agree(group)
 
     relation = group.relation
-    region = region_above_support(support_position, support_bbox, relation.spread, env_index)
+    region = region_above_support(support_position, support_bbox, relation.spread, env_index, support_rotation_xyzw)
     params = ClutterDropParams(
         clearance_m=relation.clearance_m,
         gap_m=relation.gap_m,
@@ -164,7 +202,14 @@ def plan_clutter_drops(
         # An anchored support keeps its declared pose; a solved one is already in the layout.
         support_position = layout.positions.get(support) or support.get_initial_pose().position_xyz
         support_position = tuple(float(value) for value in support_position)
-        region = region_above_support(support_position, bounding_boxes[support], group.relation.spread, env_index)
+        support_rotation = _support_rotation(support, layout)
+        region = region_above_support(
+            support_position,
+            bounding_boxes[support],
+            group.relation.spread,
+            env_index,
+            support_rotation_xyzw=support_rotation,
+        )
         # Members of earlier groups are already in the layout and must be avoided too.
         occupied = occupied_footprints_in_region(
             region,
@@ -182,4 +227,16 @@ def plan_clutter_drops(
             generator=generator,
             env_index=env_index,
             occupied=occupied,
+            support_rotation_xyzw=support_rotation,
         )
+
+
+def _support_rotation(support: PlaceableAsset, layout: PlacementResult) -> tuple[float, float, float, float]:
+    """Return the support's world rotation, preferring what the layout solved for it."""
+    rotation = layout.rotations.get(support)
+    if rotation is not None:
+        return rotation
+    yaw = layout.orientations.get(support)
+    if yaw is not None:
+        return (0.0, 0.0, math.sin(yaw * 0.5), math.cos(yaw * 0.5))
+    return tuple(float(value) for value in support.get_initial_pose().rotation_xyzw)

--- a/isaaclab_arena/relations/clutter_pour.py
+++ b/isaaclab_arena/relations/clutter_pour.py
@@ -23,6 +23,7 @@ from isaaclab_arena.relations.clutter_drop_poses import (
     compute_drop_poses,
 )
 from isaaclab_arena.relations.clutter_groups import ClutterGroup, assert_group_parameters_agree
+from isaaclab_arena.relations.placement_events import get_rotation_xyzw
 
 if TYPE_CHECKING:
     from isaaclab_arena.relations.placement_asset import PlaceableAsset
@@ -171,7 +172,14 @@ def plan_group_drops_into_layout(
         gap_m=relation.gap_m,
         random_yaw=relation.random_yaw,
     )
-    poses = compute_drop_poses(member_bboxes, region, params, generator, occupied=occupied)
+    poses = compute_drop_poses(
+        member_bboxes,
+        region,
+        params,
+        generator,
+        occupied=occupied,
+        base_rotations_xyzw=[get_rotation_xyzw(member) for member in group.members],
+    )
 
     for member, pose in zip(group.members, poses):
         layout.positions[member] = pose.position

--- a/isaaclab_arena/relations/clutter_pour.py
+++ b/isaaclab_arena/relations/clutter_pour.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
-from isaaclab_arena.relations.clutter_drop_poses import ClutterDropParams, ClutterRegion, compute_drop_poses
+from isaaclab_arena.relations.clutter_drop_poses import (
+    ClutterDropParams,
+    ClutterRegion,
+    OccupiedFootprint,
+    compute_drop_poses,
+)
 from isaaclab_arena.relations.clutter_groups import ClutterGroup, assert_group_parameters_agree
 
 if TYPE_CHECKING:
@@ -53,6 +58,45 @@ def region_above_support(
     return region.scaled(spread) if spread != 1.0 else region
 
 
+def occupied_footprints_in_region(
+    region: ClutterRegion,
+    positions: dict[PlaceableAsset, tuple[float, float, float]],
+    bounding_boxes: dict[PlaceableAsset, AxisAlignedBoundingBox],
+    exclude: set[PlaceableAsset],
+    env_index: int = 0,
+) -> list[OccupiedFootprint]:
+    """Return the footprints of already-placed objects standing in ``region``.
+
+    Nothing re-checks overlap once a pile has settled, and doing so on boxes would be
+    meaningless anyway, so the pour has to avoid what is already there rather than discover
+    the collision afterwards. Objects resting below the region's floor are ignored: they are
+    under the surface being poured onto, not on it.
+    """
+    footprints = []
+    for asset, position in positions.items():
+        if asset in exclude or asset not in bounding_boxes:
+            continue
+        bbox = bounding_boxes[asset]
+        minimum, maximum = bbox.min_point[env_index], bbox.max_point[env_index]
+        top_z = float(position[2]) + float(maximum[2])
+        if top_z <= region.floor_z:
+            continue
+        centre = (
+            float(position[0]) + float(maximum[0] + minimum[0]) * 0.5,
+            float(position[1]) + float(maximum[1] + minimum[1]) * 0.5,
+        )
+        half_extents = (float(maximum[0] - minimum[0]) * 0.5, float(maximum[1] - minimum[1]) * 0.5)
+        if (
+            centre[0] + half_extents[0] <= region.min_x
+            or centre[0] - half_extents[0] >= region.max_x
+            or centre[1] + half_extents[1] <= region.min_y
+            or centre[1] - half_extents[1] >= region.max_y
+        ):
+            continue
+        footprints.append(OccupiedFootprint(centre=centre, half_extents=half_extents, top_z=top_z))
+    return footprints
+
+
 def plan_group_drops_into_layout(
     layout: PlacementResult,
     group: ClutterGroup,
@@ -61,6 +105,7 @@ def plan_group_drops_into_layout(
     support_bbox: AxisAlignedBoundingBox,
     generator: torch.Generator,
     env_index: int = 0,
+    occupied: list[OccupiedFootprint] | None = None,
 ) -> None:
     """Write one group's drop poses into a solved layout.
 
@@ -88,7 +133,7 @@ def plan_group_drops_into_layout(
         gap_m=relation.gap_m,
         random_yaw=relation.random_yaw,
     )
-    poses = compute_drop_poses(member_bboxes, region, params, generator)
+    poses = compute_drop_poses(member_bboxes, region, params, generator, occupied=occupied)
 
     for member, pose in zip(group.members, poses):
         layout.positions[member] = pose.position
@@ -118,12 +163,23 @@ def plan_clutter_drops(
         assert not missing, f"Clutter group '{group.name}' has members without bounding boxes: {missing}"
         # An anchored support keeps its declared pose; a solved one is already in the layout.
         support_position = layout.positions.get(support) or support.get_initial_pose().position_xyz
+        support_position = tuple(float(value) for value in support_position)
+        region = region_above_support(support_position, bounding_boxes[support], group.relation.spread, env_index)
+        # Members of earlier groups are already in the layout and must be avoided too.
+        occupied = occupied_footprints_in_region(
+            region,
+            layout.positions,
+            bounding_boxes,
+            exclude={support, *group.members},
+            env_index=env_index,
+        )
         plan_group_drops_into_layout(
             layout=layout,
             group=group,
             member_bboxes=[bounding_boxes[member] for member in group.members],
-            support_position=tuple(float(value) for value in support_position),
+            support_position=support_position,
             support_bbox=bounding_boxes[support],
             generator=generator,
             env_index=env_index,
+            occupied=occupied,
         )

--- a/isaaclab_arena/relations/clutter_pour.py
+++ b/isaaclab_arena/relations/clutter_pour.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Planning of clutter drop poses into solved layouts.
+
+A clutter pile cannot be optimised into place, so its members are instead dropped above
+their support and left to settle. This module plans where each member is released; the
+settling and the capture of resting poses are done by the existing in-sim validation pass.
+"""
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.relations.clutter_drop_poses import ClutterDropParams, ClutterRegion, compute_drop_poses
+from isaaclab_arena.relations.clutter_groups import ClutterGroup, assert_group_parameters_agree
+
+if TYPE_CHECKING:
+    from isaaclab_arena.relations.placement_asset import PlaceableAsset
+    from isaaclab_arena.relations.placement_result import PlacementResult
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+
+def region_above_support(
+    support_position: tuple[float, float, float],
+    support_bbox: AxisAlignedBoundingBox,
+    spread: float = 1.0,
+    env_index: int = 0,
+) -> ClutterRegion:
+    """Return the drop region covering a support's top face.
+
+    Bounding boxes hold extents local to the object origin, so the support's world position
+    offsets them. The floor of the region is the support's top surface.
+
+    Args:
+        support_position: World position of the support, in the environment-local frame.
+        support_bbox: The support's bounding box, batched per environment.
+        spread: Fraction of the footprint to use, shrunk about the centre.
+        env_index: Which environment's extents to read.
+    """
+    minimum = support_bbox.min_point[env_index]
+    maximum = support_bbox.max_point[env_index]
+    region = ClutterRegion(
+        min_x=support_position[0] + float(minimum[0]),
+        min_y=support_position[1] + float(minimum[1]),
+        max_x=support_position[0] + float(maximum[0]),
+        max_y=support_position[1] + float(maximum[1]),
+        floor_z=support_position[2] + float(support_bbox.top_surface_z[env_index]),
+    )
+    return region.scaled(spread) if spread != 1.0 else region
+
+
+def plan_group_drops_into_layout(
+    layout: PlacementResult,
+    group: ClutterGroup,
+    member_bboxes: list[AxisAlignedBoundingBox],
+    support_position: tuple[float, float, float],
+    support_bbox: AxisAlignedBoundingBox,
+    generator: torch.Generator,
+    env_index: int = 0,
+) -> None:
+    """Write one group's drop poses into a solved layout.
+
+    The layout then carries release poses rather than solved ones, so writing it to sim and
+    stepping physics produces the pile. Resting poses are read back by the validation pass.
+
+    Args:
+        layout: The layout to write drop poses into.
+        group: The pile being poured.
+        member_bboxes: Bounding box per member, in ``group.members`` order.
+        support_position: World position of the support, in the environment-local frame.
+        support_bbox: The support's bounding box.
+        generator: Seeded RNG, so a given seed reproduces a given pile.
+        env_index: Which environment's extents to read.
+    """
+    assert len(member_bboxes) == len(
+        group.members
+    ), f"Clutter group '{group.name}' has {len(group.members)} members but {len(member_bboxes)} bounding boxes."
+    assert_group_parameters_agree(group)
+
+    relation = group.relation
+    region = region_above_support(support_position, support_bbox, relation.spread, env_index)
+    params = ClutterDropParams(
+        clearance_m=relation.clearance_m,
+        gap_m=relation.gap_m,
+        random_yaw=relation.random_yaw,
+    )
+    poses = compute_drop_poses(member_bboxes, region, params, generator)
+
+    for member, pose in zip(group.members, poses):
+        layout.positions[member] = pose.position
+        layout.rotations[member] = pose.rotation_xyzw
+
+
+def plan_clutter_drops(
+    layout: PlacementResult,
+    groups: list[ClutterGroup],
+    bounding_boxes: dict[PlaceableAsset, AxisAlignedBoundingBox],
+    generator: torch.Generator,
+    env_index: int = 0,
+) -> None:
+    """Write every group's drop poses into a solved layout.
+
+    Args:
+        layout: The layout to write drop poses into.
+        groups: The piles to pour, in the order returned by group resolution.
+        bounding_boxes: Bounding box per asset, covering every support and member.
+        generator: Seeded RNG shared across groups.
+        env_index: Which environment's extents to read.
+    """
+    for group in groups:
+        support = group.support
+        assert support in bounding_boxes, f"Clutter support '{support.name}' has no bounding box."
+        missing = [member.name for member in group.members if member not in bounding_boxes]
+        assert not missing, f"Clutter group '{group.name}' has members without bounding boxes: {missing}"
+        # An anchored support keeps its declared pose; a solved one is already in the layout.
+        support_position = layout.positions.get(support) or support.get_initial_pose().position_xyz
+        plan_group_drops_into_layout(
+            layout=layout,
+            group=group,
+            member_bboxes=[bounding_boxes[member] for member in group.members],
+            support_position=tuple(float(value) for value in support_position),
+            support_bbox=bounding_boxes[support],
+            generator=generator,
+            env_index=env_index,
+        )

--- a/isaaclab_arena/relations/clutter_validation.py
+++ b/isaaclab_arena/relations/clutter_validation.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verdicts on a poured clutter pile.
+
+Physics already guarantees that settled objects do not interpenetrate, so this checks what
+physics does not: that nothing fell off the support, fell through it, or diverged, and that
+the pile stopped moving. Overlap is deliberately not tested. A resting object is tangent to
+its support, a tilted object's axis-aligned box encloses far more than its geometry, and a
+concave asset's box encloses more still, so box intersection reports contact that is either
+expected or imaginary.
+"""
+
+from __future__ import annotations
+
+import torch
+from dataclasses import dataclass, field
+
+from isaaclab_arena.relations.clutter_drop_poses import ClutterRegion
+
+
+@dataclass(frozen=True)
+class ClutterSettleParams:
+    """Thresholds deciding when a pile has stopped and whether it came to rest correctly."""
+
+    move_thresh_m: float = 0.002
+    """No object may translate more than this between polls for the pile to count as quiet."""
+
+    turn_thresh_deg: float = 2.0
+    """No object may rotate more than this between polls for the pile to count as quiet."""
+
+    required_quiet_windows: int = 2
+    """Consecutive quiet polls before the pile is called settled.
+
+    Settling is not monotonic: a pile can go quiet, avalanche, then settle. One quiet poll is
+    therefore not evidence that it has stopped.
+    """
+
+    fall_through_tolerance_m: float = 0.01
+    """How far below the support surface an object may rest before it counts as tunnelled."""
+
+    containment_margin_m: float = 0.0
+    """How far outside the region an object may rest before it counts as fallen off."""
+
+
+@dataclass
+class ClutterRestVerdict:
+    """Which members of a pile came to rest badly, by failure mode."""
+
+    diverged: list[int] = field(default_factory=list)
+    """Indices whose pose is not finite."""
+
+    fell_through: list[int] = field(default_factory=list)
+    """Indices resting below the support surface."""
+
+    fell_off: list[int] = field(default_factory=list)
+    """Indices resting outside the region."""
+
+    @property
+    def ok(self) -> bool:
+        """Whether every member came to rest acceptably."""
+        return not (self.diverged or self.fell_through or self.fell_off)
+
+    def describe(self, names: list[str]) -> str:
+        """Return a human-readable summary naming the offending members."""
+        parts = []
+        for label, indices in (
+            ("diverged", self.diverged),
+            ("fell through", self.fell_through),
+            ("fell off", self.fell_off),
+        ):
+            if indices:
+                offenders = ", ".join(names[index] for index in indices)
+                parts.append(f"{label}: {offenders}")
+        return "; ".join(parts) if parts else "all members at rest"
+
+
+def quaternion_angle_deg(first: torch.Tensor, second: torch.Tensor) -> torch.Tensor:
+    """Return the angle in degrees between two batches of quaternions.
+
+    Args:
+        first: Quaternions, shape ``(N, 4)``.
+        second: Quaternions, shape ``(N, 4)``.
+    """
+    # A quaternion and its negation are the same rotation, so compare magnitudes.
+    dots = (first * second).sum(dim=-1).abs().clamp(max=1.0)
+    return torch.rad2deg(2.0 * torch.acos(dots))
+
+
+class SettleTracker:
+    """Decides when a pile has stopped, from a sequence of pose snapshots.
+
+    Velocity cannot decide this. Objects in stable contact keep micro-rocking indefinitely,
+    and some assets report angular speeds irreconcilable with their own pose history, so a
+    velocity threshold either never fires or fires while the pile is still rearranging.
+    """
+
+    def __init__(self, params: ClutterSettleParams | None = None):
+        """
+        Args:
+            params: Thresholds for quiet windows. Defaults to ``ClutterSettleParams()``.
+        """
+        self._params = params or ClutterSettleParams()
+        self._previous: tuple[torch.Tensor, torch.Tensor] | None = None
+        self._quiet_windows = 0
+
+    @property
+    def settled(self) -> bool:
+        """Whether enough consecutive quiet polls have been seen."""
+        return self._quiet_windows >= self._params.required_quiet_windows
+
+    @property
+    def quiet_windows(self) -> int:
+        """How many consecutive quiet polls have been seen."""
+        return self._quiet_windows
+
+    def update(self, positions: torch.Tensor, rotations: torch.Tensor) -> bool:
+        """Record a pose snapshot and return whether the pile now counts as settled.
+
+        A non-finite snapshot resets the streak, so a diverged pile can never be called settled.
+
+        Args:
+            positions: Member positions, shape ``(N, 3)``.
+            rotations: Member rotations as ``(x, y, z, w)``, shape ``(N, 4)``.
+        """
+        if not bool(torch.isfinite(positions).all() and torch.isfinite(rotations).all()):
+            self._quiet_windows = 0
+            self._previous = None
+            return False
+
+        if self._previous is None:
+            self._previous = (positions.clone(), rotations.clone())
+            return False
+
+        previous_positions, previous_rotations = self._previous
+        moved = float((positions - previous_positions).norm(dim=-1).max())
+        turned = float(quaternion_angle_deg(rotations, previous_rotations).max())
+        quiet = moved <= self._params.move_thresh_m and turned <= self._params.turn_thresh_deg
+
+        self._quiet_windows = self._quiet_windows + 1 if quiet else 0
+        self._previous = (positions.clone(), rotations.clone())
+        return self.settled
+
+
+def check_resting_poses(
+    positions: torch.Tensor,
+    region: ClutterRegion,
+    params: ClutterSettleParams | None = None,
+) -> ClutterRestVerdict:
+    """Return which members came to rest badly.
+
+    Args:
+        positions: Member positions, shape ``(N, 3)``, in the same frame as ``region``.
+        region: The region the pile was poured into, whose floor is the support surface.
+        params: Tolerances. Defaults to ``ClutterSettleParams()``.
+    """
+    params = params or ClutterSettleParams()
+    verdict = ClutterRestVerdict()
+    margin = params.containment_margin_m
+    floor = region.floor_z - params.fall_through_tolerance_m
+
+    for index in range(positions.shape[0]):
+        position = positions[index]
+        if not bool(torch.isfinite(position).all()):
+            verdict.diverged.append(index)
+            continue
+        x, y, z = (float(value) for value in position)
+        if z < floor:
+            verdict.fell_through.append(index)
+        if not (region.min_x - margin <= x <= region.max_x + margin) or not (
+            region.min_y - margin <= y <= region.max_y + margin
+        ):
+            verdict.fell_off.append(index)
+    return verdict

--- a/isaaclab_arena/relations/clutter_validation.py
+++ b/isaaclab_arena/relations/clutter_validation.py
@@ -153,7 +153,10 @@ def check_resting_poses(
 
     Args:
         positions: Member positions, shape ``(N, 3)``, in the same frame as ``region``.
-        region: The region the pile was poured into, whose floor is the support surface.
+        region: The surface the pile must stay on, whose floor is the support surface. Pass the
+            support's full footprint rather than a ``spread``-shrunk pour region: a pile poured
+            tightly is meant to relax outward, so judging it against the region it was released
+            into would report objects resting well inside the support as having fallen off.
         params: Tolerances. Defaults to ``ClutterSettleParams()``.
     """
     params = params or ClutterSettleParams()

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
-from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+from isaaclab_arena.relations.clutter_groups import get_clutter_groups, is_clutter_member
 from isaaclab_arena.relations.clutter_pour import plan_clutter_drops
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
@@ -235,6 +235,12 @@ class ObjectPlacer:
         unrotated_candidate_bboxes = env_bboxes.get_bounding_boxes_for_solver_candidates(candidates_per_env)
         per_env_bboxes = env_bboxes.get_bounding_boxes_for_all_envs()
 
+        # A pour positions clutter after solving, so any pose the optimiser gave it would be
+        # discarded. Leaving it in would make it a phantom obstacle: it carries no relation loss
+        # but does carry the global no-overlap term, so it would push the genuinely constrained
+        # objects around and inflate the loss that ranks candidates. Only its box is needed here.
+        solver_objects = [obj for obj in objects if not is_clutter_member(obj)]
+
         initial_positions: list[dict[PlaceableAsset, tuple[float, float, float]]] = []
         orientations_per_candidate: list[dict[PlaceableAsset, float]] = []
         for candidate_idx in range(num_candidates):
@@ -243,19 +249,19 @@ class ObjectPlacer:
                 assert self.params.placement_seed is not None
                 generator.manual_seed(self.params.placement_seed + candidate_idx)
             initial_positions.append(
-                self._generate_initial_positions(objects, anchor_objects_set, per_env_bboxes[cur_env], generator)
+                self._generate_initial_positions(solver_objects, anchor_objects_set, per_env_bboxes[cur_env], generator)
             )
             orientations_per_candidate.append(
-                self._generate_initial_orientations(objects, anchor_objects_set, generator)
+                self._generate_initial_orientations(solver_objects, anchor_objects_set, generator)
             )
 
         # Bake each candidate's yaw into a conservative enclosing bbox for overlap checks.
         candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
+            solver_objects, unrotated_candidate_bboxes, orientations_per_candidate
         )
 
         all_positions = self._solver.solve(
-            objects,
+            solver_objects,
             initial_positions,
             env_bboxes=candidate_bboxes,
             env_bboxes_include_yaw=any(orientations for orientations in orientations_per_candidate),
@@ -265,7 +271,7 @@ class ObjectPlacer:
         self._apply_face_to_orientations(all_positions, orientations_per_candidate)
         # FaceTo yaw is only known after solving, so rebuild from unrotated boxes before validation.
         candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
+            solver_objects, unrotated_candidate_bboxes, orientations_per_candidate
         )
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
+from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+from isaaclab_arena.relations.clutter_pour import plan_clutter_drops
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
 from isaaclab_arena.relations.placement_validation import PlacementValidationResults
@@ -33,6 +35,11 @@ if TYPE_CHECKING:
     from isaaclab_arena.relations.collision_object import CollisionObject
     from isaaclab_arena.relations.placement_asset import PlaceableAsset
     from isaaclab_arena.relations.placement_validators import PlacementValidator
+
+
+# Spacing between the seeds of successive clutter pours, so layouts drawn from one placement
+# seed do not reuse each other's random draws.
+_CLUTTER_SEED_STRIDE = 1_000_003
 
 
 @dataclass
@@ -296,10 +303,41 @@ class ObjectPlacer:
             for candidate_slice in ranked_candidate_slices
         ]
 
+        self._plan_clutter_drops_into_results(objects, ranked_results, per_env_bboxes)
+
         if self.params.verbose:
             self._print_ranked_summary(ranked_candidate_slices, num_candidates, num_envs)
 
         return ranked_results
+
+    def _plan_clutter_drops_into_results(
+        self,
+        objects: list[PlaceableAsset],
+        ranked_results: list[list[PlacementResult]],
+        per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]],
+    ) -> None:
+        """Replace clutter members' solved poses with the poses they are released from.
+
+        The solver leaves clutter members wherever it likes, since they carry no spatial
+        relations, so those poses are discarded here in favour of a pour. Each layout gets
+        its own pour, so a pool holds distinct piles rather than one pile repeated.
+        """
+        groups = get_clutter_groups(objects)
+        if not groups:
+            return
+        assert self.params.placement_seed is not None, (
+            "Clutter placement requires placement_seed to be set. Without it a pile cannot be "
+            "reproduced, and reproducibility is the point of seeding a layout at all."
+        )
+
+        generator = torch.Generator()
+        for env_index, env_results in enumerate(ranked_results):
+            for result_index, layout in enumerate(env_results):
+                generator.manual_seed(
+                    self.params.placement_seed + _CLUTTER_SEED_STRIDE * (env_index * len(env_results) + result_index)
+                )
+                # per_env_bboxes already holds one env's boxes, each of shape (1, 3).
+                plan_clutter_drops(layout, groups, per_env_bboxes[env_index], generator, env_index=0)
 
     @staticmethod
     def _rank_candidates(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -321,11 +321,6 @@ class ObjectPlacer:
         its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
-        if self.params.verbose:
-            print(
-                f"[clutter] planning pours: groups={len(groups)} "
-                f"members={sum(len(group.members) for group in groups)} of {len(objects)} objects"
-            )
         if not groups:
             return
         assert self.params.placement_seed is not None, (

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
-from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+from isaaclab_arena.relations.clutter_groups import get_clutter_groups, is_clutter_member
 from isaaclab_arena.relations.clutter_pour import plan_clutter_drops
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
@@ -233,6 +233,12 @@ class ObjectPlacer:
         unrotated_candidate_bboxes = env_bboxes.get_bounding_boxes_for_solver_candidates(candidates_per_env)
         per_env_bboxes = env_bboxes.get_bounding_boxes_for_all_envs()
 
+        # A pour positions clutter after solving, so any pose the optimiser gave it would be
+        # discarded. Leaving it in would make it a phantom obstacle: it carries no relation loss
+        # but does carry the global no-overlap term, so it would push the genuinely constrained
+        # objects around and inflate the loss that ranks candidates. Only its box is needed here.
+        solver_objects = [obj for obj in objects if not is_clutter_member(obj)]
+
         initial_positions: list[dict[PlaceableAsset, tuple[float, float, float]]] = []
         orientations_per_candidate: list[dict[PlaceableAsset, float]] = []
         for candidate_idx in range(num_candidates):
@@ -241,19 +247,19 @@ class ObjectPlacer:
                 assert self.params.placement_seed is not None
                 generator.manual_seed(self.params.placement_seed + candidate_idx)
             initial_positions.append(
-                self._generate_initial_positions(objects, anchor_objects_set, per_env_bboxes[cur_env], generator)
+                self._generate_initial_positions(solver_objects, anchor_objects_set, per_env_bboxes[cur_env], generator)
             )
             orientations_per_candidate.append(
-                self._generate_initial_orientations(objects, anchor_objects_set, generator)
+                self._generate_initial_orientations(solver_objects, anchor_objects_set, generator)
             )
 
         # Bake each candidate's yaw into a conservative enclosing bbox for overlap checks.
         candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
+            solver_objects, unrotated_candidate_bboxes, orientations_per_candidate
         )
 
         all_positions = self._solver.solve(
-            objects,
+            solver_objects,
             initial_positions,
             env_bboxes=candidate_bboxes,
             env_bboxes_include_yaw=any(orientations for orientations in orientations_per_candidate),
@@ -263,7 +269,7 @@ class ObjectPlacer:
         self._apply_face_to_orientations(all_positions, orientations_per_candidate)
         # FaceTo yaw is only known after solving, so rebuild from unrotated boxes before validation.
         candidate_bboxes = self._rotate_candidate_bboxes(
-            objects, unrotated_candidate_bboxes, orientations_per_candidate
+            solver_objects, unrotated_candidate_bboxes, orientations_per_candidate
         )
         assert self._solver.last_loss_per_env is not None
         all_losses: list[float] = self._solver.last_loss_per_env.cpu().tolist()

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -323,6 +323,11 @@ class ObjectPlacer:
         its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
+        if self.params.verbose:
+            print(
+                f"[clutter] planning pours: groups={len(groups)} "
+                f"members={sum(len(group.members) for group in groups)} of {len(objects)} objects"
+            )
         if not groups:
             return
         assert self.params.placement_seed is not None, (

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import assign_variants_for_envs, build_per_env_bounding_boxes
+from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+from isaaclab_arena.relations.clutter_pour import plan_clutter_drops
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
 from isaaclab_arena.relations.placement_validation import PlacementValidationResults
@@ -32,6 +34,11 @@ if TYPE_CHECKING:
     from isaaclab_arena.relations.collision_object import CollisionObject
     from isaaclab_arena.relations.placement_asset import PlaceableAsset
     from isaaclab_arena.relations.placement_validators import PlacementValidator
+
+
+# Spacing between the seeds of successive clutter pours, so layouts drawn from one placement
+# seed do not reuse each other's random draws.
+_CLUTTER_SEED_STRIDE = 1_000_003
 
 
 @dataclass
@@ -294,10 +301,41 @@ class ObjectPlacer:
             for candidate_slice in ranked_candidate_slices
         ]
 
+        self._plan_clutter_drops_into_results(objects, ranked_results, per_env_bboxes)
+
         if self.params.verbose:
             self._print_ranked_summary(ranked_candidate_slices, num_candidates, num_envs)
 
         return ranked_results
+
+    def _plan_clutter_drops_into_results(
+        self,
+        objects: list[PlaceableAsset],
+        ranked_results: list[list[PlacementResult]],
+        per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]],
+    ) -> None:
+        """Replace clutter members' solved poses with the poses they are released from.
+
+        The solver leaves clutter members wherever it likes, since they carry no spatial
+        relations, so those poses are discarded here in favour of a pour. Each layout gets
+        its own pour, so a pool holds distinct piles rather than one pile repeated.
+        """
+        groups = get_clutter_groups(objects)
+        if not groups:
+            return
+        assert self.params.placement_seed is not None, (
+            "Clutter placement requires placement_seed to be set. Without it a pile cannot be "
+            "reproduced, and reproducibility is the point of seeding a layout at all."
+        )
+
+        generator = torch.Generator()
+        for env_index, env_results in enumerate(ranked_results):
+            for result_index, layout in enumerate(env_results):
+                generator.manual_seed(
+                    self.params.placement_seed + _CLUTTER_SEED_STRIDE * (env_index * len(env_results) + result_index)
+                )
+                # per_env_bboxes already holds one env's boxes, each of shape (1, 3).
+                plan_clutter_drops(layout, groups, per_env_bboxes[env_index], generator, env_index=0)
 
     @staticmethod
     def _rank_candidates(

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -321,6 +321,11 @@ class ObjectPlacer:
         its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
+        if self.params.verbose:
+            print(
+                f"[clutter] planning pours: groups={len(groups)} "
+                f"members={sum(len(group.members) for group in groups)} of {len(objects)} objects"
+            )
         if not groups:
             return
         assert self.params.placement_seed is not None, (

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -323,11 +323,6 @@ class ObjectPlacer:
         its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
-        if self.params.verbose:
-            print(
-                f"[clutter] planning pours: groups={len(groups)} "
-                f"members={sum(len(group.members) for group in groups)} of {len(objects)} objects"
-            )
         if not groups:
             return
         assert self.params.placement_seed is not None, (

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -88,6 +88,9 @@ class ObjectPlacer:
         self._solver = RelationSolver(params=self.params.solver_params)
         self._visualizer = get_or_create_placement_visualizer(self.params)
         self._validators: list[PlacementValidator] = build_validators(self.params, self._visualizer)
+        # Per-env bounding boxes from the most recent solve, kept so clutter can be poured into
+        # the layouts that survive ranking rather than into every candidate.
+        self._per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]] | None = None
 
     def place(
         self,
@@ -126,6 +129,9 @@ class ObjectPlacer:
             collision_objects=collision_objects,
         )
         results_per_env = [env_results[0] for env_results in ranked_results_per_env]
+        # Pour only the layouts that survive ranking: a discarded candidate's pile is wasted
+        # work, and each pour is another chance for a fail-closed yaw draw to abort the build.
+        self._plan_clutter_drops_into_results(objects, [[result] for result in results_per_env])
 
         if self.params.verbose:
             for env_idx, result in enumerate(results_per_env):
@@ -138,7 +144,8 @@ class ObjectPlacer:
         if self.params.apply_positions_to_objects:
             positions_per_env = [r.positions for r in results_per_env]
             orientations_per_env = [r.orientations for r in results_per_env]
-            self._apply_poses(positions_per_env, anchor_objects_set, orientations_per_env)
+            rotations_per_env = [r.rotations for r in results_per_env]
+            self._apply_poses(positions_per_env, anchor_objects_set, orientations_per_env, rotations_per_env)
 
         return results_per_env
 
@@ -175,7 +182,10 @@ class ObjectPlacer:
             collision_objects=collision_objects,
         )
 
-        return [ranked_results[:results_per_env] for ranked_results in ranked_results_per_env]
+        kept = [ranked_results[:results_per_env] for ranked_results in ranked_results_per_env]
+        # Pour only the layouts the pool keeps, not every ranked candidate.
+        self._plan_clutter_drops_into_results(objects, kept)
+        return kept
 
     def _prepare_placement(
         self,
@@ -309,7 +319,7 @@ class ObjectPlacer:
             for candidate_slice in ranked_candidate_slices
         ]
 
-        self._plan_clutter_drops_into_results(objects, ranked_results, per_env_bboxes)
+        self._per_env_bboxes = per_env_bboxes
 
         if self.params.verbose:
             self._print_ranked_summary(ranked_candidate_slices, num_candidates, num_envs)
@@ -320,17 +330,16 @@ class ObjectPlacer:
         self,
         objects: list[PlaceableAsset],
         ranked_results: list[list[PlacementResult]],
-        per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]],
     ) -> None:
-        """Replace clutter members' solved poses with the poses they are released from.
+        """Add clutter members to each kept layout by pouring them onto their support.
 
-        The solver leaves clutter members wherever it likes, since they carry no spatial
-        relations, so those poses are discarded here in favour of a pour. Each layout gets
-        its own pour, so a pool holds distinct piles rather than one pile repeated.
+        Clutter is held out of the solver, so a layout arrives here without it. Each layout
+        gets its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
         if not groups:
             return
+        assert self._per_env_bboxes is not None, "_place_ranked must run before clutter is poured"
         assert self.params.placement_seed is not None, (
             "Clutter placement requires placement_seed to be set. Without it a pile cannot be "
             "reproduced, and reproducibility is the point of seeding a layout at all."
@@ -342,8 +351,8 @@ class ObjectPlacer:
                 generator.manual_seed(
                     self.params.placement_seed + _CLUTTER_SEED_STRIDE * (env_index * len(env_results) + result_index)
                 )
-                # per_env_bboxes already holds one env's boxes, each of shape (1, 3).
-                plan_clutter_drops(layout, groups, per_env_bboxes[env_index], generator, env_index=0)
+                # Each entry already holds one env's boxes, each of shape (1, 3).
+                plan_clutter_drops(layout, groups, self._per_env_bboxes[env_index], generator, env_index=0)
 
     @staticmethod
     def _rank_candidates(
@@ -760,10 +769,13 @@ class ObjectPlacer:
         positions_per_env: list[dict[PlaceableAsset, tuple[float, float, float]]],
         anchor_objects: set[PlaceableAsset],
         orientations_per_env: list[dict[PlaceableAsset, float]],
+        rotations_per_env: list[dict[PlaceableAsset, tuple[float, float, float, float]]] | None = None,
     ) -> None:
         """Apply solved positions and orientations to non-anchor objects.
 
         orientations_per_env carries absolute world yaw; marker yaw is subtracted before composition.
+        rotations_per_env carries full rotations that are already final, so no marker composition
+        applies to them; a scalar yaw cannot express the tilt a settled or poured object holds.
         """
         num_envs = len(positions_per_env)
         objects = list(positions_per_env[0])
@@ -779,9 +791,17 @@ class ObjectPlacer:
                 """Return the yaw to compose with the RotateAroundSolution marker rotation."""
                 return orientations_per_env[env_idx].get(obj, marker_yaw) - marker_yaw
 
+            def _rotation(env_idx: int) -> tuple[float, float, float, float]:
+                """Return the final world rotation for this object in this env."""
+                if rotations_per_env is not None:
+                    full = rotations_per_env[env_idx].get(obj)
+                    if full is not None:
+                        return full
+                return rotate_quat_by_yaw(marker_rotation, _yaw_delta(env_idx))
+
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
-                rotation_xyzw = rotate_quat_by_yaw(marker_rotation, _yaw_delta(0))
+                rotation_xyzw = _rotation(0)
                 random_marker = get_relation(obj, RandomAroundSolution)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
@@ -789,10 +809,7 @@ class ObjectPlacer:
                     obj.set_initial_pose(Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw))
             else:
                 poses = [
-                    Pose(
-                        position_xyz=positions_per_env[env_idx][obj],
-                        rotation_xyzw=rotate_quat_by_yaw(marker_rotation, _yaw_delta(env_idx)),
-                    )
+                    Pose(position_xyz=positions_per_env[env_idx][obj], rotation_xyzw=_rotation(env_idx))
                     for env_idx in range(num_envs)
                 ]
                 obj.set_initial_pose(PosePerEnv(poses=poses))

--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -86,6 +86,9 @@ class ObjectPlacer:
         self.params = params or ObjectPlacerParams()
         self._solver = RelationSolver(params=self.params.solver_params)
         self._validators: list[PlacementValidator] = build_validators(self.params)
+        # Per-env bounding boxes from the most recent solve, kept so clutter can be poured into
+        # the layouts that survive ranking rather than into every candidate.
+        self._per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]] | None = None
 
     def place(
         self,
@@ -124,6 +127,9 @@ class ObjectPlacer:
             collision_objects=collision_objects,
         )
         results_per_env = [env_results[0] for env_results in ranked_results_per_env]
+        # Pour only the layouts that survive ranking: a discarded candidate's pile is wasted
+        # work, and each pour is another chance for a fail-closed yaw draw to abort the build.
+        self._plan_clutter_drops_into_results(objects, [[result] for result in results_per_env])
 
         if self.params.verbose:
             for env_idx, result in enumerate(results_per_env):
@@ -136,7 +142,8 @@ class ObjectPlacer:
         if self.params.apply_positions_to_objects:
             positions_per_env = [r.positions for r in results_per_env]
             orientations_per_env = [r.orientations for r in results_per_env]
-            self._apply_poses(positions_per_env, anchor_objects_set, orientations_per_env)
+            rotations_per_env = [r.rotations for r in results_per_env]
+            self._apply_poses(positions_per_env, anchor_objects_set, orientations_per_env, rotations_per_env)
 
         return results_per_env
 
@@ -173,7 +180,10 @@ class ObjectPlacer:
             collision_objects=collision_objects,
         )
 
-        return [ranked_results[:results_per_env] for ranked_results in ranked_results_per_env]
+        kept = [ranked_results[:results_per_env] for ranked_results in ranked_results_per_env]
+        # Pour only the layouts the pool keeps, not every ranked candidate.
+        self._plan_clutter_drops_into_results(objects, kept)
+        return kept
 
     def _prepare_placement(
         self,
@@ -307,7 +317,7 @@ class ObjectPlacer:
             for candidate_slice in ranked_candidate_slices
         ]
 
-        self._plan_clutter_drops_into_results(objects, ranked_results, per_env_bboxes)
+        self._per_env_bboxes = per_env_bboxes
 
         if self.params.verbose:
             self._print_ranked_summary(ranked_candidate_slices, num_candidates, num_envs)
@@ -318,17 +328,16 @@ class ObjectPlacer:
         self,
         objects: list[PlaceableAsset],
         ranked_results: list[list[PlacementResult]],
-        per_env_bboxes: list[dict[PlaceableAsset, AxisAlignedBoundingBox]],
     ) -> None:
-        """Replace clutter members' solved poses with the poses they are released from.
+        """Add clutter members to each kept layout by pouring them onto their support.
 
-        The solver leaves clutter members wherever it likes, since they carry no spatial
-        relations, so those poses are discarded here in favour of a pour. Each layout gets
-        its own pour, so a pool holds distinct piles rather than one pile repeated.
+        Clutter is held out of the solver, so a layout arrives here without it. Each layout
+        gets its own pour, so a pool holds distinct piles rather than one pile repeated.
         """
         groups = get_clutter_groups(objects)
         if not groups:
             return
+        assert self._per_env_bboxes is not None, "_place_ranked must run before clutter is poured"
         assert self.params.placement_seed is not None, (
             "Clutter placement requires placement_seed to be set. Without it a pile cannot be "
             "reproduced, and reproducibility is the point of seeding a layout at all."
@@ -340,8 +349,8 @@ class ObjectPlacer:
                 generator.manual_seed(
                     self.params.placement_seed + _CLUTTER_SEED_STRIDE * (env_index * len(env_results) + result_index)
                 )
-                # per_env_bboxes already holds one env's boxes, each of shape (1, 3).
-                plan_clutter_drops(layout, groups, per_env_bboxes[env_index], generator, env_index=0)
+                # Each entry already holds one env's boxes, each of shape (1, 3).
+                plan_clutter_drops(layout, groups, self._per_env_bboxes[env_index], generator, env_index=0)
 
     @staticmethod
     def _rank_candidates(
@@ -747,10 +756,13 @@ class ObjectPlacer:
         positions_per_env: list[dict[PlaceableAsset, tuple[float, float, float]]],
         anchor_objects: set[PlaceableAsset],
         orientations_per_env: list[dict[PlaceableAsset, float]],
+        rotations_per_env: list[dict[PlaceableAsset, tuple[float, float, float, float]]] | None = None,
     ) -> None:
         """Apply solved positions and orientations to non-anchor objects.
 
         orientations_per_env carries absolute world yaw; marker yaw is subtracted before composition.
+        rotations_per_env carries full rotations that are already final, so no marker composition
+        applies to them; a scalar yaw cannot express the tilt a settled or poured object holds.
         """
         num_envs = len(positions_per_env)
         objects = list(positions_per_env[0])
@@ -766,9 +778,17 @@ class ObjectPlacer:
                 """Return the yaw to compose with the RotateAroundSolution marker rotation."""
                 return orientations_per_env[env_idx].get(obj, marker_yaw) - marker_yaw
 
+            def _rotation(env_idx: int) -> tuple[float, float, float, float]:
+                """Return the final world rotation for this object in this env."""
+                if rotations_per_env is not None:
+                    full = rotations_per_env[env_idx].get(obj)
+                    if full is not None:
+                        return full
+                return rotate_quat_by_yaw(marker_rotation, _yaw_delta(env_idx))
+
             if num_envs == 1:
                 pos = positions_per_env[0][obj]
-                rotation_xyzw = rotate_quat_by_yaw(marker_rotation, _yaw_delta(0))
+                rotation_xyzw = _rotation(0)
                 random_marker = get_relation(obj, RandomAroundSolution)
                 if random_marker is not None:
                     obj.set_initial_pose(random_marker.to_pose_range_centered_at(pos, rotation_xyzw=rotation_xyzw))
@@ -776,10 +796,7 @@ class ObjectPlacer:
                     obj.set_initial_pose(Pose(position_xyz=pos, rotation_xyzw=rotation_xyzw))
             else:
                 poses = [
-                    Pose(
-                        position_xyz=positions_per_env[env_idx][obj],
-                        rotation_xyzw=rotate_quat_by_yaw(marker_rotation, _yaw_delta(env_idx)),
-                    )
+                    Pose(position_xyz=positions_per_env[env_idx][obj], rotation_xyzw=_rotation(env_idx))
                     for env_idx in range(num_envs)
                 ]
                 obj.set_initial_pose(PosePerEnv(poses=poses))

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -86,6 +86,9 @@ def get_base_rotation_per_asset(
 def get_pose_from_layout(asset: PlaceableAsset, layout: PlacementResult) -> Pose:
     """Return an asset pose from a solved layout."""
     assert asset in layout.positions, f"Placement layout is missing non-anchor asset '{asset.name}'"
+    if asset in layout.rotations:
+        # A full rotation is already the final world orientation, so the marker yaw does not apply.
+        return Pose(position_xyz=layout.positions[asset], rotation_xyzw=layout.rotations[asset])
     base_rotation = get_rotation_xyzw(asset)
     marker_yaw = yaw_from_quat_xyzw(base_rotation)
     total_yaw = layout.orientations.get(asset, marker_yaw)

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -58,6 +58,9 @@ def get_base_rotation_per_asset(
 def get_pose_from_layout(asset: PlaceableAsset, layout: PlacementResult) -> Pose:
     """Return an asset pose from a solved layout."""
     assert asset in layout.positions, f"Placement layout is missing non-anchor asset '{asset.name}'"
+    if asset in layout.rotations:
+        # A full rotation is already the final world orientation, so the marker yaw does not apply.
+        return Pose(position_xyz=layout.positions[asset], rotation_xyzw=layout.rotations[asset])
     base_rotation = get_rotation_xyzw(asset)
     marker_yaw = yaw_from_quat_xyzw(base_rotation)
     total_yaw = layout.orientations.get(asset, marker_yaw)

--- a/isaaclab_arena/relations/placement_pool_validation.py
+++ b/isaaclab_arena/relations/placement_pool_validation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
+from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker
 from isaaclab_arena.relations.physics_settle_params import PhysicsSettleParams
 from isaaclab_arena.relations.placement_events import (
@@ -63,16 +64,25 @@ def _compute_physics_settled_and_add_to_validation_results(
     layouts: list[tuple[int, PlacementResult]],
     movable_object_names: list[str],
     settle_params: PhysicsSettleParams,
+    settled_override: bool | None = None,
 ) -> list[tuple[int, PlacementValidationResults]]:
     """Read back per-object velocities for a list of layouts and stamp ``PHYSICS_SETTLED`` per layout.
 
     Returns ``(env_id, validation_results)`` per layout; the settle verdict is stamped only if not already present.
+
+    Args:
+        settled_override: Verdict to stamp instead of reading velocities. Required when settling
+            was decided from pose deltas, because objects in stable contact keep micro-rocking
+            and so never satisfy a velocity threshold.
     """
 
     env_ids = [env_id for env_id, _ in layouts]
-    settled_per_env = physics_settle.are_all_objects_settled_per_env(
-        env, env_ids, movable_object_names, settle_params.lin_vel_thresh, settle_params.ang_vel_thresh
-    )
+    if settled_override is not None:
+        settled_per_env = [settled_override] * len(env_ids)
+    else:
+        settled_per_env = physics_settle.are_all_objects_settled_per_env(
+            env, env_ids, movable_object_names, settle_params.lin_vel_thresh, settle_params.ang_vel_thresh
+        )
     validation_results_all_envs: list[tuple[int, PlacementValidationResults]] = []
     for (env_id, layout), settled in zip(layouts, settled_per_env):
         validation_results_per_env = layout.validation_results
@@ -86,9 +96,8 @@ def _capture_settled_poses_into_layouts(
     env: ManagerBasedEnv,
     layouts: list[tuple[int, PlacementResult]],
     assets: list[PlaceableAsset],
-    anchor_assets: set,
 ) -> None:
-    """Overwrite each non-anchor asset's layout pose with where it came to rest.
+    """Overwrite each given asset's layout pose with where it came to rest.
 
     Settling moves objects, so a layout that is replayed later has to carry the resting
     poses rather than the poses it was dropped from. Non-finite poses are left alone, so a
@@ -98,8 +107,6 @@ def _capture_settled_poses_into_layouts(
     env_origins = scene.env_origins
     for env_id, layout in layouts:
         for asset in assets:
-            if asset in anchor_assets:
-                continue
             root_state = scene[asset.get_scene_key()].data.root_state_w[env_id]
             if not bool(torch.isfinite(root_state[:7]).all()):
                 continue
@@ -175,9 +182,9 @@ def validate_pool_layouts(
         settle_params: Settle-check tuning params. Defaults to
             ``PhysicsSettleParams()`` when omitted.
         render: When True, render each settle step so the sweep is visible in the GUI. Defaults to False.
-        capture_settled_poses: When True, write each object's resting pose back into its layout.
-            Required for layouts whose value is the settled arrangement itself. Defaults to False,
-            which leaves solved layouts untouched.
+        capture_settled_poses: When True, write each clutter member's resting pose back into its
+            layout. Required for layouts whose value is the settled arrangement itself. Defaults
+            to False, which leaves solved layouts untouched.
         pose_settle_params: When given, settle by watching poses stop changing and return as soon
             as they do, rather than always stepping the full budget. Needed for arrangements that
             physics produces, where objects in stable contact keep micro-rocking and so never meet
@@ -197,6 +204,9 @@ def validate_pool_layouts(
 
     assets = placement_pool.objects
     anchor_assets = set(get_anchor_objects(assets))
+    # Only clutter's value is the settled arrangement. Capturing every non-anchor asset would
+    # freeze the embodiment, and any object that toppled, at whatever pose gravity left it in.
+    clutter_assets = [asset for asset in assets if is_clutter_member(asset)]
     base_rotations = get_base_rotation_per_asset(assets)
     movable_object_names = get_movable_asset_names(assets, anchor_assets)
 
@@ -225,10 +235,11 @@ def validate_pool_layouts(
             base_rotations,
         )
         if layouts:
+            settled_override = None
             if pose_settle_params is None:
                 physics_settle.step_physics(env, num_physics_steps, render=render)
             else:
-                _step_until_poses_are_quiet(
+                settled_override = _step_until_poses_are_quiet(
                     env,
                     movable_object_names,
                     num_physics_steps,
@@ -237,9 +248,9 @@ def validate_pool_layouts(
                     render=render,
                 )
             if capture_settled_poses:
-                _capture_settled_poses_into_layouts(env, layouts, assets, anchor_assets)
+                _capture_settled_poses_into_layouts(env, layouts, clutter_assets)
             validation_results = _compute_physics_settled_and_add_to_validation_results(
-                env, layouts, movable_object_names, settle_params
+                env, layouts, movable_object_names, settle_params, settled_override
             )
             for env_id, validation_results_per_env in validation_results:
                 results.append((env_id, episode_index, validation_results_per_env))

--- a/isaaclab_arena/relations/placement_pool_validation.py
+++ b/isaaclab_arena/relations/placement_pool_validation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import torch
 from typing import TYPE_CHECKING
 
+from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker
 from isaaclab_arena.relations.physics_settle_params import PhysicsSettleParams
 from isaaclab_arena.relations.placement_events import (
     get_base_rotation_per_asset,
@@ -113,12 +114,54 @@ def _capture_settled_poses_into_layouts(
             )
 
 
+def _step_until_poses_are_quiet(
+    env: ManagerBasedEnv,
+    movable_object_names: list[str],
+    max_physics_steps: int,
+    params: ClutterSettleParams,
+    poll_every: int,
+    render: bool = False,
+) -> bool:
+    """Step physics until poses stop changing, or the step budget runs out.
+
+    Returns early once the poses are quiet, so a sparse arrangement does not pay the budget a
+    dense one needs. Velocity is not consulted: objects in stable contact micro-rock forever.
+
+    Args:
+        env: The Isaac Lab env.
+        movable_object_names: Scene keys of the objects being settled.
+        max_physics_steps: Upper bound on physics steps before giving up.
+        params: Quiet-window thresholds.
+        poll_every: Physics steps between pose reads.
+        render: When True, render each step.
+
+    Returns:
+        Whether the poses went quiet within the budget.
+    """
+    scene = env.unwrapped.scene
+    tracker = SettleTracker(params)
+    stepped = 0
+    while stepped < max_physics_steps:
+        chunk = min(poll_every, max_physics_steps - stepped)
+        physics_settle.step_physics(env, chunk, render=render)
+        stepped += chunk
+        states = torch.stack([scene[name].data.root_state_w for name in movable_object_names], dim=1)
+        # Flatten env and object axes: a pile is quiet only when every env's objects are.
+        positions = states[..., :3].reshape(-1, 3)
+        rotations = states[..., 3:7].reshape(-1, 4)
+        if tracker.update(positions, rotations):
+            return True
+    return tracker.settled
+
+
 def validate_pool_layouts(
     env: ManagerBasedEnv,
     placement_pool: PooledObjectPlacer | None = None,
     settle_params: PhysicsSettleParams | None = None,
     render: bool = False,
     capture_settled_poses: bool = False,
+    pose_settle_params: ClutterSettleParams | None = None,
+    poll_every: int = 50,
 ) -> list[tuple[int, int, PlacementValidationResults]] | None:
     """Physics-validate every layout in a placement pool, recording the result on its validation results.
 
@@ -135,6 +178,11 @@ def validate_pool_layouts(
         capture_settled_poses: When True, write each object's resting pose back into its layout.
             Required for layouts whose value is the settled arrangement itself. Defaults to False,
             which leaves solved layouts untouched.
+        pose_settle_params: When given, settle by watching poses stop changing and return as soon
+            as they do, rather than always stepping the full budget. Needed for arrangements that
+            physics produces, where objects in stable contact keep micro-rocking and so never meet
+            a velocity threshold. Defaults to None, which keeps the fixed-step behaviour.
+        poll_every: Physics steps between pose reads when ``pose_settle_params`` is given.
 
     Returns:
         ``(env_id, episode_index, checklist)`` for every layout, in ``(env_id, episode_index)`` order,
@@ -177,7 +225,17 @@ def validate_pool_layouts(
             base_rotations,
         )
         if layouts:
-            physics_settle.step_physics(env, num_physics_steps, render=render)
+            if pose_settle_params is None:
+                physics_settle.step_physics(env, num_physics_steps, render=render)
+            else:
+                _step_until_poses_are_quiet(
+                    env,
+                    movable_object_names,
+                    num_physics_steps,
+                    pose_settle_params,
+                    poll_every=poll_every,
+                    render=render,
+                )
             if capture_settled_poses:
                 _capture_settled_poses_into_layouts(env, layouts, assets, anchor_assets)
             validation_results = _compute_physics_settled_and_add_to_validation_results(

--- a/isaaclab_arena/relations/placement_pool_validation.py
+++ b/isaaclab_arena/relations/placement_pool_validation.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import torch
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.physics_settle_params import PhysicsSettleParams
@@ -80,11 +81,44 @@ def _compute_physics_settled_and_add_to_validation_results(
     return validation_results_all_envs
 
 
+def _capture_settled_poses_into_layouts(
+    env: ManagerBasedEnv,
+    layouts: list[tuple[int, PlacementResult]],
+    assets: list[PlaceableAsset],
+    anchor_assets: set,
+) -> None:
+    """Overwrite each non-anchor asset's layout pose with where it came to rest.
+
+    Settling moves objects, so a layout that is replayed later has to carry the resting
+    poses rather than the poses it was dropped from. Non-finite poses are left alone, so a
+    diverged step cannot poison a layout.
+    """
+    scene = env.unwrapped.scene
+    env_origins = scene.env_origins
+    for env_id, layout in layouts:
+        for asset in assets:
+            if asset in anchor_assets:
+                continue
+            root_state = scene[asset.get_scene_key()].data.root_state_w[env_id]
+            if not bool(torch.isfinite(root_state[:7]).all()):
+                continue
+            position = root_state[:3] - env_origins[env_id]
+            rotation = root_state[3:7]
+            layout.positions[asset] = (float(position[0]), float(position[1]), float(position[2]))
+            layout.rotations[asset] = (
+                float(rotation[0]),
+                float(rotation[1]),
+                float(rotation[2]),
+                float(rotation[3]),
+            )
+
+
 def validate_pool_layouts(
     env: ManagerBasedEnv,
     placement_pool: PooledObjectPlacer | None = None,
     settle_params: PhysicsSettleParams | None = None,
     render: bool = False,
+    capture_settled_poses: bool = False,
 ) -> list[tuple[int, int, PlacementValidationResults]] | None:
     """Physics-validate every layout in a placement pool, recording the result on its validation results.
 
@@ -98,6 +132,9 @@ def validate_pool_layouts(
         settle_params: Settle-check tuning params. Defaults to
             ``PhysicsSettleParams()`` when omitted.
         render: When True, render each settle step so the sweep is visible in the GUI. Defaults to False.
+        capture_settled_poses: When True, write each object's resting pose back into its layout.
+            Required for layouts whose value is the settled arrangement itself. Defaults to False,
+            which leaves solved layouts untouched.
 
     Returns:
         ``(env_id, episode_index, checklist)`` for every layout, in ``(env_id, episode_index)`` order,
@@ -141,6 +178,8 @@ def validate_pool_layouts(
         )
         if layouts:
             physics_settle.step_physics(env, num_physics_steps, render=render)
+            if capture_settled_poses:
+                _capture_settled_poses_into_layouts(env, layouts, assets, anchor_assets)
             validation_results = _compute_physics_settled_and_add_to_validation_results(
                 env, layouts, movable_object_names, settle_params
             )

--- a/isaaclab_arena/relations/placement_result.py
+++ b/isaaclab_arena/relations/placement_result.py
@@ -32,6 +32,14 @@ class PlacementResult:
     orientations: dict[PlaceableAsset, float] = field(default_factory=dict)
     """Sparse map of world yaw angles ``theta_z`` in radians; omitted assets retain marker orientation."""
 
+    rotations: dict[PlaceableAsset, tuple[float, float, float, float]] = field(default_factory=dict)
+    """Sparse map of full world rotations as ``(x, y, z, w)`` quaternions.
+
+    Takes precedence over ``orientations`` for any asset present in both. Yaw alone cannot
+    express the tilted resting poses that settled placements produce, so producers of
+    non-upright layouts populate this instead.
+    """
+
     @property
     def success(self) -> bool:
         """Whether all required validation checks passed."""

--- a/isaaclab_arena/relations/placement_validators.py
+++ b/isaaclab_arena/relations/placement_validators.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, cast
 
+from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.relations.collision_mode import CollisionMode, get_object_collision_mode, object_uses_mesh_collision
 from isaaclab_arena.relations.placement_validation import PlacementCheck
 from isaaclab_arena.relations.placement_validator_registry import PlacementValidatorRegistry, register_validator
@@ -444,6 +445,11 @@ class NoOverlapValidator(PlacementValidator):
                 if id(a) in anchor_ids and id(b) in anchor_ids:
                     continue
                 if (id(a), id(b)) in on_pairs:
+                    continue
+                # Clutter is positioned by a pour, not by the solver, so the positions seen
+                # here are discarded before reaching the sim. Its real arrangement is checked
+                # once settled, where objects are expected to be in contact.
+                if is_clutter_member(a) or is_clutter_member(b):
                     continue
                 if mesh_manager is not None and (
                     (

--- a/isaaclab_arena/relations/placement_validators.py
+++ b/isaaclab_arena/relations/placement_validators.py
@@ -11,7 +11,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, cast
 
-from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.relations.collision_mode import CollisionMode, get_object_collision_mode, object_uses_mesh_collision
 from isaaclab_arena.relations.placement_validation import PlacementCheck
 from isaaclab_arena.relations.placement_validator_registry import PlacementValidatorRegistry, register_validator
@@ -445,11 +444,6 @@ class NoOverlapValidator(PlacementValidator):
                 if id(a) in anchor_ids and id(b) in anchor_ids:
                     continue
                 if (id(a), id(b)) in on_pairs:
-                    continue
-                # Clutter is positioned by a pour, not by the solver, so the positions seen
-                # here are discarded before reaching the sim. Its real arrangement is checked
-                # once settled, where objects are expected to be in contact.
-                if is_clutter_member(a) or is_clutter_member(b):
                     continue
                 if mesh_manager is not None and (
                     (

--- a/isaaclab_arena/relations/placement_validators.py
+++ b/isaaclab_arena/relations/placement_validators.py
@@ -11,7 +11,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, cast
 
-from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.relations.collision_mode import CollisionMode, get_object_collision_mode, object_uses_mesh_collision
 from isaaclab_arena.relations.placement_validation import PlacementCheck
 from isaaclab_arena.relations.placement_validator_registry import PlacementValidatorRegistry, register_validator
@@ -439,11 +438,6 @@ class NoOverlapValidator(PlacementValidator):
                 if id(a) in anchor_ids and id(b) in anchor_ids:
                     continue
                 if (id(a), id(b)) in on_pairs:
-                    continue
-                # Clutter is positioned by a pour, not by the solver, so the positions seen
-                # here are discarded before reaching the sim. Its real arrangement is checked
-                # once settled, where objects are expected to be in contact.
-                if is_clutter_member(a) or is_clutter_member(b):
                     continue
                 if mesh_manager is not None and (
                     (

--- a/isaaclab_arena/relations/placement_validators.py
+++ b/isaaclab_arena/relations/placement_validators.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, ClassVar, cast
 
+from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.relations.collision_mode import CollisionMode, get_object_collision_mode, object_uses_mesh_collision
 from isaaclab_arena.relations.placement_validation import PlacementCheck
 from isaaclab_arena.relations.placement_validator_registry import PlacementValidatorRegistry, register_validator
@@ -438,6 +439,11 @@ class NoOverlapValidator(PlacementValidator):
                 if id(a) in anchor_ids and id(b) in anchor_ids:
                     continue
                 if (id(a), id(b)) in on_pairs:
+                    continue
+                # Clutter is positioned by a pour, not by the solver, so the positions seen
+                # here are discarded before reaching the sim. Its real arrangement is checked
+                # once settled, where objects are expected to be in contact.
+                if is_clutter_member(a) or is_clutter_member(b):
                     continue
                 if mesh_manager is not None and (
                     (

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -269,6 +269,33 @@ class PooledObjectPlacer:
             results[env_id] = pool.next()
         return results
 
+    def retain_layouts(self, keep, minimum: int = 1) -> tuple[int, int]:
+        """Drop unread layouts that ``keep`` rejects, leaving at least ``minimum`` per env.
+
+        Rejection sampling for outcomes that are only knowable after simulating, such as a
+        poured pile that spilled. An env is left with its rejected layouts when too few pass,
+        because an imperfect layout still beats having none to draw.
+
+        Args:
+            keep: Called as ``keep(env_id, layout)``; return False to reject the layout.
+            minimum: Fewest layouts to leave in an env's queue.
+
+        Returns:
+            ``(kept, rejected)`` counts across every env.
+        """
+        kept = rejected = 0
+        for env_id, pool in enumerate(self._env_pools):
+            unread = pool.layouts[pool.cursor :]
+            passing = [layout for layout in unread if keep(env_id, layout)]
+            if len(passing) < minimum:
+                kept += len(unread)
+                continue
+            rejected += len(unread) - len(passing)
+            kept += len(passing)
+            pool.layouts = passing
+            pool.cursor = 0
+        return kept, rejected
+
     @property
     def num_envs(self) -> int:
         """Number of environment pools managed by this placer."""

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -97,6 +97,7 @@ class PooledObjectPlacer:
         # and independent of other envs.
         self._env_rngs = get_rngs(self._num_envs, placer_params.placement_seed)
         self._env_pools: list[EnvLayoutPool] = [EnvLayoutPool([]) for _ in range(self._num_envs)]
+        self._recycle_layouts = False
 
         self._solve_and_store(pool_size)
         for cur_env, pool in enumerate(self._env_pools):
@@ -255,7 +256,15 @@ class PooledObjectPlacer:
         if any(env_id < 0 or env_id >= self._num_envs for env_id in env_ids):
             raise ValueError(f"env_ids must be in [0, {self._num_envs}); got {env_ids}")
 
-        if any(self._env_pools[env_id].available < 1 for env_id in env_ids):
+        exhausted = [env_id for env_id in env_ids if self._env_pools[env_id].available < 1]
+        if exhausted and self._recycle_layouts:
+            # Re-read the stored layouts instead of solving new ones. Layouts that only become
+            # usable after simulation -- a settled clutter pile is the case in hand -- are
+            # prepared once, outside any reset. A refill here would hand back layouts that
+            # preparation never saw, silently dropping the guarantee it established.
+            for env_id in exhausted:
+                self._env_pools[env_id].cursor = 0
+        elif exhausted:
             self._solve_and_store(max(self._pool_size, len(env_ids)))
 
         results: dict[int, PlacementResult] = {}
@@ -268,6 +277,22 @@ class PooledObjectPlacer:
                 )
             results[env_id] = pool.next()
         return results
+
+    @property
+    def recycle_layouts(self) -> bool:
+        """Whether an exhausted env queue rewinds instead of being refilled by a fresh solve."""
+        return self._recycle_layouts
+
+    @recycle_layouts.setter
+    def recycle_layouts(self, recycle: bool) -> None:
+        """Turn recycling on for pools whose layouts required preparation beyond solving.
+
+        A refill solves new layouts in the middle of a reset, where the preparation that made
+        the stored ones usable -- settling a poured pile, for instance -- cannot run. Recycling
+        keeps drawing from the prepared set instead, so the guarantee holds for the pool's whole
+        life at the cost of a fixed number of distinct layouts.
+        """
+        self._recycle_layouts = bool(recycle)
 
     def retain_layouts(self, keep, minimum: int = 1) -> tuple[int, int]:
         """Drop unread layouts that ``keep`` rejects, leaving at least ``minimum`` per env.

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -277,6 +277,73 @@ class IsAnchor(RelationBase):
 
 
 @register_object_relation
+class ClutteredOn(RelationBase):
+    """Places this object as one member of a settled clutter group on a support surface.
+
+    Group members are positioned by dropping them above the support and letting physics
+    settle, rather than by the relation solver. A settled pile has objects touching and
+    resting at arbitrary tilts, which the solver cannot express: it forbids overlap
+    globally and optimises positions only.
+
+    Deriving from ``RelationBase`` rather than ``Relation`` is what keeps members out of
+    gradient descent, since only ``Relation`` and ``UnaryRelation`` reach the loss.
+
+    Usage:
+        table.add_relation(IsAnchor())
+        for tool in tools:
+            tool.add_relation(ClutteredOn(table, group="tools"))
+    """
+
+    name = "cluttered_on"
+
+    def __init__(
+        self,
+        parent: PlaceableAsset,
+        group: str = "clutter",
+        spread: float = 1.0,
+        gap_m: float = 0.03,
+        clearance_m: float = 0.01,
+        random_yaw: bool = True,
+    ):
+        """
+        Args:
+            parent: The support asset the group comes to rest on.
+            group: Name tying members of one pile together. Assets sharing a parent and a
+                group are dropped as a single pile.
+            spread: Scales the usable fraction of the support's footprint about its centre.
+                Below 1.0 concentrates the pile; above 1.0 is rejected.
+            gap_m: Vertical gap left between an object and whatever it is dropped on top of.
+            clearance_m: Height above the support surface at which the lowest layer starts.
+            random_yaw: Whether to sample a yaw per object before dropping.
+        """
+        assert 0.0 < spread <= 1.0, f"spread must be in (0, 1], got {spread}"
+        assert gap_m >= 0.0, f"gap_m must be non-negative, got {gap_m}"
+        assert clearance_m >= 0.0, f"clearance_m must be non-negative, got {clearance_m}"
+        assert group, "group must be a non-empty name"
+        self.parent = parent
+        self.group = group
+        self.spread = spread
+        self.gap_m = gap_m
+        self.clearance_m = clearance_m
+        self.random_yaw = random_yaw
+
+    @staticmethod
+    def is_unary() -> bool:
+        """Return whether the relation constrains a single object."""
+        return False
+
+    def validate_placement_configuration(self, subject: PlaceableAsset, objects: set[PlaceableAsset]) -> None:
+        """Reject a clutter member whose support is absent or is itself clutter."""
+        assert (
+            self.parent in objects
+        ), f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is not part of the placement."
+        assert not self.parent.has_relation(ClutteredOn), (
+            f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is itself clutter. "
+            "Piles cannot be stacked on piles; give the group a settled support instead."
+        )
+
+
+@register_object_relation
 class RequiresReachability(RelationBase):
     """Indicates the robot shall be able to reach this object.
 

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -333,13 +333,29 @@ class ClutteredOn(RelationBase):
         return False
 
     def validate_placement_configuration(self, subject: PlaceableAsset, objects: set[PlaceableAsset]) -> None:
-        """Reject a clutter member whose support is absent or is itself clutter."""
+        """Reject a member whose support, own relations or anchoring make the pour meaningless."""
         assert (
             self.parent in objects
         ), f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is not part of the placement."
+        assert self.parent is not subject, f"Clutter member '{subject.name}' cannot rest on itself."
         assert not self.parent.has_relation(ClutteredOn), (
             f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is itself clutter. "
             "Piles cannot be stacked on piles; give the group a settled support instead."
+        )
+        # A pour assigns the member's pose, so anything else claiming to place it is a
+        # contradiction that would otherwise resolve silently to whichever ran last.
+        assert (
+            not subject.is_anchor
+        ), f"Clutter member '{subject.name}' is also an anchor. An anchor holds a fixed pose, but a pour assigns one."
+        clutter_relations = [relation for relation in subject.get_relations() if isinstance(relation, ClutteredOn)]
+        assert len(clutter_relations) == 1, (
+            f"Clutter member '{subject.name}' has {len(clutter_relations)} ClutteredOn relations; it belongs to one"
+            " pile."
+        )
+        spatial = [type(relation).__name__ for relation in subject.get_spatial_relations()]
+        assert not spatial, (
+            f"Clutter member '{subject.name}' also carries {spatial}, which constrain a pose the pour "
+            "discards. The layout would be validated against a pose that never reaches sim."
         )
 
 

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -281,6 +281,73 @@ class IsAnchor(RelationBase):
 
 
 @register_object_relation
+class ClutteredOn(RelationBase):
+    """Places this object as one member of a settled clutter group on a support surface.
+
+    Group members are positioned by dropping them above the support and letting physics
+    settle, rather than by the relation solver. A settled pile has objects touching and
+    resting at arbitrary tilts, which the solver cannot express: it forbids overlap
+    globally and optimises positions only.
+
+    Deriving from ``RelationBase`` rather than ``Relation`` is what keeps members out of
+    gradient descent, since only ``Relation`` and ``UnaryRelation`` reach the loss.
+
+    Usage:
+        table.add_relation(IsAnchor())
+        for tool in tools:
+            tool.add_relation(ClutteredOn(table, group="tools"))
+    """
+
+    name = "cluttered_on"
+
+    def __init__(
+        self,
+        parent: PlaceableAsset,
+        group: str = "clutter",
+        spread: float = 1.0,
+        gap_m: float = 0.03,
+        clearance_m: float = 0.01,
+        random_yaw: bool = True,
+    ):
+        """
+        Args:
+            parent: The support asset the group comes to rest on.
+            group: Name tying members of one pile together. Assets sharing a parent and a
+                group are dropped as a single pile.
+            spread: Scales the usable fraction of the support's footprint about its centre.
+                Below 1.0 concentrates the pile; above 1.0 is rejected.
+            gap_m: Vertical gap left between an object and whatever it is dropped on top of.
+            clearance_m: Height above the support surface at which the lowest layer starts.
+            random_yaw: Whether to sample a yaw per object before dropping.
+        """
+        assert 0.0 < spread <= 1.0, f"spread must be in (0, 1], got {spread}"
+        assert gap_m >= 0.0, f"gap_m must be non-negative, got {gap_m}"
+        assert clearance_m >= 0.0, f"clearance_m must be non-negative, got {clearance_m}"
+        assert group, "group must be a non-empty name"
+        self.parent = parent
+        self.group = group
+        self.spread = spread
+        self.gap_m = gap_m
+        self.clearance_m = clearance_m
+        self.random_yaw = random_yaw
+
+    @staticmethod
+    def is_unary() -> bool:
+        """Return whether the relation constrains a single object."""
+        return False
+
+    def validate_placement_configuration(self, subject: PlaceableAsset, objects: set[PlaceableAsset]) -> None:
+        """Reject a clutter member whose support is absent or is itself clutter."""
+        assert (
+            self.parent in objects
+        ), f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is not part of the placement."
+        assert not self.parent.has_relation(ClutteredOn), (
+            f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is itself clutter. "
+            "Piles cannot be stacked on piles; give the group a settled support instead."
+        )
+
+
+@register_object_relation
 class RequiresReachability(RelationBase):
     """Indicates the robot shall be able to reach this object.
 

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -337,13 +337,29 @@ class ClutteredOn(RelationBase):
         return False
 
     def validate_placement_configuration(self, subject: PlaceableAsset, objects: set[PlaceableAsset]) -> None:
-        """Reject a clutter member whose support is absent or is itself clutter."""
+        """Reject a member whose support, own relations or anchoring make the pour meaningless."""
         assert (
             self.parent in objects
         ), f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is not part of the placement."
+        assert self.parent is not subject, f"Clutter member '{subject.name}' cannot rest on itself."
         assert not self.parent.has_relation(ClutteredOn), (
             f"Clutter member '{subject.name}' rests on '{self.parent.name}', which is itself clutter. "
             "Piles cannot be stacked on piles; give the group a settled support instead."
+        )
+        # A pour assigns the member's pose, so anything else claiming to place it is a
+        # contradiction that would otherwise resolve silently to whichever ran last.
+        assert (
+            not subject.is_anchor
+        ), f"Clutter member '{subject.name}' is also an anchor. An anchor holds a fixed pose, but a pour assigns one."
+        clutter_relations = [relation for relation in subject.get_relations() if isinstance(relation, ClutteredOn)]
+        assert len(clutter_relations) == 1, (
+            f"Clutter member '{subject.name}' has {len(clutter_relations)} ClutteredOn relations; it belongs to one"
+            " pile."
+        )
+        spatial = [type(relation).__name__ for relation in subject.get_spatial_relations()]
+        assert not spatial, (
+            f"Clutter member '{subject.name}' also carries {spatial}, which constrain a pose the pour "
+            "discards. The layout would be validated against a pose that never reaches sim."
         )
 
 

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -16,6 +16,7 @@ from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_reference import ObjectReference
 from isaaclab_arena.assets.object_set import RigidObjectSet
+from isaaclab_arena.relations.clutter_groups import is_clutter_member
 from isaaclab_arena.utils.configclass import make_configclass
 from isaaclab_arena.utils.phyx_utils import add_contact_report
 from isaaclab_arena.variations.variation_base import VariationBase
@@ -116,7 +117,9 @@ class Scene:
             if not isinstance(asset, (Object, ObjectReference)):
                 continue
             # Those with spatial relations or an anchor, exclude those are only used in validation, e.g. RequiresReachability.
-            if asset.get_spatial_relations() or asset.is_anchor:
+            # Clutter members carry no spatial relation, because a pour positions them rather than the
+            # optimizer, but they still need the placement pass to receive any pose at all.
+            if asset.get_spatial_relations() or asset.is_anchor or is_clutter_member(asset):
                 objects_with_relations.append(asset)
         return objects_with_relations
 

--- a/isaaclab_arena/scripts/run_clutter_end_to_end.py
+++ b/isaaclab_arena/scripts/run_clutter_end_to_end.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a clutter pile through the real placement path and report how it comes to rest.
+
+Unlike the pour experiment, which writes poses directly, this declares clutter with the
+``cluttered_on`` relation and lets the solver, pour planner and validators do the work:
+
+    ./isaaclab_arena/scripts/run_clutter_end_to_end.py --headless --objects 12
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def add_experiment_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--objects", type=int, default=12, help="Number of clutter objects to pour.")
+    parser.add_argument("--group", type=str, default="tools", help="Clutter group name.")
+    parser.add_argument("--spread", type=float, default=1.0, help="Fraction of the support footprint to use.")
+    parser.add_argument("--gap_m", type=float, default=0.03, help="Vertical gap between stacked drop poses.")
+    parser.add_argument("--max_steps", type=int, default=2000, help="Physics step budget for settling.")
+    parser.add_argument("--poll_every", type=int, default=50, help="Physics steps between pose polls.")
+    parser.add_argument("--layout_seed", type=int, default=0, help="Placement seed.")
+    parser.add_argument(
+        "--containment_margin_m",
+        type=float,
+        default=0.0,
+        help="How far outside the support an object may rest before counting as fallen off.",
+    )
+
+
+SUPPORT_ASSET = "office_table_background"
+CLUTTER_ASSETS = [
+    "tomato_soup_can",
+    "cracker_box",
+    "sugar_box",
+    "mustard_bottle",
+    "dex_cube",
+    "mug",
+    "power_drill",
+]
+
+
+def _build_environment(args_cli):
+    """A table with a declared clutter group resting on it."""
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.no_task import NoTask
+    from isaaclab_arena.utils.pose import Pose
+
+    registry = AssetRegistry()
+    light = registry.get_asset_by_name("light")(spawner_cfg=sim_utils.DomeLightCfg(intensity=1500.0))
+    ground = registry.get_asset_by_name("ground_plane")()
+
+    support = registry.get_asset_by_name(SUPPORT_ASSET)()
+    support.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    support.add_relation(IsAnchor())
+
+    members = []
+    for index in range(args_cli.objects):
+        asset_name = CLUTTER_ASSETS[index % len(CLUTTER_ASSETS)]
+        member = registry.get_asset_by_name(asset_name)(instance_name=f"{asset_name}_{index}")
+        member.add_relation(ClutteredOn(support, group=args_cli.group, spread=args_cli.spread, gap_m=args_cli.gap_m))
+        members.append(member)
+
+    scene = Scene(assets=[ground, light, support, *members])
+    arena_env = IsaacLabArenaEnvironment(name="clutter_end_to_end", scene=scene, task=NoTask())
+    return arena_env, support, members
+
+
+def _run(simulation_app, args_cli) -> bool:
+    import torch
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
+    from isaaclab_arena.relations.clutter_pour import region_above_support
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker, check_resting_poses
+    from isaaclab_arena.utils import physics_settle
+
+    arena_env, support, members = _build_environment(args_cli)
+    args_cli.num_envs = 1
+    for name, default in (("language_instruction", None), ("mimic", False)):
+        if not hasattr(args_cli, name):
+            setattr(args_cli, name, default)
+    env = ArenaEnvBuilder(arena_env, args_cli).make_registered()
+    env.reset()
+
+    scene = env.unwrapped.scene
+    member_keys = [member.get_scene_key() for member in members]
+    names = [member.name for member in members]
+
+    support_bbox = get_bounding_box_per_env(support, 1)
+    support_position = support.get_initial_pose().position_xyz
+    region = region_above_support(tuple(float(v) for v in support_position), support_bbox, args_cli.spread)
+    print(
+        f"\nsupport top z = {region.floor_z:.3f}; region "
+        f"x[{region.min_x:.3f},{region.max_x:.3f}] y[{region.min_y:.3f},{region.max_y:.3f}]"
+    )
+
+    def _poses() -> tuple[torch.Tensor, torch.Tensor]:
+        states = torch.stack([scene[key].data.root_state_w[0] for key in member_keys])
+        return states[:, :3] - scene.env_origins[0], states[:, 3:7]
+
+    spawn_positions, _ = _poses()
+    above = int((spawn_positions[:, 2] > region.floor_z).sum())
+    print(f"spawned above the support surface: {above}/{len(members)}")
+
+    params = ClutterSettleParams(containment_margin_m=args_cli.containment_margin_m)
+    tracker = SettleTracker(params)
+    settled_at = None
+    stepped = 0
+    while stepped < args_cli.max_steps:
+        chunk = min(args_cli.poll_every, args_cli.max_steps - stepped)
+        physics_settle.step_physics(env, chunk)
+        stepped += chunk
+        positions, rotations = _poses()
+        if tracker.update(positions, rotations) and settled_at is None:
+            settled_at = stepped
+            break
+
+    positions, _ = _poses()
+    verdict = check_resting_poses(positions, region, params)
+
+    print(f"\nsettled at: {settled_at if settled_at is not None else 'NOT SETTLED'} (budget {args_cli.max_steps})")
+    print(f"rest verdict: {verdict.describe(names)}")
+    for name, position in zip(names, positions):
+        print(f"  {name:24s} ({position[0]:7.3f},{position[1]:7.3f},{position[2]:7.3f})")
+
+    env.close()
+    return settled_at is not None and verdict.ok
+
+
+def main() -> None:
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+    from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+
+    parser = get_isaaclab_arena_cli_parser()
+    add_experiment_args(parser)
+    args_cli, unknown = parser.parse_known_args()
+    assert not unknown, f"unrecognised arguments: {unknown}"
+    # Clutter refuses to pour without a seed, since an unreproducible pile defeats seeding.
+    if args_cli.placement_seed is None:
+        args_cli.placement_seed = args_cli.layout_seed
+
+    with SimulationAppContext(args_cli) as simulation_app:
+        ok = _run(simulation_app, args_cli)
+        print(f"\nRESULT: {'PASS' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena/scripts/run_clutter_end_to_end.py
+++ b/isaaclab_arena/scripts/run_clutter_end_to_end.py
@@ -30,6 +30,32 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
         default=0.0,
         help="How far outside the support an object may rest before counting as fallen off.",
     )
+    parser.add_argument(
+        "--record_video",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write an mp4 of the pour to PATH. Adds a fixed camera and forces --enable_cameras. "
+            "Note that enabling cameras diverges Newton above roughly 20 objects."
+        ),
+    )
+    parser.add_argument("--video_every", type=int, default=4, help="Capture a frame every N physics steps.")
+    parser.add_argument("--video_fps", type=int, default=30, help="Frame rate of the written mp4.")
+    parser.add_argument(
+        "--region_hint",
+        type=float,
+        default=1.6,
+        help="Approximate support width in metres, used only to frame the video camera.",
+    )
+    parser.add_argument(
+        "--show_pour",
+        action="store_true",
+        help=(
+            "Skip settling the pool at build time so the pour happens on this script's steps "
+            "and can be watched. The pile is normally already at rest when a reset writes it."
+        ),
+    )
 
 
 SUPPORT_ASSET = "office_table_background"
@@ -42,6 +68,12 @@ CLUTTER_ASSETS = [
     "mug",
     "power_drill",
 ]
+
+
+def _disable_build_time_settle(env_cfg):
+    """Leave the pool holding drop poses so the pour itself is visible."""
+    env_cfg.settle_clutter_on_build = False
+    return env_cfg
 
 
 def _build_environment(args_cli):
@@ -71,7 +103,27 @@ def _build_environment(args_cli):
         members.append(member)
 
     scene = Scene(assets=[ground, light, support, *members])
-    arena_env = IsaacLabArenaEnvironment(name="clutter_end_to_end", scene=scene, task=NoTask())
+    callbacks = []
+    if args_cli.record_video:
+        import functools
+
+        from isaaclab_arena.scripts.run_clutter_pour_experiment import _add_video_camera
+
+        half = 0.5 * max(args_cli.region_hint, 0.1)
+        callbacks.append(functools.partial(_add_video_camera, region_half_x=half, region_half_y=half))
+    if args_cli.show_pour:
+        callbacks.append(_disable_build_time_settle)
+
+    def env_cfg_callback(env_cfg):
+        for callback in callbacks:
+            env_cfg = callback(env_cfg)
+        return env_cfg
+
+    env_cfg_callback = env_cfg_callback if callbacks else None
+
+    arena_env = IsaacLabArenaEnvironment(
+        name="clutter_end_to_end", scene=scene, task=NoTask(), env_cfg_callback=env_cfg_callback
+    )
     return arena_env, support, members
 
 
@@ -82,10 +134,11 @@ def _run(simulation_app, args_cli) -> bool:
     from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
     from isaaclab_arena.relations.clutter_pour import region_above_support
     from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker, check_resting_poses
+    from isaaclab_arena.scripts.run_clutter_pour_experiment import _capture_frame, _write_video
     from isaaclab_arena.utils import physics_settle
 
     arena_env, support, members = _build_environment(args_cli)
-    args_cli.num_envs = 1
+    # The CLI parser supplies --num_envs; honour it so parallel envs can be inspected too.
     for name, default in (("language_instruction", None), ("mimic", False)):
         if not hasattr(args_cli, name):
             setattr(args_cli, name, default)
@@ -116,18 +169,27 @@ def _run(simulation_app, args_cli) -> bool:
 
     params = ClutterSettleParams(containment_margin_m=args_cli.containment_margin_m)
     tracker = SettleTracker(params)
+    frames: list | None = [] if args_cli.record_video else None
     settled_at = None
     stepped = 0
     while stepped < args_cli.max_steps:
-        chunk = min(args_cli.poll_every, args_cli.max_steps - stepped)
-        physics_settle.step_physics(env, chunk)
+        # Capture often enough to see the pour when recording; otherwise poll at full stride.
+        chunk = min(args_cli.video_every if frames is not None else args_cli.poll_every, args_cli.max_steps - stepped)
+        physics_settle.step_physics(env, chunk, render=frames is not None)
         stepped += chunk
+        if frames is not None:
+            _capture_frame(scene, frames)
         positions, rotations = _poses()
-        if tracker.update(positions, rotations) and settled_at is None:
+        if stepped % args_cli.poll_every == 0 and tracker.update(positions, rotations) and settled_at is None:
             settled_at = stepped
             break
 
     positions, _ = _poses()
+    if frames is not None:
+        # Linger on the settled pile so the video ends on the result rather than mid-fall.
+        for _ in range(args_cli.video_fps):
+            _capture_frame(scene, frames)
+        _write_video(frames, args_cli.record_video, args_cli.video_fps)
     verdict = check_resting_poses(positions, region, params)
 
     print(f"\nsettled at: {settled_at if settled_at is not None else 'NOT SETTLED'} (budget {args_cli.max_steps})")
@@ -150,6 +212,9 @@ def main() -> None:
     # Clutter refuses to pour without a seed, since an unreproducible pile defeats seeding.
     if args_cli.placement_seed is None:
         args_cli.placement_seed = args_cli.layout_seed
+    if args_cli.record_video:
+        # The pour camera only produces frames when the renderer is up.
+        args_cli.enable_cameras = True
 
     with SimulationAppContext(args_cli) as simulation_app:
         ok = _run(simulation_app, args_cli)

--- a/isaaclab_arena/scripts/run_clutter_end_to_end.py
+++ b/isaaclab_arena/scripts/run_clutter_end_to_end.py
@@ -98,7 +98,9 @@ def _run(simulation_app, args_cli) -> bool:
 
     support_bbox = get_bounding_box_per_env(support, 1)
     support_position = support.get_initial_pose().position_xyz
-    region = region_above_support(tuple(float(v) for v in support_position), support_bbox, args_cli.spread)
+    # Judge the settled pile against the whole support, not the shrunk region it was poured
+    # into: a tight pour is meant to relax outward as it settles.
+    region = region_above_support(tuple(float(v) for v in support_position), support_bbox)
     print(
         f"\nsupport top z = {region.floor_z:.3f}; region "
         f"x[{region.min_x:.3f},{region.max_x:.3f}] y[{region.min_y:.3f},{region.max_y:.3f}]"

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -18,6 +18,7 @@ This is a diagnostic, not part of the placement pipeline.
 from __future__ import annotations
 
 import argparse
+import functools
 import math
 
 
@@ -66,6 +67,17 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--clutter_spread", type=float, default=1.0, help="Scales the usable region.")
     parser.add_argument("--layout_seed", type=int, default=0, help="Layout seed.")
     parser.add_argument(
+        "--max_escape_fraction",
+        type=float,
+        default=0.0,
+        help="Fraction of objects allowed to end up outside the region before the run fails.",
+    )
+    parser.add_argument(
+        "--dump_bboxes",
+        action="store_true",
+        help="Print each object's measured bounding-box size before computing drop poses.",
+    )
+    parser.add_argument(
         "--layers",
         type=int,
         default=1,
@@ -88,6 +100,32 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
         default=0.0,
         help="Seconds to hold the pre-pour scene, so the drop layout is visible before it falls.",
     )
+    parser.add_argument(
+        "--record_video",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Write an mp4 of the pour to PATH. Adds a fixed camera and forces --enable_cameras.",
+    )
+    parser.add_argument(
+        "--video_every",
+        type=int,
+        default=4,
+        help="Capture a frame every N physics steps; lower is smoother but slower.",
+    )
+    parser.add_argument("--video_fps", type=int, default=30, help="Frame rate of the written mp4.")
+    parser.add_argument(
+        "--njmax",
+        type=int,
+        default=None,
+        help="Override the Newton solver's max-constraint budget (default preset value is 300).",
+    )
+    parser.add_argument(
+        "--nconmax",
+        type=int,
+        default=None,
+        help="Override the Newton solver's max-contact budget (default preset value is 400).",
+    )
 
 
 # Grocery-sized props standing in for tools: a mix of flat, bulky and elongated shapes.
@@ -102,6 +140,43 @@ CLUTTER_ASSETS = [
     "power_drill",
 ]
 BIN_ASSET = "grey_bin_robolab"
+
+
+def _is_finite(position) -> bool:
+    """Whether every component of a position is finite (a diverged solver writes NaN/inf)."""
+    return all(math.isfinite(float(v)) for v in position)
+
+
+def _solver_budget_overridden(args_cli) -> bool:
+    """Whether the user asked for non-default Newton constraint/contact budgets."""
+    return args_cli.njmax is not None or args_cli.nconmax is not None
+
+
+def _apply_callbacks(env_cfg, callbacks):
+    """Apply each env-cfg callback in order."""
+    for callback in callbacks:
+        env_cfg = callback(env_cfg)
+    return env_cfg
+
+
+def _tune_newton_solver(env_cfg, njmax: int | None, nconmax: int | None):
+    """Install the Newton preset with enlarged constraint/contact budgets.
+
+    The stock ``newton`` preset is sized for dexterous manipulation (a hand plus a
+    few props); a deep clutter pile needs a far larger contact budget.
+    """
+    import copy
+
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import ArenaPhysicsCfg
+
+    physics = copy.deepcopy(ArenaPhysicsCfg().newton)
+    if njmax is not None:
+        physics.solver_cfg.njmax = njmax
+    if nconmax is not None:
+        physics.solver_cfg.nconmax = nconmax
+    print(f"newton solver budget: njmax={physics.solver_cfg.njmax} nconmax={physics.solver_cfg.nconmax}")
+    env_cfg.sim.physics = physics
+    return env_cfg
 
 
 def _build_environment(args_cli):
@@ -119,12 +194,12 @@ def _build_environment(args_cli):
     light = registry.get_asset_by_name("light")(spawner_cfg=sim_utils.DomeLightCfg(intensity=1500.0))
     ground = registry.get_asset_by_name("ground_plane")()
 
-    # The bin is always the solver's anchor (the ground plane has no bounding box); in floor
-    # mode it is parked well clear of the pour region so objects land on open ground.
-    bin_position = BIN_POSITION if args_cli.region == "bin" else (5.0, 0.0, 0.0)
-    bin_asset = registry.get_asset_by_name(BIN_ASSET)()
-    bin_asset.set_initial_pose(Pose(position_xyz=bin_position, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
-    bin_asset.add_relation(IsAnchor())
+    pour_into_bin = args_cli.region == "bin"
+    bin_asset = None
+    if pour_into_bin:
+        bin_asset = registry.get_asset_by_name(BIN_ASSET)()
+        bin_asset.set_initial_pose(Pose(position_xyz=BIN_POSITION, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+        bin_asset.add_relation(IsAnchor())
 
     # Park the clutter off to one side; the experiment writes their real poses after reset.
     # The palette repeats for large counts, so each repeat needs its own instance name --
@@ -133,11 +208,33 @@ def _build_environment(args_cli):
     for index in range(args_cli.objects):
         asset_name = CLUTTER_ASSETS[index % len(CLUTTER_ASSETS)]
         obj = registry.get_asset_by_name(asset_name)(instance_name=f"{asset_name}_{index}")
-        obj.add_relation(AtPosition(x=1.5 + 0.3 * index, y=0.0, z=0.1))
+        parked = Pose(position_xyz=(1.5 + 0.3 * index, 0.0, 0.1), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+        if not pour_into_bin and index == 0:
+            # Floor pours keep the bin out of the scene entirely: the ground plane cannot anchor
+            # the solver (it has no bounding box), so the first clutter object does instead. Its
+            # pose is overwritten with the drop layout after reset like every other object.
+            obj.set_initial_pose(parked)
+            obj.add_relation(IsAnchor())
+        else:
+            obj.add_relation(AtPosition(x=parked.position_xyz[0], y=parked.position_xyz[1], z=parked.position_xyz[2]))
         objects.append(obj)
 
-    scene = Scene(assets=[ground, light, bin_asset, *objects])
-    arena_env = IsaacLabArenaEnvironment(name="clutter_pour_experiment", scene=scene, task=NoTask())
+    scene = Scene(assets=[ground, light, *([bin_asset] if bin_asset else []), *objects])
+    callbacks = []
+    if args_cli.record_video:
+        half_x, half_y = (
+            (0.5 * args_cli.region_size[0], 0.5 * args_cli.region_size[1])
+            if args_cli.region == "floor"
+            else (0.21, 0.14)
+        )
+        callbacks.append(functools.partial(_add_video_camera, region_half_x=half_x, region_half_y=half_y))
+    if _solver_budget_overridden(args_cli):
+        callbacks.append(functools.partial(_tune_newton_solver, njmax=args_cli.njmax, nconmax=args_cli.nconmax))
+    env_cfg_callback = functools.partial(_apply_callbacks, callbacks=callbacks) if callbacks else None
+
+    arena_env = IsaacLabArenaEnvironment(
+        name="clutter_pour_experiment", scene=scene, task=NoTask(), env_cfg_callback=env_cfg_callback
+    )
     return arena_env, objects, bin_asset
 
 
@@ -166,6 +263,12 @@ def _run(simulation_app, args_cli) -> bool:
     for name, default in (("language_instruction", None), ("mimic", False)):
         if not hasattr(args_cli, name):
             setattr(args_cli, name, default)
+    backend = args_cli.presets or "physx"
+    if _solver_budget_overridden(args_cli):
+        assert backend == "newton", "--njmax/--nconmax only apply to --presets newton"
+        # The builder applies presets *after* the env-cfg callback and treats them as final
+        # authority, so a tuned solver config only survives if no preset is requested.
+        args_cli.presets = None
     env = ArenaEnvBuilder(arena_env, args_cli).make_registered()
     env.reset()
 
@@ -206,13 +309,18 @@ def _run(simulation_app, args_cli) -> bool:
     generator.manual_seed(args_cli.layout_seed)
 
     names = [obj.name for obj in objects]
+    if args_cli.dump_bboxes:
+        for name, bbox, obj in zip(names, bboxes, objects):
+            size = [round(float(v), 5) for v in bbox.size[0]]
+            print(f"bbox {name}: {size}  usd={getattr(obj, 'usd_path', None)}")
     layers = max(1, args_cli.layers)
     per_layer = math.ceil(len(objects) / layers)
     steps_per_layer = max(1, args_cli.settle_steps // layers)
-    print(f"\n=== pouring {len(objects)} objects in {layers} layer(s), backend={args_cli.presets or 'physx'} ===")
+    print(f"\n=== pouring {len(objects)} objects in {layers} layer(s), backend={backend} ===")
 
     steps_done = 0
     settled_at = None
+    frames: list | None = [] if args_cli.record_video else None
 
     for layer_index in range(layers):
         lo, hi = layer_index * per_layer, min((layer_index + 1) * per_layer, len(objects))
@@ -236,25 +344,32 @@ def _run(simulation_app, args_cli) -> bool:
         )
 
         for name, pose in zip(layer_names, poses):
-            asset = scene[name]
-            state = asset.data.default_root_state.clone()[0:1]
-            state[0, 0:3] = torch.tensor(pose.position, device=device)
-            state[0, 3:7] = torch.tensor(list(pose.rotation_xyzw), device=device)
-            state[0, 7:13] = 0.0
-            asset.write_root_state_to_sim(state)
+            _write_pose(scene[name], pose, device)
         scene.write_data_to_sim()
 
         if args_cli.pause_before_pour > 0.0:
             _hold(env, args_cli.pause_before_pour, freeze=layer_names)
 
+        if frames is not None:
+            # Hold on the drop layout for a beat so the pre-pour arrangement is visible.
+            physics_settle.step_physics(env, 1, render=True)
+            for _ in range(args_cli.video_fps // 2):
+                _capture_frame(scene, frames)
+
         # A new layer changes the object set, so the previous snapshot no longer lines up.
         previous_poses = None
         layer_steps = 0
         while layer_steps < steps_per_layer:
-            chunk = min(args_cli.report_every, steps_per_layer - layer_steps)
-            physics_settle.step_physics(env, chunk, render=args_cli.render_settle)
+            chunk = args_cli.video_every if frames is not None else args_cli.report_every
+            chunk = min(chunk, steps_per_layer - layer_steps)
+            physics_settle.step_physics(env, chunk, render=args_cli.render_settle or frames is not None)
             layer_steps += chunk
             steps_done += chunk
+
+            if frames is not None:
+                _capture_frame(scene, frames)
+                if layer_steps % args_cli.report_every != 0 and layer_steps < steps_per_layer:
+                    continue
 
             current = _read_poses(scene, names[:hi])
             moved, turned = _pose_delta(previous_poses, current) if previous_poses else (float("inf"), float("inf"))
@@ -272,24 +387,52 @@ def _run(simulation_app, args_cli) -> bool:
     print("\n=== result ===")
     print(f"  settled first observed at: {settled_at if settled_at is not None else 'NOT SETTLED'}")
 
+    # A diverged solver writes NaN poses, which compare false against every bound and would
+    # otherwise be reported as objects that merely left the region. Fail on that explicitly.
+    diverged = [name for name in names if not _is_finite(_root_position(scene[name]))]
+    if diverged:
+        print(f"  DIVERGED: {len(diverged)}/{len(names)} objects have non-finite poses -> {diverged[:5]}")
+
     escaped = []
     for name in names:
         position = _root_position(scene[name])
-        inside = (
+        inside = _is_finite(position) and (
             region.min_x <= float(position[0]) <= region.max_x and region.min_y <= float(position[1]) <= region.max_y
         )
         if not inside:
             escaped.append((name, [round(float(v), 3) for v in position]))
         print(f"  {name:22s} final xyz=({position[0]:6.3f},{position[1]:6.3f},{position[2]:6.3f}) in_region={inside}")
 
-    print(f"\n  escaped: {len(escaped)}/{len(names)}" + (f" -> {escaped}" if escaped else ""))
+    # On open floor the region bounds spawning only, so some spreading is expected; a large
+    # fraction leaving still means the pour was too dense for the area and must not pass.
+    on_floor = args_cli.region == "floor"
+    label = "outside spawn region" if on_floor else "escaped"
+    escaped_fraction = len(escaped) / max(1, len(names))
+    over_budget = escaped_fraction > args_cli.max_escape_fraction
+    print(
+        f"\n  {label}: {len(escaped)}/{len(names)} ({escaped_fraction:.0%}, budget {args_cli.max_escape_fraction:.0%})"
+        + (f" -> {escaped}" if escaped else "")
+    )
+
+    if frames is not None:
+        # Linger on the settled pile so the video ends on the result.
+        for _ in range(args_cli.video_fps):
+            _capture_frame(scene, frames)
+        _write_video(frames, args_cli.record_video, args_cli.video_fps)
 
     if args_cli.hold_seconds > 0.0:
         print(f"\n=== holding result for {args_cli.hold_seconds:.0f}s ===")
         _hold(env, args_cli.hold_seconds)
 
     env.close()
-    return settled_at is not None and not escaped
+    for failure, reason in (
+        (diverged, "physics diverged (non-finite poses)"),
+        (settled_at is None, "never settled"),
+        (over_budget, f"{label} exceeded budget"),
+    ):
+        if failure:
+            print(f"  FAILED: {reason}")
+    return not diverged and settled_at is not None and not over_budget
 
 
 def _hold(env, seconds: float, freeze: list[str] | None = None) -> None:
@@ -297,20 +440,105 @@ def _hold(env, seconds: float, freeze: list[str] | None = None) -> None:
     import time
     import torch
 
+    import warp as wp
+
     from isaaclab_arena.utils import physics_settle
 
     deadline = time.time() + seconds
     frozen = None
     if freeze:
-        frozen = {name: env.unwrapped.scene[name].data.root_state_w[0:1].clone() for name in freeze}
+        frozen = {
+            name: (
+                wp.to_torch(env.unwrapped.scene[name].data.root_pos_w)[0:1].clone(),
+                wp.to_torch(env.unwrapped.scene[name].data.root_quat_w)[0:1].clone(),
+            )
+            for name in freeze
+        }
     while time.time() < deadline:
         if frozen:
-            for name, state in frozen.items():
-                held = state.clone()
-                held[0, 7:13] = torch.zeros(6, device=held.device)
-                env.unwrapped.scene[name].write_root_state_to_sim(held)
+            for name, (position, rotation) in frozen.items():
+                asset = env.unwrapped.scene[name]
+                root_pose = torch.cat([position, rotation], dim=1)
+                asset.write_root_pose_to_sim_index(root_pose=root_pose)
+                asset.write_root_velocity_to_sim_index(root_velocity=torch.zeros((1, 6), device=root_pose.device))
             env.unwrapped.scene.write_data_to_sim()
         physics_settle.step_physics(env, 1, render=True)
+
+
+VIDEO_CAMERA = "pour_cam"
+
+
+def _add_video_camera(env_cfg, region_half_x: float, region_half_y: float):
+    """Attach a fixed camera looking down at the pour region.
+
+    Added through the env-cfg callback rather than an embodiment because this scene has no
+    robot to mount it on. Framed from the reach of the region so the whole pile stays in shot
+    whatever size the region is.
+    """
+    import torch
+
+    import isaaclab.sim as sim_utils
+    from isaaclab.sensors import CameraCfg
+    from isaaclab.utils.math import create_rotation_matrix_from_view, quat_from_matrix
+
+    reach = max(region_half_x, region_half_y)
+    eye = (BIN_POSITION[0] + 2.2 * reach, BIN_POSITION[1] - 2.2 * reach, 1.6 * reach + 0.45)
+    target = (BIN_POSITION[0], BIN_POSITION[1], 0.05)
+
+    # Same convention as the placement code: OpenGL look-at, flipped to OpenCV/ROS optical.
+    rotation = create_rotation_matrix_from_view(
+        torch.tensor([eye], dtype=torch.float32), torch.tensor([target], dtype=torch.float32), "Z"
+    )[0] @ torch.diag(torch.tensor([1.0, -1.0, -1.0]))
+
+    env_cfg.scene.pour_cam = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/" + VIDEO_CAMERA,
+        update_period=0.0,
+        height=720,
+        width=1280,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(focal_length=18.0, focus_distance=4.0),
+        offset=CameraCfg.OffsetCfg(pos=eye, rot=tuple(quat_from_matrix(rotation).tolist()), convention="ros"),
+    )
+    return env_cfg
+
+
+def _capture_frame(scene, frames: list) -> None:
+    """Append the pour camera's current RGB frame."""
+    import numpy as np
+
+    rgb = scene[VIDEO_CAMERA].data.output["rgb"]
+    frames.append(np.ascontiguousarray(rgb[0, ..., :3].cpu().numpy().astype(np.uint8)))
+
+
+def _write_video(frames: list, path: str, fps: int) -> None:
+    """Write captured frames to an mp4, matching how Arena writes its other videos."""
+    import os
+
+    from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+
+    if not frames:
+        print(f"  no frames captured; skipping {path}")
+        return
+    os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+    clip = ImageSequenceClip(frames, fps=fps)
+    clip.write_videofile(path, logger=None, audio=False)
+    print(f"  wrote {len(frames)} frames to {path}")
+
+
+def _write_pose(asset, pose, device) -> None:
+    """Place an object at rest at ``pose``, on either physics backend.
+
+    Uses the keyword-only pose/velocity writers rather than ``write_root_state_to_sim``:
+    the latter is deprecated, and on the Newton backend its shim forwards positionally to a
+    keyword-only method, so it raises a TypeError before any physics runs.
+    """
+    import torch
+
+    root_pose = torch.zeros((1, 7), device=device)
+    root_pose[0, 0:3] = torch.tensor(pose.position, device=device)
+    root_pose[0, 3:7] = torch.tensor(list(pose.rotation_xyzw), device=device)
+    asset.write_root_pose_to_sim_index(root_pose=root_pose)
+    asset.write_root_velocity_to_sim_index(root_velocity=torch.zeros((1, 6), device=device))
 
 
 def _read_poses(scene, names):
@@ -390,6 +618,9 @@ def main() -> None:
     # feature that ran and did nothing.
     args_cli, unknown = parser.parse_known_args()
     assert not unknown, f"unrecognised arguments: {unknown}"
+    if args_cli.record_video:
+        # The pour camera only produces frames when the renderer is up.
+        args_cli.enable_cameras = True
 
     with SimulationAppContext(args_cli) as simulation_app:
         ok = _run(simulation_app, args_cli)

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -115,6 +115,13 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--video_fps", type=int, default=30, help="Frame rate of the written mp4.")
     parser.add_argument(
+        "--replicate_physics",
+        type=str,
+        default="true",
+        choices=("true", "false"),
+        help="Value of scene.replicate_physics when overriding the Newton solver budget.",
+    )
+    parser.add_argument(
         "--njmax",
         type=int,
         default=None,
@@ -159,7 +166,7 @@ def _apply_callbacks(env_cfg, callbacks):
     return env_cfg
 
 
-def _tune_newton_solver(env_cfg, njmax: int | None, nconmax: int | None):
+def _tune_newton_solver(env_cfg, njmax: int | None, nconmax: int | None, replicate_physics: bool):
     """Install the Newton preset with enlarged constraint/contact budgets.
 
     The stock ``newton`` preset is sized for dexterous manipulation (a hand plus a
@@ -174,8 +181,14 @@ def _tune_newton_solver(env_cfg, njmax: int | None, nconmax: int | None):
         physics.solver_cfg.njmax = njmax
     if nconmax is not None:
         physics.solver_cfg.nconmax = nconmax
-    print(f"newton solver budget: njmax={physics.solver_cfg.njmax} nconmax={physics.solver_cfg.nconmax}")
     env_cfg.sim.physics = physics
+    # This path runs with presets=None, which skips the builder block that would otherwise
+    # set replicate_physics for Newton. Reproduce it here so the budget is the only variable.
+    env_cfg.scene.replicate_physics = replicate_physics
+    print(
+        f"newton solver budget: njmax={physics.solver_cfg.njmax} nconmax={physics.solver_cfg.nconmax} "
+        f"replicate_physics={replicate_physics}"
+    )
     return env_cfg
 
 
@@ -229,7 +242,14 @@ def _build_environment(args_cli):
         )
         callbacks.append(functools.partial(_add_video_camera, region_half_x=half_x, region_half_y=half_y))
     if _solver_budget_overridden(args_cli):
-        callbacks.append(functools.partial(_tune_newton_solver, njmax=args_cli.njmax, nconmax=args_cli.nconmax))
+        callbacks.append(
+            functools.partial(
+                _tune_newton_solver,
+                njmax=args_cli.njmax,
+                nconmax=args_cli.nconmax,
+                replicate_physics=args_cli.replicate_physics != "false",
+            )
+        )
     env_cfg_callback = functools.partial(_apply_callbacks, callbacks=callbacks) if callbacks else None
 
     arena_env = IsaacLabArenaEnvironment(

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -18,6 +18,7 @@ This is a diagnostic, not part of the placement pipeline.
 from __future__ import annotations
 
 import argparse
+import math
 
 
 def add_experiment_args(parser: argparse.ArgumentParser) -> None:
@@ -39,11 +40,37 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--settle_steps", type=int, default=400, help="Physics steps to settle for.")
     parser.add_argument("--report_every", type=int, default=50, help="Steps between velocity reports.")
     parser.add_argument("--lin_vel_thresh", type=float, default=0.1, help="Settled linear speed (m/s).")
-    parser.add_argument("--ang_vel_thresh", type=float, default=0.1, help="Settled angular speed (rad/s).")
+    parser.add_argument(
+        "--ang_vel_thresh",
+        type=float,
+        default=0.8,
+        help=(
+            "Settled angular speed (rad/s), reported only. Objects in stable contact keep "
+            "micro-rocking at 0.25-0.65 rad/s indefinitely, so this cannot decide settling."
+        ),
+    )
+    parser.add_argument(
+        "--move_thresh_m",
+        type=float,
+        default=0.002,
+        help="Settled when no object translates more than this between checks.",
+    )
+    parser.add_argument(
+        "--turn_thresh_deg",
+        type=float,
+        default=2.0,
+        help="Settled when no object rotates more than this between checks.",
+    )
     parser.add_argument("--drop_order", type=str, default="flattest_first", help="as_listed|flattest_first|shuffle")
     parser.add_argument("--xy_sampling", type=str, default="grid_cells", help="grid_cells|uniform")
     parser.add_argument("--clutter_spread", type=float, default=1.0, help="Scales the usable region.")
     parser.add_argument("--layout_seed", type=int, default=0, help="Layout seed.")
+    parser.add_argument(
+        "--layers",
+        type=int,
+        default=1,
+        help="Pour in this many batches, settling between each so a later layer lands on the real pile.",
+    )
     parser.add_argument(
         "--render_settle",
         action="store_true",
@@ -177,50 +204,70 @@ def _run(simulation_app, args_cli) -> bool:
     bboxes = [get_bounding_box_per_env(obj, 1) for obj in objects]
     generator = torch.Generator()
     generator.manual_seed(args_cli.layout_seed)
-    poses = compute_drop_poses(bboxes, region, params, generator)
 
     names = [obj.name for obj in objects]
-    print(f"\n=== drop layout (floor_z={floor_z:.3f}, backend={args_cli.presets or 'physx'}) ===")
-    highest = 0.0
-    for name, bbox, pose in zip(names, bboxes, poses):
-        rotated = bbox.rotated_by_quat(torch.tensor([pose.rotation_xyzw], dtype=torch.float32))
-        bottom = pose.position[2] + float(rotated.bottom_surface_z[0])
-        highest = max(highest, pose.position[2] + float(rotated.top_surface_z[0]))
-        print(f"  {name:22s} xy=({pose.position[0]:6.3f},{pose.position[1]:6.3f}) bottom_z={bottom:.3f}")
-    print(f"  layout spans {highest - floor_z:.3f} m above the floor")
+    layers = max(1, args_cli.layers)
+    per_layer = math.ceil(len(objects) / layers)
+    steps_per_layer = max(1, args_cli.settle_steps // layers)
+    print(f"\n=== pouring {len(objects)} objects in {layers} layer(s), backend={args_cli.presets or 'physx'} ===")
 
-    # Write the drop layout into the sim.
-    for name, pose in zip(names, poses):
-        asset = scene[name]
-        root = asset.data.default_root_state.clone()[0:1] if hasattr(asset.data, "default_root_state") else None
-        state = torch.zeros((1, 13), device=device) if root is None else root
-        state[0, 0:3] = torch.tensor(pose.position, device=device)
-        x, y, z, w = pose.rotation_xyzw
-        state[0, 3:7] = torch.tensor([x, y, z, w], device=device)
-        state[0, 7:13] = 0.0
-        asset.write_root_state_to_sim(state)
-    scene.write_data_to_sim()
-
-    if args_cli.pause_before_pour > 0.0:
-        print(f"\n=== holding drop layout for {args_cli.pause_before_pour:.0f}s (objects frozen mid-air) ===")
-        _hold(env, args_cli.pause_before_pour, freeze=names)
-
-    print(f"\n=== settling ({args_cli.settle_steps} steps) ===")
     steps_done = 0
     settled_at = None
-    while steps_done < args_cli.settle_steps:
-        chunk = min(args_cli.report_every, args_cli.settle_steps - steps_done)
-        physics_settle.step_physics(env, chunk, render=args_cli.render_settle)
-        steps_done += chunk
-        settled = physics_settle.are_all_objects_settled_per_env(
-            env, [0], names, args_cli.lin_vel_thresh, args_cli.ang_vel_thresh
-        )[0]
-        max_lin, max_ang, worst = _max_speeds(scene, names)
-        print(
-            f"  step {steps_done:4d}: settled={settled!s:5s} max_lin={max_lin:6.3f} max_ang={max_ang:6.3f}  ({worst})"
+
+    for layer_index in range(layers):
+        lo, hi = layer_index * per_layer, min((layer_index + 1) * per_layer, len(objects))
+        if lo >= hi:
+            break
+        layer_names, layer_bboxes = names[lo:hi], bboxes[lo:hi]
+
+        # Later layers land on the pile the earlier ones actually formed, read from the sim,
+        # so the stack interleaves instead of reserving worst-case height up front.
+        layer_floor = floor_z if layer_index == 0 else _pile_top(scene, names[:lo], bboxes[:lo])
+        layer_region = ClutterRegion(region.min_x, region.min_y, region.max_x, region.max_y, layer_floor)
+        poses = compute_drop_poses(layer_bboxes, layer_region, params, generator)
+
+        highest = max(
+            pose.position[2] + float(bbox.rotated_by_quat(torch.tensor([pose.rotation_xyzw])).top_surface_z[0])
+            for bbox, pose in zip(layer_bboxes, poses)
         )
-        if settled and settled_at is None:
-            settled_at = steps_done
+        print(
+            f"\n--- layer {layer_index + 1}/{layers}: {len(layer_names)} objects, "
+            f"floor_z={layer_floor:.3f}, spans {highest - layer_floor:.3f} m ---"
+        )
+
+        for name, pose in zip(layer_names, poses):
+            asset = scene[name]
+            state = asset.data.default_root_state.clone()[0:1]
+            state[0, 0:3] = torch.tensor(pose.position, device=device)
+            state[0, 3:7] = torch.tensor(list(pose.rotation_xyzw), device=device)
+            state[0, 7:13] = 0.0
+            asset.write_root_state_to_sim(state)
+        scene.write_data_to_sim()
+
+        if args_cli.pause_before_pour > 0.0:
+            _hold(env, args_cli.pause_before_pour, freeze=layer_names)
+
+        # A new layer changes the object set, so the previous snapshot no longer lines up.
+        previous_poses = None
+        layer_steps = 0
+        while layer_steps < steps_per_layer:
+            chunk = min(args_cli.report_every, steps_per_layer - layer_steps)
+            physics_settle.step_physics(env, chunk, render=args_cli.render_settle)
+            layer_steps += chunk
+            steps_done += chunk
+
+            current = _read_poses(scene, names[:hi])
+            moved, turned = _pose_delta(previous_poses, current) if previous_poses else (float("inf"), float("inf"))
+            previous_poses = current
+            settled = moved <= args_cli.move_thresh_m and turned <= args_cli.turn_thresh_deg
+            max_lin, max_ang, worst = _max_speeds(scene, names[:hi])
+            print(
+                f"  step {steps_done:4d}: settled={settled!s:5s} "
+                f"moved={moved:7.4f}m turned={turned:6.2f}deg  |  "
+                f"max_lin={max_lin:6.3f} max_ang={max_ang:6.3f} ({worst})"
+            )
+            if settled and settled_at is None and layer_index == layers - 1:
+                settled_at = steps_done
 
     print("\n=== result ===")
     print(f"  settled first observed at: {settled_at if settled_at is not None else 'NOT SETTLED'}")
@@ -266,6 +313,52 @@ def _hold(env, seconds: float, freeze: list[str] | None = None) -> None:
         physics_settle.step_physics(env, 1, render=True)
 
 
+def _read_poses(scene, names):
+    """Current world positions and orientations, as CPU tensors."""
+    import torch
+
+    import warp as wp
+
+    positions = torch.stack([wp.to_torch(scene[name].data.root_pos_w)[0].cpu() for name in names])
+    rotations = torch.stack([wp.to_torch(scene[name].data.root_quat_w)[0].cpu() for name in names])
+    return positions, rotations
+
+
+def _pose_delta(previous, current) -> tuple[float, float]:
+    """Largest translation (m) and rotation (deg) any object underwent between two snapshots.
+
+    Preferred over a velocity threshold: an object wedged in a pile keeps micro-rocking at a
+    non-trivial angular speed indefinitely while going nowhere, so angular velocity never
+    crosses a strict threshold even though the layout is stable. Displacement measures what
+    actually matters -- whether the pile is still changing.
+    """
+    import torch
+
+    previous_positions, previous_rotations = previous
+    positions, rotations = current
+    moved = float((positions - previous_positions).norm(dim=1).max())
+    # Angle between unit quaternions, sign-invariant because q and -q are the same rotation.
+    dots = (rotations * previous_rotations).sum(dim=1).abs().clamp(max=1.0)
+    turned = float(torch.rad2deg(2.0 * torch.acos(dots)).max())
+    return moved, turned
+
+
+def _pile_top(scene, names, bboxes) -> float:
+    """Highest point of the objects already poured, as they currently rest."""
+    import torch
+
+    import warp as wp
+
+    top = 0.0
+    for name, bbox in zip(names, bboxes):
+        data = scene[name].data
+        z = float(wp.to_torch(data.root_pos_w)[0][2])
+        quat = wp.to_torch(data.root_quat_w)[0]
+        rotated = bbox.rotated_by_quat(torch.tensor([quat.tolist()], dtype=torch.float32))
+        top = max(top, z + float(rotated.top_surface_z[0]))
+    return top
+
+
 def _max_speeds(scene, names):
     """Largest linear/angular speed across the clutter, and which object holds it."""
     import warp as wp
@@ -293,7 +386,10 @@ def main() -> None:
 
     parser = get_isaaclab_arena_cli_parser()
     add_experiment_args(parser)
-    args_cli, _ = parser.parse_known_args()
+    # Reject unknown flags rather than ignoring them: a silently-dropped option looks like a
+    # feature that ran and did nothing.
+    args_cli, unknown = parser.parse_known_args()
+    assert not unknown, f"unrecognised arguments: {unknown}"
 
     with SimulationAppContext(args_cli) as simulation_app:
         ok = _run(simulation_app, args_cli)

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -39,17 +39,7 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
         help="Floor region size in metres; only used with --region floor.",
     )
     parser.add_argument("--settle_steps", type=int, default=400, help="Physics steps to settle for.")
-    parser.add_argument("--report_every", type=int, default=50, help="Steps between velocity reports.")
-    parser.add_argument("--lin_vel_thresh", type=float, default=0.1, help="Settled linear speed (m/s).")
-    parser.add_argument(
-        "--ang_vel_thresh",
-        type=float,
-        default=0.8,
-        help=(
-            "Settled angular speed (rad/s), reported only. Objects in stable contact keep "
-            "micro-rocking at 0.25-0.65 rad/s indefinitely, so this cannot decide settling."
-        ),
-    )
+    parser.add_argument("--report_every", type=int, default=50, help="Steps between progress reports.")
     parser.add_argument(
         "--move_thresh_m",
         type=float,

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -108,6 +108,14 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
         help="Write an mp4 of the pour to PATH. Adds a fixed camera and forces --enable_cameras.",
     )
     parser.add_argument(
+        "--camera_only",
+        action="store_true",
+        help=(
+            "Add the pour camera and enable the renderer, but never capture or render during "
+            "stepping. Isolates the camera's presence from the per-step render."
+        ),
+    )
+    parser.add_argument(
         "--video_every",
         type=int,
         default=4,
@@ -234,7 +242,7 @@ def _build_environment(args_cli):
 
     scene = Scene(assets=[ground, light, *([bin_asset] if bin_asset else []), *objects])
     callbacks = []
-    if args_cli.record_video:
+    if args_cli.record_video or args_cli.camera_only:
         half_x, half_y = (
             (0.5 * args_cli.region_size[0], 0.5 * args_cli.region_size[1])
             if args_cli.region == "floor"
@@ -638,7 +646,7 @@ def main() -> None:
     # feature that ran and did nothing.
     args_cli, unknown = parser.parse_known_args()
     assert not unknown, f"unrecognised arguments: {unknown}"
-    if args_cli.record_video:
+    if args_cli.record_video or args_cli.camera_only:
         # The pour camera only produces frames when the renderer is up.
         args_cli.enable_cameras = True
 

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop a computed clutter layout into a live scene and report how it settles.
+
+Answers the questions that geometry alone cannot: does a drop layout settle into a
+usable pile within a bounded step budget, does it stay in the bin, and how many steps
+does each physics backend need? Run it under both backends to compare:
+
+    ./isaaclab_arena/scripts/run_clutter_pour_experiment.py --headless
+    ./isaaclab_arena/scripts/run_clutter_pour_experiment.py --headless --presets newton
+
+This is a diagnostic, not part of the placement pipeline.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def add_experiment_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--objects", type=int, default=8, help="Number of clutter objects to pour.")
+    parser.add_argument("--settle_steps", type=int, default=400, help="Physics steps to settle for.")
+    parser.add_argument("--report_every", type=int, default=50, help="Steps between velocity reports.")
+    parser.add_argument("--lin_vel_thresh", type=float, default=0.1, help="Settled linear speed (m/s).")
+    parser.add_argument("--ang_vel_thresh", type=float, default=0.1, help="Settled angular speed (rad/s).")
+    parser.add_argument("--drop_order", type=str, default="flattest_first", help="as_listed|flattest_first|shuffle")
+    parser.add_argument("--xy_sampling", type=str, default="grid_cells", help="grid_cells|uniform")
+    parser.add_argument("--clutter_spread", type=float, default=1.0, help="Scales the usable region.")
+    parser.add_argument("--layout_seed", type=int, default=0, help="Layout seed.")
+
+
+# Grocery-sized props standing in for tools: a mix of flat, bulky and elongated shapes.
+CLUTTER_ASSETS = [
+    "tomato_soup_can",
+    "cracker_box",
+    "sugar_box",
+    "mustard_bottle",
+    "dex_cube",
+    "mug",
+    "broccoli",
+    "power_drill",
+]
+BIN_ASSET = "grey_bin_robolab"
+
+
+def _build_environment(args_cli):
+    """Bin on a table with N clutter objects, all anchored so the solver leaves them alone."""
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.relations.relations import AtPosition, IsAnchor
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.no_task import NoTask
+    from isaaclab_arena.utils.pose import Pose
+
+    registry = AssetRegistry()
+    light = registry.get_asset_by_name("light")(spawner_cfg=sim_utils.DomeLightCfg(intensity=1500.0))
+    ground = registry.get_asset_by_name("ground_plane")()
+
+    bin_asset = registry.get_asset_by_name(BIN_ASSET)()
+    bin_asset.set_initial_pose(Pose(position_xyz=BIN_POSITION, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    bin_asset.add_relation(IsAnchor())
+
+    # Park the clutter off to one side; the experiment writes their real poses after reset.
+    objects = []
+    for index, asset_name in enumerate(CLUTTER_ASSETS[: args_cli.objects]):
+        obj = registry.get_asset_by_name(asset_name)()
+        obj.add_relation(AtPosition(x=1.5 + 0.3 * index, y=0.0, z=0.1))
+        objects.append(obj)
+
+    scene = Scene(assets=[ground, light, bin_asset, *objects])
+    arena_env = IsaacLabArenaEnvironment(name="clutter_pour_experiment", scene=scene, task=NoTask())
+    return arena_env, objects, bin_asset
+
+
+BIN_POSITION = (0.0, 0.0, 0.0)
+BIN_INTERIOR_FRACTION = 0.92
+"""Fraction of the bin's outer footprint treated as usable interior (walls are not in the bbox)."""
+
+
+def _run(simulation_app, args_cli) -> bool:
+    import torch
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
+    from isaaclab_arena.relations.clutter_drop_poses import (
+        ClutterDropParams,
+        ClutterRegion,
+        DropOrder,
+        XySampling,
+        compute_drop_poses,
+    )
+    from isaaclab_arena.utils import physics_settle
+
+    arena_env, objects, bin_asset = _build_environment(args_cli)
+    # Reuse the parsed CLI namespace; the builder also reads a couple of policy-runner args.
+    args_cli.num_envs = 1
+    for name, default in (("language_instruction", None), ("mimic", False)):
+        if not hasattr(args_cli, name):
+            setattr(args_cli, name, default)
+    env = ArenaEnvBuilder(arena_env, args_cli).make_registered()
+    env.reset()
+
+    scene = env.unwrapped.scene
+    device = env.unwrapped.device
+
+    # Drop from just above the bin rim so objects fall in regardless of interior geometry.
+    bin_bbox = get_bounding_box_per_env(bin_asset, 1)
+    bin_size = bin_bbox.size[0]
+    floor_z = BIN_POSITION[2] + float(bin_bbox.top_surface_z[0])
+    half_x = float(bin_size[0]) * 0.5 * BIN_INTERIOR_FRACTION
+    half_y = float(bin_size[1]) * 0.5 * BIN_INTERIOR_FRACTION
+    print(
+        f"bin outer size = {float(bin_size[0]):.3f} x {float(bin_size[1]):.3f} x {float(bin_size[2]):.3f} m; "
+        f"usable half-extents = {half_x:.3f} x {half_y:.3f} m; rim z = {floor_z:.3f}"
+    )
+
+    region = ClutterRegion(
+        min_x=BIN_POSITION[0] - half_x,
+        min_y=BIN_POSITION[1] - half_y,
+        max_x=BIN_POSITION[0] + half_x,
+        max_y=BIN_POSITION[1] + half_y,
+        floor_z=floor_z,
+    )
+    params = ClutterDropParams(
+        clutter_spread=args_cli.clutter_spread,
+        xy_sampling=XySampling(args_cli.xy_sampling),
+        drop_order=DropOrder(args_cli.drop_order),
+    )
+
+    bboxes = [get_bounding_box_per_env(obj, 1) for obj in objects]
+    generator = torch.Generator()
+    generator.manual_seed(args_cli.layout_seed)
+    poses = compute_drop_poses(bboxes, region, params, generator)
+
+    names = [obj.name for obj in objects]
+    print(f"\n=== drop layout (floor_z={floor_z:.3f}, backend={args_cli.presets or 'physx'}) ===")
+    highest = 0.0
+    for name, bbox, pose in zip(names, bboxes, poses):
+        rotated = bbox.rotated_by_quat(torch.tensor([pose.rotation_xyzw], dtype=torch.float32))
+        bottom = pose.position[2] + float(rotated.bottom_surface_z[0])
+        highest = max(highest, pose.position[2] + float(rotated.top_surface_z[0]))
+        print(f"  {name:22s} xy=({pose.position[0]:6.3f},{pose.position[1]:6.3f}) bottom_z={bottom:.3f}")
+    print(f"  layout spans {highest - floor_z:.3f} m above the floor")
+
+    # Write the drop layout into the sim.
+    for name, pose in zip(names, poses):
+        asset = scene[name]
+        root = asset.data.default_root_state.clone()[0:1] if hasattr(asset.data, "default_root_state") else None
+        state = torch.zeros((1, 13), device=device) if root is None else root
+        state[0, 0:3] = torch.tensor(pose.position, device=device)
+        x, y, z, w = pose.rotation_xyzw
+        state[0, 3:7] = torch.tensor([x, y, z, w], device=device)
+        state[0, 7:13] = 0.0
+        asset.write_root_state_to_sim(state)
+    scene.write_data_to_sim()
+
+    print(f"\n=== settling ({args_cli.settle_steps} steps) ===")
+    steps_done = 0
+    settled_at = None
+    while steps_done < args_cli.settle_steps:
+        chunk = min(args_cli.report_every, args_cli.settle_steps - steps_done)
+        physics_settle.step_physics(env, chunk)
+        steps_done += chunk
+        settled = physics_settle.are_all_objects_settled_per_env(
+            env, [0], names, args_cli.lin_vel_thresh, args_cli.ang_vel_thresh
+        )[0]
+        max_lin, max_ang, worst = _max_speeds(scene, names)
+        print(
+            f"  step {steps_done:4d}: settled={settled!s:5s} max_lin={max_lin:6.3f} max_ang={max_ang:6.3f}  ({worst})"
+        )
+        if settled and settled_at is None:
+            settled_at = steps_done
+
+    print("\n=== result ===")
+    print(f"  settled first observed at: {settled_at if settled_at is not None else 'NOT SETTLED'}")
+
+    escaped = []
+    for name in names:
+        position = _root_position(scene[name])
+        inside = (
+            region.min_x <= float(position[0]) <= region.max_x and region.min_y <= float(position[1]) <= region.max_y
+        )
+        if not inside:
+            escaped.append((name, [round(float(v), 3) for v in position]))
+        print(f"  {name:22s} final xyz=({position[0]:6.3f},{position[1]:6.3f},{position[2]:6.3f}) in_region={inside}")
+
+    print(f"\n  escaped: {len(escaped)}/{len(names)}" + (f" -> {escaped}" if escaped else ""))
+    env.close()
+    return settled_at is not None and not escaped
+
+
+def _max_speeds(scene, names):
+    """Largest linear/angular speed across the clutter, and which object holds it."""
+    import warp as wp
+
+    max_lin, max_ang, worst = 0.0, 0.0, ""
+    for name in names:
+        data = scene[name].data
+        lin = float(wp.to_torch(data.root_lin_vel_w)[0].norm())
+        ang = float(wp.to_torch(data.root_ang_vel_w)[0].norm())
+        if lin > max_lin:
+            max_lin, worst = lin, name
+        max_ang = max(max_ang, ang)
+    return max_lin, max_ang, worst
+
+
+def _root_position(asset):
+    import warp as wp
+
+    return wp.to_torch(asset.data.root_pos_w)[0]
+
+
+def main() -> None:
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+    from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+
+    parser = get_isaaclab_arena_cli_parser()
+    add_experiment_args(parser)
+    args_cli, _ = parser.parse_known_args()
+
+    with SimulationAppContext(args_cli) as simulation_app:
+        ok = _run(simulation_app, args_cli)
+        print(f"\nRESULT: {'PASS' if ok else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena/scripts/run_clutter_pour_experiment.py
+++ b/isaaclab_arena/scripts/run_clutter_pour_experiment.py
@@ -22,6 +22,20 @@ import argparse
 
 def add_experiment_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--objects", type=int, default=8, help="Number of clutter objects to pour.")
+    parser.add_argument(
+        "--region",
+        type=str,
+        default="bin",
+        help="Where to pour: 'bin' (grey bin) or 'floor' (open ground, sized by --region_size).",
+    )
+    parser.add_argument(
+        "--region_size",
+        type=float,
+        nargs=2,
+        default=(1.0, 1.0),
+        metavar=("X", "Y"),
+        help="Floor region size in metres; only used with --region floor.",
+    )
     parser.add_argument("--settle_steps", type=int, default=400, help="Physics steps to settle for.")
     parser.add_argument("--report_every", type=int, default=50, help="Steps between velocity reports.")
     parser.add_argument("--lin_vel_thresh", type=float, default=0.1, help="Settled linear speed (m/s).")
@@ -30,6 +44,23 @@ def add_experiment_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--xy_sampling", type=str, default="grid_cells", help="grid_cells|uniform")
     parser.add_argument("--clutter_spread", type=float, default=1.0, help="Scales the usable region.")
     parser.add_argument("--layout_seed", type=int, default=0, help="Layout seed.")
+    parser.add_argument(
+        "--render_settle",
+        action="store_true",
+        help="Render every settle step so the pour is visible. Use with --viz kit.",
+    )
+    parser.add_argument(
+        "--hold_seconds",
+        type=float,
+        default=0.0,
+        help="Keep stepping after settling so the result stays on screen. Use with --viz kit.",
+    )
+    parser.add_argument(
+        "--pause_before_pour",
+        type=float,
+        default=0.0,
+        help="Seconds to hold the pre-pour scene, so the drop layout is visible before it falls.",
+    )
 
 
 # Grocery-sized props standing in for tools: a mix of flat, bulky and elongated shapes.
@@ -61,14 +92,20 @@ def _build_environment(args_cli):
     light = registry.get_asset_by_name("light")(spawner_cfg=sim_utils.DomeLightCfg(intensity=1500.0))
     ground = registry.get_asset_by_name("ground_plane")()
 
+    # The bin is always the solver's anchor (the ground plane has no bounding box); in floor
+    # mode it is parked well clear of the pour region so objects land on open ground.
+    bin_position = BIN_POSITION if args_cli.region == "bin" else (5.0, 0.0, 0.0)
     bin_asset = registry.get_asset_by_name(BIN_ASSET)()
-    bin_asset.set_initial_pose(Pose(position_xyz=BIN_POSITION, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    bin_asset.set_initial_pose(Pose(position_xyz=bin_position, rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
     bin_asset.add_relation(IsAnchor())
 
     # Park the clutter off to one side; the experiment writes their real poses after reset.
+    # The palette repeats for large counts, so each repeat needs its own instance name --
+    # duplicates would otherwise resolve to a single scene prim.
     objects = []
-    for index, asset_name in enumerate(CLUTTER_ASSETS[: args_cli.objects]):
-        obj = registry.get_asset_by_name(asset_name)()
+    for index in range(args_cli.objects):
+        asset_name = CLUTTER_ASSETS[index % len(CLUTTER_ASSETS)]
+        obj = registry.get_asset_by_name(asset_name)(instance_name=f"{asset_name}_{index}")
         obj.add_relation(AtPosition(x=1.5 + 0.3 * index, y=0.0, z=0.1))
         objects.append(obj)
 
@@ -109,15 +146,20 @@ def _run(simulation_app, args_cli) -> bool:
     device = env.unwrapped.device
 
     # Drop from just above the bin rim so objects fall in regardless of interior geometry.
-    bin_bbox = get_bounding_box_per_env(bin_asset, 1)
-    bin_size = bin_bbox.size[0]
-    floor_z = BIN_POSITION[2] + float(bin_bbox.top_surface_z[0])
-    half_x = float(bin_size[0]) * 0.5 * BIN_INTERIOR_FRACTION
-    half_y = float(bin_size[1]) * 0.5 * BIN_INTERIOR_FRACTION
-    print(
-        f"bin outer size = {float(bin_size[0]):.3f} x {float(bin_size[1]):.3f} x {float(bin_size[2]):.3f} m; "
-        f"usable half-extents = {half_x:.3f} x {half_y:.3f} m; rim z = {floor_z:.3f}"
-    )
+    if args_cli.region == "bin":
+        bin_bbox = get_bounding_box_per_env(bin_asset, 1)
+        bin_size = bin_bbox.size[0]
+        floor_z = BIN_POSITION[2] + float(bin_bbox.top_surface_z[0])
+        half_x = float(bin_size[0]) * 0.5 * BIN_INTERIOR_FRACTION
+        half_y = float(bin_size[1]) * 0.5 * BIN_INTERIOR_FRACTION
+        print(
+            f"bin outer size = {float(bin_size[0]):.3f} x {float(bin_size[1]):.3f} x {float(bin_size[2]):.3f} m; "
+            f"usable half-extents = {half_x:.3f} x {half_y:.3f} m; rim z = {floor_z:.3f}"
+        )
+    else:
+        half_x, half_y = float(args_cli.region_size[0]) * 0.5, float(args_cli.region_size[1]) * 0.5
+        floor_z = 0.0
+        print(f"floor region = {args_cli.region_size[0]:.2f} x {args_cli.region_size[1]:.2f} m at z = {floor_z:.3f}")
 
     region = ClutterRegion(
         min_x=BIN_POSITION[0] - half_x,
@@ -159,12 +201,16 @@ def _run(simulation_app, args_cli) -> bool:
         asset.write_root_state_to_sim(state)
     scene.write_data_to_sim()
 
+    if args_cli.pause_before_pour > 0.0:
+        print(f"\n=== holding drop layout for {args_cli.pause_before_pour:.0f}s (objects frozen mid-air) ===")
+        _hold(env, args_cli.pause_before_pour, freeze=names)
+
     print(f"\n=== settling ({args_cli.settle_steps} steps) ===")
     steps_done = 0
     settled_at = None
     while steps_done < args_cli.settle_steps:
         chunk = min(args_cli.report_every, args_cli.settle_steps - steps_done)
-        physics_settle.step_physics(env, chunk)
+        physics_settle.step_physics(env, chunk, render=args_cli.render_settle)
         steps_done += chunk
         settled = physics_settle.are_all_objects_settled_per_env(
             env, [0], names, args_cli.lin_vel_thresh, args_cli.ang_vel_thresh
@@ -190,8 +236,34 @@ def _run(simulation_app, args_cli) -> bool:
         print(f"  {name:22s} final xyz=({position[0]:6.3f},{position[1]:6.3f},{position[2]:6.3f}) in_region={inside}")
 
     print(f"\n  escaped: {len(escaped)}/{len(names)}" + (f" -> {escaped}" if escaped else ""))
+
+    if args_cli.hold_seconds > 0.0:
+        print(f"\n=== holding result for {args_cli.hold_seconds:.0f}s ===")
+        _hold(env, args_cli.hold_seconds)
+
     env.close()
     return settled_at is not None and not escaped
+
+
+def _hold(env, seconds: float, freeze: list[str] | None = None) -> None:
+    """Keep the viewer alive, optionally re-freezing objects so they stay put on screen."""
+    import time
+    import torch
+
+    from isaaclab_arena.utils import physics_settle
+
+    deadline = time.time() + seconds
+    frozen = None
+    if freeze:
+        frozen = {name: env.unwrapped.scene[name].data.root_state_w[0:1].clone() for name in freeze}
+    while time.time() < deadline:
+        if frozen:
+            for name, state in frozen.items():
+                held = state.clone()
+                held[0, 7:13] = torch.zeros(6, device=held.device)
+                env.unwrapped.scene[name].write_root_state_to_sim(held)
+            env.unwrapped.scene.write_data_to_sim()
+        physics_settle.step_physics(env, 1, render=True)
 
 
 def _max_speeds(scene, names):

--- a/isaaclab_arena/tasks/objects_in_regions.py
+++ b/isaaclab_arena/tasks/objects_in_regions.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A geometric success task for placing paired objects in oriented regions."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+import torch
+from dataclasses import MISSING
+from typing import TYPE_CHECKING, Any
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+import warp as wp
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import TerminationTermCfg
+from isaaclab.utils.configclass import configclass
+from isaaclab.utils.math import subtract_frame_transforms
+
+from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
+from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.tasks.terminations import SuccessMode, check_success
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+Bounds = tuple[float, float, float, float, float, float]
+
+
+def points_in_oriented_regions(
+    object_positions_w: torch.Tensor,
+    region_positions_w: torch.Tensor,
+    region_quaternions_w: torch.Tensor,
+    bounds_xyzxyz: torch.Tensor,
+) -> torch.Tensor:
+    """Return whether every corresponding point lies in its oriented local box.
+
+    The bounds are expressed in the local coordinates of their paired region and
+    are inclusive, so a point lying exactly on a face is successful.
+    """
+
+    object_pos_region, _ = subtract_frame_transforms(
+        region_positions_w,
+        region_quaternions_w,
+        object_positions_w,
+    )
+    lower = bounds_xyzxyz[:, :3]
+    upper = bounds_xyzxyz[:, 3:]
+    return ((object_pos_region >= lower) & (object_pos_region <= upper)).all(dim=-1)
+
+
+def objects_in_regions(
+    env: ManagerBasedRLEnv,
+    object_names: list[str],
+    region_names: list[str],
+    bounds_xyzxyz: list[Bounds],
+) -> torch.Tensor:
+    """Return success only where all paired objects are inside their regions."""
+
+    if not object_names or len(object_names) != len(region_names) or len(object_names) != len(bounds_xyzxyz):
+        raise ValueError("objects, regions, and bounds must be non-empty lists of the same length")
+
+    pair_results: list[torch.Tensor] = []
+    for object_name, region_name, bounds in zip(object_names, region_names, bounds_xyzxyz, strict=True):
+        object_instance: Any = env.scene[object_name]
+        region_instance: Any = env.scene[region_name]
+        object_positions_w = wp.to_torch(object_instance.data.root_pos_w)
+        if hasattr(region_instance, "data"):
+            region_positions_w = wp.to_torch(region_instance.data.root_pos_w)
+            region_quaternions_w = wp.to_torch(region_instance.data.root_quat_w)
+        else:
+            region_positions_w, region_quaternions_w = (
+                wp.to_torch(value) for value in region_instance.get_world_poses()
+            )
+        bounds_tensor = torch.as_tensor(bounds, dtype=object_positions_w.dtype, device=object_positions_w.device)
+        pair_results.append(
+            points_in_oriented_regions(
+                object_positions_w,
+                region_positions_w,
+                region_quaternions_w,
+                bounds_tensor.unsqueeze(0).expand(env.num_envs, -1),
+            )
+        )
+    return torch.stack(pair_results, dim=0).all(dim=0)
+
+
+@register_task
+class ObjectsInRegionsTask(TaskBase):
+    """Require every object to be within the local bounds of its paired region."""
+
+    def __init__(
+        self,
+        object_list: list[Asset],
+        region_list: list[Asset],
+        bounds_xyzxyz: list[Bounds],
+        episode_length_s: float = 480.0,
+        task_description: str | None = None,
+    ):
+        self._validate_inputs(object_list, region_list, bounds_xyzxyz)
+        super().__init__(
+            episode_length_s=episode_length_s,
+            task_description=task_description or "Place every object inside its paired region.",
+        )
+        self.objects = list(object_list)
+        self.regions = list(region_list)
+        self.bounds = [tuple(float(value) for value in bounds) for bounds in bounds_xyzxyz]
+        self.events_cfg = None
+        self.termination_cfg = self.make_termination_cfg()
+        self.metrics = [SuccessRateMetric()]
+
+    @staticmethod
+    def _validate_inputs(object_list: list[Asset], region_list: list[Asset], bounds_xyzxyz: list[Bounds]) -> None:
+        if not object_list or not region_list or not bounds_xyzxyz:
+            raise ValueError("objects, regions, and bounds must contain at least one paired entry")
+        if len(object_list) != len(region_list) or len(object_list) != len(bounds_xyzxyz):
+            raise ValueError("objects, regions, and bounds must have the same length")
+        for bounds in bounds_xyzxyz:
+            if not isinstance(bounds, (list, tuple)) or len(bounds) != 6:
+                raise ValueError("each region bounds entry must contain exactly six values")
+            try:
+                values = tuple(float(value) for value in bounds)
+            except (TypeError, ValueError) as error:
+                raise ValueError("region bounds must be numeric") from error
+            if not all(math.isfinite(value) for value in values):
+                raise ValueError("region bounds must be finite")
+            if any(lower > upper for lower, upper in zip(values[:3], values[3:], strict=True)):
+                raise ValueError("region bounds lower values must not exceed upper values")
+
+    def get_scene_cfg(self):
+        return None
+
+    def make_termination_cfg(self):
+        region_predicate = TerminationTermCfg(
+            func=objects_in_regions,
+            params={
+                "object_names": [object_.name for object_ in self.objects],
+                "region_names": [region.name for region in self.regions],
+                "bounds_xyzxyz": self.bounds,
+            },
+        )
+        return TerminationsCfg(
+            success=TerminationTermCfg(
+                func=check_success,
+                params={"mode": SuccessMode.ALL, "predicates": [region_predicate]},
+            )
+        )
+
+    def get_termination_cfg(self):
+        return self.termination_cfg
+
+    def get_events_cfg(self):
+        return self.events_cfg
+
+    def get_mimic_env_cfg(self, _arm_mode):
+        return None
+
+    def get_metrics(self) -> list[MetricBase]:
+        return self.metrics
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.objects[0],
+            offset=np.array([-1.5, -1.5, 1.5]),
+        )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination configuration for :class:`ObjectsInRegionsTask`."""
+
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    success: TerminationTermCfg = MISSING

--- a/isaaclab_arena/tasks/task_base.py
+++ b/isaaclab_arena/tasks/task_base.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from isaaclab.envs.common import ViewerCfg
 from isaaclab.managers.recorder_manager import RecorderManagerBaseCfg
@@ -16,6 +18,10 @@ from isaaclab_arena.metrics.metric_base import MetricBase
 from isaaclab_arena.progress_tracking.progress_objective import ProgressObjective
 from isaaclab_arena.relations.relations import RequiresReachability
 from isaaclab_arena.tasks.task_transition import TaskTransition
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderTermCfg
 
 
 class TaskBase(ABC):
@@ -63,6 +69,13 @@ class TaskBase(ABC):
 
     def get_viewer_cfg(self) -> ViewerCfg:
         return ViewerCfg()
+
+    def get_episode_recorder_terms(
+        self,
+        arena_env: IsaacLabArenaEnvironment,
+    ) -> dict[str, EpisodeRecorderTermCfg]:
+        del arena_env
+        return {}
 
     def get_episode_length_s(self) -> float:
         return self.episode_length_s

--- a/isaaclab_arena/tasks/task_library.py
+++ b/isaaclab_arena/tasks/task_library.py
@@ -14,6 +14,7 @@ from isaaclab_arena.tasks import (  # noqa: F401
     goal_pose_task,
     lift_object_task,
     no_task,
+    objects_in_regions,
     open_door_task,
     pick_and_place_task,
     place_upright_task,

--- a/isaaclab_arena/tests/test_arena_env_builder_cfg.py
+++ b/isaaclab_arena/tests/test_arena_env_builder_cfg.py
@@ -21,6 +21,66 @@ def test_cli_defaults_match_builder_configuration():
     assert arena_env_builder_cfg_from_argparse(args_cli) == ArenaEnvBuilderCfg()
 
 
+def test_builder_configuration_defaults_to_no_reset_rerenders():
+    """Keep the typed builder's reset rendering behavior backward-compatible."""
+    assert ArenaEnvBuilderCfg().num_rerenders_on_reset == 0
+
+
+def test_native_reset_executes_configured_rerenders_before_observation():
+    """Protect the Isaac Lab runtime contract that Arena's builder config relies on."""
+    import torch
+    from types import SimpleNamespace
+
+    from isaaclab.envs import ManagerBasedEnv
+
+    events = []
+
+    class Recorder:
+        def record_pre_reset(self, env_ids):
+            events.append(("pre_reset", env_ids.tolist()))
+
+        def record_post_reset(self, env_ids):
+            events.append(("post_reset", env_ids.tolist()))
+
+    env = SimpleNamespace(
+        num_envs=1,
+        device=torch.device("cpu"),
+        recorder_manager=Recorder(),
+        seed=lambda _seed: None,
+        _reset_idx=lambda env_ids: events.append(("reset", env_ids.tolist())),
+        scene=SimpleNamespace(
+            write_data_to_sim=lambda: events.append(("write", None)),
+        ),
+        sim=SimpleNamespace(
+            forward=lambda: events.append(("forward", None)),
+            render=lambda: events.append(("render", None)),
+        ),
+        has_rtx_sensors=True,
+        cfg=SimpleNamespace(num_rerenders_on_reset=5, wait_for_textures=False),
+        observation_manager=SimpleNamespace(
+            compute=lambda **_kwargs: events.append(("observe", None)) or {},
+        ),
+        obs_buf=None,
+        extras={},
+    )
+
+    ManagerBasedEnv.reset(env)
+
+    assert [name for name, _ in events] == [
+        "pre_reset",
+        "reset",
+        "write",
+        "forward",
+        "render",
+        "render",
+        "render",
+        "render",
+        "render",
+        "post_reset",
+        "observe",
+    ]
+
+
 def test_argparse_adapter_maps_builder_configuration():
     """Translate only builder-owned command-line values into the typed config."""
     parser = get_isaaclab_arena_cli_parser()
@@ -32,11 +92,15 @@ def test_argparse_adapter_maps_builder_configuration():
         "3",
         "--env_spacing",
         "2.5",
+        "--num_rerenders_on_reset",
+        "5",
         "--seed",
         "7",
         "--no_solve_relations",
         "--placement_seed",
         "11",
+        "--placement_clearance_m",
+        "0.0005",
         "--no-resolve_on_reset",
         "--disable_fabric",
         "--mimic",
@@ -53,9 +117,11 @@ def test_argparse_adapter_maps_builder_configuration():
     assert cfg == ArenaEnvBuilderCfg(
         num_envs=3,
         env_spacing=2.5,
+        num_rerenders_on_reset=5,
         seed=7,
         solve_relations=False,
         placement_seed=11,
+        placement_clearance_m=0.0005,
         resolve_on_reset=False,
         disable_fabric=True,
         mimic=True,
@@ -69,3 +135,70 @@ def test_builder_configuration_requires_positive_num_envs():
     """Reject configurations that cannot build any environment instances."""
     with pytest.raises(AssertionError, match="num_envs must be greater than zero"):
         ArenaEnvBuilderCfg(num_envs=0)
+
+
+def test_builder_configuration_rejects_negative_reset_rerenders():
+    """Reject reset rendering counts that cannot describe a number of steps."""
+    with pytest.raises(ValueError, match="num_rerenders_on_reset must be non-negative"):
+        ArenaEnvBuilderCfg(num_rerenders_on_reset=-1)
+
+
+@pytest.mark.parametrize("value", [True, 1.5])
+def test_builder_configuration_requires_integral_reset_rerenders(value):
+    """Reject booleans and fractional reset rendering counts."""
+    with pytest.raises(TypeError, match="num_rerenders_on_reset must be an integer"):
+        ArenaEnvBuilderCfg(num_rerenders_on_reset=value)
+
+
+@pytest.mark.parametrize("value", [-0.1, float("inf"), float("nan")])
+def test_builder_configuration_rejects_invalid_placement_clearance(value):
+    """Reject relation-solver clearances that cannot describe a physical distance."""
+    with pytest.raises(ValueError, match="placement_clearance_m"):
+        ArenaEnvBuilderCfg(placement_clearance_m=value)
+
+
+# ArenaEnvBuilder transitively imports pxr. Run this assertion only after
+# run_simulation_app_function has initialized Kit, regardless of pytest's test order.
+def _test_compose_manager_cfg_preserves_runtime_builder_values(_simulation_app):
+    """Expose effective builder inputs on the runtime configuration."""
+    from types import SimpleNamespace
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+    scene = SimpleNamespace(
+        assets={},
+        get_asset_variations=lambda: {},
+        get_scene_cfg=lambda: None,
+        get_observation_cfg=lambda: None,
+        get_events_cfg=lambda: None,
+        get_termination_cfg=lambda: None,
+        get_rewards_cfg=lambda: None,
+        get_curriculum_cfg=lambda: None,
+        get_commands_cfg=lambda: None,
+    )
+    builder = ArenaEnvBuilder(
+        IsaacLabArenaEnvironment(name="placement_provenance", scene=scene),
+        ArenaEnvBuilderCfg(
+            solve_relations=False,
+            num_rerenders_on_reset=5,
+            placement_seed=71,
+            placement_clearance_m=0.0005,
+        ),
+    )
+
+    env_cfg, _ = builder.compose_manager_cfg()
+
+    assert env_cfg.num_rerenders_on_reset == builder.cfg.num_rerenders_on_reset
+    assert env_cfg.placement_seed == builder.cfg.placement_seed
+    assert env_cfg.placement_clearance_m == builder.cfg.placement_clearance_m
+    return True
+
+
+def test_compose_manager_cfg_preserves_runtime_builder_values():
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    assert run_simulation_app_function(
+        _test_compose_manager_cfg_preserves_runtime_builder_values,
+        headless=True,
+    ), "runtime builder value composition test failed"

--- a/isaaclab_arena/tests/test_arena_env_builder_cfg.py
+++ b/isaaclab_arena/tests/test_arena_env_builder_cfg.py
@@ -158,7 +158,7 @@ def test_builder_configuration_rejects_invalid_placement_clearance(value):
 
 
 # ArenaEnvBuilder transitively imports pxr. Run this assertion only after
-# run_simulation_app_function has initialized Kit, regardless of pytest's test order.
+# run_function_with_persistent_simulation_app has initialized Kit, regardless of pytest's test order.
 def _test_compose_manager_cfg_preserves_runtime_builder_values(_simulation_app):
     """Expose effective builder inputs on the runtime configuration."""
     from types import SimpleNamespace
@@ -196,9 +196,9 @@ def _test_compose_manager_cfg_preserves_runtime_builder_values(_simulation_app):
 
 
 def test_compose_manager_cfg_preserves_runtime_builder_values():
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_compose_manager_cfg_preserves_runtime_builder_values,
         headless=True,
     ), "runtime builder value composition test failed"

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -105,6 +105,7 @@ def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
                 params={},
             )
         ],
+        object_sets=[],
         object_references=[
             SimpleNamespace(
                 id="tabletop",
@@ -149,9 +150,9 @@ def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
 def test_relative_reference_uses_parent_runtime_prim_path():
     pytest.importorskip("isaaclab.app")
 
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_relative_reference_uses_parent_runtime_prim_path)
+    result = run_function_with_persistent_simulation_app(_test_relative_reference_uses_parent_runtime_prim_path)
     assert result
 
 

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -89,6 +89,7 @@ def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
                 params={},
             )
         ],
+        object_sets=[],
         object_references=[
             SimpleNamespace(
                 id="tabletop",
@@ -133,9 +134,9 @@ def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
 def test_relative_reference_uses_parent_runtime_prim_path():
     pytest.importorskip("isaaclab.app")
 
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    result = run_simulation_app_function(_test_relative_reference_uses_parent_runtime_prim_path)
+    result = run_function_with_persistent_simulation_app(_test_relative_reference_uses_parent_runtime_prim_path)
     assert result
 
 

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -13,6 +13,8 @@ launch cleanly before any ``pxr`` import.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -71,6 +73,85 @@ def test_composite_task_episode_length_sums_subtasks():
     from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
     result = run_function_with_persistent_simulation_app(_test_composite_task_episode_length_sums_subtasks)
+
+
+def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
+    from isaaclab_arena.environment_spec import arena_env_graph_conversion_utils
+
+    class FakeRegistry:
+        @staticmethod
+        def get_asset_by_name(registry_name):
+            if registry_name == "downstream_background_alias":
+                return lambda **_kwargs: SimpleNamespace(get_prim_path=lambda: "{ENV_REGEX_NS}/stable_background_name")
+            if registry_name == "downstream_object_alias":
+                return lambda **_kwargs: SimpleNamespace(get_prim_path=lambda: "{ENV_REGEX_NS}/stable_object_name")
+            return lambda **_kwargs: SimpleNamespace()
+
+    graph_spec = SimpleNamespace(
+        embodiment=SimpleNamespace(
+            id="robot",
+            registry_name="robot",
+            params={},
+        ),
+        background=SimpleNamespace(
+            id="background",
+            registry_name="downstream_background_alias",
+            params={},
+        ),
+        objects=[
+            SimpleNamespace(
+                id="cabinet",
+                registry_name="downstream_object_alias",
+                params={},
+            )
+        ],
+        object_references=[
+            SimpleNamespace(
+                id="tabletop",
+                parent_id="background",
+                prim_path="table/top",
+                object_type="base",
+                params={},
+            ),
+            SimpleNamespace(
+                id="cabinet_shelf",
+                parent_id="cabinet",
+                prim_path="shelf",
+                object_type="base",
+                params={},
+            ),
+            SimpleNamespace(
+                id="qualified_reference",
+                parent_id="background",
+                prim_path="{ENV_REGEX_NS}/already/resolved",
+                object_type="base",
+                params={},
+            ),
+        ],
+    )
+
+    with patch.object(
+        arena_env_graph_conversion_utils,
+        "ObjectReference",
+        side_effect=lambda **kwargs: SimpleNamespace(**kwargs),
+    ):
+        assets = arena_env_graph_conversion_utils.instantiate_assets_from_spec(
+            graph_spec,
+            FakeRegistry(),
+        )
+
+    assert assets["tabletop"].prim_path == "{ENV_REGEX_NS}/stable_background_name/table/top"
+    assert assets["cabinet_shelf"].prim_path == "{ENV_REGEX_NS}/stable_object_name/shelf"
+    assert assets["qualified_reference"].prim_path == "{ENV_REGEX_NS}/already/resolved"
+    return True
+
+
+def test_relative_reference_uses_parent_runtime_prim_path():
+    pytest.importorskip("isaaclab.app")
+
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    result = run_simulation_app_function(_test_relative_reference_uses_parent_runtime_prim_path)
     assert result
 
 

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -13,6 +13,8 @@ launch cleanly before any ``pxr`` import.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -54,6 +56,86 @@ def test_arena_env_graph_conversion_builds_sequential_pick_and_place_task():
     result = run_function_with_persistent_simulation_app(
         _test_arena_env_graph_conversion_builds_sequential_pick_and_place_task
     )
+    assert result
+
+
+def _test_relative_reference_uses_parent_runtime_prim_path(simulation_app):
+    from isaaclab_arena.environment_spec import arena_env_graph_conversion_utils
+
+    class FakeRegistry:
+        @staticmethod
+        def get_asset_by_name(registry_name):
+            if registry_name == "downstream_background_alias":
+                return lambda **_kwargs: SimpleNamespace(get_prim_path=lambda: "{ENV_REGEX_NS}/stable_background_name")
+            if registry_name == "downstream_object_alias":
+                return lambda **_kwargs: SimpleNamespace(get_prim_path=lambda: "{ENV_REGEX_NS}/stable_object_name")
+            return lambda **_kwargs: SimpleNamespace()
+
+    graph_spec = SimpleNamespace(
+        embodiment=SimpleNamespace(
+            id="robot",
+            registry_name="robot",
+            params={},
+        ),
+        background=SimpleNamespace(
+            id="background",
+            registry_name="downstream_background_alias",
+            params={},
+        ),
+        objects=[
+            SimpleNamespace(
+                id="cabinet",
+                registry_name="downstream_object_alias",
+                params={},
+            )
+        ],
+        object_references=[
+            SimpleNamespace(
+                id="tabletop",
+                parent_id="background",
+                prim_path="table/top",
+                object_type="base",
+                params={},
+            ),
+            SimpleNamespace(
+                id="cabinet_shelf",
+                parent_id="cabinet",
+                prim_path="shelf",
+                object_type="base",
+                params={},
+            ),
+            SimpleNamespace(
+                id="qualified_reference",
+                parent_id="background",
+                prim_path="{ENV_REGEX_NS}/already/resolved",
+                object_type="base",
+                params={},
+            ),
+        ],
+    )
+
+    with patch.object(
+        arena_env_graph_conversion_utils,
+        "ObjectReference",
+        side_effect=lambda **kwargs: SimpleNamespace(**kwargs),
+    ):
+        assets = arena_env_graph_conversion_utils.instantiate_assets_from_spec(
+            graph_spec,
+            FakeRegistry(),
+        )
+
+    assert assets["tabletop"].prim_path == "{ENV_REGEX_NS}/stable_background_name/table/top"
+    assert assets["cabinet_shelf"].prim_path == "{ENV_REGEX_NS}/stable_object_name/shelf"
+    assert assets["qualified_reference"].prim_path == "{ENV_REGEX_NS}/already/resolved"
+    return True
+
+
+def test_relative_reference_uses_parent_runtime_prim_path():
+    pytest.importorskip("isaaclab.app")
+
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    result = run_simulation_app_function(_test_relative_reference_uses_parent_runtime_prim_path)
     assert result
 
 

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -109,6 +109,7 @@ def test_empty_legacy_json_experiment_is_rejected(tmp_path):
 
 
 def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):
+    runtime_is_initialized = False
     simulation_is_running = False
 
     class _SimulationAppContext:
@@ -123,8 +124,14 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
             nonlocal simulation_is_running
             simulation_is_running = False
 
+    def initialize_runtime():
+        nonlocal runtime_is_initialized
+        assert simulation_is_running
+        runtime_is_initialized = True
+
     def load_experiment_after_startup(*_args, **_kwargs):
         assert simulation_is_running
+        assert runtime_is_initialized
         return _experiment_cfg()
 
     monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
@@ -140,7 +147,71 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
         ],
     )
 
-    experiment_runner.main()
+    experiment_runner.main(runtime_initializer=initialize_runtime)
+
+    assert runtime_is_initialized
+
+
+def test_experiment_runner_initializes_runtime_after_creating_exact_output(monkeypatch, tmp_path):
+    simulation_is_running = False
+    runtime_is_initialized = False
+    exact_output = tmp_path / "exact-experiment-output"
+    experiment_cfg = _experiment_cfg()
+
+    class _SimulationAppContext:
+        def __init__(self, _args_cli):
+            pass
+
+        def __enter__(self):
+            nonlocal simulation_is_running
+            simulation_is_running = True
+
+        def __exit__(self, _exception_type, _exception, _traceback):
+            nonlocal simulation_is_running
+            simulation_is_running = False
+
+    def initialize_runtime():
+        nonlocal runtime_is_initialized
+        assert simulation_is_running
+        assert exact_output.is_dir()
+        runtime_is_initialized = True
+
+    def load_experiment_after_startup(*_args, **_kwargs):
+        assert simulation_is_running
+        assert runtime_is_initialized
+        return experiment_cfg
+
+    def execute_experiment(received_cfg, *, output_dir, **_kwargs):
+        assert received_cfg is experiment_cfg
+        assert output_dir == exact_output
+        return []
+
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(experiment_runner, "load_arena_experiment_from_config_file", load_experiment_after_startup)
+    monkeypatch.setattr(experiment_runner, "execute_experiment", execute_experiment)
+    monkeypatch.setattr(experiment_runner, "build_runs_info_table", lambda *_args: "")
+    monkeypatch.setattr(experiment_runner, "build_report", lambda output_dir: output_dir / "report.html")
+    monkeypatch.setattr(
+        experiment_runner,
+        "MetricsLogger",
+        lambda: type(
+            "_MetricsLogger", (), {"append_job_metrics": lambda *_args: None, "print_metrics": lambda *_: None}
+        )(),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_YAML_PATH),
+            "--experiment_output_directory",
+            str(exact_output),
+        ],
+    )
+
+    experiment_runner.main(runtime_initializer=initialize_runtime)
+
+    assert runtime_is_initialized
 
 
 def test_camera_support_invariant_holds_for_composed_runs():
@@ -216,6 +287,25 @@ def test_experiment_runner_rejects_yaml_chunking_before_starting_simulation(monk
 
     with pytest.raises(AssertionError, match="only legacy JSON Experiments"):
         experiment_runner.main()
+
+
+def test_experiment_runner_rejects_runtime_initializer_with_chunking(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_JSON_PATH),
+            "--chunk_size",
+            "1",
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runtime_initializer.*chunk_size",
+    ):
+        experiment_runner.main(runtime_initializer=lambda: None)
 
 
 def test_experiment_runner_rejects_exact_output_for_multiple_legacy_chunks(monkeypatch, tmp_path):

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -211,6 +211,7 @@ def test_empty_legacy_json_experiment_is_rejected(tmp_path):
 
 
 def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkeypatch):
+    runtime_is_initialized = False
     simulation_is_running = False
 
     class _SimulationAppContext:
@@ -225,8 +226,14 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
             nonlocal simulation_is_running
             simulation_is_running = False
 
+    def initialize_runtime():
+        nonlocal runtime_is_initialized
+        assert simulation_is_running
+        runtime_is_initialized = True
+
     def load_experiment_after_startup(*_args, **_kwargs):
         assert simulation_is_running
+        assert runtime_is_initialized
         return _experiment_cfg()
 
     monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
@@ -242,7 +249,71 @@ def test_experiment_runner_loads_typed_experiment_after_simulation_starts(monkey
         ],
     )
 
-    experiment_runner.main()
+    experiment_runner.main(runtime_initializer=initialize_runtime)
+
+    assert runtime_is_initialized
+
+
+def test_experiment_runner_initializes_runtime_after_creating_exact_output(monkeypatch, tmp_path):
+    simulation_is_running = False
+    runtime_is_initialized = False
+    exact_output = tmp_path / "exact-experiment-output"
+    experiment_cfg = _experiment_cfg()
+
+    class _SimulationAppContext:
+        def __init__(self, _args_cli):
+            pass
+
+        def __enter__(self):
+            nonlocal simulation_is_running
+            simulation_is_running = True
+
+        def __exit__(self, _exception_type, _exception, _traceback):
+            nonlocal simulation_is_running
+            simulation_is_running = False
+
+    def initialize_runtime():
+        nonlocal runtime_is_initialized
+        assert simulation_is_running
+        assert exact_output.is_dir()
+        runtime_is_initialized = True
+
+    def load_experiment_after_startup(*_args, **_kwargs):
+        assert simulation_is_running
+        assert runtime_is_initialized
+        return experiment_cfg
+
+    def execute_experiment(received_cfg, *, output_dir, **_kwargs):
+        assert received_cfg is experiment_cfg
+        assert output_dir == exact_output
+        return []
+
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(experiment_runner, "load_arena_experiment_from_config_file", load_experiment_after_startup)
+    monkeypatch.setattr(experiment_runner, "execute_experiment", execute_experiment)
+    monkeypatch.setattr(experiment_runner, "build_runs_info_table", lambda *_args: "")
+    monkeypatch.setattr(experiment_runner, "build_report", lambda output_dir: output_dir / "report.html")
+    monkeypatch.setattr(
+        experiment_runner,
+        "MetricsLogger",
+        lambda: type(
+            "_MetricsLogger", (), {"append_job_metrics": lambda *_args: None, "print_metrics": lambda *_: None}
+        )(),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_YAML_PATH),
+            "--experiment_output_directory",
+            str(exact_output),
+        ],
+    )
+
+    experiment_runner.main(runtime_initializer=initialize_runtime)
+
+    assert runtime_is_initialized
 
 
 def test_camera_support_invariant_holds_for_composed_runs():
@@ -318,6 +389,25 @@ def test_experiment_runner_rejects_yaml_chunking_before_starting_simulation(monk
 
     with pytest.raises(AssertionError, match="only legacy JSON Experiments"):
         experiment_runner.main()
+
+
+def test_experiment_runner_rejects_runtime_initializer_with_chunking(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_JSON_PATH),
+            "--chunk_size",
+            "1",
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="runtime_initializer.*chunk_size",
+    ):
+        experiment_runner.main(runtime_initializer=lambda: None)
 
 
 def test_experiment_runner_rejects_exact_output_for_multiple_legacy_chunks(monkeypatch, tmp_path):

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -5,14 +5,15 @@
 
 """Unit tests for CameraObsVideoRecorder.
 
-No Isaac Sim or GPU required. The moviepy encoder is mocked so tests run
-fast and on CPU-only machines.
+No Isaac Sim or GPU required. The incremental ffmpeg writer is mocked so tests
+run fast and on CPU-only machines.
 """
 
 import gymnasium as gym
 import os
 import shutil
 import torch
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -72,6 +73,45 @@ def _configure_step(env: _StubEnv, done_envs: list[int] | None = None, n_envs: i
     env._step_return = (obs, None, terminated, truncated, None)
 
 
+class _FakeWriter:
+    def __init__(self, path: str):
+        self.path = path
+        self.frame_count = 0
+        self.closed = False
+
+    def send(self, frame):
+        if frame is not None:
+            self.frame_count += 1
+
+    def close(self):
+        self.closed = True
+        with open(self.path, "wb") as stream:
+            stream.write(b"fake-mp4")
+
+
+class _FakeWriterFactory:
+    def __init__(self):
+        self.writers: list[_FakeWriter] = []
+
+    def __call__(self, path, *args, **kwargs):
+        writer = _FakeWriter(path)
+        self.writers.append(writer)
+        return writer
+
+
+def _mock_streaming_writers():
+    factory = _FakeWriterFactory()
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "isaaclab_arena.video.camera_observation_video_recorder.imageio_ffmpeg.write_frames",
+            side_effect=factory,
+        )
+    )
+    stack.enter_context(patch("isaaclab_arena.video.camera_observation_video_recorder._validate_encoded_video"))
+    return factory, stack
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -80,7 +120,8 @@ def _configure_step(env: _StubEnv, done_envs: list[int] | None = None, n_envs: i
 def test_video_files_written_on_termination(tmp_path):
     """A file per camera is written when an env terminates."""
     env = _make_env()
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip") as mock_clip_cls:
+    factory, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         _configure_step(env)
@@ -89,16 +130,17 @@ def test_video_files_written_on_termination(tmp_path):
         _configure_step(env, done_envs=[0])
         recorder.step(None)  # env 0 terminates → flush
 
-        written_paths = [c.args[0] for c in mock_clip_cls.return_value.write_videofile.call_args_list]
-        assert len(written_paths) == len(CAMERAS)
+        assert len(factory.writers) == 2 * len(CAMERAS)
         for cam in CAMERAS:
-            assert os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-0.mp4") in written_paths
+            path = os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-0.mp4")
+            assert os.path.isfile(path)
 
 
 def test_episode_counter_increments_per_env(tmp_path):
     """Each env tracks its own episode count independently via the env's centralized index."""
     env = _make_env()
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip"):
+    _, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         _configure_step(env)
@@ -123,10 +165,8 @@ def test_episode_counter_increments_per_env(tmp_path):
 def test_multiple_episodes_produce_sequential_filenames(tmp_path):
     """Consecutive episodes for an env are named episode-0, episode-1, ..."""
     env = _make_env()
-    written_paths = []
-
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip") as mock_clip_cls:
-        mock_clip_cls.return_value.write_videofile.side_effect = lambda path, **_: written_paths.append(path)
+    _, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         for _ in range(3):
@@ -137,13 +177,14 @@ def test_multiple_episodes_produce_sequential_filenames(tmp_path):
 
     for episode in range(3):
         for cam in CAMERAS:
-            assert os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-{episode}.mp4") in written_paths
+            assert os.path.isfile(os.path.join(str(tmp_path), f"robot-cam-env0-{cam}-episode-{episode}.mp4"))
 
 
 def test_partial_episode_dropped_on_close(tmp_path):
     """Frames accumulated without termination are silently discarded on close()."""
     env = _make_env()
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip") as mock_clip_cls:
+    factory, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         _configure_step(env)
@@ -151,13 +192,15 @@ def test_partial_episode_dropped_on_close(tmp_path):
 
         recorder.close()
 
-        mock_clip_cls.return_value.write_videofile.assert_not_called()
+        assert factory.writers and all(writer.closed for writer in factory.writers)
+        assert list(tmp_path.iterdir()) == []
 
 
 def test_no_video_written_for_empty_episode(tmp_path):
     """An env terminating with no buffered frames writes no video; its episode index still advances."""
     env = _make_env()
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip") as mock_clip_cls:
+    factory, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         # Terminate on the very first step — no prior frames were recorded.
@@ -166,14 +209,16 @@ def test_no_video_written_for_empty_episode(tmp_path):
 
         # No video for the empty episode, but the env's centralized index still advanced past it
         # (so a later episode's video number stays in lockstep with the per-episode results record).
-        mock_clip_cls.return_value.write_videofile.assert_not_called()
+        assert len(factory.writers) == len(CAMERAS)
+        assert not list(tmp_path.glob("robot-cam-env0-*.mp4"))
         assert env.get_episode_index(0) == 1
 
 
 def test_post_reset_frame_not_appended(tmp_path):
     """The obs on a terminal step (post-reset) is not buffered for the next episode."""
     env = _make_env()
-    with patch("isaaclab_arena.video.camera_observation_video_recorder.ImageSequenceClip"):
+    factory, mocked = _mock_streaming_writers()
+    with mocked:
         recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
 
         _configure_step(env)
@@ -182,13 +227,82 @@ def test_post_reset_frame_not_appended(tmp_path):
         _configure_step(env, done_envs=[0])
         recorder.step(None)  # env 0 terminates; post-reset frame discarded
 
-        # env 0's buffer is empty (flushed and post-reset frame discarded)
+        # env 0's writers were finalized; its post-reset frame was discarded.
         for cam in CAMERAS:
-            assert recorder.buffers[cam][0] == []
+            assert (cam, 0) not in recorder._writers
 
-        # env 1 accumulated 2 frames (neither step was terminal for it)
+        # env 1 streamed two frames (neither step was terminal for it).
         for cam in CAMERAS:
-            assert len(recorder.buffers[cam][1]) == 2
+            active = recorder._writers[(cam, 1)]
+            assert active.writer.frame_count == 2
+
+        assert sum(writer.frame_count for writer in factory.writers) == 6
+
+
+def test_long_episode_streams_without_buffering_frames(tmp_path):
+    """Recorder memory must not grow with episode length."""
+    env = _make_env()
+    factory, mocked = _mock_streaming_writers()
+    with mocked:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+        for _ in range(10_000):
+            _configure_step(env, n_envs=1)
+            recorder.step(None)
+
+        assert not hasattr(recorder, "buffers")
+        assert len(recorder._writers) == len(CAMERAS)
+        assert [writer.frame_count for writer in factory.writers] == [10_000, 10_000]
+
+        recorder.close()
+        assert list(tmp_path.iterdir()) == []
+
+
+def test_frame_shape_change_discards_partial_video(tmp_path):
+    env = _make_env()
+    _, mocked = _mock_streaming_writers()
+    with mocked:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+        _configure_step(env, n_envs=1)
+        recorder.step(None)
+        env._step_return = (
+            {CAMERA_OBS_GROUP_KEY: {cam: torch.zeros(1, H + 2, W, C, dtype=torch.uint8) for cam in CAMERAS}},
+            None,
+            torch.zeros(1, dtype=torch.bool),
+            torch.zeros(1, dtype=torch.bool),
+            None,
+        )
+
+        with pytest.raises(ValueError, match="changed frame shape"):
+            recorder.step(None)
+
+        recorder.close()
+        assert list(tmp_path.iterdir()) == []
+
+
+def test_failed_completion_validation_never_publishes(tmp_path):
+    env = _make_env()
+    factory = _FakeWriterFactory()
+    with (
+        patch(
+            "isaaclab_arena.video.camera_observation_video_recorder.imageio_ffmpeg.write_frames",
+            side_effect=factory,
+        ),
+        patch(
+            "isaaclab_arena.video.camera_observation_video_recorder._validate_encoded_video",
+            side_effect=RuntimeError("truncated stream"),
+        ),
+    ):
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+        _configure_step(env, n_envs=1)
+        recorder.step(None)
+        _configure_step(env, done_envs=[0], n_envs=1)
+        with pytest.raises(RuntimeError, match="truncated stream"):
+            recorder.step(None)
+
+        assert not recorder._writers
+
+    assert not list(tmp_path.glob("*.mp4"))
+    assert not list(tmp_path.glob("*.part"))
 
 
 @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not available")

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -151,6 +151,32 @@ def test_frames_are_streamed_not_buffered(tmp_path):
         assert all(writer.frames_written == 3 for writer in writers)
 
 
+def test_non_rgb_camera_observations_are_not_recorded(tmp_path):
+    """Depth and other non-RGB policy observations do not become video streams."""
+    env = _make_env()
+    terminated = torch.zeros(1, dtype=torch.bool)
+    truncated = torch.zeros(1, dtype=torch.bool)
+    env._step_return = (
+        {
+            CAMERA_OBS_GROUP_KEY: {
+                "exterior_rgb": torch.zeros(1, H, W, 3, dtype=torch.uint8),
+                "exterior_distance_to_image_plane": torch.zeros(1, H, W, 1),
+            }
+        },
+        None,
+        terminated,
+        truncated,
+        None,
+    )
+
+    with _patched_writers() as writers:
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+        recorder.step(None)
+
+    assert len(writers) == 1
+    assert writers[0].filename.endswith("-exterior_rgb-episode-0.mp4")
+
+
 def test_episode_counter_increments_per_env(tmp_path):
     """Each env tracks its own episode count independently via the env's centralized index."""
     env = _make_env()

--- a/isaaclab_arena/tests/test_camera_viewer.py
+++ b/isaaclab_arena/tests/test_camera_viewer.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+
+class _AssetWithInitialPose:
+    def __init__(self, initial_pose):
+        self.name = "test_asset"
+        self._initial_pose = initial_pose
+
+    def get_initial_pose(self):
+        return self._initial_pose
+
+
+def test_viewer_uses_first_environment_pose_for_pose_per_env():
+    asset = _AssetWithInitialPose(
+        PosePerEnv(
+            poses=[
+                Pose(position_xyz=(1.0, 2.0, 3.0)),
+                Pose(position_xyz=(4.0, 5.0, 6.0)),
+            ]
+        )
+    )
+
+    viewer_cfg = get_viewer_cfg_look_at_object(asset, offset=np.array([-1.0, 0.5, 2.0]))
+
+    assert viewer_cfg.lookat == (1.0, 2.0, 3.0)
+    assert viewer_cfg.eye == (0.0, 2.5, 5.0)

--- a/isaaclab_arena/tests/test_clutter_drop_poses.py
+++ b/isaaclab_arena/tests/test_clutter_drop_poses.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for clutter drop-pose generation.
+
+Pure geometry, so these run without a SimulationApp.
+"""
+
+import math
+import torch
+
+import pytest
+
+from isaaclab_arena.relations.clutter_drop_poses import (
+    ClutterDropParams,
+    ClutterRegion,
+    DropOrder,
+    DropPose,
+    XySampling,
+    compute_drop_poses,
+)
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+REGION = ClutterRegion(min_x=-0.18, min_y=-0.23, max_x=0.18, max_y=0.23, floor_z=0.8)
+
+
+def make_bbox(size_x: float, size_y: float, size_z: float, origin_offset_z: float = 0.0):
+    """Object-local bbox of the given size, optionally shifted so the origin is not centred."""
+    half_x, half_y, half_z = size_x / 2.0, size_y / 2.0, size_z / 2.0
+    return AxisAlignedBoundingBox(
+        min_point=(-half_x, -half_y, -half_z + origin_offset_z),
+        max_point=(half_x, half_y, half_z + origin_offset_z),
+    )
+
+
+def seeded(seed: int = 0) -> torch.Generator:
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    return generator
+
+
+def footprint_half_extents(bbox, rotation_xyzw):
+    rotated = bbox.rotated_by_quat(torch.tensor([rotation_xyzw], dtype=torch.float32))
+    size = rotated.size[0]
+    return float(size[0]) / 2.0, float(size[1]) / 2.0
+
+
+def assert_no_penetration(bboxes: list, poses: list[DropPose]) -> None:
+    """No two placed objects may overlap in all three axes simultaneously."""
+    for i in range(len(poses)):
+        for j in range(i + 1, len(poses)):
+            bbox_i = bboxes[i].rotated_by_quat(torch.tensor([poses[i].rotation_xyzw], dtype=torch.float32))
+            bbox_j = bboxes[j].rotated_by_quat(torch.tensor([poses[j].rotation_xyzw], dtype=torch.float32))
+            overlaps = []
+            for axis in range(3):
+                lo_i = poses[i].position[axis] + float(bbox_i.min_point[0][axis])
+                hi_i = poses[i].position[axis] + float(bbox_i.max_point[0][axis])
+                lo_j = poses[j].position[axis] + float(bbox_j.min_point[0][axis])
+                hi_j = poses[j].position[axis] + float(bbox_j.max_point[0][axis])
+                overlaps.append(lo_i < hi_j and lo_j < hi_i)
+            assert not all(overlaps), f"objects {i} and {j} interpenetrate at spawn"
+
+
+# --------------------------------------------------------------------------- basics
+
+
+def test_returns_one_pose_per_object_in_input_order():
+    bboxes = [make_bbox(0.05, 0.05, 0.04), make_bbox(0.1, 0.03, 0.02), make_bbox(0.02, 0.02, 0.08)]
+    poses = compute_drop_poses(bboxes, REGION, generator=seeded())
+
+    assert len(poses) == len(bboxes)
+    assert sorted(pose.drop_index for pose in poses) == [0, 1, 2]
+
+
+def test_rejects_empty_input():
+    with pytest.raises(AssertionError):
+        compute_drop_poses([], REGION, generator=seeded())
+
+
+def test_rejects_batched_bounding_box():
+    batched = AxisAlignedBoundingBox(
+        min_point=torch.tensor([[-0.1, -0.1, -0.1], [-0.1, -0.1, -0.1]]),
+        max_point=torch.tensor([[0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]),
+    )
+    with pytest.raises(AssertionError, match="single-env"):
+        compute_drop_poses([batched], REGION, generator=seeded())
+
+
+# --------------------------------------------------------------------- containment
+
+
+@pytest.mark.parametrize("sampling", [XySampling.UNIFORM, XySampling.GRID_CELLS])
+def test_rotated_footprint_stays_inside_region(sampling):
+    """The whole footprint must land inside the region, not merely the object origin."""
+    bboxes = [make_bbox(0.12, 0.04, 0.03) for _ in range(6)]
+    params = ClutterDropParams(xy_sampling=sampling)
+    poses = compute_drop_poses(bboxes, REGION, params, generator=seeded(3))
+
+    for bbox, pose in zip(bboxes, poses):
+        half_x, half_y = footprint_half_extents(bbox, pose.rotation_xyzw)
+        assert pose.position[0] - half_x >= REGION.min_x - 1e-6
+        assert pose.position[0] + half_x <= REGION.max_x + 1e-6
+        assert pose.position[1] - half_y >= REGION.min_y - 1e-6
+        assert pose.position[1] + half_y <= REGION.max_y + 1e-6
+
+
+def test_object_too_large_for_region_fails_closed():
+    oversized = make_bbox(1.0, 1.0, 0.05)
+    with pytest.raises(AssertionError, match="does not fit in region"):
+        compute_drop_poses([oversized], REGION, generator=seeded())
+
+
+def test_clutter_spread_narrows_the_usable_area():
+    bboxes = [make_bbox(0.02, 0.02, 0.02) for _ in range(8)]
+    tight = ClutterDropParams(clutter_spread=0.25, xy_sampling=XySampling.UNIFORM)
+    poses = compute_drop_poses(bboxes, REGION, tight, generator=seeded(5))
+
+    centre_x = (REGION.min_x + REGION.max_x) / 2.0
+    half_width = (REGION.max_x - REGION.min_x) / 2.0
+    for pose in poses:
+        assert abs(pose.position[0] - centre_x) <= half_width * 0.25 + 1e-6
+
+
+# ------------------------------------------------------------------ drop heights
+
+
+def test_clear_column_starts_just_above_the_floor():
+    """An object with nothing beneath it must not be lifted over unrelated objects."""
+    bbox = make_bbox(0.04, 0.04, 0.06)
+    poses = compute_drop_poses([bbox], REGION, ClutterDropParams(random_yaw=False), generator=seeded())
+
+    expected_bottom = REGION.floor_z + ClutterDropParams().clearance_m
+    assert poses[0].position[2] + float(bbox.min_point[0][2]) == pytest.approx(expected_bottom)
+
+
+def test_origin_offset_is_respected_so_the_base_clears_the_floor():
+    """Placement uses the box's own bottom offset, not an assumption that the origin is centred."""
+    offset_bbox = make_bbox(0.04, 0.04, 0.06, origin_offset_z=0.03)
+    poses = compute_drop_poses([offset_bbox], REGION, ClutterDropParams(random_yaw=False), generator=seeded())
+
+    lowest_point = poses[0].position[2] + float(offset_bbox.min_point[0][2])
+    assert lowest_point == pytest.approx(REGION.floor_z + ClutterDropParams().clearance_m)
+
+
+def test_overlapping_footprints_stack_and_disjoint_ones_do_not():
+    """The ladder is per column: only objects sharing a column are lifted over each other."""
+    tall = make_bbox(0.02, 0.02, 0.10)
+    # A region only wide enough for one column forces every object to overlap.
+    narrow = ClutterRegion(min_x=-0.01, min_y=-0.01, max_x=0.01, max_y=0.01, floor_z=0.5)
+    stacked = compute_drop_poses(
+        [tall, tall, tall],
+        narrow,
+        ClutterDropParams(xy_sampling=XySampling.UNIFORM, random_yaw=False),
+        generator=seeded(1),
+    )
+    heights = sorted(pose.position[2] for pose in stacked)
+    assert heights[1] > heights[0] and heights[2] > heights[1], "objects sharing a column must stack"
+
+    # Widely separated cells: nothing is lifted.
+    wide = ClutterRegion(min_x=-2.0, min_y=-2.0, max_x=2.0, max_y=2.0, floor_z=0.5)
+    spread = compute_drop_poses(
+        [make_bbox(0.02, 0.02, 0.02) for _ in range(4)],
+        wide,
+        ClutterDropParams(random_yaw=False),
+        generator=seeded(2),
+    )
+    assert len({round(pose.position[2], 6) for pose in spread}) == 1, "disjoint columns must share a height"
+
+
+@pytest.mark.parametrize("sampling", [XySampling.UNIFORM, XySampling.GRID_CELLS])
+def test_no_interpenetration_at_spawn(sampling):
+    """The core guarantee: a drop layout is always penetration-free."""
+    bboxes = [make_bbox(0.06, 0.03, 0.02), make_bbox(0.03, 0.03, 0.09), make_bbox(0.08, 0.05, 0.03)] * 3
+    params = ClutterDropParams(xy_sampling=sampling)
+    for seed in range(5):
+        poses = compute_drop_poses(bboxes, REGION, params, generator=seeded(seed))
+        assert_no_penetration(bboxes, poses)
+
+
+# ------------------------------------------------------------------- drop order
+
+
+def test_flattest_first_drops_shortest_object_first():
+    tall, flat, medium = make_bbox(0.03, 0.03, 0.20), make_bbox(0.05, 0.05, 0.01), make_bbox(0.04, 0.04, 0.07)
+    poses = compute_drop_poses(
+        [tall, flat, medium], REGION, ClutterDropParams(drop_order=DropOrder.FLATTEST_FIRST), generator=seeded()
+    )
+    assert poses[1].drop_index == 0, "flattest object must be dropped first"
+    assert poses[0].drop_index == 2, "tallest object must be dropped last"
+
+
+def test_as_listed_preserves_caller_order():
+    bboxes = [make_bbox(0.03, 0.03, 0.20), make_bbox(0.05, 0.05, 0.01), make_bbox(0.04, 0.04, 0.07)]
+    poses = compute_drop_poses(bboxes, REGION, ClutterDropParams(drop_order=DropOrder.AS_LISTED), generator=seeded())
+    assert [pose.drop_index for pose in poses] == [0, 1, 2]
+
+
+def test_shuffle_varies_order_across_seeds():
+    bboxes = [make_bbox(0.03, 0.03, 0.02) for _ in range(8)]
+    params = ClutterDropParams(drop_order=DropOrder.SHUFFLE)
+    orders = {
+        tuple(pose.drop_index for pose in compute_drop_poses(bboxes, REGION, params, generator=seeded(seed)))
+        for seed in range(6)
+    }
+    assert len(orders) > 1, "shuffling must produce different orders across seeds"
+
+
+# ---------------------------------------------------------------- reproducibility
+
+
+def test_same_seed_reproduces_layout_exactly():
+    bboxes = [make_bbox(0.05, 0.03, 0.04) for _ in range(6)]
+    first = compute_drop_poses(bboxes, REGION, generator=seeded(11))
+    second = compute_drop_poses(bboxes, REGION, generator=seeded(11))
+    assert first == second
+
+
+def test_different_seeds_produce_different_layouts():
+    bboxes = [make_bbox(0.05, 0.03, 0.04) for _ in range(6)]
+    first = compute_drop_poses(bboxes, REGION, generator=seeded(11))
+    second = compute_drop_poses(bboxes, REGION, generator=seeded(12))
+    assert first != second
+
+
+# ---------------------------------------------------------------------- rotation
+
+
+def test_random_yaw_disabled_gives_identity_rotation():
+    poses = compute_drop_poses(
+        [make_bbox(0.05, 0.05, 0.05)], REGION, ClutterDropParams(random_yaw=False), generator=seeded()
+    )
+    assert poses[0].rotation_xyzw == (0.0, 0.0, 0.0, 1.0)
+
+
+def test_rotation_is_a_unit_yaw_quaternion():
+    poses = compute_drop_poses([make_bbox(0.05, 0.05, 0.05) for _ in range(5)], REGION, generator=seeded(7))
+    for pose in poses:
+        x, y, z, w = pose.rotation_xyzw
+        assert math.isclose(math.sqrt(x * x + y * y + z * z + w * w), 1.0, rel_tol=1e-6)
+        assert (x, y) == (0.0, 0.0), "clutter yaw must rotate about Z only"
+
+
+def test_yaw_widens_footprint_and_placement_accounts_for_it():
+    """A long object turned 45 degrees needs more room, and must still land inside."""
+    elongated = [make_bbox(0.16, 0.02, 0.02) for _ in range(4)]
+    poses = compute_drop_poses(elongated, REGION, generator=seeded(4))
+    for bbox, pose in zip(elongated, poses):
+        half_x, half_y = footprint_half_extents(bbox, pose.rotation_xyzw)
+        assert pose.position[0] - half_x >= REGION.min_x - 1e-6
+        assert pose.position[0] + half_x <= REGION.max_x + 1e-6
+        assert pose.position[1] - half_y >= REGION.min_y - 1e-6
+        assert pose.position[1] + half_y <= REGION.max_y + 1e-6
+
+
+# ------------------------------------------------------------------------ region
+
+
+def test_region_rejects_inverted_bounds():
+    with pytest.raises(AssertionError):
+        ClutterRegion(min_x=0.2, min_y=-0.1, max_x=-0.2, max_y=0.1, floor_z=0.0)
+
+
+def test_region_scaled_keeps_centre_and_floor():
+    region = ClutterRegion(min_x=0.0, min_y=0.0, max_x=1.0, max_y=2.0, floor_z=0.7)
+    scaled = region.scaled(0.5)
+    assert (scaled.min_x, scaled.max_x) == pytest.approx((0.25, 0.75))
+    assert (scaled.min_y, scaled.max_y) == pytest.approx((0.5, 1.5))
+    assert scaled.floor_z == region.floor_z

--- a/isaaclab_arena/tests/test_clutter_drop_poses.py
+++ b/isaaclab_arena/tests/test_clutter_drop_poses.py
@@ -295,6 +295,29 @@ def test_random_yaw_disabled_gives_identity_rotation():
     assert poses[0].rotation_xyzw == (0.0, 0.0, 0.0, 1.0)
 
 
+def test_base_rotation_tilts_object_and_refits_drop_height():
+    """A source-authored tilt must affect both the emitted pose and spawn geometry."""
+    pitch_quarter_turn = (0.0, math.sin(math.pi / 4.0), 0.0, math.cos(math.pi / 4.0))
+    upright = make_bbox(0.04, 0.04, 0.20)
+
+    poses = compute_drop_poses(
+        [upright],
+        REGION,
+        ClutterDropParams(random_yaw=False),
+        generator=seeded(),
+        base_rotations_xyzw=[pitch_quarter_turn],
+    )
+
+    pose = poses[0]
+    assert pose.rotation_xyzw == pytest.approx(pitch_quarter_turn)
+    rotated = upright.rotated_by_quat(torch.tensor([pose.rotation_xyzw], dtype=torch.float32))
+    assert float(rotated.size[0][0]) == pytest.approx(0.20)
+    assert float(rotated.size[0][2]) == pytest.approx(0.04)
+    assert pose.position[2] + float(rotated.bottom_surface_z[0]) == pytest.approx(
+        REGION.floor_z + ClutterDropParams().clearance_m
+    )
+
+
 def test_rotation_is_a_unit_yaw_quaternion():
     poses = compute_drop_poses([make_bbox(0.05, 0.05, 0.05) for _ in range(5)], REGION, generator=seeded(7))
     for pose in poses:

--- a/isaaclab_arena/tests/test_clutter_drop_poses.py
+++ b/isaaclab_arena/tests/test_clutter_drop_poses.py
@@ -26,13 +26,38 @@ from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 REGION = ClutterRegion(min_x=-0.18, min_y=-0.23, max_x=0.18, max_y=0.23, floor_z=0.8)
 
 
-def make_bbox(size_x: float, size_y: float, size_z: float, origin_offset_z: float = 0.0):
-    """Object-local bbox of the given size, optionally shifted so the origin is not centred."""
+def make_bbox(
+    size_x: float,
+    size_y: float,
+    size_z: float,
+    origin_offset_z: float = 0.0,
+    origin_offset_x: float = 0.0,
+    origin_offset_y: float = 0.0,
+):
+    """Object-local bbox of the given size, optionally shifted so the origin is not centred.
+
+    USD pivots sit wherever the asset author put them, so an off-centre box is the normal
+    case rather than an edge case.
+    """
     half_x, half_y, half_z = size_x / 2.0, size_y / 2.0, size_z / 2.0
     return AxisAlignedBoundingBox(
-        min_point=(-half_x, -half_y, -half_z + origin_offset_z),
-        max_point=(half_x, half_y, half_z + origin_offset_z),
+        min_point=(-half_x + origin_offset_x, -half_y + origin_offset_y, -half_z + origin_offset_z),
+        max_point=(half_x + origin_offset_x, half_y + origin_offset_y, half_z + origin_offset_z),
     )
+
+
+def assert_footprints_inside(bboxes: list, poses: list[DropPose], region: ClutterRegion) -> None:
+    """Every placed object's rotated footprint must lie wholly within the region."""
+    for index, (bbox, pose) in enumerate(zip(bboxes, poses)):
+        rotated = bbox.rotated_by_quat(torch.tensor([pose.rotation_xyzw], dtype=torch.float32))
+        min_x = pose.position[0] + float(rotated.min_point[0][0])
+        max_x = pose.position[0] + float(rotated.max_point[0][0])
+        min_y = pose.position[1] + float(rotated.min_point[0][1])
+        max_y = pose.position[1] + float(rotated.max_point[0][1])
+        assert min_x >= region.min_x - 1e-6, f"object {index} spans x={min_x:.4f} past {region.min_x}"
+        assert max_x <= region.max_x + 1e-6, f"object {index} spans x={max_x:.4f} past {region.max_x}"
+        assert min_y >= region.min_y - 1e-6, f"object {index} spans y={min_y:.4f} past {region.min_y}"
+        assert max_y <= region.max_y + 1e-6, f"object {index} spans y={max_y:.4f} past {region.max_y}"
 
 
 def seeded(seed: int = 0) -> torch.Generator:
@@ -304,3 +329,44 @@ def test_region_scaled_keeps_centre_and_floor():
     assert (scaled.min_x, scaled.max_x) == pytest.approx((0.25, 0.75))
     assert (scaled.min_y, scaled.max_y) == pytest.approx((0.5, 1.5))
     assert scaled.floor_z == region.floor_z
+
+
+# ------------------------------------------------------- off-centre bounding boxes
+
+
+def test_off_centre_footprint_stays_inside_the_region():
+    # Origin at one corner of the box, the shape a USD pivot commonly takes.
+    bboxes = [make_bbox(0.06, 0.06, 0.04, origin_offset_x=0.03, origin_offset_y=0.03) for _ in range(6)]
+    poses = compute_drop_poses(bboxes, REGION, generator=seeded())
+    assert_footprints_inside(bboxes, poses, REGION)
+
+
+def test_off_centre_footprint_does_not_interpenetrate():
+    bboxes = [
+        make_bbox(0.05, 0.05, 0.04, origin_offset_x=0.025, origin_offset_y=-0.025),
+        make_bbox(0.06, 0.04, 0.03, origin_offset_x=-0.03),
+        make_bbox(0.04, 0.06, 0.05, origin_offset_y=0.03),
+        make_bbox(0.05, 0.05, 0.04),
+    ]
+    for seed in range(5):
+        poses = compute_drop_poses(bboxes, REGION, generator=seeded(seed))
+        assert_no_penetration(bboxes, poses)
+        assert_footprints_inside(bboxes, poses, REGION)
+
+
+def test_strongly_offset_origin_is_still_contained_without_yaw():
+    # A box lying entirely on the +X side of its origin has nothing centred about it.
+    params = ClutterDropParams(random_yaw=False)
+    bboxes = [make_bbox(0.08, 0.04, 0.03, origin_offset_x=0.04) for _ in range(4)]
+    poses = compute_drop_poses(bboxes, REGION, params, generator=seeded())
+    assert_footprints_inside(bboxes, poses, REGION)
+    assert_no_penetration(bboxes, poses)
+
+
+def test_off_centre_boxes_are_contained_under_both_samplers():
+    bboxes = [make_bbox(0.05, 0.05, 0.03, origin_offset_x=0.025, origin_offset_y=0.025) for _ in range(8)]
+    for sampling in (XySampling.GRID_CELLS, XySampling.UNIFORM):
+        params = ClutterDropParams(xy_sampling=sampling)
+        poses = compute_drop_poses(bboxes, REGION, params, generator=seeded(3))
+        assert_footprints_inside(bboxes, poses, REGION)
+        assert_no_penetration(bboxes, poses)

--- a/isaaclab_arena/tests/test_clutter_drop_poses.py
+++ b/isaaclab_arena/tests/test_clutter_drop_poses.py
@@ -112,6 +112,42 @@ def test_object_too_large_for_region_fails_closed():
         compute_drop_poses([oversized], REGION, generator=seeded())
 
 
+def test_unlucky_yaw_is_resampled_rather_than_failing():
+    """A long object in a narrow region only fits near-axis-aligned; retry until it does.
+
+    A 0.28 x 0.04 m object fits lengthwise in a 0.36 x 0.12 m region but not turned much
+    past ~17 degrees, so most draws miss. Without retrying, four in five layouts would fail.
+    Attempts are raised well above the default because the odds compound: the default suits
+    ordinary regions, not a deliberately punishing one.
+    """
+    narrow = ClutterRegion(min_x=-0.18, min_y=-0.06, max_x=0.18, max_y=0.06, floor_z=0.0)
+    elongated = make_bbox(0.28, 0.04, 0.02)
+    params = ClutterDropParams(max_yaw_attempts=64)
+
+    for seed in range(5):
+        poses = compute_drop_poses([elongated], narrow, params, generator=seeded(seed))
+        half_x, half_y = footprint_half_extents(elongated, poses[0].rotation_xyzw)
+        assert half_y <= (narrow.max_y - narrow.min_y) / 2.0 + 1e-6, "chosen yaw must fit the narrow axis"
+        assert poses[0].position[1] - half_y >= narrow.min_y - 1e-6
+        assert poses[0].position[1] + half_y <= narrow.max_y + 1e-6
+
+
+def test_no_orientation_fits_reports_attempt_count():
+    """When no yaw can fit, the failure says so rather than blaming one unlucky draw."""
+    oversized = make_bbox(1.0, 1.0, 0.05)
+    params = ClutterDropParams(max_yaw_attempts=3)
+    with pytest.raises(AssertionError, match="after 3 orientation attempt"):
+        compute_drop_poses([oversized], REGION, params, generator=seeded())
+
+
+def test_axis_aligned_layouts_try_a_single_orientation():
+    """With random_yaw disabled there is only one orientation, so retrying is pointless."""
+    oversized = make_bbox(1.0, 1.0, 0.05)
+    params = ClutterDropParams(random_yaw=False, max_yaw_attempts=8)
+    with pytest.raises(AssertionError, match="after 1 orientation attempt"):
+        compute_drop_poses([oversized], REGION, params, generator=seeded())
+
+
 def test_clutter_spread_narrows_the_usable_area():
     bboxes = [make_bbox(0.02, 0.02, 0.02) for _ in range(8)]
     tight = ClutterDropParams(clutter_spread=0.25, xy_sampling=XySampling.UNIFORM)

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -51,16 +51,14 @@ def _build_scene(seed: int):
     return arena_env, support, members
 
 
-def _pour_and_settle(seed: int):
-    """Build, settle, and return (region, settled_at, resting positions, member names)."""
+def _build_and_reset(seed: int):
+    """Build the env and reset it, returning (env, support, members, region, poses_fn)."""
     import torch
 
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
     from isaaclab_arena.relations.clutter_pour import region_above_support
-    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker
-    from isaaclab_arena.utils import physics_settle
 
     arena_env, support, members = _build_scene(seed)
     # Build args from the real parser rather than a hand-rolled Namespace: the builder reads
@@ -76,7 +74,6 @@ def _pour_and_settle(seed: int):
 
     scene = env.unwrapped.scene
     member_keys = [member.get_scene_key() for member in members]
-    names = [member.name for member in members]
     region = region_above_support(
         tuple(float(value) for value in support.get_initial_pose().position_xyz),
         get_bounding_box_per_env(support, 1),
@@ -85,6 +82,17 @@ def _pour_and_settle(seed: int):
     def poses():
         states = torch.stack([scene[key].data.root_state_w[0] for key in member_keys])
         return states[:, :3] - scene.env_origins[0], states[:, 3:7]
+
+    return env, support, members, region, poses
+
+
+def _pour_and_settle(seed: int):
+    """Build, settle, and return (region, settled_at, spawn positions, resting positions, names)."""
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker
+    from isaaclab_arena.utils import physics_settle
+
+    env, _support, members, region, poses = _build_and_reset(seed)
+    names = [member.name for member in members]
 
     spawn_positions, _ = poses()
     tracker = SettleTracker(ClutterSettleParams())
@@ -124,6 +132,29 @@ def _test_clutter_settles_on_its_support(simulation_app) -> bool:
     return True
 
 
+def _test_pile_is_already_settled_at_reset(simulation_app) -> bool:
+    """A reset must place the resting pile, not the poses it was released from."""
+    import torch
+
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, check_resting_poses
+    from isaaclab_arena.utils import physics_settle
+
+    env, support, members, region, poses = _build_and_reset(seed=0)
+    positions, rotations = poses()
+
+    verdict = check_resting_poses(positions, region, ClutterSettleParams(containment_margin_m=0.05))
+    assert not verdict.diverged, "reset produced non-finite poses"
+
+    # Stepping a settled pile barely moves it; a pile still falling moves a long way.
+    physics_settle.step_physics(env, 60)
+    moved_positions, moved_rotations = poses()
+    drift = float((moved_positions - positions).norm(dim=-1).max())
+    env.close()
+
+    assert drift < 0.02, f"pile moved {drift:.3f} m after reset, so the reset wrote falling poses"
+    return True
+
+
 def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
     import torch
 
@@ -135,6 +166,10 @@ def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
 
 def test_clutter_settles_on_its_support():
     assert run_simulation_app_function(_test_clutter_settles_on_its_support)
+
+
+def test_pile_is_already_settled_at_reset():
+    assert run_simulation_app_function(_test_pile_is_already_settled_at_reset)
 
 
 def test_same_seed_reproduces_the_pile():

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-sim tests for clutter declared with the ``cluttered_on`` relation.
+
+Covers the path the sim-free tests cannot: that members reach placement at all, that drop
+poses survive as spawn poses, and that the pile comes to rest on its support.
+"""
+
+from __future__ import annotations
+
+from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+SUPPORT_ASSET = "office_table_background"
+CLUTTER_ASSETS = ["tomato_soup_can", "cracker_box", "sugar_box", "mustard_bottle", "dex_cube", "mug"]
+OBJECT_COUNT = 6
+MAX_SETTLE_STEPS = 2000
+POLL_EVERY = 50
+
+
+def _build_scene(seed: int):
+    """A kinematic table with one declared clutter group resting on it."""
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.no_task import NoTask
+    from isaaclab_arena.utils.pose import Pose
+
+    registry = AssetRegistry()
+    light = registry.get_asset_by_name("light")(spawner_cfg=sim_utils.DomeLightCfg(intensity=1500.0))
+    ground = registry.get_asset_by_name("ground_plane")()
+
+    support = registry.get_asset_by_name(SUPPORT_ASSET)()
+    support.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+    support.add_relation(IsAnchor())
+
+    members = []
+    for index in range(OBJECT_COUNT):
+        asset_name = CLUTTER_ASSETS[index % len(CLUTTER_ASSETS)]
+        member = registry.get_asset_by_name(asset_name)(instance_name=f"{asset_name}_{index}")
+        member.add_relation(ClutteredOn(support, group="tools"))
+        members.append(member)
+
+    scene = Scene(assets=[ground, light, support, *members])
+    arena_env = IsaacLabArenaEnvironment(name=f"clutter_test_{seed}", scene=scene, task=NoTask())
+    return arena_env, support, members
+
+
+def _pour_and_settle(seed: int):
+    """Build, settle, and return (region, settled_at, resting positions, member names)."""
+    import argparse
+    import torch
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
+    from isaaclab_arena.relations.clutter_pour import region_above_support
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, SettleTracker
+    from isaaclab_arena.utils import physics_settle
+
+    arena_env, support, members = _build_scene(seed)
+    args = argparse.Namespace(
+        num_envs=1,
+        placement_seed=seed,
+        language_instruction=None,
+        mimic=False,
+        presets=None,
+        resolve_on_reset=None,
+    )
+    env = ArenaEnvBuilder(arena_env, args).make_registered()
+    env.reset()
+
+    scene = env.unwrapped.scene
+    member_keys = [member.get_scene_key() for member in members]
+    names = [member.name for member in members]
+    region = region_above_support(
+        tuple(float(value) for value in support.get_initial_pose().position_xyz),
+        get_bounding_box_per_env(support, 1),
+    )
+
+    def poses():
+        states = torch.stack([scene[key].data.root_state_w[0] for key in member_keys])
+        return states[:, :3] - scene.env_origins[0], states[:, 3:7]
+
+    spawn_positions, _ = poses()
+    tracker = SettleTracker(ClutterSettleParams())
+    settled_at = None
+    stepped = 0
+    while stepped < MAX_SETTLE_STEPS:
+        chunk = min(POLL_EVERY, MAX_SETTLE_STEPS - stepped)
+        physics_settle.step_physics(env, chunk)
+        stepped += chunk
+        if tracker.update(*poses()):
+            settled_at = stepped
+            break
+
+    positions, _ = poses()
+    result = (region, settled_at, spawn_positions.clone(), positions.clone(), names)
+    env.close()
+    return result
+
+
+def _test_clutter_settles_on_its_support(simulation_app) -> bool:
+    from isaaclab_arena.relations.clutter_validation import check_resting_poses
+
+    region, settled_at, spawn_positions, positions, names = _pour_and_settle(seed=0)
+
+    # Members must reach placement and be released above the support, not left at the origin.
+    above = int((spawn_positions[:, 2] > region.floor_z).sum())
+    assert above == len(names), f"only {above}/{len(names)} members spawned above the support surface"
+
+    assert settled_at is not None, f"pile never settled within {MAX_SETTLE_STEPS} steps"
+
+    verdict = check_resting_poses(positions, region)
+    assert verdict.ok, f"pile came to rest badly: {verdict.describe(names)}"
+
+    # Resting on the support, not merely inside its footprint at ground level.
+    lowest = float(positions[:, 2].min())
+    assert lowest > region.floor_z, f"lowest member rests at {lowest:.3f}, at or below support top {region.floor_z:.3f}"
+    return True
+
+
+def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
+    import torch
+
+    _, _, _, first, _ = _pour_and_settle(seed=7)
+    _, _, _, second, _ = _pour_and_settle(seed=7)
+    assert torch.allclose(first, second, atol=1e-4), "same seed produced different piles"
+    return True
+
+
+def test_clutter_settles_on_its_support():
+    assert run_simulation_app_function(_test_clutter_settles_on_its_support)
+
+
+def test_same_seed_reproduces_the_pile():
+    assert run_simulation_app_function(_test_same_seed_reproduces_the_pile)

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -261,15 +261,15 @@ def test_pile_is_already_settled_at_reset():
 
 
 def test_every_parallel_env_gets_its_own_settled_pile():
-    assert run_simulation_app_function(_test_every_parallel_env_gets_its_own_settled_pile)
+    assert run_function_with_persistent_simulation_app(_test_every_parallel_env_gets_its_own_settled_pile)
 
 
 def test_spilled_layouts_are_rejected_from_the_cache():
-    assert run_simulation_app_function(_test_spilled_layouts_are_rejected_from_the_cache)
+    assert run_function_with_persistent_simulation_app(_test_spilled_layouts_are_rejected_from_the_cache)
 
 
 def test_pile_stays_settled_after_the_pool_refills():
-    assert run_simulation_app_function(_test_pile_stays_settled_after_the_pool_refills)
+    assert run_function_with_persistent_simulation_app(_test_pile_stays_settled_after_the_pool_refills)
 
 
 def test_same_seed_reproduces_the_pile():

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -51,8 +51,12 @@ def _build_scene(seed: int):
     return arena_env, support, members
 
 
-def _build_and_reset(seed: int):
-    """Build the env and reset it, returning (env, support, members, region, poses_fn)."""
+def _build_and_reset(seed: int, num_envs: int = 1):
+    """Build the env and reset it, returning (env, support, members, region, poses_fn).
+
+    ``poses_fn(env_id)`` returns that environment's member poses in its own local frame, so
+    per-env results are directly comparable against the same region.
+    """
     import torch
 
     from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
@@ -64,7 +68,7 @@ def _build_and_reset(seed: int):
     # Build args from the real parser rather than a hand-rolled Namespace: the builder reads
     # more fields than are obvious, and a missing one fails only once the env is constructed.
     args = get_isaaclab_arena_cli_parser().parse_args([])
-    args.num_envs = 1
+    args.num_envs = num_envs
     args.placement_seed = seed
     for name, default in (("language_instruction", None), ("mimic", False)):
         if not hasattr(args, name):
@@ -76,12 +80,12 @@ def _build_and_reset(seed: int):
     member_keys = [member.get_scene_key() for member in members]
     region = region_above_support(
         tuple(float(value) for value in support.get_initial_pose().position_xyz),
-        get_bounding_box_per_env(support, 1),
+        get_bounding_box_per_env(support, num_envs),
     )
 
-    def poses():
-        states = torch.stack([scene[key].data.root_state_w[0] for key in member_keys])
-        return states[:, :3] - scene.env_origins[0], states[:, 3:7]
+    def poses(env_id: int = 0):
+        states = torch.stack([scene[key].data.root_state_w[env_id] for key in member_keys])
+        return states[:, :3] - scene.env_origins[env_id], states[:, 3:7]
 
     return env, support, members, region, poses
 
@@ -153,6 +157,34 @@ def _test_pile_is_already_settled_at_reset(simulation_app) -> bool:
     return True
 
 
+def _test_every_parallel_env_gets_its_own_settled_pile(simulation_app) -> bool:
+    """Each environment must receive a pile of its own, settled on its own support."""
+    import torch
+
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, check_resting_poses
+
+    num_envs = 4
+    env, _support, members, region, poses = _build_and_reset(seed=0, num_envs=num_envs)
+    names = [member.name for member in members]
+    params = ClutterSettleParams(containment_margin_m=0.05)
+
+    per_env_positions = []
+    for env_id in range(num_envs):
+        positions, _ = poses(env_id)
+        per_env_positions.append(positions.clone())
+        verdict = check_resting_poses(positions, region, params)
+        assert verdict.ok, f"env {env_id} came to rest badly: {verdict.describe(names)}"
+        lowest = float(positions[:, 2].min())
+        assert lowest > region.floor_z, f"env {env_id} lowest member rests at {lowest:.3f}, below the support"
+
+    env.close()
+
+    # A pool that hands every env the same layout would defeat per-env variation.
+    distinct = any(not torch.allclose(per_env_positions[0], other, atol=1e-4) for other in per_env_positions[1:])
+    assert distinct, "every parallel env received an identical pile"
+    return True
+
+
 def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
     import torch
 
@@ -168,6 +200,10 @@ def test_clutter_settles_on_its_support():
 
 def test_pile_is_already_settled_at_reset():
     assert run_function_with_persistent_simulation_app(_test_pile_is_already_settled_at_reset)
+
+
+def test_every_parallel_env_gets_its_own_settled_pile():
+    assert run_simulation_app_function(_test_every_parallel_env_gets_its_own_settled_pile)
 
 
 def test_same_seed_reproduces_the_pile():

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -216,25 +216,30 @@ def _test_spilled_layouts_are_rejected_from_the_cache(simulation_app) -> bool:
 
 
 def _test_pile_stays_settled_after_the_pool_refills(simulation_app) -> bool:
-    """Layouts added when the pool refills must be settled too, not left as drop poses."""
+    """Every reset must place a settled pile, including past the cached set.
+
+    Settling steps physics and so cannot run inside a reset. A pool that solved fresh layouts
+    when its queue ran dry would hand back poses nothing had settled, and the pile would be
+    released mid-air from the reset that exhausted the cache onwards.
+    """
     from isaaclab_arena.utils import physics_settle
 
     layouts_per_env = 2
     env, _support, _members, _region, poses = _build_and_reset(seed=0, layouts_per_env=layouts_per_env)
 
     worst_drift = 0.0
-    # Reset well past the initial pool so the refill path is exercised.
-    for reset_index in range(layouts_per_env * 3):
+    # Well past the cached set, so a queue that refilled instead of rewinding would show.
+    for reset_index in range(layouts_per_env * 4):
         env.reset()
         before, _ = poses()
-        physics_settle.step_physics(env, 60)
+        physics_settle.step_physics(env, 200)
         after, _ = poses()
         drift = float((after - before).norm(dim=-1).max())
         worst_drift = max(worst_drift, drift)
         print(f"  reset {reset_index}: drift {drift:.4f} m")
     env.close()
 
-    assert worst_drift < 0.02, f"a reset placed a falling pile: worst drift {worst_drift:.3f} m"
+    assert worst_drift < 0.05, f"a reset placed a pile that was not settled: worst drift {worst_drift:.3f} m"
     return True
 
 

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -134,8 +134,6 @@ def _test_clutter_settles_on_its_support(simulation_app) -> bool:
 
 def _test_pile_is_already_settled_at_reset(simulation_app) -> bool:
     """A reset must place the resting pile, not the poses it was released from."""
-    import torch
-
     from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, check_resting_poses
     from isaaclab_arena.utils import physics_settle
 

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -11,7 +11,7 @@ poses survive as spawn poses, and that the pile comes to rest on its support.
 
 from __future__ import annotations
 
-from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 SUPPORT_ASSET = "office_table_background"
 CLUTTER_ASSETS = ["tomato_soup_can", "cracker_box", "sugar_box", "mustard_bottle", "dex_cube", "mug"]
@@ -163,12 +163,12 @@ def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
 
 
 def test_clutter_settles_on_its_support():
-    assert run_simulation_app_function(_test_clutter_settles_on_its_support)
+    assert run_function_with_persistent_simulation_app(_test_clutter_settles_on_its_support)
 
 
 def test_pile_is_already_settled_at_reset():
-    assert run_simulation_app_function(_test_pile_is_already_settled_at_reset)
+    assert run_function_with_persistent_simulation_app(_test_pile_is_already_settled_at_reset)
 
 
 def test_same_seed_reproduces_the_pile():
-    assert run_simulation_app_function(_test_same_seed_reproduces_the_pile)
+    assert run_function_with_persistent_simulation_app(_test_same_seed_reproduces_the_pile)

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -20,7 +20,7 @@ MAX_SETTLE_STEPS = 2000
 POLL_EVERY = 50
 
 
-def _build_scene(seed: int):
+def _build_scene(seed: int, layouts_per_env: int | None = None):
     """A kinematic table with one declared clutter group resting on it."""
     import isaaclab.sim as sim_utils
 
@@ -46,12 +46,24 @@ def _build_scene(seed: int):
         member.add_relation(ClutteredOn(support, group="tools"))
         members.append(member)
 
+    placer_params = None
+    if layouts_per_env is not None:
+        from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+        from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+
+        placer_params = ObjectPlacerParams(
+            solver_params=RelationSolverParams(verbose=False, save_position_history=False),
+            min_unique_layouts_per_env=layouts_per_env,
+        )
+
     scene = Scene(assets=[ground, light, support, *members])
-    arena_env = IsaacLabArenaEnvironment(name=f"clutter_test_{seed}", scene=scene, task=NoTask())
+    arena_env = IsaacLabArenaEnvironment(
+        name=f"clutter_test_{seed}", scene=scene, task=NoTask(), placer_params=placer_params
+    )
     return arena_env, support, members
 
 
-def _build_and_reset(seed: int, num_envs: int = 1):
+def _build_and_reset(seed: int, num_envs: int = 1, layouts_per_env: int | None = None):
     """Build the env and reset it, returning (env, support, members, region, poses_fn).
 
     ``poses_fn(env_id)`` returns that environment's member poses in its own local frame, so
@@ -64,7 +76,7 @@ def _build_and_reset(seed: int, num_envs: int = 1):
     from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
     from isaaclab_arena.relations.clutter_pour import region_above_support
 
-    arena_env, support, members = _build_scene(seed)
+    arena_env, support, members = _build_scene(seed, layouts_per_env=layouts_per_env)
     # Build args from the real parser rather than a hand-rolled Namespace: the builder reads
     # more fields than are obvious, and a missing one fails only once the env is constructed.
     args = get_isaaclab_arena_cli_parser().parse_args([])
@@ -185,6 +197,47 @@ def _test_every_parallel_env_gets_its_own_settled_pile(simulation_app) -> bool:
     return True
 
 
+def _test_spilled_layouts_are_rejected_from_the_cache(simulation_app) -> bool:
+    """Every cached layout must hold its pile on the support, across repeated draws."""
+    from isaaclab_arena.relations.clutter_validation import ClutterSettleParams, check_resting_poses
+
+    layouts_per_env = 6
+    env, _support, members, region, poses = _build_and_reset(seed=1, layouts_per_env=layouts_per_env)
+    names = [member.name for member in members]
+    params = ClutterSettleParams(containment_margin_m=0.02)
+
+    for draw in range(layouts_per_env):
+        env.reset()
+        positions, _ = poses()
+        verdict = check_resting_poses(positions, region, params)
+        assert verdict.ok, f"cached layout {draw} spilled: {verdict.describe(names)}"
+    env.close()
+    return True
+
+
+def _test_pile_stays_settled_after_the_pool_refills(simulation_app) -> bool:
+    """Layouts added when the pool refills must be settled too, not left as drop poses."""
+    from isaaclab_arena.utils import physics_settle
+
+    layouts_per_env = 2
+    env, _support, _members, _region, poses = _build_and_reset(seed=0, layouts_per_env=layouts_per_env)
+
+    worst_drift = 0.0
+    # Reset well past the initial pool so the refill path is exercised.
+    for reset_index in range(layouts_per_env * 3):
+        env.reset()
+        before, _ = poses()
+        physics_settle.step_physics(env, 60)
+        after, _ = poses()
+        drift = float((after - before).norm(dim=-1).max())
+        worst_drift = max(worst_drift, drift)
+        print(f"  reset {reset_index}: drift {drift:.4f} m")
+    env.close()
+
+    assert worst_drift < 0.02, f"a reset placed a falling pile: worst drift {worst_drift:.3f} m"
+    return True
+
+
 def _test_same_seed_reproduces_the_pile(simulation_app) -> bool:
     import torch
 
@@ -204,6 +257,14 @@ def test_pile_is_already_settled_at_reset():
 
 def test_every_parallel_env_gets_its_own_settled_pile():
     assert run_simulation_app_function(_test_every_parallel_env_gets_its_own_settled_pile)
+
+
+def test_spilled_layouts_are_rejected_from_the_cache():
+    assert run_simulation_app_function(_test_spilled_layouts_are_rejected_from_the_cache)
+
+
+def test_pile_stays_settled_after_the_pool_refills():
+    assert run_simulation_app_function(_test_pile_stays_settled_after_the_pool_refills)
 
 
 def test_same_seed_reproduces_the_pile():

--- a/isaaclab_arena/tests/test_clutter_end_to_end.py
+++ b/isaaclab_arena/tests/test_clutter_end_to_end.py
@@ -53,9 +53,9 @@ def _build_scene(seed: int):
 
 def _pour_and_settle(seed: int):
     """Build, settle, and return (region, settled_at, resting positions, member names)."""
-    import argparse
     import torch
 
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.relations.bounding_box_helpers import get_bounding_box_per_env
     from isaaclab_arena.relations.clutter_pour import region_above_support
@@ -63,14 +63,14 @@ def _pour_and_settle(seed: int):
     from isaaclab_arena.utils import physics_settle
 
     arena_env, support, members = _build_scene(seed)
-    args = argparse.Namespace(
-        num_envs=1,
-        placement_seed=seed,
-        language_instruction=None,
-        mimic=False,
-        presets=None,
-        resolve_on_reset=None,
-    )
+    # Build args from the real parser rather than a hand-rolled Namespace: the builder reads
+    # more fields than are obvious, and a missing one fails only once the env is constructed.
+    args = get_isaaclab_arena_cli_parser().parse_args([])
+    args.num_envs = 1
+    args.placement_seed = seed
+    for name, default in (("language_instruction", None), ("mimic", False)):
+        if not hasattr(args, name):
+            setattr(args, name, default)
     env = ArenaEnvBuilder(arena_env, args).make_registered()
     env.reset()
 

--- a/isaaclab_arena/tests/test_clutter_groups.py
+++ b/isaaclab_arena/tests/test_clutter_groups.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sim-free tests for resolving clutter members into piles."""
+
+from __future__ import annotations
+
+import pytest
+
+from isaaclab_arena.relations.clutter_groups import assert_group_parameters_agree, get_clutter_groups, is_clutter_member
+from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor
+
+
+class _Asset:
+    """Minimal stand-in exposing only what group resolution reads."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.relations: list = []
+
+    def add_relation(self, relation) -> None:
+        self.relations.append(relation)
+
+    def get_relations(self) -> list:
+        return self.relations
+
+    def has_relation(self, relation_type: type) -> bool:
+        return any(isinstance(relation, relation_type) for relation in self.relations)
+
+
+def _table_with(*member_names: str, group: str = "clutter", **kwargs) -> tuple[_Asset, list[_Asset]]:
+    table = _Asset("table")
+    table.add_relation(IsAnchor())
+    members = []
+    for name in member_names:
+        member = _Asset(name)
+        member.add_relation(ClutteredOn(table, group=group, **kwargs))
+        members.append(member)
+    return table, members
+
+
+def test_members_are_identified_as_clutter():
+    table, members = _table_with("a", "b")
+    assert not is_clutter_member(table)
+    assert all(is_clutter_member(member) for member in members)
+
+
+def test_group_collects_members_in_declaration_order():
+    table, members = _table_with("a", "b", "c")
+    groups = get_clutter_groups([table, *members])
+    assert len(groups) == 1
+    assert groups[0].support is table
+    assert [member.name for member in groups[0].members] == ["a", "b", "c"]
+
+
+def test_distinct_group_names_on_one_support_are_separate_piles():
+    table = _Asset("table")
+    left = _Asset("left")
+    right = _Asset("right")
+    left.add_relation(ClutteredOn(table, group="left_pile"))
+    right.add_relation(ClutteredOn(table, group="right_pile"))
+
+    groups = get_clutter_groups([table, left, right])
+    assert [group.name for group in groups] == ["left_pile", "right_pile"]
+    assert [len(group.members) for group in groups] == [1, 1]
+
+
+def test_same_group_name_on_different_supports_stays_separate():
+    first, first_members = _table_with("a", group="tools")
+    second, second_members = _table_with("b", group="tools")
+
+    groups = get_clutter_groups([first, second, *first_members, *second_members])
+    assert len(groups) == 2
+    assert {group.support for group in groups} == {first, second}
+
+
+def test_group_order_follows_first_member():
+    table = _Asset("table")
+    second = _Asset("second")
+    first = _Asset("first")
+    second.add_relation(ClutteredOn(table, group="b"))
+    first.add_relation(ClutteredOn(table, group="a"))
+
+    # 'b' is declared first, so it leads regardless of alphabetical order.
+    groups = get_clutter_groups([table, second, first])
+    assert [group.name for group in groups] == ["b", "a"]
+
+
+def test_no_clutter_yields_no_groups():
+    table = _Asset("table")
+    table.add_relation(IsAnchor())
+    assert get_clutter_groups([table]) == []
+
+
+def test_agreeing_parameters_are_accepted():
+    table, members = _table_with("a", "b", spread=0.5, gap_m=0.02)
+    (group,) = get_clutter_groups([table, *members])
+    assert_group_parameters_agree(group)
+
+
+def test_conflicting_parameters_are_rejected():
+    table = _Asset("table")
+    agreeing = _Asset("agreeing")
+    conflicting = _Asset("conflicting")
+    agreeing.add_relation(ClutteredOn(table, group="tools", spread=0.5))
+    conflicting.add_relation(ClutteredOn(table, group="tools", spread=0.9))
+
+    (group,) = get_clutter_groups([table, agreeing, conflicting])
+    with pytest.raises(AssertionError, match="conflicting spread"):
+        assert_group_parameters_agree(group)
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"spread": 0.0}, "spread must be in"),
+        ({"spread": 1.5}, "spread must be in"),
+        ({"gap_m": -0.01}, "gap_m must be non-negative"),
+        ({"clearance_m": -0.01}, "clearance_m must be non-negative"),
+        ({"group": ""}, "group must be a non-empty name"),
+    ],
+)
+def test_invalid_parameters_are_rejected(kwargs, message):
+    with pytest.raises(AssertionError, match=message):
+        ClutteredOn(_Asset("table"), **kwargs)
+
+
+def test_clutter_may_not_rest_on_clutter():
+    table, (lower,) = _table_with("lower")
+    upper = _Asset("upper")
+    relation = ClutteredOn(lower, group="tools")
+    upper.add_relation(relation)
+
+    with pytest.raises(AssertionError, match="itself clutter"):
+        relation.validate_placement_configuration(upper, {table, lower, upper})
+
+
+def test_support_must_participate_in_placement():
+    absent = _Asset("absent")
+    member = _Asset("member")
+    relation = ClutteredOn(absent, group="tools")
+    member.add_relation(relation)
+
+    with pytest.raises(AssertionError, match="not part of the placement"):
+        relation.validate_placement_configuration(member, {member})

--- a/isaaclab_arena/tests/test_clutter_groups.py
+++ b/isaaclab_arena/tests/test_clutter_groups.py
@@ -29,6 +29,15 @@ class _Asset:
     def has_relation(self, relation_type: type) -> bool:
         return any(isinstance(relation, relation_type) for relation in self.relations)
 
+    @property
+    def is_anchor(self) -> bool:
+        return self.has_relation(IsAnchor)
+
+    def get_spatial_relations(self) -> list:
+        from isaaclab_arena.relations.relations import Relation, UnaryRelation
+
+        return [r for r in self.relations if isinstance(r, (Relation, UnaryRelation))]
+
 
 def _table_with(*member_names: str, group: str = "clutter", **kwargs) -> tuple[_Asset, list[_Asset]]:
     table = _Asset("table")
@@ -144,4 +153,44 @@ def test_support_must_participate_in_placement():
     member.add_relation(relation)
 
     with pytest.raises(AssertionError, match="not part of the placement"):
+        relation.validate_placement_configuration(member, {member})
+
+
+def test_member_that_is_also_an_anchor_is_rejected():
+    table, (member,) = _table_with("member")
+    member.add_relation(IsAnchor())
+    relation = member.get_relations()[0]
+
+    with pytest.raises(AssertionError, match="also an anchor"):
+        relation.validate_placement_configuration(member, {table, member})
+
+
+def test_member_with_two_clutter_relations_is_rejected():
+    table = _Asset("table")
+    member = _Asset("member")
+    member.add_relation(ClutteredOn(table, group="a"))
+    member.add_relation(ClutteredOn(table, group="b"))
+
+    with pytest.raises(AssertionError, match="belongs to one pile"):
+        member.get_relations()[0].validate_placement_configuration(member, {table, member})
+
+
+def test_member_combining_clutter_with_a_spatial_relation_is_rejected():
+    from isaaclab_arena.relations.relations import On
+
+    table = _Asset("table")
+    member = _Asset("member")
+    member.add_relation(ClutteredOn(table, group="tools"))
+    member.add_relation(On(table))
+
+    with pytest.raises(AssertionError, match="also carries"):
+        member.get_relations()[0].validate_placement_configuration(member, {table, member})
+
+
+def test_member_resting_on_itself_is_rejected():
+    member = _Asset("member")
+    relation = ClutteredOn(member, group="tools")
+    member.add_relation(relation)
+
+    with pytest.raises(AssertionError, match="cannot rest on itself"):
         relation.validate_placement_configuration(member, {member})

--- a/isaaclab_arena/tests/test_clutter_pour.py
+++ b/isaaclab_arena/tests/test_clutter_pour.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import math
 import torch
 
 import pytest
@@ -45,6 +46,7 @@ class _Layout:
     def __init__(self):
         self.positions: dict = {}
         self.rotations: dict = {}
+        self.orientations: dict = {}
 
 
 def _box(half_x: float, half_y: float, half_z: float) -> AxisAlignedBoundingBox:
@@ -262,3 +264,55 @@ def test_objects_outside_the_region_are_ignored():
     region = region_above_support((0.0, 0.0, 0.0), bounding_boxes[support])
     positions = {far_away: (5.0, 0.0, 0.2)}
     assert occupied_footprints_in_region(region, positions, bounding_boxes, exclude=set()) == []
+
+
+# ------------------------------------------------------------- rotated supports
+
+
+def _yaw_quat(degrees: float) -> tuple[float, float, float, float]:
+    half = math.radians(degrees) * 0.5
+    return (0.0, 0.0, math.sin(half), math.cos(half))
+
+
+def test_quarter_turned_support_swaps_the_region_extents():
+    bbox = _box(0.6, 0.4, 0.1)
+    upright = region_above_support((0.0, 0.0, 0.0), bbox)
+    turned = region_above_support((0.0, 0.0, 0.0), bbox, support_rotation_xyzw=_yaw_quat(90.0))
+
+    assert (upright.max_x - upright.min_x) == pytest.approx(1.2)
+    assert (turned.max_x - turned.min_x) == pytest.approx(0.8)
+    assert (turned.max_y - turned.min_y) == pytest.approx(1.2)
+
+
+def test_half_turned_support_keeps_its_extents():
+    bbox = _box(0.6, 0.4, 0.1)
+    turned = region_above_support((0.0, 0.0, 0.0), bbox, support_rotation_xyzw=_yaw_quat(180.0))
+    assert (turned.max_x - turned.min_x) == pytest.approx(1.2)
+    assert (turned.max_y - turned.min_y) == pytest.approx(0.8)
+
+
+def test_off_axis_support_shrinks_rather_than_overreaching():
+    """An axis-aligned region cannot cover a turned support, so it must not try."""
+    bbox = _box(0.6, 0.4, 0.1)
+    turned = region_above_support((0.0, 0.0, 0.0), bbox, support_rotation_xyzw=_yaw_quat(45.0))
+
+    # Fits inside the footprint's inscribed circle, which no rotation can shrink.
+    inscribed_diameter = 0.8
+    assert (turned.max_x - turned.min_x) == pytest.approx(inscribed_diameter / math.sqrt(2.0))
+    assert (turned.max_x - turned.min_x) < 0.8
+
+
+def test_off_centre_support_region_follows_its_rotation():
+    """A support whose box is offset from its origin swings that offset around when turned."""
+    offset_bbox = AxisAlignedBoundingBox(min_point=(0.0, -0.2, -0.05), max_point=(0.6, 0.2, 0.05))
+    turned = region_above_support((0.0, 0.0, 0.0), offset_bbox, support_rotation_xyzw=_yaw_quat(90.0))
+    # The box centre sits at local x=0.3, which a quarter turn moves to world y=0.3.
+    assert (turned.min_y + turned.max_y) * 0.5 == pytest.approx(0.3)
+    assert (turned.min_x + turned.max_x) * 0.5 == pytest.approx(0.0)
+
+
+def test_tilted_support_is_rejected():
+    bbox = _box(0.6, 0.4, 0.1)
+    tilted = (math.sin(math.radians(15.0)), 0.0, 0.0, math.cos(math.radians(15.0)))
+    with pytest.raises(AssertionError, match="yaw-only"):
+        region_above_support((0.0, 0.0, 0.0), bbox, support_rotation_xyzw=tilted)

--- a/isaaclab_arena/tests/test_clutter_pour.py
+++ b/isaaclab_arena/tests/test_clutter_pour.py
@@ -14,7 +14,7 @@ import pytest
 
 from isaaclab_arena.relations.clutter_groups import get_clutter_groups
 from isaaclab_arena.relations.clutter_pour import plan_clutter_drops, region_above_support
-from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor
+from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor, RotateAroundSolution
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose
 
@@ -104,6 +104,24 @@ def test_every_member_receives_a_drop_pose():
     assert set(layout.rotations) == set(members)
     for member in members:
         assert len(layout.rotations[member]) == 4
+
+
+def test_member_rotate_marker_is_preserved_by_clutter_planning():
+    """Clutter placement must retain source-authored roll and pitch markers."""
+    support, members, bounding_boxes = _scene(1, random_yaw=False)
+    members[0].add_relation(RotateAroundSolution(pitch_rad=math.pi / 2.0))
+    layout = _Layout()
+
+    plan_clutter_drops(
+        layout,
+        get_clutter_groups([support, *members]),
+        bounding_boxes,
+        torch.Generator().manual_seed(0),
+    )
+
+    assert layout.rotations[members[0]] == pytest.approx(
+        RotateAroundSolution(pitch_rad=math.pi / 2.0).get_rotation_xyzw()
+    )
 
 
 def test_drops_start_above_the_support_surface():

--- a/isaaclab_arena/tests/test_clutter_pour.py
+++ b/isaaclab_arena/tests/test_clutter_pour.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sim-free tests for planning clutter drop poses into layouts."""
+
+from __future__ import annotations
+
+import torch
+
+import pytest
+
+from isaaclab_arena.relations.clutter_groups import get_clutter_groups
+from isaaclab_arena.relations.clutter_pour import plan_clutter_drops, region_above_support
+from isaaclab_arena.relations.relations import ClutteredOn, IsAnchor
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.pose import Pose
+
+
+class _Asset:
+    """Minimal stand-in exposing only what pour planning reads."""
+
+    def __init__(self, name: str, position=(0.0, 0.0, 0.0)):
+        self.name = name
+        self.relations: list = []
+        self._pose = Pose(position_xyz=position, rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+
+    def add_relation(self, relation) -> None:
+        self.relations.append(relation)
+
+    def get_relations(self) -> list:
+        return self.relations
+
+    def has_relation(self, relation_type: type) -> bool:
+        return any(isinstance(relation, relation_type) for relation in self.relations)
+
+    def get_initial_pose(self) -> Pose:
+        return self._pose
+
+
+class _Layout:
+    """Stands in for PlacementResult, which needs validation machinery we do not exercise."""
+
+    def __init__(self):
+        self.positions: dict = {}
+        self.rotations: dict = {}
+
+
+def _box(half_x: float, half_y: float, half_z: float) -> AxisAlignedBoundingBox:
+    return AxisAlignedBoundingBox(
+        min_point=(-half_x, -half_y, -half_z),
+        max_point=(half_x, half_y, half_z),
+    )
+
+
+def _scene(member_count: int, support_position=(0.0, 0.0, 0.0), **relation_kwargs):
+    support = _Asset("table", position=support_position)
+    support.add_relation(IsAnchor())
+    members = []
+    for index in range(member_count):
+        member = _Asset(f"item_{index}")
+        member.add_relation(ClutteredOn(support, group="tools", **relation_kwargs))
+        members.append(member)
+
+    bounding_boxes = {support: _box(0.5, 0.5, 0.1)}
+    for member in members:
+        bounding_boxes[member] = _box(0.03, 0.03, 0.04)
+    return support, members, bounding_boxes
+
+
+def test_region_sits_on_the_support_top_face():
+    support_bbox = _box(0.5, 0.4, 0.1)
+    region = region_above_support((1.0, 2.0, 0.75), support_bbox)
+
+    assert region.min_x == pytest.approx(0.5)
+    assert region.max_x == pytest.approx(1.5)
+    assert region.min_y == pytest.approx(1.6)
+    assert region.max_y == pytest.approx(2.4)
+    # Floor is the support's top surface, not its origin.
+    assert region.floor_z == pytest.approx(0.85)
+
+
+def test_spread_shrinks_the_region_about_its_centre():
+    support_bbox = _box(0.5, 0.5, 0.1)
+    full = region_above_support((0.0, 0.0, 0.0), support_bbox)
+    half = region_above_support((0.0, 0.0, 0.0), support_bbox, spread=0.5)
+
+    assert (half.max_x - half.min_x) == pytest.approx(0.5 * (full.max_x - full.min_x))
+    assert (half.max_x + half.min_x) == pytest.approx(full.max_x + full.min_x)
+    assert half.floor_z == pytest.approx(full.floor_z)
+
+
+def test_every_member_receives_a_drop_pose():
+    support, members, bounding_boxes = _scene(6)
+    layout = _Layout()
+    groups = get_clutter_groups([support, *members])
+
+    plan_clutter_drops(layout, groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+    assert set(layout.positions) == set(members)
+    assert set(layout.rotations) == set(members)
+    for member in members:
+        assert len(layout.rotations[member]) == 4
+
+
+def test_drops_start_above_the_support_surface():
+    support, members, bounding_boxes = _scene(8, support_position=(0.0, 0.0, 0.75))
+    layout = _Layout()
+    groups = get_clutter_groups([support, *members])
+
+    plan_clutter_drops(layout, groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+    support_top = 0.75 + 0.1
+    for member in members:
+        assert layout.positions[member][2] > support_top
+
+
+def test_drops_stay_within_the_support_footprint():
+    support, members, bounding_boxes = _scene(10)
+    layout = _Layout()
+    groups = get_clutter_groups([support, *members])
+
+    plan_clutter_drops(layout, groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+    for member in members:
+        x, y, _ = layout.positions[member]
+        assert -0.5 <= x <= 0.5
+        assert -0.5 <= y <= 0.5
+
+
+def test_same_seed_reproduces_the_same_pile():
+    support, members, bounding_boxes = _scene(8)
+    groups = get_clutter_groups([support, *members])
+
+    first, second = _Layout(), _Layout()
+    plan_clutter_drops(first, groups, bounding_boxes, torch.Generator().manual_seed(7))
+    plan_clutter_drops(second, groups, bounding_boxes, torch.Generator().manual_seed(7))
+
+    assert first.positions == second.positions
+    assert first.rotations == second.rotations
+
+
+def test_different_seeds_produce_different_piles():
+    support, members, bounding_boxes = _scene(8)
+    groups = get_clutter_groups([support, *members])
+
+    first, second = _Layout(), _Layout()
+    plan_clutter_drops(first, groups, bounding_boxes, torch.Generator().manual_seed(1))
+    plan_clutter_drops(second, groups, bounding_boxes, torch.Generator().manual_seed(2))
+
+    assert first.positions != second.positions
+
+
+def test_two_groups_on_one_support_are_both_poured():
+    support = _Asset("table")
+    support.add_relation(IsAnchor())
+    left = _Asset("left")
+    right = _Asset("right")
+    left.add_relation(ClutteredOn(support, group="left_pile"))
+    right.add_relation(ClutteredOn(support, group="right_pile"))
+
+    bounding_boxes = {support: _box(0.5, 0.5, 0.1), left: _box(0.03, 0.03, 0.04), right: _box(0.03, 0.03, 0.04)}
+    layout = _Layout()
+    plan_clutter_drops(
+        layout, get_clutter_groups([support, left, right]), bounding_boxes, torch.Generator().manual_seed(0)
+    )
+
+    assert set(layout.positions) == {left, right}
+
+
+def test_missing_member_bounding_box_is_rejected():
+    support, members, bounding_boxes = _scene(3)
+    del bounding_boxes[members[1]]
+    groups = get_clutter_groups([support, *members])
+
+    with pytest.raises(AssertionError, match="without bounding boxes"):
+        plan_clutter_drops(_Layout(), groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+
+def test_missing_support_bounding_box_is_rejected():
+    support, members, bounding_boxes = _scene(3)
+    del bounding_boxes[support]
+    groups = get_clutter_groups([support, *members])
+
+    with pytest.raises(AssertionError, match="no bounding box"):
+        plan_clutter_drops(_Layout(), groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+
+def test_solved_support_position_is_preferred_over_the_declared_one():
+    support, members, bounding_boxes = _scene(4, support_position=(0.0, 0.0, 0.0))
+    groups = get_clutter_groups([support, *members])
+
+    layout = _Layout()
+    # The solver moved the support; the pile must follow it rather than its declared pose.
+    layout.positions[support] = (3.0, 0.0, 0.0)
+    plan_clutter_drops(layout, groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+    for member in members:
+        assert 2.5 <= layout.positions[member][0] <= 3.5
+
+
+def test_oversized_member_is_rejected_rather_than_placed_outside():
+    support = _Asset("table")
+    support.add_relation(IsAnchor())
+    huge = _Asset("huge")
+    huge.add_relation(ClutteredOn(support, group="tools"))
+    bounding_boxes = {support: _box(0.1, 0.1, 0.05), huge: _box(0.5, 0.5, 0.05)}
+
+    with pytest.raises(AssertionError, match="does not fit"):
+        plan_clutter_drops(
+            _Layout(), get_clutter_groups([support, huge]), bounding_boxes, torch.Generator().manual_seed(0)
+        )

--- a/isaaclab_arena/tests/test_clutter_pour.py
+++ b/isaaclab_arena/tests/test_clutter_pour.py
@@ -211,3 +211,54 @@ def test_oversized_member_is_rejected_rather_than_placed_outside():
         plan_clutter_drops(
             _Layout(), get_clutter_groups([support, huge]), bounding_boxes, torch.Generator().manual_seed(0)
         )
+
+
+def test_pour_avoids_an_object_already_on_the_support():
+    """A solver-placed object on the same surface must not be dropped into."""
+    from isaaclab_arena.relations.clutter_pour import occupied_footprints_in_region, region_above_support
+
+    support, members, bounding_boxes = _scene(6)
+    resident = _Asset("resident")
+    bounding_boxes[resident] = _box(0.12, 0.12, 0.1)
+
+    layout = _Layout()
+    layout.positions[resident] = (0.0, 0.0, 0.2)
+    groups = get_clutter_groups([support, *members])
+
+    region = region_above_support((0.0, 0.0, 0.0), bounding_boxes[support])
+    occupied = occupied_footprints_in_region(region, layout.positions, bounding_boxes, exclude={support})
+    assert len(occupied) == 1, "the resident object should be seen as occupying the surface"
+
+    plan_clutter_drops(layout, groups, bounding_boxes, torch.Generator().manual_seed(0))
+
+    resident_top = 0.2 + 0.05
+    for member in members:
+        x, y, z = layout.positions[member]
+        overlaps = abs(x - 0.0) < 0.06 + 0.03 and abs(y - 0.0) < 0.06 + 0.03
+        if overlaps:
+            assert z > resident_top, f"{member.name} was dropped into the resident object at z={z:.3f}"
+
+
+def test_objects_below_the_support_surface_are_ignored():
+    """Something under the table is not in the way of a pile poured on top of it."""
+    from isaaclab_arena.relations.clutter_pour import occupied_footprints_in_region, region_above_support
+
+    support, _members, bounding_boxes = _scene(2)
+    underneath = _Asset("underneath")
+    bounding_boxes[underneath] = _box(0.1, 0.1, 0.05)
+
+    region = region_above_support((0.0, 0.0, 0.5), bounding_boxes[support])
+    positions = {underneath: (0.0, 0.0, 0.0)}
+    assert occupied_footprints_in_region(region, positions, bounding_boxes, exclude=set()) == []
+
+
+def test_objects_outside_the_region_are_ignored():
+    from isaaclab_arena.relations.clutter_pour import occupied_footprints_in_region, region_above_support
+
+    support, _members, bounding_boxes = _scene(2)
+    far_away = _Asset("far_away")
+    bounding_boxes[far_away] = _box(0.1, 0.1, 0.1)
+
+    region = region_above_support((0.0, 0.0, 0.0), bounding_boxes[support])
+    positions = {far_away: (5.0, 0.0, 0.2)}
+    assert occupied_footprints_in_region(region, positions, bounding_boxes, exclude=set()) == []

--- a/isaaclab_arena/tests/test_clutter_validation.py
+++ b/isaaclab_arena/tests/test_clutter_validation.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sim-free tests for clutter rest and settle verdicts."""
+
+from __future__ import annotations
+
+import math
+import torch
+
+from isaaclab_arena.relations.clutter_drop_poses import ClutterRegion
+from isaaclab_arena.relations.clutter_validation import (
+    ClutterSettleParams,
+    SettleTracker,
+    check_resting_poses,
+    quaternion_angle_deg,
+)
+
+IDENTITY = (0.0, 0.0, 0.0, 1.0)
+REGION = ClutterRegion(min_x=-0.5, min_y=-0.5, max_x=0.5, max_y=0.5, floor_z=0.75)
+
+
+def _rotations(count: int, quaternion=IDENTITY) -> torch.Tensor:
+    return torch.tensor([quaternion] * count, dtype=torch.float32)
+
+
+def _yaw_quaternion(degrees: float) -> tuple[float, float, float, float]:
+    half = math.radians(degrees) * 0.5
+    return (0.0, 0.0, math.sin(half), math.cos(half))
+
+
+def test_objects_at_rest_on_the_support_pass():
+    positions = torch.tensor([[0.0, 0.0, 0.78], [0.2, -0.3, 0.80]])
+    assert check_resting_poses(positions, REGION).ok
+
+
+def test_object_outside_the_footprint_is_reported_as_fallen_off():
+    positions = torch.tensor([[0.0, 0.0, 0.78], [0.9, 0.0, 0.78]])
+    verdict = check_resting_poses(positions, REGION)
+    assert verdict.fell_off == [1]
+    assert not verdict.ok
+
+
+def test_object_below_the_support_is_reported_as_fallen_through():
+    positions = torch.tensor([[0.0, 0.0, 0.78], [0.0, 0.0, 0.50]])
+    verdict = check_resting_poses(positions, REGION)
+    assert verdict.fell_through == [1]
+
+
+def test_resting_slightly_below_the_surface_is_tolerated():
+    # Contact resolution can leave a small negative offset; that is not tunnelling.
+    positions = torch.tensor([[0.0, 0.0, 0.745]])
+    assert check_resting_poses(positions, REGION).ok
+
+
+def test_non_finite_pose_is_reported_as_diverged_only():
+    positions = torch.tensor([[float("nan"), float("nan"), float("nan")]])
+    verdict = check_resting_poses(positions, REGION)
+    assert verdict.diverged == [0]
+    # A diverged object must not also be counted as having fallen off or through.
+    assert verdict.fell_off == []
+    assert verdict.fell_through == []
+
+
+def test_containment_margin_admits_objects_just_past_the_edge():
+    positions = torch.tensor([[0.52, 0.0, 0.78]])
+    assert not check_resting_poses(positions, REGION).ok
+    lenient = ClutterSettleParams(containment_margin_m=0.05)
+    assert check_resting_poses(positions, REGION, lenient).ok
+
+
+def test_verdict_describes_offenders_by_name():
+    positions = torch.tensor([[0.9, 0.0, 0.78], [0.0, 0.0, 0.2]])
+    verdict = check_resting_poses(positions, REGION)
+    description = verdict.describe(["mug", "can"])
+    assert "fell off" in description and "mug" in description
+    assert "fell through" in description and "can" in description
+
+
+def test_quaternion_angle_is_zero_for_identical_rotations():
+    angles = quaternion_angle_deg(_rotations(2), _rotations(2))
+    assert torch.allclose(angles, torch.zeros(2), atol=1e-4)
+
+
+def test_quaternion_angle_ignores_sign_convention():
+    first = _rotations(1)
+    negated = -_rotations(1)
+    # q and -q are the same rotation.
+    assert float(quaternion_angle_deg(first, negated).max()) < 1e-3
+
+
+def test_quaternion_angle_measures_yaw():
+    angles = quaternion_angle_deg(_rotations(1), _rotations(1, _yaw_quaternion(90.0)))
+    assert abs(float(angles.max()) - 90.0) < 1e-3
+
+
+def test_first_poll_is_never_settled():
+    tracker = SettleTracker()
+    assert not tracker.update(torch.zeros(3, 3), _rotations(3))
+
+
+def test_settling_requires_consecutive_quiet_windows():
+    tracker = SettleTracker(ClutterSettleParams(required_quiet_windows=2))
+    positions = torch.zeros(3, 3)
+    rotations = _rotations(3)
+
+    assert not tracker.update(positions, rotations)  # baseline
+    assert not tracker.update(positions, rotations)  # one quiet window
+    assert tracker.update(positions, rotations)  # two, settled
+    assert tracker.settled
+
+
+def test_movement_resets_the_quiet_streak():
+    tracker = SettleTracker(ClutterSettleParams(required_quiet_windows=2))
+    rotations = _rotations(1)
+    still = torch.zeros(1, 3)
+
+    tracker.update(still, rotations)
+    tracker.update(still, rotations)
+    assert tracker.quiet_windows == 1
+
+    # An avalanche after apparent calm must reset the streak, not be ignored.
+    tracker.update(torch.tensor([[0.0, 0.0, 0.05]]), rotations)
+    assert tracker.quiet_windows == 0
+    assert not tracker.settled
+
+
+def test_rotation_alone_prevents_settling():
+    tracker = SettleTracker(ClutterSettleParams(required_quiet_windows=1))
+    still = torch.zeros(1, 3)
+
+    tracker.update(still, _rotations(1))
+    # Position is unchanged but the object is still turning.
+    assert not tracker.update(still, _rotations(1, _yaw_quaternion(30.0)))
+
+
+def test_divergence_resets_and_blocks_settling():
+    tracker = SettleTracker(ClutterSettleParams(required_quiet_windows=1))
+    still = torch.zeros(2, 3)
+    rotations = _rotations(2)
+
+    tracker.update(still, rotations)
+    assert tracker.update(still, rotations)
+    assert tracker.settled
+
+    nan_positions = torch.full((2, 3), float("nan"))
+    assert not tracker.update(nan_positions, rotations)
+    assert not tracker.settled
+
+
+def test_tracker_is_unaffected_by_caller_mutating_the_snapshot():
+    tracker = SettleTracker(ClutterSettleParams(required_quiet_windows=1))
+    positions = torch.zeros(1, 3)
+    rotations = _rotations(1)
+
+    tracker.update(positions, rotations)
+    # Reusing and mutating the same buffer, as a sim read-back loop would.
+    positions[0, 2] = 1.0
+    positions[0, 2] = 0.0
+    assert tracker.update(positions, rotations)

--- a/isaaclab_arena/tests/test_episode_recorder.py
+++ b/isaaclab_arena/tests/test_episode_recorder.py
@@ -368,7 +368,7 @@ def test_custom_term(tmp_path):
 
 
 def test_post_reset_recorder_hook():
-    assert run_simulation_app_function(
+    assert run_function_with_persistent_simulation_app(
         _test_post_reset_recorder_hook, headless=HEADLESS
     ), "post-reset recorder hook test failed"
 

--- a/isaaclab_arena/tests/test_episode_recorder.py
+++ b/isaaclab_arena/tests/test_episode_recorder.py
@@ -9,6 +9,7 @@ import torch
 import tqdm
 from dataclasses import field
 from pathlib import Path
+from types import SimpleNamespace
 
 from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.utils.configclass import configclass
@@ -248,6 +249,106 @@ def _test_custom_term(simulation_app, output_dir):  # noqa: ARG001
     return True
 
 
+def _test_post_reset_recorder_hook(_simulation_app):
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnv
+    from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderManager
+
+    events = []
+
+    class LifecycleRecorderTerm:
+        def __call__(self, _env, _env_id):
+            return {}
+
+        def record_post_reset(self, env_ids):
+            events.append(("term_post_reset", list(env_ids)))
+
+    manager = object.__new__(EpisodeRecorderManager)
+    manager._env = SimpleNamespace(num_envs=3)
+    manager._resolve_terms_handle = None
+    manager._term_cfgs = [
+        SimpleNamespace(func=LifecycleRecorderTerm()),
+        SimpleNamespace(func=record_step_bucket),
+    ]
+
+    manager.record_post_reset(torch.tensor([2, 0]))
+    manager.record_post_reset(None)
+    assert events == [
+        ("term_post_reset", [2, 0]),
+        ("term_post_reset", [0, 1, 2]),
+    ]
+
+    class Recorder:
+        def record_pre_reset(self, env_ids):
+            events.append(("manager_pre_reset", env_ids.tolist()))
+
+        def record_post_reset(self, env_ids):
+            events.append(("manager_post_reset", env_ids.tolist()))
+
+    reset_env = object.__new__(IsaacLabArenaManagerBasedRLEnv)
+    reset_env._is_closed = True
+    reset_env._first_reset = False
+    reset_env._episode_counts = {}
+    reset_env._external_policy_termination_buf = torch.tensor([True, True])
+    reset_env.episode_recorder_manager = Recorder()
+
+    original_reset = IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx
+    try:
+        IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx = lambda _self, env_ids: events.append(
+            ("base_reset", env_ids.tolist())
+        )
+        IsaacLabArenaManagerBasedRLEnv._reset_idx(reset_env, torch.tensor([0]))
+
+        reset_env._first_reset = True
+        IsaacLabArenaManagerBasedRLEnv._reset_idx(reset_env, torch.tensor([0, 1]))
+    finally:
+        IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx = original_reset
+
+    assert events[2:] == [
+        ("manager_pre_reset", [0]),
+        ("base_reset", [0]),
+        ("manager_post_reset", [0]),
+        ("base_reset", [0, 1]),
+        ("manager_post_reset", [0, 1]),
+    ]
+    return True
+
+
+def test_builder_merges_environment_and_task_episode_recorder_terms():
+    from types import SimpleNamespace
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    environment_term = object()
+    task_term = object()
+    arena_env = SimpleNamespace(episode_recorder_terms={"environment": environment_term})
+    task = SimpleNamespace(
+        get_episode_recorder_terms=lambda received: ({"task": task_term} if received is arena_env else {})
+    )
+    builder = ArenaEnvBuilder.__new__(ArenaEnvBuilder)
+    builder.arena_env = arena_env
+
+    assert builder._collect_episode_recorder_terms(task) == {
+        "environment": environment_term,
+        "task": task_term,
+    }
+
+
+def test_builder_rejects_duplicate_environment_and_task_recorder_names():
+    from types import SimpleNamespace
+
+    import pytest
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    arena_env = SimpleNamespace(episode_recorder_terms={"poses": object()})
+    task = SimpleNamespace(get_episode_recorder_terms=lambda _: {"poses": object()})
+    builder = ArenaEnvBuilder.__new__(ArenaEnvBuilder)
+    builder.arena_env = arena_env
+
+    with pytest.raises(ValueError, match="duplicate episode recorder term 'poses'"):
+        builder._collect_episode_recorder_terms(task)
+
+
 def test_core_terms(tmp_path):
     assert run_function_with_persistent_simulation_app(
         _test_core_terms, headless=HEADLESS, output_dir=tmp_path
@@ -266,8 +367,15 @@ def test_custom_term(tmp_path):
     ), "custom recorder term test failed"
 
 
+def test_post_reset_recorder_hook():
+    assert run_simulation_app_function(
+        _test_post_reset_recorder_hook, headless=HEADLESS
+    ), "post-reset recorder hook test failed"
+
+
 if __name__ == "__main__":
     with tempfile.TemporaryDirectory(prefix="episode_recorder_") as _tmp_dir:
         test_core_terms(Path(_tmp_dir))
         test_variations_recorded(Path(_tmp_dir))
         test_custom_term(Path(_tmp_dir))
+        test_post_reset_recorder_hook()

--- a/isaaclab_arena/tests/test_external_policy_termination.py
+++ b/isaaclab_arena/tests/test_external_policy_termination.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+import pytest
+
+
+def _test_external_policy_termination_contract(_simulation_app):
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import (
+        IsaacLabArenaManagerBasedRLEnv,
+        external_policy_termination,
+    )
+    from isaaclab_arena.evaluation.policy_runner import _forward_policy_episode_terminations
+
+    class StubArenaEnv:
+        def __init__(self, num_envs: int = 2):
+            self.num_envs = num_envs
+            self.device = torch.device("cpu")
+            self._external_policy_termination_buf = torch.zeros(num_envs, dtype=torch.bool)
+
+        @property
+        def external_policy_termination_buf(self) -> torch.Tensor:
+            return self._external_policy_termination_buf
+
+        def request_external_policy_termination(self, termination_mask: torch.Tensor) -> None:
+            IsaacLabArenaManagerBasedRLEnv.request_external_policy_termination(self, termination_mask)
+
+    class StubGymEnv:
+        def __init__(self, num_envs: int = 2):
+            self.unwrapped = StubArenaEnv(num_envs)
+
+    class StubPolicy:
+        def __init__(self, termination_mask):
+            self._termination_mask = termination_mask
+
+        def get_episode_termination_mask(self):
+            return self._termination_mask
+
+    env = StubGymEnv()
+    _forward_policy_episode_terminations(env, StubPolicy(torch.tensor([True, False])))
+    _forward_policy_episode_terminations(env, StubPolicy(torch.tensor([False, True])))
+    assert external_policy_termination(env.unwrapped).tolist() == [True, True]
+
+    noop_env = StubGymEnv()
+    _forward_policy_episode_terminations(noop_env, StubPolicy(None))
+    assert not noop_env.unwrapped.external_policy_termination_buf.any()
+
+    invalid_masks = [
+        ([True, False], "torch.Tensor"),
+        (torch.tensor([1, 0]), "torch.bool"),
+        (torch.tensor([[True, False]]), "shape"),
+        (torch.tensor([True]), "shape"),
+    ]
+    for termination_mask, message in invalid_masks:
+        with pytest.raises(AssertionError, match=message):
+            _forward_policy_episode_terminations(env, StubPolicy(termination_mask))
+
+    unsupported_env = type(
+        "UnsupportedGymEnv",
+        (),
+        {"unwrapped": type("UnsupportedEnv", (), {"num_envs": 2})()},
+    )()
+    with pytest.raises(RuntimeError, match="does not support"):
+        _forward_policy_episode_terminations(unsupported_env, StubPolicy(torch.tensor([True, False])))
+
+    with pytest.raises(AssertionError, match="shape"):
+        env.unwrapped.request_external_policy_termination(torch.tensor([True]))
+
+    events = []
+    reset_env = object.__new__(IsaacLabArenaManagerBasedRLEnv)
+    reset_env._is_closed = True
+    reset_env._first_reset = False
+    reset_env._episode_counts = {}
+    reset_env._external_policy_termination_buf = torch.tensor([True, True])
+
+    class Recorder:
+        def record_pre_reset(self, env_ids):
+            events.append(("record", reset_env._external_policy_termination_buf.clone()))
+
+        def record_post_reset(self, _env_ids):
+            pass
+
+    reset_env.episode_recorder_manager = Recorder()
+    original_reset = IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx
+    try:
+        IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx = lambda self, env_ids: events.append(
+            ("reset", self._external_policy_termination_buf.clone())
+        )
+        IsaacLabArenaManagerBasedRLEnv._reset_idx(reset_env, torch.tensor([0]))
+    finally:
+        IsaacLabArenaManagerBasedRLEnv.__mro__[1]._reset_idx = original_reset
+
+    assert events[0][0] == "record"
+    assert events[0][1].tolist() == [True, True]
+    assert events[1][0] == "reset"
+    assert events[1][1].tolist() == [False, True]
+    return True
+
+
+def test_external_policy_termination_contract():
+    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+
+    assert run_simulation_app_function(_test_external_policy_termination_contract, headless=True)

--- a/isaaclab_arena/tests/test_external_policy_termination.py
+++ b/isaaclab_arena/tests/test_external_policy_termination.py
@@ -101,6 +101,6 @@ def _test_external_policy_termination_contract(_simulation_app):
 
 
 def test_external_policy_termination_contract():
-    from isaaclab_arena.tests.utils.subprocess import run_simulation_app_function
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
-    assert run_simulation_app_function(_test_external_policy_termination_contract, headless=True)
+    assert run_function_with_persistent_simulation_app(_test_external_policy_termination_contract, headless=True)

--- a/isaaclab_arena/tests/test_legacy_eval_config.py
+++ b/isaaclab_arena/tests/test_legacy_eval_config.py
@@ -27,12 +27,14 @@ def test_legacy_environment_arguments_keep_cli_order_and_boolean_flags():
         "num_envs": 4,
         "headless": True,
         "enable_cameras": False,
+        "resolve_on_reset": False,
     })
 
     assert args[:3] == ["--num_envs", "4", "test_env"]
     assert args[args.index("--object") + 1] == "box"
     assert "--headless" in args
     assert "--enable_cameras" not in args
+    assert "--no-resolve_on_reset" in args
 
 
 def test_legacy_jobs_become_concrete_run_configs():
@@ -45,6 +47,7 @@ def test_legacy_jobs_become_concrete_run_configs():
                 "pick_up_object": "mustard_bottle_hot3d_robolab",
                 "num_envs": 4,
                 "env_spacing": 2.5,
+                "num_rerenders_on_reset": 5,
                 "enable_cameras": True,
             },
             "policy_type": "zero_action",
@@ -65,6 +68,7 @@ def test_legacy_jobs_become_concrete_run_configs():
     )
     assert run.environment_builder.num_envs == 4
     assert run.environment_builder.env_spacing == 2.5
+    assert run.environment_builder.num_rerenders_on_reset == 5
     assert run.environment_builder.device == "cuda:1"
     assert run.environment_builder.language_instruction == "Move the bottle."
     assert run.policy == ZeroActionPolicyCfg()
@@ -81,6 +85,7 @@ def test_legacy_graph_environment_stays_in_the_existing_cli_path():
                 "environment": str(graph_path),
                 "enable_cameras": True,
                 "object": "dex_cube",
+                "num_rerenders_on_reset": 5,
             },
             "policy_type": "zero_action",
             "num_steps": 2,
@@ -93,6 +98,9 @@ def test_legacy_graph_environment_stays_in_the_existing_cli_path():
     assert run.environment.arena_env_args == legacy_environment_args_to_cli_args(
         legacy_config["jobs"][0]["arena_env_args"]
     )
+    assert run.environment_builder.num_rerenders_on_reset == 5
+    flag_index = run.environment.arena_env_args.index("--num_rerenders_on_reset")
+    assert run.environment.arena_env_args[flag_index + 1] == "5"
 
 
 def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeypatch):

--- a/isaaclab_arena/tests/test_legacy_eval_config.py
+++ b/isaaclab_arena/tests/test_legacy_eval_config.py
@@ -27,12 +27,14 @@ def test_legacy_environment_arguments_keep_cli_order_and_boolean_flags():
         "num_envs": 4,
         "headless": True,
         "enable_cameras": False,
+        "resolve_on_reset": False,
     })
 
     assert args[:3] == ["--num_envs", "4", "test_env"]
     assert args[args.index("--object") + 1] == "box"
     assert "--headless" in args
     assert "--enable_cameras" not in args
+    assert "--no-resolve_on_reset" in args
 
 
 def test_legacy_jobs_become_concrete_run_configs():
@@ -45,6 +47,7 @@ def test_legacy_jobs_become_concrete_run_configs():
                 "pick_up_object": "mustard_bottle_hot3d_robolab",
                 "num_envs": 4,
                 "env_spacing": 2.5,
+                "num_rerenders_on_reset": 5,
                 "enable_cameras": True,
             },
             "policy_type": "zero_action",
@@ -65,6 +68,7 @@ def test_legacy_jobs_become_concrete_run_configs():
     )
     assert run.environment_builder.num_envs == 4
     assert run.environment_builder.env_spacing == 2.5
+    assert run.environment_builder.num_rerenders_on_reset == 5
     assert run.environment_builder.device == "cuda:1"
     assert run.environment_builder.language_instruction == "Move the bottle."
     assert run.policy == ZeroActionPolicyCfg()
@@ -81,6 +85,7 @@ def test_legacy_graph_environment_stays_in_the_existing_cli_path():
                 "environment": str(graph_path),
                 "enable_cameras": True,
                 "object": "dex_cube",
+                "num_rerenders_on_reset": 5,
             },
             "policy_type": "zero_action",
             "num_steps": 2,
@@ -91,7 +96,12 @@ def test_legacy_graph_environment_stays_in_the_existing_cli_path():
 
     assert isinstance(run.environment, LegacyGraphEnvironmentCfg)
     assert run.environment.env_spec_path == str(graph_path)
-    assert run.environment.per_run_overrides == {"enable_cameras": True, "object": "dex_cube"}
+    assert run.environment.per_run_overrides == {
+        "enable_cameras": True,
+        "object": "dex_cube",
+        "num_rerenders_on_reset": 5,
+    }
+    assert run.environment_builder.num_rerenders_on_reset == 5
 
 
 def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeypatch):

--- a/isaaclab_arena/tests/test_pooled_layout_rejection.py
+++ b/isaaclab_arena/tests/test_pooled_layout_rejection.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sim-free tests for discarding pooled layouts that only prove unusable after simulating."""
+
+from __future__ import annotations
+
+from isaaclab_arena.relations.pooled_object_placer import EnvLayoutPool, PooledObjectPlacer
+
+
+class _Layout:
+    """Stands in for PlacementResult; rejection only reads what the predicate looks at."""
+
+    def __init__(self, tag: str, good: bool = True):
+        self.tag = tag
+        self.good = good
+
+
+def _placer_with(*queues: list[_Layout]) -> PooledObjectPlacer:
+    """A placer whose env pools hold the given layouts, without solving anything."""
+    placer = PooledObjectPlacer.__new__(PooledObjectPlacer)
+    placer._env_pools = [EnvLayoutPool(layouts=list(queue)) for queue in queues]
+    placer._num_envs = len(queues)
+    return placer
+
+
+def _tags(placer: PooledObjectPlacer, env_id: int) -> list[str]:
+    pool = placer._env_pools[env_id]
+    return [layout.tag for layout in pool.layouts[pool.cursor :]]
+
+
+def test_rejected_layouts_are_dropped():
+    placer = _placer_with([_Layout("a"), _Layout("b", good=False), _Layout("c")])
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
+
+    assert (kept, rejected) == (2, 1)
+    assert _tags(placer, 0) == ["a", "c"]
+
+
+def test_every_layout_kept_when_all_pass():
+    placer = _placer_with([_Layout("a"), _Layout("b")])
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
+
+    assert (kept, rejected) == (2, 0)
+    assert _tags(placer, 0) == ["a", "b"]
+
+
+def test_env_keeps_its_rejects_when_too_few_survive():
+    """An imperfect layout still beats an env having nothing to draw."""
+    placer = _placer_with([_Layout("a", good=False), _Layout("b", good=False)])
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
+
+    assert rejected == 0, "an env with no passing layout must not be emptied"
+    assert kept == 2
+    assert _tags(placer, 0) == ["a", "b"]
+
+
+def test_minimum_governs_whether_rejection_applies():
+    passing = [_Layout(f"p{i}") for i in range(2)]
+    placer = _placer_with([*passing, _Layout("bad", good=False)])
+
+    # Two survivors clear a minimum of two, so the reject is dropped.
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good, minimum=2)
+    assert (kept, rejected) == (2, 1)
+
+    # The same queue against a minimum of three keeps everything instead.
+    placer = _placer_with([*passing, _Layout("bad", good=False)])
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good, minimum=3)
+    assert (kept, rejected) == (3, 0)
+
+
+def test_each_env_is_filtered_independently():
+    placer = _placer_with(
+        [_Layout("a0"), _Layout("b0", good=False)],
+        [_Layout("a1"), _Layout("b1")],
+    )
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
+
+    assert (kept, rejected) == (3, 1)
+    assert _tags(placer, 0) == ["a0"]
+    assert _tags(placer, 1) == ["a1", "b1"]
+
+
+def test_predicate_receives_the_env_id():
+    placer = _placer_with([_Layout("a0")], [_Layout("a1")])
+    seen: list[int] = []
+
+    def record(env_id: int, _layout) -> bool:
+        seen.append(env_id)
+        return True
+
+    placer.retain_layouts(record)
+    assert seen == [0, 1]
+
+
+def test_consumed_layouts_are_not_reconsidered():
+    """Only unread layouts matter; a consumed one is already behind the cursor."""
+    placer = _placer_with([_Layout("used", good=False), _Layout("a"), _Layout("b", good=False)])
+    placer._env_pools[0].next()
+
+    kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
+    assert (kept, rejected) == (1, 1)
+    assert _tags(placer, 0) == ["a"]

--- a/isaaclab_arena/tests/test_pooled_layout_rejection.py
+++ b/isaaclab_arena/tests/test_pooled_layout_rejection.py
@@ -23,6 +23,7 @@ def _placer_with(*queues: list[_Layout]) -> PooledObjectPlacer:
     placer = PooledObjectPlacer.__new__(PooledObjectPlacer)
     placer._env_pools = [EnvLayoutPool(layouts=list(queue)) for queue in queues]
     placer._num_envs = len(queues)
+    placer._recycle_layouts = False
     return placer
 
 
@@ -103,3 +104,46 @@ def test_consumed_layouts_are_not_reconsidered():
     kept, rejected = placer.retain_layouts(lambda _env, layout: layout.good)
     assert (kept, rejected) == (1, 1)
     assert _tags(placer, 0) == ["a"]
+
+
+# ------------------------------------------------------------------ recycling
+
+
+def _drawing_placer(*queues: list[_Layout]) -> PooledObjectPlacer:
+    placer = _placer_with(*queues)
+    placer._pool_size = sum(len(q) for q in queues)
+    return placer
+
+
+def test_recycling_rewinds_an_exhausted_queue():
+    """A prepared pool must keep handing back prepared layouts, not solve new ones."""
+    placer = _drawing_placer([_Layout("a"), _Layout("b")])
+    placer.recycle_layouts = True
+
+    drawn = [placer.sample_for_envs([0])[0].tag for _ in range(5)]
+    assert drawn == ["a", "b", "a", "b", "a"]
+
+
+def test_recycling_is_off_by_default():
+    placer = _drawing_placer([_Layout("a")])
+    assert placer.recycle_layouts is False
+
+
+def test_recycling_rewinds_only_the_exhausted_envs():
+    placer = _drawing_placer([_Layout("a0")], [_Layout("a1"), _Layout("b1")])
+    placer.recycle_layouts = True
+
+    first = placer.sample_for_envs([0, 1])
+    assert [first[0].tag, first[1].tag] == ["a0", "a1"]
+    # Env 0 has run out and rewinds; env 1 still has an unread layout and advances.
+    second = placer.sample_for_envs([0, 1])
+    assert [second[0].tag, second[1].tag] == ["a0", "b1"]
+
+
+def test_recycling_survives_rejection_shrinking_the_queue():
+    placer = _drawing_placer([_Layout("a"), _Layout("bad", good=False), _Layout("c")])
+    placer.retain_layouts(lambda _env, layout: layout.good)
+    placer.recycle_layouts = True
+
+    drawn = [placer.sample_for_envs([0])[0].tag for _ in range(4)]
+    assert drawn == ["a", "c", "a", "c"], "recycling must cycle the layouts rejection left behind"

--- a/isaaclab_arena/tests/test_pose.py
+++ b/isaaclab_arena/tests/test_pose.py
@@ -37,6 +37,17 @@ def test_rotate_quat_by_yaw_composes_and_wraps():
     assert rotate_quat_by_yaw(base, 2.0 * math.pi) == base
 
 
+def test_rotate_quat_by_yaw_uses_world_z_for_a_tilted_base():
+    """Sampled yaw must turn a tilted object's horizontal axis around world Z."""
+    half_sqrt_two = math.sqrt(0.5)
+    pitch_quarter_turn = (0.0, half_sqrt_two, 0.0, half_sqrt_two)
+
+    rotated = rotate_quat_by_yaw(pitch_quarter_turn, math.pi / 2.0)
+
+    expected = (-0.5, 0.5, 0.5, 0.5)
+    assert all(math.isclose(actual, wanted, abs_tol=1e-6) for actual, wanted in zip(rotated, expected))
+
+
 def test_pose_composition():
     T_B_A = Pose(position_xyz=(1.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
     T_C_B = Pose(position_xyz=(2.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -596,6 +596,7 @@ def test_arena_env_builder_forwards_empty_relation_graph(monkeypatch):
         scene_assets=None,
     ):
         calls["objects"] = objects
+        calls["placer_params"] = placer_params
         calls["scene_assets"] = list(scene_assets)
         calls["collision_objects"] = collision_objects
 
@@ -606,6 +607,7 @@ def test_arena_env_builder_forwards_empty_relation_graph(monkeypatch):
     builder._solve_relations()
 
     assert calls["objects"] == []
+    assert calls["placer_params"].solver_params.clearance_m == 0.01
     assert calls["scene_assets"] == []
     assert calls["collision_objects"] is None
 
@@ -642,6 +644,85 @@ def test_arena_env_builder_includes_embodiment_relations(monkeypatch):
     ArenaEnvBuilder(arena_env, ArenaEnvBuilderCfg())._solve_relations()
 
     assert calls["objects"] == [embodiment]
+
+
+def test_arena_env_builder_applies_requested_default_solver_clearance(monkeypatch):
+    """A builder-owned placer forwards the requested seed and collision clearance."""
+    from types import SimpleNamespace
+
+    import pytest
+
+    import isaaclab_arena.environments.arena_env_builder as builder_module
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+
+    captured = {}
+    scene = SimpleNamespace(
+        assets={},
+        get_objects_with_relations=lambda: [],
+    )
+
+    def fake_solve(objects, num_envs, placer_params, collision_objects=None, scene_assets=None):
+        captured["placer_params"] = placer_params
+
+    monkeypatch.setattr(
+        builder_module,
+        "solve_and_apply_relation_placement",
+        fake_solve,
+    )
+    builder = ArenaEnvBuilder(
+        SimpleNamespace(scene=scene, placer_params=None, embodiment=None, task=None),
+        ArenaEnvBuilderCfg(
+            placement_seed=71,
+            placement_clearance_m=0.0005,
+        ),
+    )
+
+    builder._solve_relations()
+
+    assert captured["placer_params"].placement_seed == 71
+    assert captured["placer_params"].solver_params.clearance_m == pytest.approx(0.0005)
+
+
+def test_arena_env_builder_applies_clearance_to_environment_placement_validators(monkeypatch):
+    """The CLI override reaches both the relation solver and pluggable validators."""
+    from types import SimpleNamespace
+
+    import pytest
+
+    import isaaclab_arena.environments.arena_env_builder as builder_module
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+    from isaaclab_arena.relations.placement_validation import PlacementCheck
+    from isaaclab_arena.relations.placement_validators import NoOverlapValidator, build_validators
+    from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+
+    captured = {}
+    placer_params = ObjectPlacerParams(
+        solver_params=RelationSolverParams(clearance_m=0.02),
+        enabled_checks={PlacementCheck.NO_OVERLAP},
+    )
+    scene = SimpleNamespace(assets={}, get_objects_with_relations=lambda: [])
+
+    def fake_solve(objects, num_envs, placer_params, collision_objects=None, scene_assets=None):
+        captured["placer_params"] = placer_params
+
+    monkeypatch.setattr(builder_module, "solve_and_apply_relation_placement", fake_solve)
+    builder = ArenaEnvBuilder(
+        SimpleNamespace(scene=scene, placer_params=placer_params, embodiment=None, task=None),
+        ArenaEnvBuilderCfg(placement_clearance_m=0.0005),
+    )
+
+    builder._solve_relations()
+
+    effective_params = captured["placer_params"]
+    validators = build_validators(effective_params)
+    assert effective_params is placer_params
+    assert effective_params.solver_params.clearance_m == pytest.approx(0.0005)
+    assert len(validators) == 1
+    assert isinstance(validators[0], NoOverlapValidator)
+    assert validators[0]._params.solver_params.clearance_m == pytest.approx(0.0005)
 
 
 def test_relation_placement_includes_background_mesh_for_object_mesh_override(monkeypatch):

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -731,6 +731,7 @@ def test_arena_env_builder_forwards_empty_relation_graph(monkeypatch):
         scene_assets=None,
     ):
         calls["objects"] = objects
+        calls["placer_params"] = placer_params
         calls["scene_assets"] = list(scene_assets)
         calls["collision_objects"] = collision_objects
 
@@ -741,6 +742,7 @@ def test_arena_env_builder_forwards_empty_relation_graph(monkeypatch):
     builder._solve_relations()
 
     assert calls["objects"] == []
+    assert calls["placer_params"].solver_params.clearance_m == 0.01
     assert calls["scene_assets"] == []
     assert calls["collision_objects"] is None
 
@@ -777,6 +779,85 @@ def test_arena_env_builder_includes_embodiment_relations(monkeypatch):
     ArenaEnvBuilder(arena_env, ArenaEnvBuilderCfg())._solve_relations()
 
     assert calls["objects"] == [embodiment]
+
+
+def test_arena_env_builder_applies_requested_default_solver_clearance(monkeypatch):
+    """A builder-owned placer forwards the requested seed and collision clearance."""
+    from types import SimpleNamespace
+
+    import pytest
+
+    import isaaclab_arena.environments.arena_env_builder as builder_module
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+
+    captured = {}
+    scene = SimpleNamespace(
+        assets={},
+        get_objects_with_relations=lambda: [],
+    )
+
+    def fake_solve(objects, num_envs, placer_params, collision_objects=None, scene_assets=None):
+        captured["placer_params"] = placer_params
+
+    monkeypatch.setattr(
+        builder_module,
+        "solve_and_apply_relation_placement",
+        fake_solve,
+    )
+    builder = ArenaEnvBuilder(
+        SimpleNamespace(scene=scene, placer_params=None, embodiment=None, task=None),
+        ArenaEnvBuilderCfg(
+            placement_seed=71,
+            placement_clearance_m=0.0005,
+        ),
+    )
+
+    builder._solve_relations()
+
+    assert captured["placer_params"].placement_seed == 71
+    assert captured["placer_params"].solver_params.clearance_m == pytest.approx(0.0005)
+
+
+def test_arena_env_builder_applies_clearance_to_environment_placement_validators(monkeypatch):
+    """The CLI override reaches both the relation solver and pluggable validators."""
+    from types import SimpleNamespace
+
+    import pytest
+
+    import isaaclab_arena.environments.arena_env_builder as builder_module
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+    from isaaclab_arena.relations.placement_validation import PlacementCheck
+    from isaaclab_arena.relations.placement_validators import NoOverlapValidator, build_validators
+    from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
+
+    captured = {}
+    placer_params = ObjectPlacerParams(
+        solver_params=RelationSolverParams(clearance_m=0.02),
+        enabled_checks={PlacementCheck.NO_OVERLAP},
+    )
+    scene = SimpleNamespace(assets={}, get_objects_with_relations=lambda: [])
+
+    def fake_solve(objects, num_envs, placer_params, collision_objects=None, scene_assets=None):
+        captured["placer_params"] = placer_params
+
+    monkeypatch.setattr(builder_module, "solve_and_apply_relation_placement", fake_solve)
+    builder = ArenaEnvBuilder(
+        SimpleNamespace(scene=scene, placer_params=placer_params, embodiment=None, task=None),
+        ArenaEnvBuilderCfg(placement_clearance_m=0.0005),
+    )
+
+    builder._solve_relations()
+
+    effective_params = captured["placer_params"]
+    validators = build_validators(effective_params)
+    assert effective_params is placer_params
+    assert effective_params.solver_params.clearance_m == pytest.approx(0.0005)
+    assert len(validators) == 1
+    assert isinstance(validators[0], NoOverlapValidator)
+    assert validators[0]._params.solver_params.clearance_m == pytest.approx(0.0005)
 
 
 def test_relation_placement_forwards_anchor_background_mesh_exclusions(monkeypatch):
@@ -823,6 +904,51 @@ def test_relation_placement_forwards_anchor_background_mesh_exclusions(monkeypat
     assert calls["include_background"] is True
     assert calls["background_mesh_exclusions"] == [reference]
     assert calls["objects"] == [reference]
+    assert calls["collision_objects"] == []
+
+
+def test_relation_placement_includes_background_mesh_for_object_mesh_override(monkeypatch):
+    """Object-level MESH override enables aggregate background meshes."""
+    import isaaclab_arena.environments.relation_solver_interface as interface_module
+    from isaaclab_arena.environments.relation_solver_interface import solve_and_apply_relation_placement
+    from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+    from isaaclab_arena.relations.relation_solver_params import CollisionMode, RelationSolverParams
+    from isaaclab_arena.relations.relations import IsAnchor
+    from isaaclab_arena.tests.dummy_object import DummyObject
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+    mesh_object = DummyObject(
+        "mesh_object",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.1, -0.1, -0.1), max_point=(0.1, 0.1, 0.1)),
+    )
+    mesh_object.add_relation(IsAnchor())
+    mesh_object.collision_mode = CollisionMode.MESH
+    calls = {}
+
+    def fake_get_passive_collision_objects(assets, include_background: bool = False, background_mesh_exclusions=()):
+        calls["assets"] = list(assets)
+        calls["include_background"] = include_background
+        return []
+
+    class FakePooledObjectPlacer:
+        had_fallbacks = False
+
+        def __init__(self, objects, placer_params, pool_size, num_envs, collision_objects):
+            calls["objects"] = objects
+            calls["collision_objects"] = collision_objects
+
+    monkeypatch.setattr(
+        "isaaclab_arena.relations.passive_collision_objects.get_passive_collision_objects",
+        fake_get_passive_collision_objects,
+    )
+    monkeypatch.setattr(interface_module, "PooledObjectPlacer", FakePooledObjectPlacer)
+    placer_params = ObjectPlacerParams(solver_params=RelationSolverParams(collision_mode=CollisionMode.BBOX))
+
+    solve_and_apply_relation_placement([mesh_object], num_envs=1, placer_params=placer_params, scene_assets=[])
+
+    assert calls["assets"] == []
+    assert calls["include_background"] is True
+    assert calls["objects"] == [mesh_object]
     assert calls["collision_objects"] == []
 
 

--- a/isaaclab_arena/tests/test_task_base.py
+++ b/isaaclab_arena/tests/test_task_base.py
@@ -37,6 +37,8 @@ def _test_episode_length_defaults(simulation_app) -> bool:
     assert _StubTask().get_episode_length_s() == 20.0
     assert _StubTask(episode_length_s=None).get_episode_length_s() == 20.0
     assert _StubTask(episode_length_s=5.0).get_episode_length_s() == 5.0
+    arena_env = object()
+    assert _StubTask().get_episode_recorder_terms(arena_env) == {}
     return True
 
 

--- a/isaaclab_arena/tests/test_task_base.py
+++ b/isaaclab_arena/tests/test_task_base.py
@@ -44,6 +44,8 @@ def _test_episode_length_defaults(simulation_app) -> bool:
     subtasks = [_StubTask(episode_length_s=20.0), _StubTask(episode_length_s=30.0)]
     assert CompositeTaskBase(subtasks=subtasks).get_episode_length_s() == 50.0
     assert CompositeTaskBase(subtasks=subtasks, episode_length_s=12.0).get_episode_length_s() == 12.0
+    arena_env = object()
+    assert _StubTask().get_episode_recorder_terms(arena_env) == {}
     return True
 
 

--- a/isaaclab_arena/tests/test_task_registry.py
+++ b/isaaclab_arena/tests/test_task_registry.py
@@ -24,6 +24,7 @@ def _test_task_registry_resolves_concrete_tasks(simulation_app):
         "TurnKnobTask",
         "AssemblyTask",
         "SortMultiObjectTask",
+        "ObjectsInRegionsTask",
     ]
     registry = TaskRegistry()
     for name in expected:

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -18,7 +18,7 @@ from isaaclab.sensors import CameraCfg, TiledCameraCfg  # noqa: F401
 
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.utils.configclass import make_configclass
-from isaaclab_arena.utils.pose import PoseRange
+from isaaclab_arena.utils.pose import PosePerEnv, PoseRange
 
 
 class ArenaCameraCfg:
@@ -167,7 +167,11 @@ def get_viewer_cfg_look_at_object(lookat_object: Asset, offset: np.ndarray) -> V
         print(f"{lookat_object.name} has no initial pose set. Using default ViewerCfg.")
         return ViewerCfg()
 
-    if isinstance(initial_pose, PoseRange):
+    if isinstance(initial_pose, PosePerEnv):
+        # The viewport has one global camera, so use the first environment as
+        # its reference when placement produced one pose per environment.
+        initial_pose = initial_pose.poses[0]
+    elif isinstance(initial_pose, PoseRange):
         initial_pose = initial_pose.get_midpoint()
 
     # TODO(cvolk): Add float coercion to Pose.__post_init__ so this conversion is unnecessary.

--- a/isaaclab_arena/utils/cameras.py
+++ b/isaaclab_arena/utils/cameras.py
@@ -179,6 +179,13 @@ def get_viewer_cfg_look_at_object(lookat_object: Asset, offset: np.ndarray) -> V
         print(f"{lookat_object.name} has no initial pose set. Using default ViewerCfg.")
         return ViewerCfg()
 
+    if isinstance(initial_pose, PosePerEnv):
+        # The viewport has one global camera, so use the first environment as
+        # its reference when placement produced one pose per environment.
+        initial_pose = initial_pose.poses[0]
+    elif isinstance(initial_pose, PoseRange):
+        initial_pose = initial_pose.get_midpoint()
+
     # TODO(cvolk): Add float coercion to Pose.__post_init__ so this conversion is unnecessary.
     # Ensure we only pass primitive Python floats (not NumPy scalars) into ViewerCfg,
     # since downstream config systems like Hydra/OmegaConf don't support np.float64.

--- a/isaaclab_arena/utils/yaw.py
+++ b/isaaclab_arena/utils/yaw.py
@@ -61,8 +61,8 @@ def rotate_quat_by_yaw(
     bx, by, bz, bw = base_xyzw
     sz = math.sin(yaw_rad / 2.0)
     cz = math.cos(yaw_rad / 2.0)
-    # Hamilton product base ⊗ (0, 0, sz, cz). Both rotations are about Z, so they commute.
-    return (bx * cz + by * sz, -bx * sz + by * cz, bz * cz + bw * sz, -bz * sz + bw * cz)
+    # Hamilton product (0, 0, sz, cz) ⊗ base applies yaw around world Z.
+    return (bx * cz - by * sz, by * cz + bx * sz, bz * cz + bw * sz, bw * cz - bz * sz)
 
 
 def rotate_points_by_yaw(points: torch.Tensor, yaw: float) -> torch.Tensor:

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -5,8 +5,9 @@
 
 """Gym wrapper that records one mp4 per (env, camera, episode) in ``obs['camera_obs']``.
 
-Frames are flushed to disk each time an environment resets (terminated or
-truncated), so each output file corresponds to exactly one complete episode.
+Frames are streamed to disk and atomically published each time an environment
+resets (terminated or truncated), so each output file corresponds to exactly
+one complete episode.
 Partial episodes cut off by ``num_steps`` are discarded on ``close()``.
 
 Output filename: ``<name_prefix>-env<N>-<camera_name>-episode-<E>.mp4``
@@ -16,23 +17,23 @@ the kit viewport mp4 (third-person scene view) and the embodiment-
 mounted camera mp4s (what the policy actually sees) are written
 together when ``--record_viewport_video --record_camera_video`` is set.
 
-Memory note: each env buffers raw uint8 frames for its current episode before
-encoding.  Buffers are cleared after each episode is written to disk, so peak
-RAM is N×L×H×W×C bytes where L is max episode length, not the full rollout.
-For 10 envs, 500-step episodes, 512×512×3 frames that is ~3.8 GB of raw frames
-— the encoded mp4s are far smaller (H.264 compresses ~100:1).
+Each active camera uses one ffmpeg pipe. Frames are encoded incrementally, so
+recorder memory is bounded by the active streams and encoder pipe buffers
+rather than growing with episode length.
 """
 
 from __future__ import annotations
 
+import contextlib
 import gymnasium as gym
 import numpy as np
 import os
 import re
+import subprocess
 import torch
 from dataclasses import dataclass
 
-from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+import imageio_ffmpeg
 
 CAMERA_OBS_GROUP_KEY = "camera_obs"
 
@@ -52,6 +53,17 @@ class ParsedEpisodeVideoName:
     episode_index: int
     rebuild_index: int | None
     """The rebuild this video belongs to, or ``None`` when the prefix carried no ``-rebuild`` segment."""
+
+
+@dataclass
+class _ActiveWriter:
+    """One incrementally encoded, not-yet-published episode video."""
+
+    writer: object
+    temporary_path: str
+    final_path: str
+    frame_shape: tuple[int, ...]
+    frame_count: int = 0
 
 
 def format_episode_video_filename(name_prefix: str, env_index: int, camera_name: str, episode_index: int) -> str:
@@ -91,6 +103,36 @@ def _sanitize_cam_key(camera_name: str) -> str:
     return camera_name.replace("/", "_").replace(os.sep, "_")
 
 
+def _validate_encoded_video(path: str, expected_frames: int) -> None:
+    """Decode a completed stream and require every submitted frame."""
+    command = [
+        imageio_ffmpeg.get_ffmpeg_exe(),
+        "-v",
+        "error",
+        "-xerror",
+        "-i",
+        path,
+        "-map",
+        "0:v:0",
+        "-f",
+        "null",
+        "-",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+    ]
+    result = subprocess.run(command, capture_output=True, text=True)
+    frame_counts = [
+        int(line.removeprefix("frame=")) for line in result.stdout.splitlines() if line.startswith("frame=")
+    ]
+    encoded_frames = frame_counts[-1] if frame_counts else None
+    if result.returncode != 0 or encoded_frames != expected_frames:
+        detail = result.stderr.strip() or "no ffmpeg diagnostic"
+        raise RuntimeError(
+            f"Invalid encoded video {path}: expected {expected_frames} frames, decoded {encoded_frames}; {detail}"
+        )
+
+
 class CameraObsVideoRecorder(gym.Wrapper):
     """Record one mp4 per (env, camera, episode) in ``obs['camera_obs']``.
 
@@ -113,8 +155,8 @@ class CameraObsVideoRecorder(gym.Wrapper):
         self.name_prefix = name_prefix
         self.fps = fps if fps is not None else int(env.metadata.get("render_fps", 30))
 
-        # camera_name -> list of per-env frame lists: buffers[camera_name][env_idx] = [frame, ...]
-        self.buffers: dict[str, list[list[np.ndarray]]] = {}
+        # (camera_name, env_idx) -> active encoder for the current episode.
+        self._writers: dict[tuple[str, int], _ActiveWriter] = {}
 
     def step(self, action):
         result = self.env.step(action)
@@ -133,37 +175,124 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_set = set(done_envs)
 
             for camera_name, frames in cam_obs.items():
-                if camera_name not in self.buffers:
-                    self.buffers[camera_name] = [[] for _ in range(n_envs)]
                 for env_idx in range(n_envs):
                     if env_idx not in done_set:
-                        self.buffers[camera_name][env_idx].append(_to_uint8(frames[env_idx]))
+                        self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
 
             if done_envs:
                 self._flush_envs(done_envs)
 
         return result
 
+    def _write_frame(self, camera_name: str, env_idx: int, frame: np.ndarray) -> None:
+        key = (camera_name, env_idx)
+        active = self._writers.get(key)
+        if active is None:
+            active = self._open_writer(camera_name, env_idx, frame)
+            self._writers[key] = active
+        if tuple(frame.shape) != active.frame_shape:
+            self._discard_writer(key, active)
+            raise ValueError(
+                f"Camera {camera_name!r} env {env_idx} changed frame shape from "
+                f"{active.frame_shape} to {tuple(frame.shape)}"
+            )
+        try:
+            active.writer.send(np.ascontiguousarray(frame))
+            active.frame_count += 1
+        except BaseException:
+            self._discard_writer(key, active)
+            raise
+
+    def _open_writer(self, camera_name: str, env_idx: int, frame: np.ndarray) -> _ActiveWriter:
+        if frame.ndim == 2:
+            height, width = frame.shape
+            pixel_format = "gray"
+        elif frame.ndim == 3 and frame.shape[2] in (1, 3, 4):
+            height, width, channels = frame.shape
+            pixel_format = {1: "gray", 3: "rgb24", 4: "rgba"}[channels]
+        else:
+            raise ValueError(f"Camera frame must be HxW, HxWx1, HxWx3, or HxWx4; got {frame.shape}")
+
+        episode_num = self.unwrapped.get_episode_index(env_idx)
+        final_path = os.path.join(
+            self.video_folder,
+            format_episode_video_filename(self.name_prefix, env_idx, camera_name, episode_num),
+        )
+        temporary_path = f"{final_path}.part"
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_path)
+        writer = imageio_ffmpeg.write_frames(
+            temporary_path,
+            (width, height),
+            pix_fmt_in=pixel_format,
+            fps=self.fps,
+            macro_block_size=1,
+            output_params=["-f", "mp4"],
+        )
+        try:
+            writer.send(None)
+        except BaseException:
+            try:
+                writer.close()
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(temporary_path)
+            raise
+        return _ActiveWriter(
+            writer=writer,
+            temporary_path=temporary_path,
+            final_path=final_path,
+            frame_shape=tuple(frame.shape),
+        )
+
     def _flush_envs(self, env_ids: list[int]) -> None:
         for env_idx in env_ids:
-            # The Arena env has already advanced its per-env episode counter for this reset (within
-            # env.step, before it returned), so the just-finished episode's index is one behind the
-            # current count. Sharing the env's index keeps the filename's episode number in lockstep
-            # with the per-episode results record's ``episode_in_env``.
-            episode_num = self.unwrapped.get_episode_index(env_idx) - 1
-            for camera_name, env_frame_lists in self.buffers.items():
-                frames = env_frame_lists[env_idx]
-                if not frames:
-                    continue
-                path = os.path.join(
-                    self.video_folder,
-                    format_episode_video_filename(self.name_prefix, env_idx, camera_name, episode_num),
-                )
-                clip = ImageSequenceClip(list(frames), fps=self.fps)
-                clip.write_videofile(path, logger=None, audio=False)
-                del clip
-                env_frame_lists[env_idx] = []
+            keys = [key for key in self._writers if key[1] == env_idx]
+            try:
+                for key in keys:
+                    active = self._writers.pop(key)
+                    try:
+                        active.writer.close()
+                        if not os.path.isfile(active.temporary_path) or os.path.getsize(active.temporary_path) == 0:
+                            raise RuntimeError(f"ffmpeg produced no video: {active.temporary_path}")
+                        _validate_encoded_video(active.temporary_path, expected_frames=active.frame_count)
+                        os.replace(active.temporary_path, active.final_path)
+                    except BaseException:
+                        with contextlib.suppress(FileNotFoundError):
+                            os.unlink(active.temporary_path)
+                        raise
+            except BaseException:
+                # If one camera fails, discard every other stream for the same episode so the caller
+                # never sees a partial set of active encoders or temporary files.
+                for key in keys:
+                    active = self._writers.get(key)
+                    if active is None:
+                        continue
+                    with contextlib.suppress(BaseException):
+                        self._discard_writer(key, active)
+                raise
+
+    def _discard_writer(self, key: tuple[str, int], active: _ActiveWriter) -> None:
+        self._writers.pop(key, None)
+        try:
+            active.writer.close()
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(active.temporary_path)
 
     def close(self) -> None:
         # Partial episodes (cut off by num_steps rather than a real reset) are discarded.
-        self.env.close()
+        first_error: BaseException | None = None
+        for key, active in list(self._writers.items()):
+            try:
+                self._discard_writer(key, active)
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+        try:
+            self.env.close()
+        except BaseException as error:
+            if first_error is None:
+                first_error = error
+        if first_error is not None:
+            raise first_error

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -143,6 +143,10 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_set = set(done_envs)
 
             for camera_name, frames in cam_obs.items():
+                # Observation groups may also contain depth, segmentation, or other
+                # policy inputs. The mp4 encoder records only batched RGB streams.
+                if frames.ndim != 4 or frames.shape[-1] != 3:
+                    continue
                 if camera_name not in self.writers:
                     self.writers[camera_name] = [None] * n_envs
                 for env_idx in range(n_envs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "pytest",
     "pydantic>=2.0",
     "openai>=2.0",
+    # Incremental camera-video encoding keeps memory bounded for long episodes.
+    "imageio-ffmpeg>=0.6,<0.7",
     # Sensitivity analysis (isaaclab_arena.analysis.sensitivity), imported at module level.
     "sbi",
     "scipy",

--- a/uv.lock
+++ b/uv.lock
@@ -2048,6 +2048,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "decorator", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
+    { name = "imageio-ffmpeg", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "lightwheel-sdk", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "matplotlib", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
     { name = "onnxruntime", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine != 'x86_64' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel') or (sys_platform != 'linux' and extra == 'group-14-isaaclab-arena-isaaclab-from-source' and extra == 'group-14-isaaclab-arena-isaaclab-from-wheel')" },
@@ -2108,6 +2109,7 @@ openpi = [
 [package.metadata]
 requires-dist = [
     { name = "decorator", specifier = ">=4.0.2,<5" },
+    { name = "imageio-ffmpeg", specifier = ">=0.6,<0.7" },
     { name = "debugpy", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'dev'" },
     { name = "lightwheel-sdk" },


### PR DESCRIPTION
## Summary

- stack Rafael Cathomen physics-settled clutter placement on current Arena main
- preserve the generic CAP extension contracts and objects-in-regions task
- compose source-authored rotations with random world-Z clutter yaw and refit rotated bounds before drop placement

## Relationship

This is the Arena dependency for Isaac-cap branch `lgulich/mr3/clutter-placement`, stacked on Isaac-cap PR #18. The Isaac-cap gitlink is pinned to this PR exact head, `ac5c715de761cd720bc2e5485279a0b0db3cd93a`.

The integration history remains visible: Rafael clutter tip is `299985fc353b33b822606845ac7e761834999290`; the CAP extension/task integration reaches `09f73451a3ccddc83d150e031af25cc320d73177`; source-orientation support ends at `ac5c715de761cd720bc2e5485279a0b0db3cd93a`.

## Verification

- Arena focused quaternion, placement, and clutter suites passed in the preserved handoff
- Isaac-cap post-rebase full Arena/benchmark suite: 813 passed, 20 skipped
- retained Newton evidence qualifies scene reset, placement retention, and short stepping only; it does not establish manipulation success or long-horizon stability

Draft only; do not merge until the stacked Isaac-cap review is complete.