### PR TITLE
Mark time_out termination terms as truncations

### DIFF
--- a/docs/pages/arena_in_your_repo/external_tasks_and_embodiments.rst
+++ b/docs/pages/arena_in_your_repo/external_tasks_and_embodiments.rst
@@ -39,7 +39,7 @@ This task can be passed to the ``ArenaEnvBuilder`` to create an environment
 
    @configclass
    class SuccessAfterNStepsTerminationsCfg:
-       time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+       time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
        success: TerminationTermCfg = MISSING
 
 

--- a/isaaclab_arena/tasks/assembly_task.py
+++ b/isaaclab_arena/tasks/assembly_task.py
@@ -155,7 +155,7 @@ class AssemblyTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     success: TerminationTermCfg = MISSING
 

--- a/isaaclab_arena/tasks/close_door_task.py
+++ b/isaaclab_arena/tasks/close_door_task.py
@@ -63,7 +63,7 @@ class CloseDoorTask(RotateRevoluteJointTask):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     # Dependent on the openable object, so this is passed in from the task at
     # construction time.

--- a/isaaclab_arena/tasks/goal_pose_task.py
+++ b/isaaclab_arena/tasks/goal_pose_task.py
@@ -112,5 +112,5 @@ class GoalPoseTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
     success: TerminationTermCfg = MISSING

--- a/isaaclab_arena/tasks/lift_object_task.py
+++ b/isaaclab_arena/tasks/lift_object_task.py
@@ -127,7 +127,7 @@ class LiftObjectTerminationsCfg:
     termination on success is not desired.
     """
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
     object_dropped: TerminationTermCfg = MISSING
     success: TerminationTermCfg = MISSING
 

--- a/isaaclab_arena/tasks/open_door_task.py
+++ b/isaaclab_arena/tasks/open_door_task.py
@@ -63,7 +63,7 @@ class OpenDoorTask(RotateRevoluteJointTask):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     # Dependent on the openable object, so this is passed in from the task at
     # construction time.

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -144,7 +144,7 @@ class SceneCfg:
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     success: TerminationTermCfg = MISSING
 

--- a/isaaclab_arena/tasks/place_upright_task.py
+++ b/isaaclab_arena/tasks/place_upright_task.py
@@ -86,7 +86,7 @@ class PlaceUprightTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     # Dependent on the placeable object, so this is passed in from the task at
     # construction time.

--- a/isaaclab_arena/tasks/press_button_task.py
+++ b/isaaclab_arena/tasks/press_button_task.py
@@ -74,7 +74,7 @@ class PressButtonTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     # Dependent on the openable object, so this is passed in from the task at
     # construction time.

--- a/isaaclab_arena/tasks/sorting_task.py
+++ b/isaaclab_arena/tasks/sorting_task.py
@@ -117,6 +117,6 @@ class SortMultiObjectTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
     success: TerminationTermCfg = MISSING
     object_dropped: TerminationTermCfg = MISSING

--- a/isaaclab_arena/tasks/turn_knob_task.py
+++ b/isaaclab_arena/tasks/turn_knob_task.py
@@ -84,7 +84,7 @@ class TurnKnobTask(TaskBase):
 class TerminationsCfg:
     """Termination terms for the MDP."""
 
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
 
     # Dependent on the openable object, so this is passed in from the task at
     # construction time.

--- a/isaaclab_arena/tests/test_time_out_truncation.py
+++ b/isaaclab_arena/tests/test_time_out_truncation.py
@@ -1,44 +1,69 @@
-# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
 # All rights reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import importlib
-import pkgutil
+"""Guard that every task cfg marks its time-out term as a truncation.
+
+``TerminationTermCfg.time_out`` defaults to ``False``, which makes
+``TerminationManager`` report episode-length expiry as ``terminated`` instead of
+``truncated``.
+
+The sweep imports every task module, which pulls in Isaac Lab cfg modules, so it runs
+in a child process: doing it in the pytest process would trip the duplicate
+``ArticulationCfg`` problem that ``test_collection_import_hygiene`` describes and break
+every robot-building test that runs afterwards.
+"""
+
+import json
+import subprocess
+
+from isaaclab_arena.tests.utils.constants import TestConstants
 
 # Packages whose task cfgs must mark their time-out term as a truncation.
-TASK_PACKAGES = ("isaaclab_arena.tasks", "isaaclab_arena_examples.external_environments")
+_TASK_PACKAGES = ("isaaclab_arena.tasks", "isaaclab_arena_examples.external_environments")
 
+_CHILD_SCRIPT = f"""
+import dataclasses, importlib, json, pkgutil
 
