### PR TITLE
Add pi0-vs-Cosmos experiment configs for the robolab tasks

### DIFF
--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
@@ -3,18 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# The 18 robolab tasks not covered by robolab_20_tasks_pi0_and_cosmos.yaml (i.e. all 38 tasks minus
-# that file's 20), each run with both the OpenPI (pi0) and Cosmos policies (36 runs). On OSMO the
-# inference server for each Run is derived from its policy type, so this launches pi0 servers for the
-# *_pi0 Runs and Cosmos servers for the *_cosmos Runs. Both pi0 and Cosmos Runs use 5 parallel environments.
-# All runs use the home_office_robolab HDR environment map as the dome-light background.
+# The 18 robolab tasks not in robolab_20_tasks_pi0_and_cosmos.yaml, each run with both the OpenPI (pi0)
+# and Cosmos policies (36 runs, 20 parallel environments each).
 runs:
 
   apple_and_yogurt_in_bowl_pi0:
     environment: &apple_and_yogurt_in_bowl_env
       type: isaaclab_arena_environments/robolab/tasks/apple_and_yogurt_in_bowl.yaml
       enable_cameras: true
-    # This YAML anchor keeps the shared OpenPI policy configuration in one place.
     policy: &openpi_policy
       type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
       policy_variant: pi05
@@ -22,32 +18,29 @@ runs:
       remote_host: 127.0.0.1
       remote_port: 8000
       openpi_embodiment_adapter: droid
-    # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
     environment_builder: &pi0_builder
-      num_envs: 30
+      num_envs: 20
     variations: &hdr_variation
       light:
         hdr_image:
           enabled: true
           hdr_names: ["home_office_robolab"]
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   apple_and_yogurt_in_bowl_cosmos:
     environment: *apple_and_yogurt_in_bowl_env
-    # This YAML anchor keeps the shared Cosmos policy configuration in one place.
     policy: &cosmos_policy
       type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
       cosmos_embodiment_adapter: droid
       policy_device: cuda:0
       remote_host: 127.0.0.1
       remote_port: 8000
-    # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
     environment_builder: &cosmos_builder
-      num_envs: 30
+      num_envs: 20
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bagels_on_plate_pi0:
     environment: &bagels_on_plate_env
@@ -57,7 +50,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bagels_on_plate_cosmos:
     environment: *bagels_on_plate_env
@@ -65,7 +58,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   banana_then_rubiks_cube_pi0:
     environment: &banana_then_rubiks_cube_env
@@ -75,7 +68,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   banana_then_rubiks_cube_cosmos:
     environment: *banana_then_rubiks_cube_env
@@ -83,7 +76,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bbq_sauce_in_bin_pi0:
     environment: &bbq_sauce_in_bin_env
@@ -93,7 +86,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bbq_sauce_in_bin_cosmos:
     environment: *bbq_sauce_in_bin_env
@@ -101,7 +94,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   black_items_in_bin_pi0:
     environment: &black_items_in_bin_env
@@ -111,7 +104,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   black_items_in_bin_cosmos:
     environment: *black_items_in_bin_env
@@ -119,7 +112,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clear_organic_objects_pi0:
     environment: &clear_organic_objects_env
@@ -129,7 +122,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clear_organic_objects_cosmos:
     environment: *clear_organic_objects_env
@@ -137,7 +130,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clutter_plastic_pi0:
     environment: &clutter_plastic_env
@@ -147,7 +140,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clutter_plastic_cosmos:
     environment: *clutter_plastic_env
@@ -155,7 +148,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clutter_pumpkin_pi0:
     environment: &clutter_pumpkin_env
@@ -165,7 +158,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clutter_pumpkin_cosmos:
     environment: *clutter_pumpkin_env
@@ -173,7 +166,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   condiments_in_bin_pi0:
     environment: &condiments_in_bin_env
@@ -183,7 +176,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   condiments_in_bin_cosmos:
     environment: *condiments_in_bin_env
@@ -191,7 +184,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   electronics_in_bin_pi0:
     environment: &electronics_in_bin_env
@@ -201,7 +194,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   electronics_in_bin_cosmos:
     environment: *electronics_in_bin_env
