### PR TITLE
Enable Curobo collision checking in reachability validator & add viz

### DIFF
--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -6,12 +6,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
+from isaaclab_arena.relations.reachability_config import ReachabilityConfig
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
-
-if TYPE_CHECKING:
-    from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 
 
 @dataclass
@@ -70,26 +67,3 @@ class ObjectPlacerParams:
 
     debug_visualize_output_path: str | None = None
     """Path to record the debug visualization to as a Rerun ``.rrd`` file, for headless runs."""
-
-
-@dataclass
-class ReachabilityConfig:
-    """Declarative tuning for the optional build-time IK-reachability check.
-
-    Pure data forwarded to the extension that builds the check (cuRobo); core placement never reads it.
-    """
-
-    embodiment: EmbodimentBase | None = None
-    """Robot embodiment the grasps must be reachable by; the cuRobo check builds its IK solver from it."""
-
-    grasp_z_offset_m: float = 0.02
-    """Height above each object's root for the top-down grasp pose the check tests."""
-
-    ik_position_threshold_m: float = 0.01
-    """Max IK position error (m) for a grasp to count as reachable."""
-
-    ik_rotation_threshold_rad: float = 0.1
-    """Max IK rotation error (rad) for a grasp to count as reachable."""
-
-    require_collision_free: bool = True
-    """If True, it's also collision-free with the robot itself."""

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -15,31 +15,6 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class ReachabilityConfig:
-    """Declarative tuning for the optional build-time IK-reachability check.
-
-    Pure data forwarded to the extension that builds the check (cuRobo); core placement never reads it.
-    """
-
-    embodiment: EmbodimentBase | None = None
-    """Robot embodiment the grasps must be reachable by; the cuRobo check builds its IK solver from it."""
-
-    grasp_z_offset_m: float = 0.02
-    """Height above each object's root for the top-down grasp pose the check tests."""
-
-    ik_position_threshold_m: float = 0.01
-    """Max IK position error (m) for a grasp to count as reachable."""
-
-    ik_rotation_threshold_rad: float = 0.1
-    """Max IK rotation error (rad) for a grasp to count as reachable."""
-
-    require_collision_free: bool = True
-    """If True, a grasp also has to be collision-free (arm clear of the layout's other objects and of
-    itself), not just reachable. The gripper's own links and the objects being grasped are exempt, so
-    closing on a target is not a collision."""
-
-
-@dataclass
 class ObjectPlacerParams:
     """Configuration parameters for ObjectPlacer."""
 
@@ -95,3 +70,26 @@ class ObjectPlacerParams:
 
     debug_visualize_output_path: str | None = None
     """Path to record the debug visualization to as a Rerun ``.rrd`` file, for headless runs."""
+
+
+@dataclass
+class ReachabilityConfig:
+    """Declarative tuning for the optional build-time IK-reachability check.
+
+    Pure data forwarded to the extension that builds the check (cuRobo); core placement never reads it.
+    """
+
+    embodiment: EmbodimentBase | None = None
+    """Robot embodiment the grasps must be reachable by; the cuRobo check builds its IK solver from it."""
+
+    grasp_z_offset_m: float = 0.02
+    """Height above each object's root for the top-down grasp pose the check tests."""
+
+    ik_position_threshold_m: float = 0.01
+    """Max IK position error (m) for a grasp to count as reachable."""
+
+    ik_rotation_threshold_rad: float = 0.1
+    """Max IK rotation error (rad) for a grasp to count as reachable."""
+
+    require_collision_free: bool = True
+    """If True, it's also collision-free with the robot itself."""

--- a/isaaclab_arena/relations/object_placer_params.py
+++ b/isaaclab_arena/relations/object_placer_params.py
@@ -33,6 +33,11 @@ class ReachabilityConfig:
     ik_rotation_threshold_rad: float = 0.1
     """Max IK rotation error (rad) for a grasp to count as reachable."""
 
+    require_collision_free: bool = True
+    """If True, a grasp also has to be collision-free (arm clear of the layout's other objects and of
+    itself), not just reachable. The gripper's own links and the objects being grasped are exempt, so
+    closing on a target is not a collision."""
+
 
 @dataclass
 class ObjectPlacerParams:

--- a/isaaclab_arena/relations/reachability_config.py
+++ b/isaaclab_arena/relations/reachability_config.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
+
+
+@dataclass
+class ReachabilityConfig:
+    """Declarative tuning for the optional build-time IK-reachability check.
+
+    Pure data forwarded to the extension that builds the check (cuRobo); core placement never reads it.
+    """
+
+    embodiment: EmbodimentBase | None = None
+    """Robot embodiment the grasps must be reachable by; the cuRobo check builds its IK solver from it."""
+
+    grasp_z_offset_m: float = 0.02
+    """Height above each object's root for the top-down grasp pose the check tests."""
+
+    ik_position_threshold_m: float = 0.01
+    """Max IK position error (m) for a grasp to count as reachable."""
+
+    ik_rotation_threshold_rad: float = 0.1
+    """Max IK rotation error (rad) for a grasp to count as reachable."""
+
+    require_collision_free: bool = True
+    """If True, it's also collision-free with the robot itself."""

--- a/isaaclab_arena/relations/reachability_config.py
+++ b/isaaclab_arena/relations/reachability_config.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/isaaclab_arena_curobo/curobo_embodiment_cfg.py
+++ b/isaaclab_arena_curobo/curobo_embodiment_cfg.py
@@ -36,7 +36,8 @@ class CuroboEmbodimentCfg:
     """Gripper joint targets for the closed pose, merged over the robot config's locked joints."""
 
     hand_link_names: list[str]
-    """Links forming the hand, excluded from self-collision against the grasped object."""
+    """Links forming the hand, whose collision spheres are muted while checking a grasp so that
+    contact with the grasped object does not read as a collision."""
 
     grasp_gripper_open_val: float = 10.0
     """cuRobo grasp-approach gripper opening value."""

--- a/isaaclab_arena_curobo/curobo_embodiment_cfg.py
+++ b/isaaclab_arena_curobo/curobo_embodiment_cfg.py
@@ -36,7 +36,7 @@ class CuroboEmbodimentCfg:
     """Gripper joint targets for the closed pose, merged over the robot config's locked joints."""
 
     hand_link_names: list[str]
-    """Links forming the hand, whose collision spheres are muted while checking a grasp so that
+    """Links forming the hand, whose collision spheres are disabled while checking so that
     contact with the grasped object does not read as a collision."""
 
     grasp_gripper_open_val: float = 10.0

--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -10,7 +10,8 @@ top-down grasp at every movable object -- by default without the arm colliding o
 (reject-&-refill) until every env has enough reachable layouts.
 
 With the placement debug view on (``ObjectPlacerParams.debug_visualize``), the check also draws what it solved for each
-candidate -- the robot base, the grasps, and their IK errors; see ``isaaclab_arena_curobo.reachability_visualizer``.
+candidate -- the robot base, the grasps, their IK errors, and the collision spheres the arm holds at each solved grasp;
+see ``isaaclab_arena_curobo.reachability_visualizer``.
 """
 
 from __future__ import annotations
@@ -28,7 +29,12 @@ from isaaclab_arena.utils.yaw import rotate_quat_by_yaw, yaw_from_quat_xyzw
 from isaaclab_arena_curobo.embodiment_curobo_registry import get_embodiment_curobo_cfg
 from isaaclab_arena_curobo.ik_solver import CuroboIKSolver
 from isaaclab_arena_curobo.utils.frame_utils import top_down_grasp_pose_from_world_poses
-from isaaclab_arena_curobo.utils.ik_solver_utils import get_aabb_collision_cuboid_for_object, solve_ik_feasibility
+from isaaclab_arena_curobo.utils.ik_solver_utils import (
+    get_aabb_collision_cuboid_for_object,
+    hand_sphere_mask,
+    robot_collision_spheres,
+    solve_ik_feasibility,
+)
 
 if TYPE_CHECKING:
     from isaaclab_arena.assets.object_base import ObjectBase
@@ -182,7 +188,7 @@ class ReachabilityValidator(PlacementValidator):
             )
             for obj in targets
         ])
