### PR TITLE
Fix memory leak.

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -447,9 +447,14 @@ class ArenaEnvBuilder:
             env_kwargs = {}
         entry_point = self.get_entry_point()
         # Register the environment with the Gym registry.
+        # NOTE(alexmillane, 2026-08-05): Do not spread env_kwargs into the registry kwargs. env_kwargs carries the
+        # VariationRecorder, whose bind_env() holds a reference to the constructed env
+        # (and thus its SimulationContext/PhysX GPU buffers). The Gym registry is process-global
+        # and never cleared, so pinning it there retains every registered env's GPU memory until
+        # process exit — an unbounded leak across a persistent SimulationApp.
+        # TODO(alexmillane, 2026-08-05): Fix this issue and remove this note.
         kwargs = {
             "env_cfg_entry_point": env_cfg,
-            **env_kwargs,
         }
         if env_cfg.demo_recorder_config is not None:
             kwargs["demo_recorder_cfg_entry_point"] = env_cfg.demo_recorder_config


### PR DESCRIPTION
## Summary
Fixes a memory leak in Arena

## Detailed description
- #960 introduced a change to pass the env_kwargs to the gym registry.
- Because our kwargs contain a variation recorder which in turn carry a reference to the live env, this caused a GPU memory leak that the live envs build up as multiple are built over, for example, a testing run.
- This MR band-aids the fix by reintroducing the failure to pass the kwargs.