@@ -209,7 +202,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   hammers_in_left_bin_pi0:
     environment: &hammers_in_left_bin_env
@@ -219,7 +212,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   hammers_in_left_bin_cosmos:
     environment: *hammers_in_left_bin_env
@@ -227,7 +220,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_in_right_bin_pi0:
     environment: &mustard_in_right_bin_env
@@ -237,7 +230,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_in_right_bin_cosmos:
     environment: *mustard_in_right_bin_env
@@ -245,7 +238,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   non_hammer_tools_in_right_bin_pi0:
     environment: &non_hammer_tools_in_right_bin_env
@@ -255,7 +248,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   non_hammer_tools_in_right_bin_cosmos:
     environment: *non_hammer_tools_in_right_bin_env
@@ -263,7 +256,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_and_banana_pi0:
     environment: &rubiks_cube_and_banana_env
@@ -273,7 +266,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_and_banana_cosmos:
     environment: *rubiks_cube_and_banana_env
@@ -281,7 +274,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_then_banana_pi0:
     environment: &rubiks_cube_then_banana_env
@@ -291,7 +284,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_then_banana_cosmos:
     environment: *rubiks_cube_then_banana_env
@@ -299,7 +292,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   small_pumpkin_in_bin_pi0:
     environment: &small_pumpkin_in_bin_env
@@ -309,7 +302,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   small_pumpkin_in_bin_cosmos:
     environment: *small_pumpkin_in_bin_env
@@ -317,7 +310,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   smaller_object_butter_in_bin_pi0:
     environment: &smaller_object_butter_in_bin_env
@@ -327,7 +320,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   smaller_object_butter_in_bin_cosmos:
     environment: *smaller_object_butter_in_bin_env
@@ -335,7 +328,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   throw_away_snacks_pi0:
     environment: &throw_away_snacks_env
@@ -345,7 +338,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   throw_away_snacks_cosmos:
     environment: *throw_away_snacks_env
@@ -353,4 +346,4 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
@@ -25,7 +25,6 @@ runs:
     # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
     environment_builder: &pi0_builder
       num_envs: 30
-      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
     variations: &hdr_variation
       light:
         hdr_image:
@@ -46,7 +45,6 @@ runs:
     # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
     environment_builder: &cosmos_builder
       num_envs: 30