-        feasible, position_error, rotation_error = solve_ik_feasibility(
+        ik = solve_ik_feasibility(
             self._solver,
             grasp_poses,
             position_threshold=self._ik_pos_threshold,
@@ -197,11 +203,14 @@ class ReachabilityValidator(PlacementValidator):
                 robot_base_quat_w_xyzw=self._robot_base_quat_w_xyzw,
                 target_names=[obj.name for obj in targets],
                 grasp_poses_base_frame=grasp_poses,
-                feasible=feasible,
-                position_error=position_error,
-                rotation_error=rotation_error,
+                feasible=ik.feasible,
+                position_error=ik.position_error,
+                rotation_error=ik.rotation_error,
+                # The pose the arm ended up in is what explains a rejection, so it is drawn alongside it.
+                robot_spheres=robot_collision_spheres(self._solver, ik.joint_positions),
+                muted_sphere_mask=hand_sphere_mask(self._solver) if self._require_collision_free else None,
             )
-        return bool(feasible.all().item())
+        return bool(ik.feasible.all().item())
 
     def _select_reachability_targets(self, objects: list[ObjectBase], anchors: set[ObjectBase]) -> list[ObjectBase]:
         """Movable objects the task marked as reachability targets (carry a RequiresReachability relation)."""

--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -6,8 +6,7 @@
 """Build-time cuRobo IK-reachability gate for pooled placement, sim-free (no SimApp).
 
 The pool's solve loop calls it on each geometry-valid candidate; a candidate is stored only when the robot can reach a
-top-down grasp at every movable object -- by default without the arm colliding on the way -- so the loop keeps solving
-(reject-&-refill) until every env has enough reachable layouts.
+top-down grasp at every movable object, so the loop keeps solving (reject-&-refill) until every env has enough reachable layouts.
 
 With the placement debug view on (``ObjectPlacerParams.debug_visualize``), the check also draws what it solved for each
 candidate -- the robot base, the grasps, their IK errors, and the collision spheres the arm holds at each solved grasp;
@@ -66,11 +65,6 @@ def get_object_world_pose_from_layout(
 @register_validator
 class ReachabilityValidator(PlacementValidator):
     """Build-time placement gate: the robot can reach a top-down grasp at the target objects (cuRobo IK).
-
-    With ``ReachabilityConfig.require_collision_free`` the grasp must also keep the arm clear of the layout's
-    other objects and of itself; the gripper's own links and the grasp targets are exempt, so reaching into
-    a target still passes while the surface under it, or a neighbour leaning over it, rejects the layout.
-
     Can be delisted (see ``is_available``) when the params carry no embodiment with a registered cuRobo config.
     """
 
@@ -155,10 +149,7 @@ class ReachabilityValidator(PlacementValidator):
         }
         # non-anchor objects with a RequiresReachability relation
         targets = self._select_reachability_targets(objects, anchors)
-        # A target is what the gripper closes on, so it is not an obstacle to its own grasp; everything else
-        # in the layout (the surface, other objects) is. Since one solve covers every target at once, no target
-        # blocks any other -- fine while tasks reach for one or two well-separated objects.
-        # TODO(xinjieyao, 2026-08-03): Solve per target against a world holding the other targets.
+        # A target is not an obstacle to its own grasp, but everything else in the layout is.
         cuboids = [
             get_aabb_collision_cuboid_for_object(obj, world_poses[obj].position_xyz, world_poses[obj].rotation_xyzw)
             for obj in objects

--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -9,8 +9,7 @@ The pool's solve loop calls it on each geometry-valid candidate; a candidate is 
 top-down grasp at every movable object, so the loop keeps solving (reject-&-refill) until every env has enough reachable layouts.
 
 With the placement debug view on (``ObjectPlacerParams.debug_visualize``), the check also draws what it solved for each
-candidate -- the robot base, the grasps, their IK errors, and the collision spheres the arm holds at each solved grasp;
-see ``isaaclab_arena_curobo.reachability_visualizer``.
+candidate -- the robot base, the grasps, their IK errors; see ``isaaclab_arena_curobo.reachability_visualizer``.
 """
 
 from __future__ import annotations

--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -6,7 +6,11 @@
 """Build-time cuRobo IK-reachability gate for pooled placement, sim-free (no SimApp).
 
 The pool's solve loop calls it on each geometry-valid candidate; a candidate is stored only when the robot can reach a
-top-down grasp at every movable object, so the loop keeps solving (reject-&-refill) until every env has enough reachable layouts.
+top-down grasp at every movable object -- by default without the arm colliding on the way -- so the loop keeps solving
+(reject-&-refill) until every env has enough reachable layouts.
+
+With the placement debug view on (``ObjectPlacerParams.debug_visualize``), the check also draws what it solved for each
+candidate -- the robot base, the grasps, and their IK errors; see ``isaaclab_arena_curobo.reachability_visualizer``.
 """
 
 from __future__ import annotations
@@ -57,6 +61,10 @@ def get_object_world_pose_from_layout(
 class ReachabilityValidator(PlacementValidator):
     """Build-time placement gate: the robot can reach a top-down grasp at the target objects (cuRobo IK).
 
+    With ``ReachabilityConfig.require_collision_free`` the grasp must also keep the arm clear of the layout's
+    other objects and of itself; the gripper's own links and the grasp targets are exempt, so reaching into
+    a target still passes while the surface under it, or a neighbour leaning over it, rejects the layout.
+
     Can be delisted (see ``is_available``) when the params carry no embodiment with a registered cuRobo config.
     """
 
@@ -69,6 +77,7 @@ class ReachabilityValidator(PlacementValidator):
         self._grasp_z_offset = config.grasp_z_offset_m
         self._ik_pos_threshold = config.ik_position_threshold_m
         self._ik_rot_threshold = config.ik_rotation_threshold_rad
+        self._require_collision_free = config.require_collision_free
         self._solver = CuroboIKSolver(
             get_embodiment_curobo_cfg(config.embodiment),
             position_threshold=self._ik_pos_threshold,
@@ -121,9 +130,10 @@ class ReachabilityValidator(PlacementValidator):
     ) -> bool:
         """Whether the robot can reach a top-down grasp at the target objects in one candidate layout.
 
-        Rebuilds each object's world pose and a per-object collision cuboid, syncs them into the solver's
-        world, then batches a single IK solve over the target objects' top-down grasps. A layout with
-        nothing to grasp (anchor-only, or no target present) is trivially reachable.
+        Rebuilds each object's world pose, syncs a collision cuboid per non-target object into the solver's
+        world -- what makes those objects block a grasp when collision checking is on -- then batches a
+        single IK solve over the target objects' top-down grasps. A layout with nothing to grasp
+        (anchor-only, or no target present) is trivially reachable.
 
         Args:
             positions: Solved (x, y, z) per object.
@@ -137,14 +147,19 @@ class ReachabilityValidator(PlacementValidator):
         world_poses = {
             obj: get_object_world_pose_from_layout(positions, orientations, obj, base_rotations) for obj in objects
         }
+        # non-anchor objects with a RequiresReachability relation
+        targets = self._select_reachability_targets(objects, anchors)
+        # A target is what the gripper closes on, so it is not an obstacle to its own grasp; everything else
+        # in the layout (the surface, other objects) is. Since one solve covers every target at once, no target
+        # blocks any other -- fine while tasks reach for one or two well-separated objects.
+        # TODO(xinjieyao, 2026-08-03): Solve per target against a world holding the other targets.
         cuboids = [
             get_aabb_collision_cuboid_for_object(obj, world_poses[obj].position_xyz, world_poses[obj].rotation_xyzw)
             for obj in objects
+            if obj not in targets
         ]
         self._solver.update_world(cuboids, self._robot_base_pos_w, self._robot_base_quat_w_xyzw)
 
-        # non-anchor objects with a RequiresReachability relation
-        targets = self._select_reachability_targets(objects, anchors)
         if not targets:
             # The check is enabled but no movable object is stamped as a reachability target, so it passes every
             # layout trivially.
@@ -172,6 +187,7 @@ class ReachabilityValidator(PlacementValidator):
             grasp_poses,
             position_threshold=self._ik_pos_threshold,
             rotation_threshold=self._ik_rot_threshold,
+            require_collision_free=self._require_collision_free,
         )
         if self._rerun_layer is not None:
             layout_index_across_batch = self._visualizer.get_layout_index_across_batch(layout_index_within_batch)

--- a/isaaclab_arena_curobo/ik_solver.py
+++ b/isaaclab_arena_curobo/ik_solver.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import logging
 import torch
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from curobo.geom.types import WorldConfig
 from curobo.types.base import TensorDeviceType
@@ -19,8 +21,10 @@ from curobo.wrap.reacher.ik_solver import IKSolver, IKSolverConfig
 from isaaclab_arena.utils.device import resolve_cuda_device
 from isaaclab_arena_curobo.curobo_embodiment_cfg import CuroboEmbodimentCfg
 from isaaclab_arena_curobo.embodiment_curobo_registry import get_embodiment_curobo_cfg
-from isaaclab_arena_curobo.utils.ik_solver_utils import AABBCollisionCuboid, world_config_from_cuboids
 from isaaclab_arena_curobo.utils.robot_cfg_utils import load_patched_robot_yaml
+
+if TYPE_CHECKING:
+    from isaaclab_arena_curobo.utils.ik_solver_utils import AABBCollisionCuboid
 
 
 class CuroboIKSolver:
@@ -149,6 +153,9 @@ class CuroboIKSolver:
         moving obstacle poses, so this handles both moved objects and a changed object set per layout,
         as long as the obstacle count stays within the collision cache.
         """
+        # Imported here because ik_solver_utils imports IKFeasibility from this module.
+        from isaaclab_arena_curobo.utils.ik_solver_utils import world_config_from_cuboids
+
         world_cfg = world_config_from_cuboids(cuboids, robot_base_pos_w, robot_base_quat_w_xyzw, self.device)
         self.ik_solver.update_world(world_cfg)
         if torch.cuda.is_available():

--- a/isaaclab_arena_curobo/ik_solver.py
+++ b/isaaclab_arena_curobo/ik_solver.py
@@ -153,3 +153,20 @@ class CuroboIKSolver:
         self.ik_solver.update_world(world_cfg)
         if torch.cuda.is_available():
             torch.cuda.synchronize()
+
+
+@dataclass
+class IKFeasibility:
+    """One batched IK solver's solved results."""
+
+    feasible: torch.Tensor
+    """Per-pose verdict: converged within the thresholds, and collision-free when that was required."""
+
+    position_error: torch.Tensor
+    """Per-pose IK position error (m) of the returned solution."""
+
+    rotation_error: torch.Tensor
+    """Per-pose IK rotation error (rad) of the returned solution."""
+
+    joint_positions: torch.Tensor
+    """Joint configuration solved per pose, of length joint_dim of the robot."""

--- a/isaaclab_arena_curobo/ik_solver.py
+++ b/isaaclab_arena_curobo/ik_solver.py
@@ -28,8 +28,8 @@ class CuroboIKSolver:
 
     Constructs a cuRobo solver from an embodiment's registered cuRobo config on an explicit CUDA
     device, holds a bounding-box collision world, and answers per-pose IK feasibility via a single
-    batched solve. Feasibility is pose reachability (position/rotation convergence) only; the
-    collision-free check is not wired up yet (see ``solve_ik_feasibility``'s ``require_collision_free``).
+    batched solve. Feasibility is pose reachability (position/rotation convergence), optionally also
+    collision-freeness against that world (see ``solve_ik_feasibility``'s ``require_collision_free``).
     """
 
     # Note(xinjieyao, 2026-07-23): When validating params like EventTermCfg.params, Isaac Lab's configclass recursively
@@ -43,7 +43,8 @@ class CuroboIKSolver:
     #     tensor_args: The tensor arguments for the solver.
     #     robot_cfg: The curobo robot configuration for the solver.
     #     ik_solver: The IK solver for the solver.
-    __slots__ = ("logger", "device", "tensor_args", "robot_cfg", "ik_solver")
+    #     hand_link_names: The robot's hand links, muted during a collision-free solve.
+    __slots__ = ("logger", "device", "tensor_args", "robot_cfg", "ik_solver", "hand_link_names")
 
     def __init__(
         self,
@@ -79,6 +80,7 @@ class CuroboIKSolver:
         collision_cache = collision_cache_size or {"obb": 150, "mesh": 150}
 
         self.robot_cfg = load_patched_robot_yaml(curobo_cfg)["robot_cfg"]
+        self.hand_link_names = list(curobo_cfg.hand_link_names)
         # Start with an empty collision world; update_world() fills it per layout.
         world_cfg = WorldConfig(cuboid=[])
 

--- a/isaaclab_arena_curobo/placement_pool_ik_validation.py
+++ b/isaaclab_arena_curobo/placement_pool_ik_validation.py
@@ -59,13 +59,13 @@ def _layout_is_ik_reachable(
     grasp_poses = torch.stack(
         [top_down_grasp_pose_from_env(env, name, grasp_z_offset, env_id) for name in movable_object_names]
     )
-    feasible, _, _ = solve_ik_feasibility(
+    ik = solve_ik_feasibility(
         planner,
         grasp_poses,
         position_threshold=ik_pos_threshold,
         rotation_threshold=ik_rot_threshold,
     )
-    return bool(feasible.all().item())
+    return bool(ik.feasible.all().item())
 
 
 def validate_pool_ik(

--- a/isaaclab_arena_curobo/reachability_visualizer.py
+++ b/isaaclab_arena_curobo/reachability_visualizer.py
@@ -5,7 +5,8 @@
 
 """The reachability check's layer of the placement Rerun debug view, sim-free (no SimApp).
 Adds to existing visualizer what only the IK check knows -- where the
-robot stands, the top-down grasps it solved, and whether each one was reachable.
+robot stands, the top-down grasps it solved, whether each one was reachable, and the collision
+spheres the robot holds at each solved grasp.
 """
 
 from __future__ import annotations
@@ -26,8 +27,17 @@ BASE_AXIS_LENGTH = 0.2
 GRASP_AXIS_LENGTH = 0.1
 """Length (m) of the drawn grasp frame axes."""
 
+MUTED_SPHERE_COLOR = (235, 180, 60)
+"""Color of a collision sphere muted for the solve, i.e. one allowed to touch the layout."""
+
+SPHERE_ALPHA = 110
+"""Opacity of the drawn collision spheres, so the layout stays visible through the robot."""
+
 BASE_ENTITY = f"{ROBOT_ENTITY}/base"
 """Entity path of the robot base frame; the grasps below it are logged in that frame."""
+
+SPHERES_ENTITY = f"{BASE_ENTITY}/collision_spheres"
+"""Entity path of the robot's collision spheres, one child per grasp the check solved."""
 
 
 class ReachabilityRerunLayer:
@@ -51,6 +61,8 @@ class ReachabilityRerunLayer:
         feasible: torch.Tensor,
         position_error: torch.Tensor,
         rotation_error: torch.Tensor,
+        robot_spheres: torch.Tensor | None = None,
+        muted_sphere_mask: torch.Tensor | None = None,
     ) -> None:
         """Log the robot's side of one evaluated layout.
 
@@ -63,6 +75,10 @@ class ReachabilityRerunLayer:
             feasible: ``(b,)`` per-grasp IK verdict.
             position_error: ``(b,)`` per-grasp IK position error (m).
             rotation_error: ``(b,)`` per-grasp IK rotation error (rad).
+            robot_spheres: ``(b, n, 4)`` collision spheres ``(x, y, z, radius)`` in the robot base frame,
+                one set per grasp; omitted when the check did not compute them.
+            muted_sphere_mask: ``(n,)`` mask of the spheres excluded from collision checking, drawn
+                apart from the rest. None means none were.
         """
         import rerun as rr
 
@@ -76,9 +92,13 @@ class ReachabilityRerunLayer:
         rr.log(BASE_ENTITY, rr.TransformAxes3D(BASE_AXIS_LENGTH))
 
         grasps = grasp_poses_base_frame.detach().cpu()
+        spheres = None if robot_spheres is None else robot_spheres.detach().cpu()
+        muted = None if muted_sphere_mask is None else muted_sphere_mask.detach().cpu()
         for i, name in enumerate(target_names):
             reachable = bool(feasible[i].item())
             color = REACHABLE_COLOR if reachable else UNREACHABLE_COLOR
+            if spheres is not None:
+                self._log_robot_spheres(f"{SPHERES_ENTITY}/{name}", spheres[i], muted, color)
             entity = f"{BASE_ENTITY}/grasps/{name}"
             rr.log(entity, rr.Transform3D(translation=grasps[i, :3, 3], mat3x3=grasps[i, :3, :3]))
             rr.log(entity, rr.TransformAxes3D(GRASP_AXIS_LENGTH))
@@ -93,3 +113,37 @@ class ReachabilityRerunLayer:
             )
             rr.log(f"errors/{name}/position_m", rr.Scalars(float(position_error[i].item())))
             rr.log(f"errors/{name}/rotation_rad", rr.Scalars(float(rotation_error[i].item())))
+
+    @staticmethod
+    def _log_robot_spheres(
+        entity: str,
+        spheres: torch.Tensor,
+        muted_sphere_mask: torch.Tensor | None,
+        checked_color: tuple[int, int, int],
+    ) -> None:
+        """Draw the robot's collision spheres at one solved grasp, muted ones set apart from checked ones.
+
+        Args:
+            entity: Entity path to draw under; a child of the base transform, as the spheres are in that frame.
+            spheres: ``(n, 4)`` spheres ``(x, y, z, radius)`` in the robot base frame.
+            muted_sphere_mask: ``(n,)`` mask of the spheres excluded from collision checking, or None for none.
+            checked_color: Color of the collision-checked spheres; the grasp's own verdict color.
+        """
+        import rerun as rr
+
+        radii = spheres[:, 3]
+        # cuRobo leaves spheres it does not use in the tensor with a negative radius, which Rerun would
+        # read as a radius in screen points rather than as metres.
+        kept = radii > 0.0
+        muted = torch.zeros_like(kept) if muted_sphere_mask is None else muted_sphere_mask
+        rr.log(
+            entity,
+            rr.Points3D(
+                spheres[kept][:, :3],
+                radii=radii[kept],
+                colors=[
+                    (*MUTED_SPHERE_COLOR, SPHERE_ALPHA) if is_muted else (*checked_color, SPHERE_ALPHA)
+                    for is_muted in muted[kept].tolist()
+                ],
+            ),
+        )

--- a/isaaclab_arena_curobo/reachability_visualizer.py
+++ b/isaaclab_arena_curobo/reachability_visualizer.py
@@ -121,7 +121,7 @@ class ReachabilityRerunLayer:
         muted_sphere_mask: torch.Tensor | None,
         checked_color: tuple[int, int, int],
     ) -> None:
-        """Draw the robot's collision spheres at one solved grasp, muted ones set apart from checked ones.
+        """Draw the robot's collision spheres at one solved grasp.
 
         Args:
             entity: Entity path to draw under; a child of the base transform, as the spheres are in that frame.

--- a/isaaclab_arena_curobo/tests/test_ik_reachability.py
+++ b/isaaclab_arena_curobo/tests/test_ik_reachability.py
@@ -230,7 +230,7 @@ def _run_reachability_check(args_cli) -> bool:
         top_down_grasp_pose_from_env(env, OBSTACLE_OBJECT, GRASP_Z_OFFSET),
         top_down_grasp_pose_from_env(env, NON_OBSTACLE_OBJECT, GRASP_Z_OFFSET),
     ])
