### PR TITLE
Increase the remote server timeout.

### DIFF
--- a/isaaclab_arena_cosmos/policy/cosmos_remote_config.py
+++ b/isaaclab_arena_cosmos/policy/cosmos_remote_config.py
@@ -39,7 +39,7 @@ class CosmosRemotePolicyCfg(PolicyCfg):
     ping_interval: float | None = 20.0
     """Seconds between websocket keepalive pings, or None to disable pings."""
 
-    ping_timeout: float | None = 20.0
+    ping_timeout: float | None = 300.0
     """Seconds to wait for a keepalive pong before dropping, or None to wait indefinitely."""
 
     def __post_init__(self) -> None:

--- a/isaaclab_arena_openpi/policy/pi0_remote_config.py
+++ b/isaaclab_arena_openpi/policy/pi0_remote_config.py
@@ -29,5 +29,5 @@ class Pi0RemotePolicyCfg(PolicyCfg):
     ping_interval: float | None = 20.0
     """Seconds between websocket keepalive pings, or None to disable pings."""
 
-    ping_timeout: float | None = 20.0
+    ping_timeout: float | None = 300.0
     """Seconds to wait for a keepalive pong before dropping, or None to wait indefinitely."""


### PR DESCRIPTION
## Summary
Increase the remote server timeout to 300s

## Detailed description
- **Why:** Jobs were failing on OSMO when the sim would come up while the server was still booting.
- **What:** A simple fix is increasing the timeout on the policy side.