-      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
     variations: *hdr_variation
     rollout_limit:
       num_episodes: 300

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
@@ -1,0 +1,358 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The 18 robolab tasks not covered by robolab_20_tasks_pi0_and_cosmos.yaml (i.e. all 38 tasks minus
+# that file's 20), each run with both the OpenPI (pi0) and Cosmos policies (36 runs). On OSMO the
+# inference server for each Run is derived from its policy type, so this launches pi0 servers for the
+# *_pi0 Runs and Cosmos servers for the *_cosmos Runs. Both pi0 and Cosmos Runs use 5 parallel environments.
+# All runs use the home_office_robolab HDR environment map as the dome-light background.
+runs:
+
+  apple_and_yogurt_in_bowl_pi0:
+    environment: &apple_and_yogurt_in_bowl_env
+      type: isaaclab_arena_environments/robolab/tasks/apple_and_yogurt_in_bowl.yaml
+      enable_cameras: true
+    # This YAML anchor keeps the shared OpenPI policy configuration in one place.
+    policy: &openpi_policy
+      type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
+      policy_variant: pi05
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+      openpi_embodiment_adapter: droid
+    # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
+    environment_builder: &pi0_builder
+      num_envs: 30
+      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
+    variations: &hdr_variation
+      light:
+        hdr_image:
+          enabled: true
+          hdr_names: ["home_office_robolab"]
+    rollout_limit:
+      num_episodes: 300
+
+  apple_and_yogurt_in_bowl_cosmos:
+    environment: *apple_and_yogurt_in_bowl_env
+    # This YAML anchor keeps the shared Cosmos policy configuration in one place.
+    policy: &cosmos_policy
+      type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
+      cosmos_embodiment_adapter: droid
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+    # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
+    environment_builder: &cosmos_builder
+      num_envs: 30
+      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bagels_on_plate_pi0:
+    environment: &bagels_on_plate_env
+      type: isaaclab_arena_environments/robolab/tasks/bagels_on_plate.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bagels_on_plate_cosmos:
+    environment: *bagels_on_plate_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  banana_then_rubiks_cube_pi0:
+    environment: &banana_then_rubiks_cube_env
+      type: isaaclab_arena_environments/robolab/tasks/banana_then_rubiks_cube.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  banana_then_rubiks_cube_cosmos:
+    environment: *banana_then_rubiks_cube_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bbq_sauce_in_bin_pi0:
+    environment: &bbq_sauce_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/bbq_sauce_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bbq_sauce_in_bin_cosmos:
+    environment: *bbq_sauce_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  black_items_in_bin_pi0:
+    environment: &black_items_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/black_items_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  black_items_in_bin_cosmos:
+    environment: *black_items_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clear_organic_objects_pi0:
+    environment: &clear_organic_objects_env
+      type: isaaclab_arena_environments/robolab/tasks/clear_organic_objects.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clear_organic_objects_cosmos:
+    environment: *clear_organic_objects_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clutter_plastic_pi0:
+    environment: &clutter_plastic_env
+      type: isaaclab_arena_environments/robolab/tasks/clutter_plastic.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clutter_plastic_cosmos:
+    environment: *clutter_plastic_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clutter_pumpkin_pi0:
+    environment: &clutter_pumpkin_env
+      type: isaaclab_arena_environments/robolab/tasks/clutter_pumpkin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clutter_pumpkin_cosmos:
+    environment: *clutter_pumpkin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  condiments_in_bin_pi0:
+    environment: &condiments_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/condiments_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  condiments_in_bin_cosmos:
+    environment: *condiments_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  electronics_in_bin_pi0:
+    environment: &electronics_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/electronics_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  electronics_in_bin_cosmos:
+    environment: *electronics_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  hammers_in_left_bin_pi0:
+    environment: &hammers_in_left_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/hammers_in_left_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  hammers_in_left_bin_cosmos:
+    environment: *hammers_in_left_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_in_right_bin_pi0:
+    environment: &mustard_in_right_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/mustard_in_right_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_in_right_bin_cosmos:
+    environment: *mustard_in_right_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  non_hammer_tools_in_right_bin_pi0:
+    environment: &non_hammer_tools_in_right_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/non_hammer_tools_in_right_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  non_hammer_tools_in_right_bin_cosmos:
+    environment: *non_hammer_tools_in_right_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_and_banana_pi0:
+    environment: &rubiks_cube_and_banana_env
+      type: isaaclab_arena_environments/robolab/tasks/rubiks_cube_and_banana.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_and_banana_cosmos:
+    environment: *rubiks_cube_and_banana_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_then_banana_pi0:
+    environment: &rubiks_cube_then_banana_env
+      type: isaaclab_arena_environments/robolab/tasks/rubiks_cube_then_banana.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_then_banana_cosmos:
+    environment: *rubiks_cube_then_banana_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  small_pumpkin_in_bin_pi0:
+    environment: &small_pumpkin_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/small_pumpkin_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  small_pumpkin_in_bin_cosmos:
+    environment: *small_pumpkin_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  smaller_object_butter_in_bin_pi0:
+    environment: &smaller_object_butter_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/smaller_object_butter_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  smaller_object_butter_in_bin_cosmos:
+    environment: *smaller_object_butter_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  throw_away_snacks_pi0:
+    environment: &throw_away_snacks_env
+      type: isaaclab_arena_environments/robolab/tasks/throw_away_snacks.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  throw_away_snacks_cosmos:
+    environment: *throw_away_snacks_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
@@ -4,17 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # 20 single-subtask robolab tasks, each run with both the OpenPI (pi0) and Cosmos policies
-# (40 runs). On OSMO the inference server for each Run is derived from its policy type, so
-# this launches pi0 servers for the *_pi0 Runs and Cosmos servers for the *_cosmos Runs.
-# Both pi0 and Cosmos Runs use 5 parallel environments.
-# All runs use the home_office_robolab HDR environment map as the dome-light background.
+# (40 runs, 20 parallel environments each).
 runs:
 
   banana_in_bowl_pi0:
     environment: &banana_in_bowl_env
       type: isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
       enable_cameras: true
-    # This YAML anchor keeps the shared OpenPI policy configuration in one place.
     policy: &openpi_policy
       type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
       policy_variant: pi05
@@ -22,32 +18,29 @@ runs:
       remote_host: 127.0.0.1
       remote_port: 8000
       openpi_embodiment_adapter: droid
-    # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
     environment_builder: &pi0_builder
-      num_envs: 30
+      num_envs: 20
     variations: &hdr_variation
       light:
         hdr_image:
           enabled: true
           hdr_names: ["home_office_robolab"]
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   banana_in_bowl_cosmos:
     environment: *banana_in_bowl_env
-    # This YAML anchor keeps the shared Cosmos policy configuration in one place.
     policy: &cosmos_policy
       type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
       cosmos_embodiment_adapter: droid
       policy_device: cuda:0
       remote_host: 127.0.0.1
       remote_port: 8000
-    # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
     environment_builder: &cosmos_builder
-      num_envs: 30
+      num_envs: 20
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   banana_on_plate_pi0:
     environment: &banana_on_plate_env
@@ -57,7 +50,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   banana_on_plate_cosmos:
     environment: *banana_on_plate_env
@@ -65,7 +58,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   big_pumpkin_in_bin_pi0:
     environment: &big_pumpkin_in_bin_env
@@ -75,7 +68,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   big_pumpkin_in_bin_cosmos:
     environment: *big_pumpkin_in_bin_env
@@ -83,7 +76,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bowl_in_bin_pi0:
     environment: &bowl_in_bin_env
@@ -93,7 +86,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   bowl_in_bin_cosmos:
     environment: *bowl_in_bin_env
@@ -101,7 +94,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   butter_above_raisin_pi0:
     environment: &butter_above_raisin_env
@@ -111,7 +104,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   butter_above_raisin_cosmos:
     environment: *butter_above_raisin_env
@@ -119,7 +112,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   canned_food_in_bin_pi0:
     environment: &canned_food_in_bin_env
@@ -129,7 +122,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   canned_food_in_bin_cosmos:
     environment: *canned_food_in_bin_env
@@ -137,7 +130,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clamp_in_right_bin_pi0:
     environment: &clamp_in_right_bin_env
@@ -147,7 +140,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   clamp_in_right_bin_cosmos:
     environment: *clamp_in_right_bin_env
@@ -155,7 +148,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   coffee_pot_in_bin_pi0:
     environment: &coffee_pot_in_bin_env
@@ -165,7 +158,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   coffee_pot_in_bin_cosmos:
     environment: *coffee_pot_in_bin_env
@@ -173,7 +166,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   food_packing_1_boxes_pi0:
     environment: &food_packing_1_boxes_env
@@ -183,7 +176,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   food_packing_1_boxes_cosmos:
     environment: *food_packing_1_boxes_env
@@ -191,7 +184,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   food_packing_1_cans_pi0:
     environment: &food_packing_1_cans_env
@@ -201,7 +194,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   food_packing_1_cans_cosmos:
     environment: *food_packing_1_cans_env
@@ -209,7 +202,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   larger_object_raisin_box_in_bin_pi0:
     environment: &larger_object_raisin_box_in_bin_env
@@ -219,7 +212,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   larger_object_raisin_box_in_bin_cosmos:
     environment: *larger_object_raisin_box_in_bin_env
@@ -227,7 +220,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   marker_in_mug_pi0:
     environment: &marker_in_mug_env
@@ -237,7 +230,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   marker_in_mug_cosmos:
     environment: *marker_in_mug_env
@@ -245,7 +238,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mouse_on_keyboard_pi0:
     environment: &mouse_on_keyboard_env
@@ -255,7 +248,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mouse_on_keyboard_cosmos:
     environment: *mouse_on_keyboard_env
@@ -263,7 +256,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_above_raisin_pi0:
     environment: &mustard_above_raisin_env
@@ -273,7 +266,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_above_raisin_cosmos:
     environment: *mustard_above_raisin_env
@@ -281,7 +274,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_in_left_bin_pi0:
     environment: &mustard_in_left_bin_env
@@ -291,7 +284,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   mustard_in_left_bin_cosmos:
     environment: *mustard_in_left_bin_env
@@ -299,7 +292,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_pi0:
     environment: &rubiks_cube_env
@@ -309,7 +302,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   rubiks_cube_cosmos:
     environment: *rubiks_cube_env
@@ -317,7 +310,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   sauce_bottles_crate_pi0:
     environment: &sauce_bottles_crate_env
@@ -327,7 +320,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   sauce_bottles_crate_cosmos:
     environment: *sauce_bottles_crate_env
@@ -335,7 +328,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   smartphone_in_bin_pi0:
     environment: &smartphone_in_bin_env
@@ -345,7 +338,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   smartphone_in_bin_cosmos:
     environment: *smartphone_in_bin_env
@@ -353,7 +346,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   throw_away_apple_pi0:
     environment: &throw_away_apple_env
@@ -363,7 +356,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   throw_away_apple_cosmos:
     environment: *throw_away_apple_env
@@ -371,7 +364,7 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   toy_in_bin_pi0:
     environment: &toy_in_bin_env
@@ -381,7 +374,7 @@ runs:
     environment_builder: *pi0_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100
 
   toy_in_bin_cosmos:
     environment: *toy_in_bin_env
@@ -389,4 +382,4 @@ runs:
     environment_builder: *cosmos_builder
     variations: *hdr_variation
     rollout_limit:
-      num_episodes: 300
+      num_episodes: 100

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
@@ -25,7 +25,6 @@ runs:
     # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
     environment_builder: &pi0_builder
       num_envs: 30
-      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
     variations: &hdr_variation
       light:
         hdr_image:
@@ -46,7 +45,6 @@ runs:
     # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
     environment_builder: &cosmos_builder
       num_envs: 30
-      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
     variations: *hdr_variation
     rollout_limit:
       num_episodes: 300

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
@@ -1,0 +1,394 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# 20 single-subtask robolab tasks, each run with both the OpenPI (pi0) and Cosmos policies
+# (40 runs). On OSMO the inference server for each Run is derived from its policy type, so
+# this launches pi0 servers for the *_pi0 Runs and Cosmos servers for the *_cosmos Runs.
+# Both pi0 and Cosmos Runs use 5 parallel environments.
+# All runs use the home_office_robolab HDR environment map as the dome-light background.
+runs:
+
+  banana_in_bowl_pi0:
+    environment: &banana_in_bowl_env
+      type: isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
+      enable_cameras: true
+    # This YAML anchor keeps the shared OpenPI policy configuration in one place.
+    policy: &openpi_policy
+      type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
+      policy_variant: pi05
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+      openpi_embodiment_adapter: droid
+    # This YAML anchor keeps the shared pi0 environment-builder settings in one place.
+    environment_builder: &pi0_builder
+      num_envs: 30
+      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
+    variations: &hdr_variation
+      light:
+        hdr_image:
+          enabled: true
+          hdr_names: ["home_office_robolab"]
+    rollout_limit:
+      num_episodes: 300
+
+  banana_in_bowl_cosmos:
+    environment: *banana_in_bowl_env
+    # This YAML anchor keeps the shared Cosmos policy configuration in one place.
+    policy: &cosmos_policy
+      type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
+      cosmos_embodiment_adapter: droid
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+    # This YAML anchor keeps the shared Cosmos environment-builder settings in one place.
+    environment_builder: &cosmos_builder
+      num_envs: 30
+      episode_length_s: 66.0  # ~1000 policy steps at 15 Hz control, overriding the tasks' 20 s
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  banana_on_plate_pi0:
+    environment: &banana_on_plate_env
+      type: isaaclab_arena_environments/robolab/tasks/banana_on_plate.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  banana_on_plate_cosmos:
+    environment: *banana_on_plate_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  big_pumpkin_in_bin_pi0:
+    environment: &big_pumpkin_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/big_pumpkin_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  big_pumpkin_in_bin_cosmos:
+    environment: *big_pumpkin_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bowl_in_bin_pi0:
+    environment: &bowl_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/bowl_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  bowl_in_bin_cosmos:
+    environment: *bowl_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  butter_above_raisin_pi0:
+    environment: &butter_above_raisin_env
+      type: isaaclab_arena_environments/robolab/tasks/butter_above_raisin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  butter_above_raisin_cosmos:
+    environment: *butter_above_raisin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  canned_food_in_bin_pi0:
+    environment: &canned_food_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/canned_food_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  canned_food_in_bin_cosmos:
+    environment: *canned_food_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clamp_in_right_bin_pi0:
+    environment: &clamp_in_right_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/clamp_in_right_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  clamp_in_right_bin_cosmos:
+    environment: *clamp_in_right_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  coffee_pot_in_bin_pi0:
+    environment: &coffee_pot_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/coffee_pot_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  coffee_pot_in_bin_cosmos:
+    environment: *coffee_pot_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  food_packing_1_boxes_pi0:
+    environment: &food_packing_1_boxes_env
+      type: isaaclab_arena_environments/robolab/tasks/food_packing_1_boxes.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  food_packing_1_boxes_cosmos:
+    environment: *food_packing_1_boxes_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  food_packing_1_cans_pi0:
+    environment: &food_packing_1_cans_env
+      type: isaaclab_arena_environments/robolab/tasks/food_packing_1_cans.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  food_packing_1_cans_cosmos:
+    environment: *food_packing_1_cans_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  larger_object_raisin_box_in_bin_pi0:
+    environment: &larger_object_raisin_box_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/larger_object_raisin_box_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  larger_object_raisin_box_in_bin_cosmos:
+    environment: *larger_object_raisin_box_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  marker_in_mug_pi0:
+    environment: &marker_in_mug_env
+      type: isaaclab_arena_environments/robolab/tasks/marker_in_mug.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  marker_in_mug_cosmos:
+    environment: *marker_in_mug_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mouse_on_keyboard_pi0:
+    environment: &mouse_on_keyboard_env
+      type: isaaclab_arena_environments/robolab/tasks/mouse_on_keyboard.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mouse_on_keyboard_cosmos:
+    environment: *mouse_on_keyboard_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_above_raisin_pi0:
+    environment: &mustard_above_raisin_env
+      type: isaaclab_arena_environments/robolab/tasks/mustard_above_raisin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_above_raisin_cosmos:
+    environment: *mustard_above_raisin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_in_left_bin_pi0:
+    environment: &mustard_in_left_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/mustard_in_left_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  mustard_in_left_bin_cosmos:
+    environment: *mustard_in_left_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_pi0:
+    environment: &rubiks_cube_env
+      type: isaaclab_arena_environments/robolab/tasks/rubiks_cube.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  rubiks_cube_cosmos:
+    environment: *rubiks_cube_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  sauce_bottles_crate_pi0:
+    environment: &sauce_bottles_crate_env
+      type: isaaclab_arena_environments/robolab/tasks/sauce_bottles_crate.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  sauce_bottles_crate_cosmos:
+    environment: *sauce_bottles_crate_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  smartphone_in_bin_pi0:
+    environment: &smartphone_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/smartphone_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  smartphone_in_bin_cosmos:
+    environment: *smartphone_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  throw_away_apple_pi0:
+    environment: &throw_away_apple_env
+      type: isaaclab_arena_environments/robolab/tasks/throw_away_apple.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  throw_away_apple_cosmos:
+    environment: *throw_away_apple_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  toy_in_bin_pi0:
+    environment: &toy_in_bin_env
+      type: isaaclab_arena_environments/robolab/tasks/toy_in_bin.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300
+
+  toy_in_bin_cosmos:
+    environment: *toy_in_bin_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    variations: *hdr_variation
+    rollout_limit:
+      num_episodes: 300


### PR DESCRIPTION
## Summary
Add pi0-vs-Cosmos robolab experiment configs

## Detailed description
- **Why:** 
  - Headline experiments for Arena `v0.3`
  - Enables experiments comparing pi0.5 vs cosmos action (edge) across robolab tasks.
- **What**
  - Adds 2 files
    - 20 (easiest) tasks.
    - 18 remaining (more complex) tasks