-    feasible, pos_err, rot_err = solve_ik_feasibility(planner, grasp_poses)
+    feasible, pos_err, rot_err, _ = solve_ik_feasibility(planner, grasp_poses)
     print(
         f"reach: feasible={bool(feasible[0])} pos_err={float(pos_err[0]):.4f}m rot_err={float(rot_err[0]):.4f}rad",
         flush=True,

--- a/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
@@ -19,6 +19,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
+DOF = 7
+"""Joint count the patched IK solve reports; only its width matters, no kinematics run here."""
+
+NUM_SPHERES = 5
+"""Collision-sphere count the patched kinematics reports, for the same reason."""
+
 
 def _make_desk_box_pool(num_envs: int = 1, min_layouts_per_env: int = 2):
     """Build a small valid desk (anchor) + box (On desk) pool and return it."""
@@ -80,15 +86,20 @@ def _patch_curobo(monkeypatch, feasible_fn):
         return captured["solver"]
 
     def _fake_ik(solver, target_poses, **kwargs):
+        from isaaclab_arena_curobo.utils.ik_solver_utils import IKFeasibility
+
         num = target_poses.shape[0]
         feasible = torch.tensor(feasible_fn(num), dtype=torch.bool)
         captured["num_grasps"] = num
         captured["ik_kwargs"] = kwargs
-        return feasible, torch.zeros(num), torch.zeros(num)
+        return IKFeasibility(feasible, torch.zeros(num), torch.zeros(num), torch.zeros(num, DOF))
 
     monkeypatch.setattr(mod, "CuroboIKSolver", _make_solver)
     monkeypatch.setattr(mod, "solve_ik_feasibility", _fake_ik)
     monkeypatch.setattr(mod, "get_embodiment_curobo_cfg", lambda embodiment: None)
+    # The sphere helpers are cuRobo kinematics calls; they are covered in test_ik_solver_utils.py.
+    monkeypatch.setattr(mod, "robot_collision_spheres", lambda solver, q: torch.zeros(q.shape[0], NUM_SPHERES, 4))
+    monkeypatch.setattr(mod, "hand_sphere_mask", lambda solver: torch.zeros(NUM_SPHERES, dtype=torch.bool))
     return captured
 
 
@@ -224,6 +235,10 @@ def test_validator_draws_each_candidate_on_its_own_frame(monkeypatch):
 
     assert [entry["layout_index_across_batch"] for entry in drawn] == [7, 9]
     assert [entry["target_names"] for entry in drawn] == [["box"], ["box"]]
+    # The arm's pose at each solved grasp is drawn with it, one set of collision spheres per grasp,
+    # with the hand spheres marked as the ones the solve muted.
+    assert [tuple(entry["robot_spheres"].shape) for entry in drawn] == [(1, NUM_SPHERES, 4), (1, NUM_SPHERES, 4)]
+    assert all(entry["muted_sphere_mask"] is not None for entry in drawn)
 
 
 def test_reachability_layer_records_to_rrd(tmp_path):
@@ -244,6 +259,8 @@ def test_reachability_layer_records_to_rrd(tmp_path):
         feasible=torch.tensor([False]),
         position_error=torch.tensor([0.3]),
         rotation_error=torch.tensor([0.1]),
+        robot_spheres=torch.tensor([[[0.1, 0.0, 0.2, 0.05], [0.2, 0.0, 0.3, 0.04]]]),
+        muted_sphere_mask=torch.tensor([False, True]),
     )
     visualizer.close()
 

