### PR TITLE
Add NIST gear evaluation environment

### DIFF
--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -225,6 +225,48 @@ class OfficeTable(LibraryObject):
     scale = (1.0, 1.0, 0.7)
 
 
+# NIST insertion assets use Arena's high-precision assembly preset to mirror
+# Factory/Forge dense-contact settings for small-clearance gear insertion.
+@register_asset
+class GearsAndBase(LibraryObject):
+    """NIST gear base with SDF collision (gear_base as root prim)."""
+
+    name = "gears_and_base"
+    tags = ["nist", "object"]
+    usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/NIST/gearbase_and_gears_gearbase_root.usd"
+
+    spawn_cfg_addon = {
+        "rigid_props": RIGID_BODY_PROPS_HIGH_PRECISION.replace(disable_gravity=False, kinematic_enabled=True),
+        "mass_props": sim_utils.MassPropertiesCfg(mass=0.012),
+        "collision_props": sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
+    }
+
+    def __init__(
+        self, instance_name: str | None = None, prim_path: str | None = None, initial_pose: Pose | None = None
+    ):
+        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose)
+
+
+@register_asset
+class MediumNistGear(LibraryObject):
+    """NIST medium gear (held asset for gear insertion)."""
+
+    name = "medium_nist_gear"
+    tags = ["nist", "object"]
+    usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/NIST/gear_medium.usd"
+
+    spawn_cfg_addon = {
+        "rigid_props": RIGID_BODY_PROPS_HIGH_PRECISION.replace(disable_gravity=False),
+        "mass_props": sim_utils.MassPropertiesCfg(mass=0.012),
+        "collision_props": sim_utils.CollisionPropertiesCfg(contact_offset=0.005, rest_offset=0.0),
+    }
+
+    def __init__(
+        self, instance_name: str | None = None, prim_path: str | None = None, initial_pose: Pose | None = None
+    ):
+        super().__init__(instance_name=instance_name, prim_path=prim_path, initial_pose=initial_pose)
+
+
 @register_asset
 class BlueSortingBin(LibraryObject):
     """

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -24,7 +24,9 @@ class ArenaPhysicsCfg(PresetCfg):
 
     ``default`` / ``physx`` use the stock PhysX backend.
     ``newton`` uses MuJoCo-Warp via Newton with solver parameters tuned
-    for dexterous manipulation (matches ``KukaAllegroPhysicsCfg.newton``).
+    for assembly tasks. ``impratio=1.0`` (MuJoCo default) keeps initial
+    contact forces stable; ``num_substeps=4`` gives fine-grained contact
+    resolution at the same 30 Hz control rate.
     """
 
     physx = PhysxCfg()
@@ -34,16 +36,16 @@ class ArenaPhysicsCfg(PresetCfg):
             integrator="implicitfast",
             njmax=300,
             nconmax=400,
-            impratio=10.0,
+            impratio=1.0,
             cone="elliptic",
             update_data_interval=2,
             iterations=100,
-            ls_iterations=15,
+            ls_iterations=50,
             ls_parallel=False,
             use_mujoco_contacts=False,
             ccd_iterations=15000,
         ),
-        num_substeps=2,
+        num_substeps=4,
         debug_mode=False,
     )
     default = physx