-def _iter_time_out_terms():
-    """Yield ``(module_name, cls_name, term)`` for every configclass exposing a ``time_out`` field."""
-    from isaaclab.managers import TerminationTermCfg
+from isaaclab.managers import TerminationTermCfg
 
-    for package_name in TASK_PACKAGES:
-        package = importlib.import_module(package_name)
-        module_names = [name for _, name, _ in pkgutil.walk_packages(package.__path__, prefix=f"{package_name}.")]
-        for module_name in [package_name, *module_names]:
-            module = importlib.import_module(module_name)
-            for cls in vars(module).values():
-                # Only classes defined in this module, so a cfg imported elsewhere is not double-counted.
-                if not isinstance(cls, type) or getattr(cls, "__module__", None) != module_name:
-                    continue
-                if "time_out" not in getattr(cls, "__annotations__", {}):
-                    continue
-                term = cls().time_out
-                if isinstance(term, TerminationTermCfg):
-                    yield module_name, cls.__name__, term
+terms = {{}}
+for package_name in {_TASK_PACKAGES!r}:
+    package = importlib.import_module(package_name)
+    module_names = [n for _, n, _ in pkgutil.walk_packages(package.__path__, prefix=package_name + ".")]
+    for module_name in [package_name, *module_names]:
+        module = importlib.import_module(module_name)
+        for cls in vars(module).values():
+            # Only classes defined in this module, so a cfg imported elsewhere is not double-counted.
+            if not isinstance(cls, type) or getattr(cls, "__module__", None) != module_name:
+                continue
+            # dataclasses.fields() includes inherited fields, unlike __annotations__.
+            if not dataclasses.is_dataclass(cls):
+                continue
+            if not any(f.name == "time_out" for f in dataclasses.fields(cls)):
+                continue
+            term = cls().time_out
+            if isinstance(term, TerminationTermCfg):
+                terms[module_name + "." + cls.__name__] = term.time_out
+print("TERMS_JSON=" + json.dumps(terms))
+"""
 
 
 def test_all_task_cfgs_mark_time_out_as_truncation():
-    """``TerminationTermCfg.time_out`` defaults to False, which makes ``TerminationManager``
-    report episode-length expiry as ``terminated`` instead of ``truncated``.
+    """Walks the task packages rather than listing cfgs, so a new task that forgets the
+    flag fails here without anyone remembering to update this test."""
+    result = subprocess.run(
+        [TestConstants.python_path, "-c", _CHILD_SCRIPT],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, f"collecting time_out terms failed:\n{result.stderr}"
+    json_lines = [line for line in result.stdout.splitlines() if line.startswith("TERMS_JSON=")]
+    assert len(json_lines) == 1, f"marker line not found in child output:\n{result.stdout}"
+    terms = json.loads(json_lines[0].removeprefix("TERMS_JSON="))
 
-    Walks the task packages rather than listing cfgs, so a new task that forgets the flag
-    fails here without anyone remembering to update this test.
-    """
-    terms = list(_iter_time_out_terms())
-    assert terms, f"No time_out terms discovered in {TASK_PACKAGES}; the sweep is not testing anything."
-
-    offenders = [f"{module}.{cls_name}" for module, cls_name, term in terms if term.time_out is not True]
+    assert terms, f"No time_out terms discovered in {_TASK_PACKAGES}; the sweep is not testing anything."
+    offenders = sorted(name for name, is_time_out in terms.items() if is_time_out is not True)
     assert not offenders, f"Termination cfgs declaring a time_out term without time_out=True: {offenders}"

--- a/isaaclab_arena/tests/test_time_out_truncation.py
+++ b/isaaclab_arena/tests/test_time_out_truncation.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025-2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import pkgutil
+
+# Packages whose task cfgs must mark their time-out term as a truncation.
+TASK_PACKAGES = ("isaaclab_arena.tasks", "isaaclab_arena_examples.external_environments")
+
+
+def _iter_time_out_terms():
+    """Yield ``(module_name, cls_name, term)`` for every configclass exposing a ``time_out`` field."""
+    from isaaclab.managers import TerminationTermCfg
+
+    for package_name in TASK_PACKAGES:
+        package = importlib.import_module(package_name)
+        module_names = [name for _, name, _ in pkgutil.walk_packages(package.__path__, prefix=f"{package_name}.")]
+        for module_name in [package_name, *module_names]:
+            module = importlib.import_module(module_name)
+            for cls in vars(module).values():
+                # Only classes defined in this module, so a cfg imported elsewhere is not double-counted.
+                if not isinstance(cls, type) or getattr(cls, "__module__", None) != module_name:
+                    continue
+                if "time_out" not in getattr(cls, "__annotations__", {}):
+                    continue
+                term = cls().time_out
+                if isinstance(term, TerminationTermCfg):
+                    yield module_name, cls.__name__, term
+
+
+def test_all_task_cfgs_mark_time_out_as_truncation():
+    """``TerminationTermCfg.time_out`` defaults to False, which makes ``TerminationManager``
+    report episode-length expiry as ``terminated`` instead of ``truncated``.
+
+    Walks the task packages rather than listing cfgs, so a new task that forgets the flag
+    fails here without anyone remembering to update this test.
+    """
+    terms = list(_iter_time_out_terms())
+    assert terms, f"No time_out terms discovered in {TASK_PACKAGES}; the sweep is not testing anything."
+
+    offenders = [f"{module}.{cls_name}" for module, cls_name, term in terms if term.time_out is not True]
+    assert not offenders, f"Termination cfgs declaring a time_out term without time_out=True: {offenders}"

--- a/isaaclab_arena_examples/external_environments/advanced.py
+++ b/isaaclab_arena_examples/external_environments/advanced.py
@@ -69,7 +69,7 @@ class SuccessAfterNStepsTask(TaskBase):
 
 @configclass
 class SuccessAfterNStepsTerminationsCfg:
-    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out, time_out=True)
     success: TerminationTermCfg = MISSING
 
 


### PR DESCRIPTION
# Mark time_out termination terms as truncations

## Summary
Set `time_out=True` on every task's time-out term, which is essential for RL training

## Detailed description

- **Reason:** `TerminationTermCfg.time_out` defaults to `False`. Every Arena task declared its
  time-out term as `TerminationTermCfg(func=mdp_isaac_lab.time_out)` without the flag, so
  `TerminationManager` routed episode-length expiry into `terminated` rather than `time_outs`.
  `ManagerBasedRLEnv.step()` therefore always returned `truncated=False`, the RSL-RL wrappers 
 never populated `extras["time_outs"]` (so value bootstrapping was skipped on timeout,
  biasing the value function low).

- **What changed:** Added `time_out=True` to the `mdp_isaac_lab.time_out` term in 11 files:
  `assembly_task`, `close_door_task`, `goal_pose_task`, `lift_object_task`, `open_door_task`,
  `pick_and_place_task`, `place_upright_task`, `press_button_task`, `sorting_task`,
  `turn_knob_task`, and `isaaclab_arena_examples/external_environments/advanced.py`.
 
- **Impact:** RL training paths now receive the correct terminated/truncated split. Evaluation is
  unaffected.

- **Docs:** the "Defining a Custom Task" snippet in
  `docs/pages/arena_in_your_repo/external_tasks_and_embodiments.rst` is the documented twin of
  `advanced.py` and carried the same bug; it now shows the flag.

- **Regression guard:** `isaaclab_arena/tests/test_time_out_truncation.py` walks
  `isaaclab_arena.tasks` and `isaaclab_arena_examples.external_environments` and asserts every
  configclass exposing a `time_out` term sets `time_out=True`. Walking the packages rather than
  listing cfgs means a newly added task that forgets the flag fails without anyone remembering to
  update the test.