--- a/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
@@ -5,9 +5,9 @@
 
 """Logic tests for ReachabilityValidator, with cuRobo mocked out.
 
-Exercises what the validator does around cuRobo -- reconstruct object poses from a layout, build one
-collision cuboid per object, and IK-check one grasp per movable (non-anchor) object -- against a real
-geometry-solved layout, asserting the per-layout ``validate_batch`` verdict. The cuRobo solver build
+Exercises what the validator does around cuRobo -- reconstruct object poses from a layout, build a
+collision cuboid per non-target object, and IK-check one grasp per movable (non-anchor) object -- against
+a real geometry-solved layout, asserting the per-layout ``validate_batch`` verdict. The cuRobo solver build
 and the batched IK solve are patched, so no GPU or cuRobo install is needed; the pure-math grasp
 reconstruction runs for real on CPU.
 """
@@ -83,6 +83,7 @@ def _patch_curobo(monkeypatch, feasible_fn):
         num = target_poses.shape[0]
         feasible = torch.tensor(feasible_fn(num), dtype=torch.bool)
         captured["num_grasps"] = num
+        captured["ik_kwargs"] = kwargs
         return feasible, torch.zeros(num), torch.zeros(num)
 
     monkeypatch.setattr(mod, "CuroboIKSolver", _make_solver)
@@ -178,13 +179,18 @@ def _make_unstamped_desk_box_pool(num_envs: int = 1, min_layouts_per_env: int = 
     )
 
 
-def _make_reachability_validator(embodiment, visualizer=None):
-    """Construct the registered ReachabilityValidator with ``embodiment`` set on its params."""
+def _make_reachability_validator(embodiment, visualizer=None, require_collision_free=None):
+    """Construct the registered ReachabilityValidator with ``embodiment`` set on its params.
+
+    ``require_collision_free`` overrides that config default when given.
+    """
     from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
     from isaaclab_arena_curobo.ik_reachability_validator import ReachabilityValidator
 
     params = ObjectPlacerParams()
     params.reachability_config.embodiment = embodiment
+    if require_collision_free is not None:
+        params.reachability_config.require_collision_free = require_collision_free
     return ReachabilityValidator(params, visualizer)
 
 
@@ -252,9 +258,24 @@ def test_validator_accepts_when_all_grasps_feasible(monkeypatch):
 
     layout = _make_desk_box_pool().layouts_per_env()[0][0]
     assert validator.validate_batch([layout.positions], [layout.orientations], [{}], []) == [True]
-    # One collision cuboid per object (desk + box); one grasp per movable object (box only, desk is anchor).
-    assert len(captured["solver"].world_cuboids) == 2
+    # One collision cuboid per non-target object (the desk); one grasp per target (the box).
+    assert [cuboid.name for cuboid in captured["solver"].world_cuboids] == ["desk"]
     assert captured["num_grasps"] == 1
+
+
+@pytest.mark.curobo_deps
+def test_validator_collision_checks_grasps_by_default(monkeypatch):
+    """Grasps are collision-checked unless the task's reachability config opts out."""
+    captured = _patch_curobo(monkeypatch, feasible_fn=lambda n: [True] * n)
+    layout = _make_desk_box_pool().layouts_per_env()[0][0]
+
+    _make_reachability_validator(_fake_embodiment()).validate_batch([layout.positions], [layout.orientations], [{}], [])
+    assert captured["ik_kwargs"]["require_collision_free"] is True
+
+    _make_reachability_validator(_fake_embodiment(), require_collision_free=False).validate_batch(
+        [layout.positions], [layout.orientations], [{}], []
+    )
+    assert captured["ik_kwargs"]["require_collision_free"] is False
 
 
 @pytest.mark.curobo_deps
@@ -265,6 +286,19 @@ def test_validator_rejects_when_any_grasp_infeasible(monkeypatch):
 
     layout = _make_desk_box_pool().layouts_per_env()[0][0]
     assert validator.validate_batch([layout.positions], [layout.orientations], [{}], []) == [False]
+
+
+@pytest.mark.curobo_deps
+def test_grasp_targets_do_not_obstruct_their_own_grasp(monkeypatch):
+    """Targets are what the gripper closes on, so only the other objects go into the collision world."""
+    captured = _patch_curobo(monkeypatch, feasible_fn=lambda n: [True] * n)
+    validator = _make_reachability_validator(_fake_embodiment())
+
+    # Of the three objects, only box_a is a target; the desk and the unstamped box_b stay obstacles.
+    layout = _make_two_box_pool().layouts_per_env()[0][0]
+    validator.validate_batch([layout.positions], [layout.orientations], [{}], [])
+
+    assert sorted(cuboid.name for cuboid in captured["solver"].world_cuboids) == ["box_b", "desk"]
 
 
 @pytest.mark.curobo_deps