--- a/isaaclab_arena/tasks/nist_gear_insertion/__init__.py
+++ b/isaaclab_arena/tasks/nist_gear_insertion/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task modules for NIST gear insertion."""
+
+from .task import GearInsertionGeometryCfg, NistGearInsertionTask
+
+__all__ = [
+    "GearInsertionGeometryCfg",
+    "NistGearInsertionTask",
+]

--- a/isaaclab_arena/tasks/nist_gear_insertion/geometry.py
+++ b/isaaclab_arena/tasks/nist_gear_insertion/geometry.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared geometry utilities for gear insertion.
+
+The frame math follows the Isaac Lab Factory/Forge insertion tasks: represent
+the peg and held-gear insertion points as local offsets on their owning assets,
+then compare those points in each environment frame.
+"""
+
+from __future__ import annotations
+
+import torch
+
+import isaaclab.utils.math as math_utils
+import warp as wp
+from isaaclab.assets import RigidObject
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+
+
+def compute_asset_local_offset_pos(
+    env: ManagerBasedRLEnv,
+    asset: RigidObject,
+    offset: tuple[float, ...] | torch.Tensor,
+) -> torch.Tensor:
+    """Return an asset-local offset position in each environment frame.
+
+    Isaac Lab stores rigid-object root poses in world coordinates. Gear
+    insertion observations and terminations compare geometry in the per-environment
+    frame, so this function subtracts ``env.scene.env_origins`` before rotating
+    the local offset into the asset root frame.
+    """
+    num_envs = env.num_envs
+    root_pos = wp.to_torch(asset.data.root_pos_w)[:num_envs] - env.scene.env_origins[:num_envs]
+    root_quat = wp.to_torch(asset.data.root_quat_w)[:num_envs]
+    offset_tensor = torch.as_tensor(offset, device=env.device, dtype=torch.float32)
+    offset_tensor = offset_tensor.unsqueeze(0).expand(num_envs, 3)
+    return root_pos + math_utils.quat_apply(root_quat, offset_tensor)
+
+
+def peg_pos_in_env_frame(
+    env: ManagerBasedRLEnv,
+    board_cfg: SceneEntityCfg,
+    peg_offset: tuple[float, ...] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """Return the target peg position in each environment frame.
+
+    ``peg_offset`` is measured in the fixed board or gear-base asset frame.
+    """
+    board: RigidObject = env.scene[board_cfg.name]
+    return compute_asset_local_offset_pos(env, board, peg_offset)
+
+
+def held_gear_base_pos_in_env_frame(
+    env: ManagerBasedRLEnv,
+    gear_cfg: SceneEntityCfg,
+    held_gear_base_offset: tuple[float, ...] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """Return the held gear insertion point in each environment frame.
+
+    The held gear's root is not necessarily the point that should align with
+    the peg, so insertion logic compares this offset point against the peg.
+    """
+    gear: RigidObject = env.scene[gear_cfg.name]
+    return compute_asset_local_offset_pos(env, gear, held_gear_base_offset)
+
+
+def peg_delta_from_held_gear_base(
+    env: ManagerBasedRLEnv,
+    gear_cfg: SceneEntityCfg,
+    board_cfg: SceneEntityCfg,
+    peg_offset: tuple[float, ...] = (0.0, 0.0, 0.0),
+    held_gear_base_offset: tuple[float, ...] = (0.0, 0.0, 0.0),
+) -> torch.Tensor:
+    """Return the vector from the held gear insertion point to the peg."""
+    held_base = held_gear_base_pos_in_env_frame(env, gear_cfg, held_gear_base_offset)
+    peg_pos = peg_pos_in_env_frame(env, board_cfg, peg_offset)
+    return peg_pos - held_base
+
+
+def check_gear_insertion_geometry(
+    held_base_pos: torch.Tensor,
+    peg_pos: torch.Tensor,
+    gear_peg_height: float,
+    z_fraction: float,
+    xy_threshold: float,
+) -> torch.Tensor:
+    """Return whether the gear is centered and inserted on the peg.
+
+    Success is geometric: the insertion point must be within the XY tolerance
+    and below the configured fraction of the peg height. Lower Z values mean the
+    gear has moved farther down the peg.
+    """
+    xy_dist = torch.norm(held_base_pos[:, :2] - peg_pos[:, :2], dim=-1)
+    z_diff = held_base_pos[:, 2] - peg_pos[:, 2]
+    return (xy_dist < xy_threshold) & (z_diff < gear_peg_height * z_fraction)
+
+
+def compute_gear_insertion_success(
+    env: ManagerBasedRLEnv,
+    gear_cfg: SceneEntityCfg,
+    board_cfg: SceneEntityCfg,
+    peg_offset: tuple[float, ...] | torch.Tensor,
+    held_gear_base_offset: tuple[float, ...] | torch.Tensor,
+    gear_peg_height: float,
+    z_fraction: float,
+    xy_threshold: float,
+) -> torch.Tensor:
+    """Return whether the held gear meets the insertion success geometry.
+
+    This is the shared implementation used by observations and terminations so
+    they agree on the success geometry.
+    """
+    gear: RigidObject = env.scene[gear_cfg.name]
+    board: RigidObject = env.scene[board_cfg.name]
+    held_base_pos = compute_asset_local_offset_pos(env, gear, held_gear_base_offset)
+    peg_pos = compute_asset_local_offset_pos(env, board, peg_offset)
+    return check_gear_insertion_geometry(held_base_pos, peg_pos, gear_peg_height, z_fraction, xy_threshold)

--- a/isaaclab_arena/tasks/nist_gear_insertion/task.py
+++ b/isaaclab_arena/tasks/nist_gear_insertion/task.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIST gear insertion task for Arena policy evaluation."""
+
+from __future__ import annotations
+
+import numpy as np
+from dataclasses import MISSING
+from typing import Any
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
+from isaaclab_arena.embodiments.common.arm_mode import ArmMode
+from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+
+from . import geometry as gear_insertion_geometry
+from .terminations import gear_mesh_insertion_success
+
+
+@configclass
+class GearInsertionGeometryCfg:
+    """NIST board gear-insertion geometry shared by observations and success."""
+
+    peg_base_offset: tuple[float, float, float] = (0.02025, 0.0, 0.0)
+    peg_tip_offset: tuple[float, float, float] = (0.02025, 0.0, 0.025)
+    held_gear_base_offset: tuple[float, float, float] = (0.02025, 0.0, 0.0)
+    gear_peg_height: float = 0.02
+    success_z_fraction: float = 0.30
+    xy_threshold: float = 0.0025
+
+
+@register_task
+class NistGearInsertionTask(TaskBase):
+    """Evaluation task for inserting the medium NIST gear onto the board peg."""
+
+    def __init__(
+        self,
+        held_gear: Asset,
+        background_scene: Asset,
+        gear_base_asset: Asset,
+        geometry_cfg: GearInsertionGeometryCfg | None = None,
+        episode_length_s: float | None = None,
+        task_description: str | None = None,
+    ):
+        super().__init__(episode_length_s=episode_length_s, task_description=task_description)
+        self.held_gear = held_gear
+        self.background_scene = background_scene
+        self.gear_base_asset = gear_base_asset
+        self.geometry_cfg = geometry_cfg if geometry_cfg is not None else GearInsertionGeometryCfg()
+        if self.task_description is None:
+            self.task_description = "Insert the medium NIST gear onto the NIST gear base."
+
+    def get_scene_cfg(self) -> Any:
+        """Return no additional scene config."""
+
+    def get_observation_cfg(self) -> GearInsertionObservationsCfg:
+        """Return task-state observations for the gear and target peg."""
+        geometry_cfg = self.geometry_cfg
+        return GearInsertionObservationsCfg(
+            gear_name=self.held_gear.name,
+            board_name=self.gear_base_asset.name,
+            peg_offset=geometry_cfg.peg_tip_offset,
+            held_gear_base_offset=geometry_cfg.held_gear_base_offset,
+        )
+
+    def get_rewards_cfg(self) -> Any:
+        """Return no rewards for evaluation-only rollouts."""
+
+    def get_termination_cfg(self) -> GearInsertionTerminationsCfg:
+        """Return timeout, success, and object-drop terminations."""
+        geometry_cfg = self.geometry_cfg
+        success = TerminationTermCfg(
+            func=gear_mesh_insertion_success,
+            params={
+                "held_object_cfg": SceneEntityCfg(self.held_gear.name),
+                "fixed_object_cfg": SceneEntityCfg(self.gear_base_asset.name),
+                "gear_base_offset": geometry_cfg.peg_base_offset,
+                "held_gear_base_offset": geometry_cfg.held_gear_base_offset,
+                "gear_peg_height": geometry_cfg.gear_peg_height,
+                "success_z_fraction": geometry_cfg.success_z_fraction,
+                "xy_threshold": geometry_cfg.xy_threshold,
+            },
+        )
+        object_dropped = TerminationTermCfg(
+            func=mdp_isaac_lab.root_height_below_minimum,
+            params={
+                "minimum_height": self.background_scene.object_min_z,
+                "asset_cfg": SceneEntityCfg(self.held_gear.name),
+            },
+        )
+        return GearInsertionTerminationsCfg(success=success, object_dropped=object_dropped)
+
+    def get_events_cfg(self) -> Any:
+        """Return no task-specific reset events."""
+
+    def get_mimic_env_cfg(self, arm_mode: ArmMode) -> Any:
+        """Raise because this task currently only defines policy evaluation."""
+        del arm_mode
+        raise NotImplementedError("NIST gear insertion does not define a Mimic configuration yet.")
+
+    def get_metrics(self) -> list[MetricBase]:
+        """Return task metrics used during evaluation."""
+        return [SuccessRateMetric()]
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        """Return a camera view focused on the held gear and peg area."""
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.held_gear,
+            offset=np.array([1.5, -0.5, 1.0]),
+        )
+
+
+@configclass
+class GearInsertionTerminationsCfg:
+    """Termination terms for NIST gear insertion evaluation."""
+
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    success: TerminationTermCfg = MISSING
+    object_dropped: TerminationTermCfg = MISSING
+
+
+@configclass
+class GearInsertionTaskObsCfg(ObsGroup):
+    """Task-state observations for the NIST gear and target peg."""
+
+    gear_pos: ObsTerm = MISSING
+    gear_quat: ObsTerm = MISSING
+    fixed_base_pos: ObsTerm = MISSING
+    fixed_base_quat: ObsTerm = MISSING
+    peg_pos: ObsTerm = MISSING
+    peg_delta: ObsTerm = MISSING
+
+    def __post_init__(self):
+        self.enable_corruption = False
+        self.concatenate_terms = True
+
+
+@configclass
+class GearInsertionObservationsCfg:
+    """Observation config for NIST gear insertion task state."""
+
+    task_obs: GearInsertionTaskObsCfg = MISSING
+
+    def __init__(
+        self,
+        gear_name: str,
+        board_name: str,
+        peg_offset: tuple[float, float, float],
+        held_gear_base_offset: tuple[float, float, float],
+    ):
+        self.task_obs = GearInsertionTaskObsCfg()
+        gear_cfg = SceneEntityCfg(gear_name)
+        board_cfg = SceneEntityCfg(board_name)
+
+        self.task_obs.gear_pos = ObsTerm(
+            func=mdp_isaac_lab.root_pos_w,
+            params={"asset_cfg": gear_cfg},
+        )
+        self.task_obs.gear_quat = ObsTerm(
+            func=mdp_isaac_lab.root_quat_w,
+            params={"make_quat_unique": True, "asset_cfg": gear_cfg},
+        )
+        self.task_obs.fixed_base_pos = ObsTerm(
+            func=mdp_isaac_lab.root_pos_w,
+            params={"asset_cfg": board_cfg},
+        )
+        self.task_obs.fixed_base_quat = ObsTerm(
+            func=mdp_isaac_lab.root_quat_w,
+            params={"make_quat_unique": True, "asset_cfg": board_cfg},
+        )
+        self.task_obs.peg_pos = ObsTerm(
+            func=gear_insertion_geometry.peg_pos_in_env_frame,
+            params={"board_cfg": board_cfg, "peg_offset": peg_offset},
+        )
+        self.task_obs.peg_delta = ObsTerm(
+            func=gear_insertion_geometry.peg_delta_from_held_gear_base,
+            params={
+                "gear_cfg": gear_cfg,
+                "board_cfg": board_cfg,
+                "peg_offset": peg_offset,
+                "held_gear_base_offset": held_gear_base_offset,
+            },
+        )

--- a/isaaclab_arena/tasks/nist_gear_insertion/terminations.py
+++ b/isaaclab_arena/tasks/nist_gear_insertion/terminations.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Termination terms for NIST gear insertion tasks."""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+
+from isaaclab_arena.tasks.nist_gear_insertion.geometry import compute_gear_insertion_success
+
+
+def gear_mesh_insertion_success(
+    env: ManagerBasedRLEnv,
+    held_object_cfg: SceneEntityCfg,
+    fixed_object_cfg: SceneEntityCfg,
+    gear_base_offset: tuple[float, float, float],
+    gear_peg_height: float,
+    success_z_fraction: float,
+    xy_threshold: float,
+    held_gear_base_offset: tuple[float, float, float] | None = None,
+) -> torch.Tensor:
+    """Terminate when the held gear is centered on the peg and lowered to the success depth."""
+    return compute_gear_insertion_success(
+        env=env,
+        gear_cfg=held_object_cfg,
+        board_cfg=fixed_object_cfg,
+        peg_offset=gear_base_offset,
+        held_gear_base_offset=held_gear_base_offset if held_gear_base_offset is not None else gear_base_offset,
+        gear_peg_height=gear_peg_height,
+        z_fraction=success_z_fraction,
+        xy_threshold=xy_threshold,
+    )

--- a/isaaclab_arena/tasks/task_library.py
+++ b/isaaclab_arena/tasks/task_library.py
@@ -13,6 +13,7 @@ from isaaclab_arena.tasks import (  # noqa: F401
     close_door_task,
     goal_pose_task,
     lift_object_task,
+    nist_gear_insertion,
     no_task,
     open_door_task,
     pick_and_place_task,

--- a/isaaclab_arena/tests/test_nist_gear_insertion_task.py
+++ b/isaaclab_arena/tests/test_nist_gear_insertion_task.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import torch
+from dataclasses import dataclass
+
+import pytest
+
+_PEG_BASE_OFFSET = (0.02025, 0.0, 0.0)
+_PEG_TIP_OFFSET = (0.02025, 0.0, 0.025)
+
+
+@dataclass
+class _DummyAsset:
+    name: str
+    object_min_z: float | None = None
+    reset_pose_disabled: bool = False
+
+    def disable_reset_pose(self) -> None:
+        self.reset_pose_disabled = True
+
+
+def _make_nist_task(**kwargs):
+    from isaaclab_arena.tasks.nist_gear_insertion.task import GearInsertionGeometryCfg, NistGearInsertionTask
+
+    return NistGearInsertionTask(
+        held_gear=_DummyAsset("medium_nist_gear"),
+        background_scene=_DummyAsset("table", object_min_z=-0.05),
+        gear_base_asset=_DummyAsset("gears_and_base"),
+        geometry_cfg=GearInsertionGeometryCfg(
+            peg_base_offset=_PEG_BASE_OFFSET,
+            peg_tip_offset=_PEG_TIP_OFFSET,
+            held_gear_base_offset=_PEG_BASE_OFFSET,
+            success_z_fraction=0.20,
+            xy_threshold=0.0025,
+        ),
+        **kwargs,
+    )
+
+
+def test_task_is_evaluation_only_and_uses_geometry_for_success():
+    from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+    from isaaclab_arena.tasks.nist_gear_insertion import geometry
+    from isaaclab_arena.tasks.nist_gear_insertion.terminations import gear_mesh_insertion_success
+
+    task = _make_nist_task()
+
+    obs_cfg = task.get_observation_cfg()
+    termination_cfg = task.get_termination_cfg()
+
+    assert not task.held_gear.reset_pose_disabled
+    assert task.get_events_cfg() is None
+    assert task.get_rewards_cfg() is None
+    assert task.get_commands_cfg() is None
+    assert task.get_curriculum_cfg() is None
+    assert task.get_scene_cfg() is None
+    assert task.get_task_description() == "Insert the medium NIST gear onto the NIST gear base."
+
+    metrics = task.get_metrics()
+    assert len(metrics) == 1
+    assert isinstance(metrics[0], SuccessRateMetric)
+
+    assert obs_cfg.task_obs.gear_pos.params["asset_cfg"].name == "medium_nist_gear"
+    assert obs_cfg.task_obs.fixed_base_pos.params["asset_cfg"].name == "gears_and_base"
+    assert obs_cfg.task_obs.peg_pos.func is geometry.peg_pos_in_env_frame
+    assert obs_cfg.task_obs.peg_pos.params["peg_offset"] == _PEG_TIP_OFFSET
+    assert obs_cfg.task_obs.peg_delta.func is geometry.peg_delta_from_held_gear_base
+    assert obs_cfg.task_obs.peg_delta.params["held_gear_base_offset"] == _PEG_BASE_OFFSET
+    assert obs_cfg.task_obs.concatenate_terms
+
+    assert termination_cfg.success.func is gear_mesh_insertion_success
+    assert termination_cfg.success.params["gear_base_offset"] == _PEG_BASE_OFFSET
+    assert termination_cfg.success.params["held_gear_base_offset"] == _PEG_BASE_OFFSET
+    assert termination_cfg.success.params["success_z_fraction"] == 0.20
+    assert "disable_success_termination" not in termination_cfg.success.params
+    assert termination_cfg.object_dropped.params["asset_cfg"].name == "medium_nist_gear"
+    assert termination_cfg.object_dropped.params["minimum_height"] == -0.05
+
+
+def test_gear_insertion_geometry_success_thresholds():
+    from isaaclab_arena.tasks.nist_gear_insertion.geometry import check_gear_insertion_geometry
+
+    held_base_pos = torch.tensor([
+        [0.0, 0.0, 0.001],
+        [0.01, 0.0, 0.001],
+        [0.0, 0.0, 0.01],
+    ])
+    peg_pos = torch.zeros(3, 3)
+
+    success = check_gear_insertion_geometry(
+        held_base_pos=held_base_pos,
+        peg_pos=peg_pos,
+        gear_peg_height=0.02,
+        z_fraction=0.2,
+        xy_threshold=0.0025,
+    )
+
+    assert success.tolist() == [True, False, False]
+
+
+def test_nist_environment_is_registered_with_default_droid_args():
+    from isaaclab_arena.assets.registries import EnvironmentRegistry
+    from isaaclab_arena_environments.cli import add_environment_cli_args, ensure_environments_registered
+    from isaaclab_arena_environments.nist_assembled_gear_mesh_environment import (
+        DROID_EMBODIMENTS,
+        NistAssembledGearMeshEnvironmentCfg,
+    )
+
+    ensure_environments_registered()
+    env_registry = EnvironmentRegistry()
+    assert env_registry.is_registered("nist_assembled_gear_mesh")
+
+    environment_factory_type = env_registry.get_component_by_name("nist_assembled_gear_mesh")
+    assert environment_factory_type.name == "nist_assembled_gear_mesh"
+    assert environment_factory_type._legacy_argparse_cfg_type is NistAssembledGearMeshEnvironmentCfg
+
+    cfg = NistAssembledGearMeshEnvironmentCfg()
+    assert cfg.embodiment == "droid_abs_joint_pos"
+    assert cfg.embodiment in DROID_EMBODIMENTS
+    assert cfg.episode_length_s == 15.0
+
+    parser = argparse.ArgumentParser(exit_on_error=False)
+    add_environment_cli_args(parser, environment_factory_type)
+    args = parser.parse_args([])
+    assert args.embodiment == "droid_abs_joint_pos"
+    assert args.episode_length_s == 15.0
+
+
+def test_nist_environment_rejects_non_droid_embodiment():
+    from isaaclab_arena_environments.nist_assembled_gear_mesh_environment import (
+        NistAssembledGearMeshEnvironment,
+        NistAssembledGearMeshEnvironmentCfg,
+    )
+
+    environment = NistAssembledGearMeshEnvironment()
+    with pytest.raises(AssertionError, match="only supports existing DROID embodiments"):
+        environment.build(NistAssembledGearMeshEnvironmentCfg(embodiment="unsupported_robot"))

--- a/isaaclab_arena/tests/test_nist_newton_gear_only.py
+++ b/isaaclab_arena/tests/test_nist_newton_gear_only.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Newton stability tests for the NIST gear insertion scene objects.
+
+The DROID robot embodiment is excluded because its Robotiq 2F-85 passive
+linkages need a separate Newton mass-floor workaround. These tests focus on
+the NIST gear, gear base, and Newton-compatible landing slab.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+NUM_STEPS = 300
+SETTLE_LIN_THRESH = 0.01
+FINAL_LIN_THRESH = 0.05
+BASE_LIN_THRESH = 0.001
+MAX_GEAR_LIN_SPEED = 10.0
+
+GEAR_DROP_Z_NEAR = 0.00
+GEAR_DROP_Z_HIGH = 0.10
+
+
+def _run_newton_scene_test(simulation_app, gear_initial_z: float) -> bool:
+    """Build a no-robot NIST Newton scene and verify gear stability."""
+    import torch
+
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.register import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.pose import Pose
+    from isaaclab_arena_environments.cli import ensure_environments_registered
+    from isaaclab_arena_environments.mdp import nist_gear_insertion_env_cfg_callback
+
+    ensure_environments_registered()
+
+    asset_registry = AssetRegistry()
+    gears_and_base = asset_registry.get_asset_by_name("gears_and_base")()
+    medium_gear = asset_registry.get_asset_by_name("medium_nist_gear")()
+    light = asset_registry.get_asset_by_name("light")(
+        spawner_cfg=sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=1500.0)
+    )
+    table = asset_registry.get_asset_by_name("table")()
+
+    table.set_initial_pose(Pose(position_xyz=(0.55, 0.0, -0.009), rotation_xyzw=(0.0, 0.0, 0.707, 0.707)))
+    gears_and_base.set_initial_pose(Pose(position_xyz=(0.585, -0.074, 0.0), rotation_xyzw=(0.0, 0.0, 0.9239, 0.3827)))
+    medium_gear.set_initial_pose(Pose(position_xyz=(0.50, -0.24, gear_initial_z), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+    scene = Scene(assets=[table, medium_gear, gears_and_base, light])
+    arena_env = IsaacLabArenaEnvironment(
+        name=f"nist_newton_scene_test_{gear_initial_z:.2f}",
+        scene=scene,
+        env_cfg_callback=nist_gear_insertion_env_cfg_callback,
+    )
+
+    args_cli = get_isaaclab_arena_cli_parser().parse_args([])
+    args_cli.num_envs = 1
+    builder_cfg = arena_env_builder_cfg_from_argparse(args_cli)
+    builder_cfg.presets = "newton"
+
+    builder = ArenaEnvBuilder(arena_env, builder_cfg)
+    env = builder.make_registered()
+
+    try:
+        env.reset()
+        gear_obj = env.unwrapped.scene["medium_nist_gear"]
+        base_obj = env.unwrapped.scene["gears_and_base"]
+        zero_actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+
+        gear_settled = False
+        max_gear_speed = 0.0
+
+        for _ in range(NUM_STEPS):
+            env.step(zero_actions)
+
+            gear_pos = gear_obj.data.root_pos_w.torch[0].cpu().numpy()
+            gear_vel = gear_obj.data.root_lin_vel_w.torch[0].cpu().numpy()
+            base_pos = base_obj.data.root_pos_w.torch[0].cpu().numpy()
+            base_vel = base_obj.data.root_lin_vel_w.torch[0].cpu().numpy()
+
+            if not (
+                np.all(np.isfinite(gear_pos))
+                and np.all(np.isfinite(gear_vel))
+                and np.all(np.isfinite(base_pos))
+                and np.all(np.isfinite(base_vel))
+            ):
+                return False
+
+            gear_speed = float(np.linalg.norm(gear_vel))
+            max_gear_speed = max(max_gear_speed, gear_speed)
+            gear_settled = gear_settled or gear_speed < SETTLE_LIN_THRESH
+
+        final_gear_speed = float(np.linalg.norm(gear_vel))
+        final_base_speed = float(np.linalg.norm(base_vel))
+        return (
+            gear_settled
+            and max_gear_speed < MAX_GEAR_LIN_SPEED
+            and final_gear_speed < FINAL_LIN_THRESH
+            and final_base_speed < BASE_LIN_THRESH
+        )
+
+    finally:
+        env.close()
+
+
+def _test_near_drop(simulation_app) -> bool:
+    return _run_newton_scene_test(simulation_app, GEAR_DROP_Z_NEAR)
+
+
+def _test_high_drop(simulation_app) -> bool:
+    return _run_newton_scene_test(simulation_app, GEAR_DROP_Z_HIGH)
+
+
+def test_nist_scene_objects_stable_newton():
+    """Gear drops 17 mm onto the landing slab."""
+    result = run_function_with_persistent_simulation_app(_test_near_drop, headless=True)
+    assert result, "Newton near-drop stability test failed"
+
+
+def test_nist_scene_objects_stable_newton_high_drop():
+    """Gear drops 117 mm onto the landing slab."""
+    result = run_function_with_persistent_simulation_app(_test_high_drop, headless=True)
+    assert result, "Newton high-drop stability test failed"

--- a/isaaclab_arena/tests/test_task_registry.py
+++ b/isaaclab_arena/tests/test_task_registry.py
@@ -16,6 +16,7 @@ def _test_task_registry_resolves_concrete_tasks(simulation_app):
         "LiftObjectTask",
         "LiftObjectTaskRL",
         "DexsuiteLiftTask",
+        "NistGearInsertionTask",
         "GoalPoseTask",
         "PressButtonTask",
         "RotateRevoluteJointTask",

--- a/isaaclab_arena_environments/mdp/env_callbacks.py
+++ b/isaaclab_arena_environments/mdp/env_callbacks.py
@@ -70,3 +70,45 @@ def assembly_env_cfg_callback(env_cfg: IsaacLabArenaManagerBasedRLEnvCfg) -> Isa
     env_cfg.decimation = 2
 
     return env_cfg
+
+
+def nist_gear_insertion_env_cfg_callback(
+    env_cfg: IsaacLabArenaManagerBasedRLEnvCfg,
+) -> IsaacLabArenaManagerBasedRLEnvCfg:
+    """Assembly callback for NIST gear insertion, extended with a Newton-compatible gear-landing slab.
+
+    The SeattleLabTable USD uses USD point instancing, so its CollisionAPI meshes are not
+    reachable at runtime. Newton requires an explicit RigidBodyAPI prim for contact generation,
+    while PhysX handles the table's USD collision geometry automatically.
+
+    A small invisible kinematic cuboid (0.30 x 0.30 x 0.10 m) is added directly under the
+    medium NIST gear drop zone (0.50, -0.24). It is sized to cover only the gear landing area,
+    keeping it well clear of the DROID robot arm workspace so that arm-table contacts (which
+    cause Newton constraint divergence for high-stiffness joints) cannot occur.
+    """
+    from isaaclab.assets.rigid_object import RigidObjectCfg
+    from isaaclab.sim.schemas import CollisionPropertiesCfg, RigidBodyPropertiesCfg
+    from isaaclab.sim.spawners.shapes import CuboidCfg
+
+    env_cfg = assembly_env_cfg_callback(env_cfg)
+
+    # Surface at z = -0.017 m (PhysX-measured gear resting height).
+    # The thick slab prevents high-velocity gear drops from tunneling through in
+    # a single Newton control step.
+    # Center = surface - half_thickness = -0.017 - 0.05 = -0.067 m.
+    _SLAB_HALF_T = 0.05
+    env_cfg.scene.gear_landing_slab = RigidObjectCfg(
+        prim_path="{ENV_REGEX_NS}/gear_landing_slab",
+        spawn=CuboidCfg(
+            size=(0.30, 0.30, _SLAB_HALF_T * 2),
+            rigid_props=RigidBodyPropertiesCfg(kinematic_enabled=True),
+            collision_props=CollisionPropertiesCfg(contact_offset=0.005),
+            visible=False,
+        ),
+        init_state=RigidObjectCfg.InitialStateCfg(
+            pos=(0.50, -0.24, -0.017 - _SLAB_HALF_T),
+            rot=(0.0, 0.0, 0.0, 1.0),
+        ),
+    )
+
+    return env_cfg

--- a/isaaclab_arena_environments/nist_assembled_gear_mesh_environment.py
+++ b/isaaclab_arena_environments/nist_assembled_gear_mesh_environment.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""NIST gear insertion environment for DROID policy evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+
+DROID_EMBODIMENTS = (
+    "droid_abs_joint_pos",
+    "droid_rel_joint_pos",
+    "droid_differential_ik",
+)
+
+
+@dataclass
+class NistAssembledGearMeshEnvironmentCfg(ArenaEnvironmentCfg):
+    """Configure the NIST gear insertion environment."""
+
+    embodiment: str = "droid_abs_joint_pos"
+    episode_length_s: float = 15.0
+
+
+@register_environment
+class NistAssembledGearMeshEnvironment(ArenaEnvironmentFactory[NistAssembledGearMeshEnvironmentCfg]):
+    """NIST gear insertion environment using existing DROID embodiments."""
+
+    name: str = "nist_assembled_gear_mesh"
+    _legacy_argparse_cfg_type = NistAssembledGearMeshEnvironmentCfg
+
+    def build(self, cfg: NistAssembledGearMeshEnvironmentCfg) -> IsaacLabArenaEnvironment:
+        """Build the environment from its typed configuration."""
+        assert (
+            cfg.embodiment in DROID_EMBODIMENTS
+        ), f"{self.name} only supports existing DROID embodiments {DROID_EMBODIMENTS}, got '{cfg.embodiment}'."
+
+        import isaaclab.sim as sim_utils
+
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.tasks.nist_gear_insertion.task import GearInsertionGeometryCfg, NistGearInsertionTask
+        from isaaclab_arena.utils.pose import Pose
+        from isaaclab_arena_environments import mdp
+
+        table = self.asset_registry.get_asset_by_name("table")()
+        gears_and_base = self.asset_registry.get_asset_by_name("gears_and_base")()
+        medium_gear = self.asset_registry.get_asset_by_name("medium_nist_gear")()
+        light_spawner_cfg = sim_utils.DomeLightCfg(color=(0.75, 0.75, 0.75), intensity=1500.0)
+        light = self.asset_registry.get_asset_by_name("light")(spawner_cfg=light_spawner_cfg)
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)
+
+        table.set_initial_pose(Pose(position_xyz=(0.55, 0.0, -0.009), rotation_xyzw=(0.0, 0.0, 0.707, 0.707)))
+        gears_and_base.set_initial_pose(
+            Pose(position_xyz=(0.585, -0.074, 0.0), rotation_xyzw=(0.0, 0.0, 0.9239, 0.3827))
+        )
+        medium_gear.set_initial_pose(Pose(position_xyz=(0.50, -0.24, 0.02), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        scene = Scene(assets=[table, medium_gear, gears_and_base, light])
+        geometry_cfg = GearInsertionGeometryCfg()
+        task = NistGearInsertionTask(
+            held_gear=medium_gear,
+            background_scene=table,
+            gear_base_asset=gears_and_base,
+            geometry_cfg=geometry_cfg,
+            episode_length_s=cfg.episode_length_s,
+        )
+
+        return IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=task,
+            teleop_device=None,
+            env_cfg_callback=mdp.assembly_env_cfg_callback,
+        )

--- a/isaaclab_arena_environments/nist_assembled_gear_mesh_environment.py
+++ b/isaaclab_arena_environments/nist_assembled_gear_mesh_environment.py
@@ -82,5 +82,5 @@ class NistAssembledGearMeshEnvironment(ArenaEnvironmentFactory[NistAssembledGear
             scene=scene,
             task=task,
             teleop_device=None,
-            env_cfg_callback=mdp.assembly_env_cfg_callback,
+            env_cfg_callback=mdp.nist_gear_insertion_env_cfg_callback,
         )


### PR DESCRIPTION
## Summary
Add NIST gear evaluation env

## Detailed description
- Adds registered NIST gear assets and a DROID-only environment.
- Adds an evaluation-only NIST task with task observations, success/drop/timeout terminations, and success-rate metrics.


https://github.com/user-attachments/assets/a8208ded-e8c5-481b-bd8f-6fdb8de42034