--- a/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
@@ -86,7 +86,7 @@ def _patch_curobo(monkeypatch, feasible_fn):
         return captured["solver"]
 
     def _fake_ik(solver, target_poses, **kwargs):
-        from isaaclab_arena_curobo.utils.ik_solver_utils import IKFeasibility
+        from isaaclab_arena_curobo.ik_solver import IKFeasibility
 
         num = target_poses.shape[0]
         feasible = torch.tensor(feasible_fn(num), dtype=torch.bool)

--- a/isaaclab_arena_curobo/tests/test_ik_solver_utils.py
+++ b/isaaclab_arena_curobo/tests/test_ik_solver_utils.py
@@ -7,8 +7,9 @@
 
 Exercises what ``solve_ik_feasibility`` does around cuRobo when collision checking is on -- mute the
 hand links for the solve, restore them afterwards, and fold cuRobo's ``success`` into the verdict --
-against a fake kinematics config that mimics cuRobo's in-place sphere edits. Needs no GPU, but does
-need the cuRobo image, since the module under test imports cuRobo at import time.
+plus the sphere helpers the debug view draws with, against a fake kinematics config that mimics
+cuRobo's in-place sphere edits. Needs no GPU, but does need the cuRobo image, since the module under
+test imports cuRobo at import time.
 """
 
 from __future__ import annotations
@@ -21,6 +22,9 @@ pytestmark = pytest.mark.curobo_deps
 
 HAND_LINKS = ["left_finger", "right_finger"]
 ARM_LINK = "forearm"
+DOF = 7
+"""Joint count of the fake robot; only its width matters, since no real kinematics run here."""
+
 DISABLED_RADIUS = -100.0
 """Radius cuRobo writes into a muted sphere; anything negative is ignored by its collision kernels."""
 
@@ -31,6 +35,11 @@ class _FakeKinematicsConfig:
     def __init__(self, link_names: list[str]) -> None:
         self.link_name_to_idx_map = {name: index for index, name in enumerate(link_names)}
         self._spheres = {name: torch.tensor([[0.0, 0.0, 0.0, 0.05]]) for name in link_names}
+        # One sphere per link, in link order, so sphere i belongs to link i.
+        self.link_sphere_idx_map = torch.arange(len(link_names))
+
+    def get_sphere_index_from_link_name(self, link_name: str) -> torch.Tensor:
+        return torch.nonzero(self.link_sphere_idx_map == self.link_name_to_idx_map[link_name]).view(-1)
 
     def get_link_spheres(self, link_name: str) -> torch.Tensor:
         return self._spheres[link_name]
@@ -52,13 +61,29 @@ class _FakeIKResult:
         self.position_error = torch.zeros(num_poses)
         self.rotation_error = torch.zeros(num_poses)
         self.success = torch.full((num_poses,), success, dtype=torch.bool)
+        # cuRobo returns (batch, return_seeds, dof); the joint values themselves are arbitrary here.
+        self.solution = torch.arange(num_poses * DOF, dtype=torch.float32).view(num_poses, 1, DOF)
+
+
+class _FakeKinematics:
+    """Stand-in for cuRobo's ``CudaRobotModel``: the sphere config plus forward kinematics onto it."""
+
+    def __init__(self, kinematics_config: _FakeKinematicsConfig) -> None:
+        self.kinematics_config = kinematics_config
+
+    def get_state(self, joint_positions: torch.Tensor):
+        """Return one set of link spheres per given joint configuration."""
+        spheres = torch.stack(
+            [self.kinematics_config.get_link_spheres(name)[0] for name in self.kinematics_config.link_name_to_idx_map]
+        )
+        return type("_State", (), {"link_spheres_tensor": spheres.expand(joint_positions.shape[0], -1, -1)})()
 
 
 class _FakeIKSolver:
     """Records the sphere radii cuRobo would have seen at solve time, then returns a canned result."""
 
     def __init__(self, kinematics_config: _FakeKinematicsConfig, success: bool, raises: bool = False) -> None:
-        self.kinematics = type("_Kinematics", (), {"kinematics_config": kinematics_config})()
+        self.kinematics = _FakeKinematics(kinematics_config)
         self._success = success
         self._raises = raises
         self.radii_during_solve: dict[str, float] = {}
@@ -147,11 +172,36 @@ def test_colliding_pose_is_infeasible_only_when_collision_checking_is_on():
     from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
 
     host, _ = _make_host(success=False)
-    reachable, _, _ = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=False)
-    collision_free, _, _ = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)
+    reachable = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=False).feasible
+    collision_free = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True).feasible
 
     assert reachable.tolist() == [True, True]
     assert collision_free.tolist() == [False, False]
+
+
+def test_hand_sphere_mask_marks_the_hand_spheres_only():
+    """The mask singles out exactly the spheres a collision-free solve mutes."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import hand_sphere_mask
+
+    host, _ = _make_host()
+
+    # One sphere per link, in link order: the two hand links, then the arm link.
+    assert hand_sphere_mask(host).tolist() == [True, True, False]
+
+
+def test_solved_configuration_comes_back_and_forward_kinematics_to_spheres():
+    """The solved joint configuration is returned, and the spheres to draw come from posing the robot at it."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import robot_collision_spheres, solve_ik_feasibility
+
+    host, _ = _make_host()
+    ik = solve_ik_feasibility(host, _identity_grasps(num_poses=2), require_collision_free=True)
+    spheres = robot_collision_spheres(host, ik.joint_positions)
+
+    # One row per pose, cuRobo's ``(batch, return_seeds, dof)`` collapsed onto the best seed.
+    assert ik.joint_positions.shape == (2, DOF)
+    assert spheres.shape == (2, len(HAND_LINKS) + 1, 4)
+    # Muting is scoped to the solve, so the spheres drawn afterwards carry their real radii.
+    assert (spheres[..., 3] > 0.0).all()
 
 
 def test_unknown_hand_link_is_reported_against_the_robot_config():

--- a/isaaclab_arena_curobo/tests/test_ik_solver_utils.py
+++ b/isaaclab_arena_curobo/tests/test_ik_solver_utils.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Logic tests for the collision-free IK path, with cuRobo's solver faked out.
+
+Exercises what ``solve_ik_feasibility`` does around cuRobo when collision checking is on -- mute the
+hand links for the solve, restore them afterwards, and fold cuRobo's ``success`` into the verdict --
+against a fake kinematics config that mimics cuRobo's in-place sphere edits. Needs no GPU, but does
+need the cuRobo image, since the module under test imports cuRobo at import time.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import pytest
+
+pytestmark = pytest.mark.curobo_deps
+
+HAND_LINKS = ["left_finger", "right_finger"]
+ARM_LINK = "forearm"
+DISABLED_RADIUS = -100.0
+"""Radius cuRobo writes into a muted sphere; anything negative is ignored by its collision kernels."""
+
+
+class _FakeKinematicsConfig:
+    """Stand-in for cuRobo's ``KinematicsTensorConfig``, one unit-radius sphere per link."""
+
+    def __init__(self, link_names: list[str]) -> None:
+        self.link_name_to_idx_map = {name: index for index, name in enumerate(link_names)}
+        self._spheres = {name: torch.tensor([[0.0, 0.0, 0.0, 0.05]]) for name in link_names}
+
+    def get_link_spheres(self, link_name: str) -> torch.Tensor:
+        return self._spheres[link_name]
+
+    def update_link_spheres(self, link_name: str, sphere_position_radius: torch.Tensor) -> None:
+        self._spheres[link_name] = sphere_position_radius
+
+    def disable_link_spheres(self, link_name: str) -> None:
+        spheres = self.get_link_spheres(link_name).clone()
+        spheres[:, 3] = DISABLED_RADIUS
+        self.update_link_spheres(link_name, spheres)
+
+    def radius(self, link_name: str) -> float:
+        return float(self._spheres[link_name][0, 3].item())
+
+
+class _FakeIKResult:
+    def __init__(self, num_poses: int, success: bool) -> None:
+        self.position_error = torch.zeros(num_poses)
+        self.rotation_error = torch.zeros(num_poses)
+        self.success = torch.full((num_poses,), success, dtype=torch.bool)
+
+
+class _FakeIKSolver:
+    """Records the sphere radii cuRobo would have seen at solve time, then returns a canned result."""
+
+    def __init__(self, kinematics_config: _FakeKinematicsConfig, success: bool, raises: bool = False) -> None:
+        self.kinematics = type("_Kinematics", (), {"kinematics_config": kinematics_config})()
+        self._success = success
+        self._raises = raises
+        self.radii_during_solve: dict[str, float] = {}
+
+    def solve_batch(self, goal_pose, seed_config=None) -> _FakeIKResult:
+        config = self.kinematics.kinematics_config
+        self.radii_during_solve = {name: config.radius(name) for name in config.link_name_to_idx_map}
+        if self._raises:
+            raise RuntimeError("solve blew up")
+        return _FakeIKResult(goal_pose.position.shape[0], self._success)
+
+
+class _FakeHost:
+    """Minimal ``CuroboIKSolver``-shaped host: owns the solver, the hand links, and the pose plumbing."""
+
+    def __init__(self, ik_solver: _FakeIKSolver, hand_link_names: list[str]) -> None:
+        import logging
+
+        self.ik_solver = ik_solver
+        self.hand_link_names = hand_link_names
+        self.logger = logging.getLogger("test_ik_solver_utils")
+
+    def _to_curobo_device(self, tensor: torch.Tensor) -> torch.Tensor:
+        return tensor.to(dtype=torch.float32)
+
+    def _make_pose(self, position, quaternion, quat_is_xyzw: bool = True):
+        return type("_Pose", (), {"position": position, "quaternion": quaternion})()
+
+
+def _make_host(success: bool = True, raises: bool = False) -> tuple[_FakeHost, _FakeKinematicsConfig]:
+    """Build a fake host whose solve reports ``success`` (cuRobo's converged-and-collision-free flag)."""
+    kinematics_config = _FakeKinematicsConfig([*HAND_LINKS, ARM_LINK])
+    host = _FakeHost(_FakeIKSolver(kinematics_config, success=success, raises=raises), HAND_LINKS)
+    return host, kinematics_config
+
+
+def _identity_grasps(num_poses: int = 2) -> torch.Tensor:
+    return torch.eye(4).repeat(num_poses, 1, 1)
+
+
+def test_collision_free_solve_mutes_only_the_hand_links():
+    """The gripper's links are muted for the solve; the rest of the arm keeps its spheres."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, _ = _make_host()
+    solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)
+
+    radii = host.ik_solver.radii_during_solve
+    assert [radii[name] for name in HAND_LINKS] == [DISABLED_RADIUS, DISABLED_RADIUS]
+    assert radii[ARM_LINK] > 0.0
+
+
+def test_hand_links_are_restored_after_the_solve():
+    """Muting is scoped to the solve, so a later solve (or planner) sees the original spheres."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, kinematics_config = _make_host()
+    solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)
+
+    assert all(kinematics_config.radius(name) > 0.0 for name in HAND_LINKS)
+
+
+def test_hand_links_are_restored_when_the_solve_raises():
+    """A failed solve must not leave the shared kinematics permanently muted."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, kinematics_config = _make_host(raises=True)
+    with pytest.raises(RuntimeError):
+        solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)
+
+    assert all(kinematics_config.radius(name) > 0.0 for name in HAND_LINKS)
+
+
+def test_reachability_only_solve_leaves_every_sphere_alone():
+    """With collision checking off, the solve is pure reachability and touches no spheres."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, _ = _make_host()
+    solve_ik_feasibility(host, _identity_grasps(), require_collision_free=False)
+
+    assert all(radius > 0.0 for radius in host.ik_solver.radii_during_solve.values())
+
+
+def test_colliding_pose_is_infeasible_only_when_collision_checking_is_on():
+    """A converged but colliding solution passes the reachability-only check and fails the collision one."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, _ = _make_host(success=False)
+    reachable, _, _ = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=False)
+    collision_free, _, _ = solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)
+
+    assert reachable.tolist() == [True, True]
+    assert collision_free.tolist() == [False, False]
+
+
+def test_unknown_hand_link_is_reported_against_the_robot_config():
+    """A hand link with no spheres in the robot config fails loudly rather than silently doing nothing."""
+    from isaaclab_arena_curobo.utils.ik_solver_utils import solve_ik_feasibility
+
+    host, _ = _make_host()
+    host.hand_link_names = ["not_a_link"]
+    with pytest.raises(AssertionError, match="not_a_link"):
+        solve_ik_feasibility(host, _identity_grasps(), require_collision_free=True)

--- a/isaaclab_arena_curobo/utils/ik_solver_utils.py
+++ b/isaaclab_arena_curobo/utils/ik_solver_utils.py
@@ -8,6 +8,8 @@
 from __future__ import annotations
 
 import torch
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -36,6 +38,46 @@ def resolve_ik_solver(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> IKSo
     if ik_solver is None:
         ik_solver = ik_solver_context.motion_gen.ik_solver
     return ik_solver
+
+
+def resolve_hand_link_names(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> list[str]:
+    """Get the embodiment's hand link names from a host, whichever way it exposes them.
+
+    ``CuroboIKSolver`` holds them as ``hand_link_names``; the upstream ``CuroboPlanner`` (not ours to
+    change) holds them on its ``config``.
+    """
+    hand_link_names = getattr(ik_solver_context, "hand_link_names", None)
+    if hand_link_names is None:
+        hand_link_names = ik_solver_context.config.hand_link_names
+    return list(hand_link_names)
+
+
+@contextmanager
+def disabled_link_spheres(ik_solver: IKSolver, link_names: Sequence[str]) -> Iterator[None]:
+    """Mute the collision spheres of ``link_names`` for the duration of the block, then restore them.
+
+    cuRobo has no per-solve collision mask, so the spheres are edited in place on the solver's shared
+    kinematics and put back on exit (including on error). Restoring the saved spheres rather than the
+    robot config's originals keeps any other in-place edit (e.g. an attached object) intact.
+
+    Args:
+        ik_solver: The cuRobo IK solver whose kinematics carry the spheres.
+        link_names: Links to mute; an empty sequence makes the block a no-op.
+    """
+    kinematics_config = ik_solver.kinematics.kinematics_config
+    for name in link_names:
+        assert name in kinematics_config.link_name_to_idx_map, (
+            f"Link '{name}' has no collision spheres in this robot config. "
+            f"Known: {sorted(kinematics_config.link_name_to_idx_map)}."
+        )
+    saved_spheres = {name: kinematics_config.get_link_spheres(name).clone() for name in link_names}
+    for name in link_names:
+        kinematics_config.disable_link_spheres(name)
+    try:
+        yield
+    finally:
+        for name, spheres in saved_spheres.items():
+            kinematics_config.update_link_spheres(name, spheres)
 
 
 @dataclass
@@ -119,8 +161,9 @@ def solve_ik_feasibility(
         position_threshold: Max position error (m) to count as feasible.
         rotation_threshold: Max rotation error (rad) to count as feasible.
         require_collision_free: Also require a collision-free joint solution (cuRobo ``success``), not
-            just pose convergence. The caller must first exclude the grasped object's own contact --
-            e.g. disable the hand-link spheres -- or the gripper over its target reads as a collision.
+            just pose convergence. The embodiment's hand links are muted for the solve, so the gripper
+            closing over its target does not read as a collision; the rest of the arm is still checked
+            against the solver's world and against itself.
 
     Returns:
         ``(feasible, position_error, rotation_error)``, each length ``b`` and aligned with the input;
@@ -141,15 +184,16 @@ def solve_ik_feasibility(
         while ik_seed.dim() < 3:
             ik_seed = ik_seed.unsqueeze(0)
 
-    ik_result = ik_solver.solve_batch(goal_pose, seed_config=ik_seed)
+    # The gripper is meant to touch what it grasps, so its own links are muted for a collision-free solve.
+    muted_links = resolve_hand_link_names(ik_solver_context) if require_collision_free else []
+    with disabled_link_spheres(ik_solver, muted_links):
+        ik_result = ik_solver.solve_batch(goal_pose, seed_config=ik_seed)
 
     num_poses = positions.shape[0]
     pos_err = ik_result.position_error.view(num_poses, -1)
     rot_err = ik_result.rotation_error.view(num_poses, -1)
 
     ok = (pos_err < position_threshold) & (rot_err < rotation_threshold)
-    # TODO(xinjieyao, 2026-07-15): Support collision-free IK by disabling the hand-link spheres during collision checking
-    assert require_collision_free is False, "Collision-free IK is not supported yet. Needs extra machinery."
     if require_collision_free:
         # cuRobo folds collision-free-ness into ``success`` (success = converged AND feasible).
         ok = ok & ik_result.success.view(num_poses, -1).bool()

--- a/isaaclab_arena_curobo/utils/ik_solver_utils.py
+++ b/isaaclab_arena_curobo/utils/ik_solver_utils.py
@@ -11,7 +11,7 @@ import torch
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import isaaclab.utils.math as math_utils
 from curobo.geom.types import Cuboid, WorldConfig
@@ -50,6 +50,43 @@ def resolve_hand_link_names(ik_solver_context: CuroboIKSolver | CuroboPlanner) -
     if hand_link_names is None:
         hand_link_names = ik_solver_context.config.hand_link_names
     return list(hand_link_names)
+
+
+def hand_sphere_mask(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> torch.Tensor:
+    """Mask over the robot's collision spheres selecting the hand ones, i.e. those a collision-free solve mutes.
+
+    Args:
+        ik_solver_context: The host that owns the solver and names the embodiment's hand links.
+
+    Returns:
+        ``(num_spheres,)`` bool tensor aligned with the spheres ``robot_collision_spheres`` returns.
+    """
+    kinematics_config = resolve_ik_solver(ik_solver_context).kinematics.kinematics_config
+    sphere_link_indices = kinematics_config.link_sphere_idx_map
+    mask = torch.zeros(sphere_link_indices.shape[0], dtype=torch.bool, device=sphere_link_indices.device)
+    for name in resolve_hand_link_names(ik_solver_context):
+        mask[kinematics_config.get_sphere_index_from_link_name(name)] = True
+    return mask
+
+
+def robot_collision_spheres(
+    ik_solver_context: CuroboIKSolver | CuroboPlanner, joint_positions: torch.Tensor
+) -> torch.Tensor:
+    """Forward-kinematics the robot's collision spheres at each given joint configuration.
+
+    These are the spheres cuRobo collision-checks, so they show what a rejected grasp actually ran into.
+
+    Args:
+        ik_solver_context: The host that owns the solver and supplies device plumbing.
+        joint_positions: ``(b, dof)`` joint configuration per pose.
+
+    Returns:
+        ``(b, num_spheres, 4)`` of ``(x, y, z, radius)`` in the robot base frame; cuRobo leaves unused
+        spheres in with a negative radius.
+    """
+    ik_solver = resolve_ik_solver(ik_solver_context)
+    joint_positions = ik_solver_context._to_curobo_device(joint_positions)
+    return ik_solver.kinematics.get_state(joint_positions).link_spheres_tensor
 
 
 @contextmanager
@@ -143,6 +180,22 @@ def world_config_from_cuboids(
     return WorldConfig(cuboid=curobo_cuboids)
 
 
+class IKFeasibility(NamedTuple):
+    """One batched IK solve's outcome, every field length ``b`` and aligned with the input poses."""
+
+    feasible: torch.Tensor
+    """Per-pose verdict: converged within the thresholds, and collision-free when that was required."""
+
+    position_error: torch.Tensor
+    """Per-pose IK position error (m) of the returned solution."""
+
+    rotation_error: torch.Tensor
+    """Per-pose IK rotation error (rad) of the returned solution."""
+
+    joint_positions: torch.Tensor
+    """``(b, dof)`` joint configuration solved per pose; the best seed's, feasible or not."""
+
+
 def solve_ik_feasibility(
     ik_solver_context: CuroboIKSolver | CuroboPlanner,
     target_poses: torch.Tensor,
@@ -150,7 +203,7 @@ def solve_ik_feasibility(
     position_threshold: float = 0.01,
     rotation_threshold: float = 0.1,
     require_collision_free: bool = False,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> IKFeasibility:
     """Batched IK feasibility of all ``target_poses`` against a cuRobo IK solver. Shared between sim-free and env-coupled paths.
     Runs a single ``solve_batch`` for one layout.
 
@@ -166,8 +219,8 @@ def solve_ik_feasibility(
             against the solver's world and against itself.
 
     Returns:
-        ``(feasible, position_error, rotation_error)``, each length ``b`` and aligned with the input;
-        errors are the best-seed values per pose.
+        An ``IKFeasibility`` holding the per-pose verdict, the best-seed errors, and the joint
+        configuration those errors belong to.
     """
     ik_solver = resolve_ik_solver(ik_solver_context)
     target_poses = ik_solver_context._to_curobo_device(target_poses)
@@ -203,6 +256,8 @@ def solve_ik_feasibility(
     best_idx = pos_err.argmin(dim=1, keepdim=True)
     best_pos_err = pos_err.gather(1, best_idx).squeeze(1)
     best_rot_err = rot_err.gather(1, best_idx).squeeze(1)
+    solutions = ik_result.solution.view(num_poses, pos_err.shape[1], -1)
+    best_solution = solutions.gather(1, best_idx.unsqueeze(-1).expand(-1, -1, solutions.shape[-1])).squeeze(1)
 
     ik_solver_context.logger.debug(f"Batch IK feasibility: {int(feasible.sum().item())}/{num_poses} feasible")
-    return feasible, best_pos_err, best_rot_err
+    return IKFeasibility(feasible, best_pos_err, best_rot_err, best_solution)

--- a/isaaclab_arena_curobo/utils/ik_solver_utils.py
+++ b/isaaclab_arena_curobo/utils/ik_solver_utils.py
@@ -19,6 +19,7 @@ from curobo.geom.types import Cuboid, WorldConfig
 from isaaclab_arena.assets.object_base import ObjectBase
 from isaaclab_arena.utils.device import resolve_cuda_device
 from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena_curobo.ik_solver import IKFeasibility
 from isaaclab_arena_curobo.utils.frame_utils import world_pose_to_robot_frame
 
 if TYPE_CHECKING:
@@ -180,22 +181,6 @@ def world_config_from_cuboids(
     return WorldConfig(cuboid=curobo_cuboids)
 
 
-class IKFeasibility(NamedTuple):
-    """One batched IK solve's outcome, every field length ``b`` and aligned with the input poses."""
-
-    feasible: torch.Tensor
-    """Per-pose verdict: converged within the thresholds, and collision-free when that was required."""
-
-    position_error: torch.Tensor
-    """Per-pose IK position error (m) of the returned solution."""
-
-    rotation_error: torch.Tensor
-    """Per-pose IK rotation error (rad) of the returned solution."""
-
-    joint_positions: torch.Tensor
-    """``(b, dof)`` joint configuration solved per pose; the best seed's, feasible or not."""
-
-
 def solve_ik_feasibility(
     ik_solver_context: CuroboIKSolver | CuroboPlanner,
     target_poses: torch.Tensor,
@@ -213,14 +198,11 @@ def solve_ik_feasibility(
         seed_config: Optional joint seed tensor.
         position_threshold: Max position error (m) to count as feasible.
         rotation_threshold: Max rotation error (rad) to count as feasible.
-        require_collision_free: Also require a collision-free joint solution (cuRobo ``success``), not
-            just pose convergence. The embodiment's hand links are muted for the solve, so the gripper
-            closing over its target does not read as a collision; the rest of the arm is still checked
-            against the solver's world and against itself.
+        require_collision_free: Also require a collision-free joint solution, not just pose convergence.
 
     Returns:
-        An ``IKFeasibility`` holding the per-pose verdict, the best-seed errors, and the joint
-        configuration those errors belong to.
+        An ``IKFeasibility`` holding the per-pose verdict, position/rotation errors, and the joint
+        configuration solved per pose.
     """
     ik_solver = resolve_ik_solver(ik_solver_context)
     target_poses = ik_solver_context._to_curobo_device(target_poses)
@@ -237,7 +219,7 @@ def solve_ik_feasibility(
         while ik_seed.dim() < 3:
             ik_seed = ik_seed.unsqueeze(0)
 
-    # The gripper is meant to touch what it grasps, so its own links are muted for a collision-free solve.
+    # The gripper is meant to touch what it grasps, so its own links are disabled to detect collisions with the grasped object.
     muted_links = resolve_hand_link_names(ik_solver_context) if require_collision_free else []
     with disabled_link_spheres(ik_solver, muted_links):
         ik_result = ik_solver.solve_batch(goal_pose, seed_config=ik_seed)

--- a/isaaclab_arena_curobo/utils/ik_solver_utils.py
+++ b/isaaclab_arena_curobo/utils/ik_solver_utils.py
@@ -11,7 +11,7 @@ import torch
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING
 
 import isaaclab.utils.math as math_utils
 from curobo.geom.types import Cuboid, WorldConfig
@@ -27,95 +27,6 @@ if TYPE_CHECKING:
     from isaaclab_mimic.motion_planners.curobo.curobo_planner import CuroboPlanner
 
     from isaaclab_arena_curobo.ik_solver import CuroboIKSolver
-
-
-def resolve_ik_solver(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> IKSolver:
-    """Get the cuRobo ``IKSolver`` from a host, whichever way it exposes it.
-
-    ``CuroboIKSolver`` holds it as ``ik_solver``; the upstream ``CuroboPlanner`` (not ours to change)
-    holds it as ``motion_gen.ik_solver``. Centralizing the lookup lets the solve take just the host.
-    """
-    ik_solver = getattr(ik_solver_context, "ik_solver", None)
-    if ik_solver is None:
-        ik_solver = ik_solver_context.motion_gen.ik_solver
-    return ik_solver
-
-
-def resolve_hand_link_names(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> list[str]:
-    """Get the embodiment's hand link names from a host, whichever way it exposes them.
-
-    ``CuroboIKSolver`` holds them as ``hand_link_names``; the upstream ``CuroboPlanner`` (not ours to
-    change) holds them on its ``config``.
-    """
-    hand_link_names = getattr(ik_solver_context, "hand_link_names", None)
-    if hand_link_names is None:
-        hand_link_names = ik_solver_context.config.hand_link_names
-    return list(hand_link_names)
-
-
-def hand_sphere_mask(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> torch.Tensor:
-    """Mask over the robot's collision spheres selecting the hand ones, i.e. those a collision-free solve mutes.
-
-    Args:
-        ik_solver_context: The host that owns the solver and names the embodiment's hand links.
-
-    Returns:
-        ``(num_spheres,)`` bool tensor aligned with the spheres ``robot_collision_spheres`` returns.
-    """
-    kinematics_config = resolve_ik_solver(ik_solver_context).kinematics.kinematics_config
-    sphere_link_indices = kinematics_config.link_sphere_idx_map
-    mask = torch.zeros(sphere_link_indices.shape[0], dtype=torch.bool, device=sphere_link_indices.device)
-    for name in resolve_hand_link_names(ik_solver_context):
-        mask[kinematics_config.get_sphere_index_from_link_name(name)] = True
-    return mask
-
-
-def robot_collision_spheres(
-    ik_solver_context: CuroboIKSolver | CuroboPlanner, joint_positions: torch.Tensor
-) -> torch.Tensor:
-    """Forward-kinematics the robot's collision spheres at each given joint configuration.
-
-    These are the spheres cuRobo collision-checks, so they show what a rejected grasp actually ran into.
-
-    Args:
-        ik_solver_context: The host that owns the solver and supplies device plumbing.
-        joint_positions: ``(b, dof)`` joint configuration per pose.
-
-    Returns:
-        ``(b, num_spheres, 4)`` of ``(x, y, z, radius)`` in the robot base frame; cuRobo leaves unused
-        spheres in with a negative radius.
-    """
-    ik_solver = resolve_ik_solver(ik_solver_context)
-    joint_positions = ik_solver_context._to_curobo_device(joint_positions)
-    return ik_solver.kinematics.get_state(joint_positions).link_spheres_tensor
-
-
-@contextmanager
-def disabled_link_spheres(ik_solver: IKSolver, link_names: Sequence[str]) -> Iterator[None]:
-    """Mute the collision spheres of ``link_names`` for the duration of the block, then restore them.
-
-    cuRobo has no per-solve collision mask, so the spheres are edited in place on the solver's shared
-    kinematics and put back on exit (including on error). Restoring the saved spheres rather than the
-    robot config's originals keeps any other in-place edit (e.g. an attached object) intact.
-
-    Args:
-        ik_solver: The cuRobo IK solver whose kinematics carry the spheres.
-        link_names: Links to mute; an empty sequence makes the block a no-op.
-    """
-    kinematics_config = ik_solver.kinematics.kinematics_config
-    for name in link_names:
-        assert name in kinematics_config.link_name_to_idx_map, (
-            f"Link '{name}' has no collision spheres in this robot config. "
-            f"Known: {sorted(kinematics_config.link_name_to_idx_map)}."
-        )
-    saved_spheres = {name: kinematics_config.get_link_spheres(name).clone() for name in link_names}
-    for name in link_names:
-        kinematics_config.disable_link_spheres(name)
-    try:
-        yield
-    finally:
-        for name, spheres in saved_spheres.items():
-            kinematics_config.update_link_spheres(name, spheres)
 
 
 @dataclass
@@ -204,7 +115,7 @@ def solve_ik_feasibility(
         An ``IKFeasibility`` holding the per-pose verdict, position/rotation errors, and the joint
         configuration solved per pose.
     """
-    ik_solver = resolve_ik_solver(ik_solver_context)
+    ik_solver = _resolve_ik_solver(ik_solver_context)
     target_poses = ik_solver_context._to_curobo_device(target_poses)
     positions, rotations = math_utils.unmake_pose(target_poses)
     goal_pose = ik_solver_context._make_pose(
@@ -220,8 +131,8 @@ def solve_ik_feasibility(
             ik_seed = ik_seed.unsqueeze(0)
 
     # The gripper is meant to touch what it grasps, so its own links are disabled to detect collisions with the grasped object.
-    muted_links = resolve_hand_link_names(ik_solver_context) if require_collision_free else []
-    with disabled_link_spheres(ik_solver, muted_links):
+    muted_links = _resolve_hand_link_names(ik_solver_context) if require_collision_free else []
+    with _disabled_link_spheres(ik_solver, muted_links):
         ik_result = ik_solver.solve_batch(goal_pose, seed_config=ik_seed)
 
     num_poses = positions.shape[0]
@@ -243,3 +154,85 @@ def solve_ik_feasibility(
 
     ik_solver_context.logger.debug(f"Batch IK feasibility: {int(feasible.sum().item())}/{num_poses} feasible")
     return IKFeasibility(feasible, best_pos_err, best_rot_err, best_solution)
+
+
+def hand_sphere_mask(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> torch.Tensor:
+    """Mask over the robot's collision spheres selecting the hand links.
+
+    Args:
+        ik_solver_context: The host that owns the solver and names the embodiment's hand links.
+
+    Returns:
+        ``(num_spheres,)`` bool tensor aligned with the spheres ``robot_collision_spheres`` returns.
+    """
+    kinematics_config = _resolve_ik_solver(ik_solver_context).kinematics.kinematics_config
+    sphere_link_indices = kinematics_config.link_sphere_idx_map
+    mask = torch.zeros(sphere_link_indices.shape[0], dtype=torch.bool, device=sphere_link_indices.device)
+    for name in _resolve_hand_link_names(ik_solver_context):
+        mask[kinematics_config.get_sphere_index_from_link_name(name)] = True
+    return mask
+
+
+def robot_collision_spheres(
+    ik_solver_context: CuroboIKSolver | CuroboPlanner, joint_positions: torch.Tensor
+) -> torch.Tensor:
+    """Forward-kinematics the robot's collision spheres at each given joint configuration. Curobo collision-checks use these spheres.
+
+    Args:
+        ik_solver_context: The host that owns the solver and supplies device plumbing.
+        joint_positions: shape of (b, dof), b:number of poses, dof:number of joints.
+
+    Returns:
+        shape of (b, num_spheres, 4), b:number of poses, 4:x, y, z, radius; cuRobo leaves unused
+        spheres in with a negative radius.
+    """
+    ik_solver = _resolve_ik_solver(ik_solver_context)
+    joint_positions = ik_solver_context._to_curobo_device(joint_positions)
+    return ik_solver.kinematics.get_state(joint_positions).link_spheres_tensor
+
+
+def _resolve_ik_solver(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> IKSolver:
+    """Get the cuRobo ``IKSolver`` from a host, whichever way it exposes it.
+
+    ``CuroboIKSolver`` holds it as ``ik_solver``; the upstream ``CuroboPlanner`` (not ours to change)
+    holds it as ``motion_gen.ik_solver``. Centralizing the lookup lets the solve take just the host.
+    """
+    ik_solver = getattr(ik_solver_context, "ik_solver", None)
+    if ik_solver is None:
+        ik_solver = ik_solver_context.motion_gen.ik_solver
+    return ik_solver
+
+
+def _resolve_hand_link_names(ik_solver_context: CuroboIKSolver | CuroboPlanner) -> list[str]:
+    """Get the embodiment's hand link names from a host, whichever way it exposes them."""
+    hand_link_names = getattr(ik_solver_context, "hand_link_names", None)
+    if hand_link_names is None:
+        # CuroboPlanner holds them on its config.
+        hand_link_names = ik_solver_context.config.hand_link_names
+    return list(hand_link_names)
+
+
+@contextmanager
+def _disabled_link_spheres(ik_solver: IKSolver, link_names: Sequence[str]) -> Iterator[None]:
+    """Mute the collision spheres of given links for the duration of the block, then restore them.
+
+    Args:
+        ik_solver: The cuRobo IK solver whose kinematics carry the spheres.
+        link_names: Links to mute; an empty sequence makes the block a no-op.
+    """
+    kinematics_config = ik_solver.kinematics.kinematics_config
+    for name in link_names:
+        assert name in kinematics_config.link_name_to_idx_map, (
+            f"Link '{name}' has no collision spheres in this robot config. "
+            f"Known: {sorted(kinematics_config.link_name_to_idx_map)}."
+        )
+    # save the spheres to restore them later as all edits are in place
+    saved_spheres = {name: kinematics_config.get_link_spheres(name).clone() for name in link_names}
+    for name in link_names:
+        kinematics_config.disable_link_spheres(name)
+    try:
+        yield
+    # restore the spheres because they are edited in place on the solver's shared kinematics
+    finally:
+        for name, spheres in saved_spheres.items():
+            kinematics_config.update_link_spheres(name, spheres)


### PR DESCRIPTION
## Summary
Enable collision checking in reachability validator

## Detailed description
- Disabled hand link and target objects in Curobo collision modeling
- Collision checking is enabled by default in its validator config
- Added viz func in debug visualizer (curobo treats world/itself as spheres for collision checking, red is unreachable target.)

https://github.com/user-attachments/assets/b96061ea-b6a5-4abc-a107-a0d71274c123


