### PR TITLE
Patch fix to Lab's EA2 bug: ObjectSet scenes with robot-mounted cameras crash during scene build

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -44,6 +44,7 @@ from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.tasks.no_task import NoTask
 from isaaclab_arena.utils.configclass import combine_configclass_instances, make_configclass
 from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
+from isaaclab_arena.utils.isaaclab_utils.resolve_clone_plan_source_patch import patch_resolve_clone_plan_source
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import reapply_viewer_cfg
 from isaaclab_arena.utils.multiprocess import get_local_rank
 from isaaclab_arena.variations import variations_hydra, variations_printing
@@ -516,6 +517,12 @@ class ArenaEnvBuilder:
             A tuple containing the environment and the environment configuration.
         """
         name, cfg, env_kwargs = self.build_registered(env_cfg, env_kwargs)
+        # During Lab's env build, ObjectSets give every env cfg its own clone-plan destination
+        # It is an issue for cameras nested under the robot that multiple destination are returned for the same source.
+        # E.g. camera gets /World/envs/env_{}/Robot, /World/envs/env_{}/Robot/panda_link0/external_camera  as destinations.
+        # Lab EA2 cannot pick one so patching to support single destination for the same source.
+        # TODO(xinjieyao, 2026-08-05): Remove this patch once Lab is updated to GA.
+        patch_resolve_clone_plan_source()
         env = gym.make(name, cfg=cfg, render_mode=render_mode, **env_kwargs)
         # ViewportCameraController sets the camera before KitVisualizer.initialize() is called,
         # so the call is silently ignored. Re-apply here once the visualizers are fully initialized.

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -473,6 +473,12 @@ class ArenaEnvBuilder:
             num_envs=self.cfg.num_envs,
             use_fabric=not self.cfg.disable_fabric,
         )
+        # During Lab's env build, ObjectSets give every env cfg its own clone-plan destination
+        # It is an issue for cameras nested under the robot that multiple destination are returned for the same source.
+        # E.g. camera gets /World/envs/env_{}/Robot, /World/envs/env_{}/Robot/panda_link0/external_camera  as destinations.
+        # Lab EA2 cannot pick one so patching to support single destination for the same source.
+        # TODO(xinjieyao, 2026-08-05): Remove this patch once Lab is updated to GA.
+        patch_resolve_clone_plan_source()
         return name, cfg, env_kwargs
 
     def make_registered(
@@ -517,12 +523,6 @@ class ArenaEnvBuilder:
             A tuple containing the environment and the environment configuration.
         """
         name, cfg, env_kwargs = self.build_registered(env_cfg, env_kwargs)
-        # During Lab's env build, ObjectSets give every env cfg its own clone-plan destination
-        # It is an issue for cameras nested under the robot that multiple destination are returned for the same source.
-        # E.g. camera gets /World/envs/env_{}/Robot, /World/envs/env_{}/Robot/panda_link0/external_camera  as destinations.
-        # Lab EA2 cannot pick one so patching to support single destination for the same source.
-        # TODO(xinjieyao, 2026-08-05): Remove this patch once Lab is updated to GA.
-        patch_resolve_clone_plan_source()
         env = gym.make(name, cfg=cfg, render_mode=render_mode, **env_kwargs)
         # ViewportCameraController sets the camera before KitVisualizer.initialize() is called,
         # so the call is silently ignored. Re-apply here once the visualizers are fully initialized.

--- a/isaaclab_arena/tests/test_object_set.py
+++ b/isaaclab_arena/tests/test_object_set.py
@@ -4,13 +4,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import torch
+import tqdm
 import traceback
 from unittest.mock import patch
+
+import pytest
 
 from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
 NUM_ENVS = 10
+# Kept lower than NUM_ENVS because each env renders three 720p cameras. Must stay > 1 so the
+# object set still produces a heterogeneous clone plan.
+NUM_ENVS_WITH_CAMERAS = 4
+NUM_STEPS_WITH_CAMERAS = 2
 OBJECT_SET_1_PRIM_PATH = "/World/envs/env_.*/ObjectSet_1"
 OBJECT_SET_2_PRIM_PATH = "/World/envs/env_.*/ObjectSet_2"
 OBJECT_SET_JUG_PRIM_PATH = "/World/envs/env_.*/ObjectSet_Jug"
@@ -475,6 +483,81 @@ def _test_multi_object_sets(simulation_app):
     return True
 
 
+def _test_object_set_with_robot_mounted_cameras(simulation_app) -> bool:
+    """An object set clones correctly in a scene whose cameras are mounted on the robot.
+
+    An object set spawns one USD variant per env, which puts the scene on Isaac Lab's
+    heterogeneous clone-plan path: every cfg gets its own destination template instead of a
+    single env-root one. DROID's cameras live under the robot, so their templates nest
+    inside the robot's, and resolving them used to raise. See the resolve_clone_plan_source
+    patch. Needs more than one env; a single env takes the homogeneous fast path and never
+    builds the nested templates.
+    """
+    from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.droid.droid import DroidAbsoluteJointPositionEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.pose import Pose
+
+    args_parser = get_isaaclab_arena_cli_parser()
+    args_cli = args_parser.parse_args(["--enable_cameras"])
+    args_cli.num_envs = NUM_ENVS_WITH_CAMERAS
+
+    asset_registry = AssetRegistry()
+    background = asset_registry.get_asset_by_name("packing_table")()
+    sweet_potato = asset_registry.get_asset_by_name("sweet_potato")()
+    jug = asset_registry.get_asset_by_name("jug")()
+
+    object_set = RigidObjectSet(name="object_set", objects=[sweet_potato, jug])
+    object_set.set_initial_pose(
+        Pose(position_xyz=(0.0758066475391388, -0.5088448524475098, 0.5), rotation_xyzw=(0, 0, 0, 1))
+    )
+
+    scene = Scene(assets=[background, object_set])
+
+    isaaclab_arena_environment = IsaacLabArenaEnvironment(
+        name="object_set_with_cameras_test",
+        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=True),
+        scene=scene,
+    )
+
+    # Scene construction is what used to raise, so reaching the first observation is the
+    # regression signal.
+    builder = ArenaEnvBuilder(isaaclab_arena_environment, arena_env_builder_cfg_from_argparse(args_cli))
+    env = builder.make_registered()
+    env.reset()
+
+    # The observation dict is the env's own buffer, so it must be read before env.close().
+    try:
+        for _ in tqdm.tqdm(range(NUM_STEPS_WITH_CAMERAS)):
+            with torch.inference_mode():
+                actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+                obs, _, _, _, _ = env.step(actions)
+
+                assert "camera_obs" in obs, f"No camera observation group; got groups {sorted(obs)}"
+                camera_obs = obs["camera_obs"]
+                # Every camera nested under the robot must survive cloning: the two external
+                # ones under panda_link0 and the wrist one under the gripper.
+                for camera_key in ("external_camera_rgb", "external_camera_2_rgb", "wrist_camera_rgb"):
+                    assert camera_key in camera_obs, f"Missing {camera_key!r}; got {sorted(camera_obs)}"
+                    images = camera_obs[camera_key]
+                    num_envs = images.shape[0]
+                    assert num_envs == NUM_ENVS_WITH_CAMERAS, f"{camera_key} has {num_envs} envs"
+                    assert images.shape[3] == 3, f"{camera_key} rgb observation does not have three channels"
+                    assert images.any(), f"{camera_key} observation contains only 0s"
+    except Exception as e:
+        print(f"Error: {e}")
+        traceback.print_exc()
+        return False
+    finally:
+        env.close()
+
+    return True
+
+
 def test_empty_object_set():
     result = run_function_with_persistent_simulation_app(
         _test_empty_object_set,
@@ -547,9 +630,20 @@ def test_multi_object_sets():
     assert result, f"Test {_test_multi_object_sets.__name__} failed"
 
 
+@pytest.mark.with_cameras
+def test_object_set_with_robot_mounted_cameras():
+    result = run_function_with_persistent_simulation_app(
+        _test_object_set_with_robot_mounted_cameras,
+        headless=HEADLESS,
+        enable_cameras=True,
+    )
+    assert result, f"Test {_test_object_set_with_robot_mounted_cameras.__name__} failed"
+
+
 if __name__ == "__main__":
     test_empty_object_set()
     test_articulation_object_set()
     test_single_object_in_one_object_set()
     test_multi_objects_in_one_object_set()
     test_multi_object_sets()
+    test_object_set_with_robot_mounted_cameras()

--- a/isaaclab_arena/utils/isaaclab_utils/resolve_clone_plan_source_patch.py
+++ b/isaaclab_arena/utils/isaaclab_utils/resolve_clone_plan_source_patch.py
@@ -24,7 +24,8 @@ _PATCHED_MARKER = "_isaaclab_arena_nested_clone_template_patch"
 
 
 def _resolve_clone_plan_source(path_expr: str, plan: ClonePlan) -> tuple[str, str, str] | None:
-    """Resolve a destination path expression to its owning source path. E.g. for camera at /World/envs/env_{}/Robot/panda_link0/external_camera, return /World/envs/env_{}/Robot.
+    """Resolve a destination path expression to its owning source path. E.g. for camera at
+    /World/envs/env_{}/Robot/panda_link0/external_camera, return its exact source path instead of /World/envs/env_{}/Robot.
 
     Args:
         path_expr: Destination-side path expression.

--- a/isaaclab_arena/utils/isaaclab_utils/resolve_clone_plan_source_patch.py
+++ b/isaaclab_arena/utils/isaaclab_utils/resolve_clone_plan_source_patch.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime patch for ``isaaclab.cloner.cloner_utils.resolve_clone_plan_source``.
+
+The pinned Isaac Lab raises when a prim path is owned by two clone-plan destination
+templates, even when one is nested in the other. ObjectSets trigger it: they force a
+per-cfg clone plan, so a camera under the robot matches both ``/World/envs/env_{}/Robot``
+and its own template. Ports upstream #5929, which prefers the nearest owner.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isaaclab.cloner import ClonePlan
+
+_PATCHED_MARKER = "_isaaclab_arena_nested_clone_template_patch"
+
+
+def _resolve_clone_plan_source(path_expr: str, plan: ClonePlan) -> tuple[str, str, str] | None:
+    """Resolve a destination path expression to its owning source path. E.g. for camera at /World/envs/env_{}/Robot/panda_link0/external_camera, return /World/envs/env_{}/Robot.
+
+    Args:
+        path_expr: Destination-side path expression.
+        plan: Active clone plan.
+
+    Returns:
+        A ``(source_path, destination_glob, asset_suffix)`` tuple, or None when no source path owns
+        ``path_expr`` so callers fall back to direct stage resolution.
+    """
+    from isaaclab.cloner.cloner_utils import get_suffix
+
+    # Collect all candidates that own the path expression.
+    candidates: list[tuple[str, str, int]] = []
+    for source_index, destination_template in enumerate(plan.destinations):
+        if "{}" in destination_template:
+            suffix = get_suffix(path_expr, destination_template)
+            if suffix is not None:
+                candidates.append((destination_template, suffix, source_index))
+
+    if not candidates:
+        return None
+    # Pick the path with the shortest suffix.
+    min_suffix_len = min(len(suffix) for _, suffix, _ in candidates)
+    owning_templates = {template for template, suffix, _ in candidates if len(suffix) == min_suffix_len}
+    # It shall have only one owning template.
+    if len(owning_templates) > 1:
+        raise ValueError(f"path_expr {path_expr!r}: matches multiple destination templates {sorted(owning_templates)}.")
+
+    matching_template = next(iter(owning_templates))
+    matching_rows = [index for template, _, index in candidates if template == matching_template]
+    matching_suffix = next(suffix for template, suffix, _ in candidates if template == matching_template)
+    # It shall cover all envs.
+    if not plan.clone_mask[matching_rows].any(dim=0).all():
+        raise NotImplementedError(
+            f"path_expr {path_expr!r}: partial-env heterogeneous coverage is unsupported;"
+            " matching rows must collectively cover all envs."
+        )
+    # override the destination glob and asset suffix to the matching template and suffix.
+    return plan.sources[matching_rows[0]], matching_template.replace("{}", "*"), matching_suffix or ""
+
+
+def installed_resolver_handles_nesting() -> bool:
+    """Return whether the installed Isaac Lab already resolves nested destination templates."""
+    import torch
+
+    from isaaclab.cloner import ClonePlan
+    from isaaclab.cloner.cloner_utils import resolve_clone_plan_source
+
+    plan = ClonePlan(
+        sources=("/World/envs/env_0/Robot", "/World/envs/env_0/Robot/link/camera"),
+        destinations=("/World/envs/env_{}/Robot", "/World/envs/env_{}/Robot/link/camera"),
+        clone_mask=torch.ones((2, 1), dtype=torch.bool),
+    )
+    try:
+        resolve_clone_plan_source("/World/envs/env_0/Robot/link/camera", plan)
+    except ValueError:
+        return False
+    return True
+
+
+def patch_resolve_clone_plan_source() -> bool:
+    """Install the patched resolver, rebinding every module that holds the stock function.
+
+    Returns:
+        Whether this call installed the patch.
+    """
+    import isaaclab.cloner.cloner_utils as cloner_utils
+
+    original = cloner_utils.resolve_clone_plan_source
+    if getattr(original, _PATCHED_MARKER, False):
+        return False
+    if installed_resolver_handles_nesting():
+        return False
+
+    # Import the known importers so their stale bindings are visible to the sweep below.
+    import isaaclab.cloner  # noqa: F401
+    import isaaclab.sim.utils.queries  # noqa: F401
+
+    setattr(_resolve_clone_plan_source, _PATCHED_MARKER, True)
+    patched_modules = []
+    for module in list(sys.modules.values()):
+        with contextlib.suppress(Exception):
+            if getattr(module, "resolve_clone_plan_source", None) is original:
+                module.resolve_clone_plan_source = _resolve_clone_plan_source
+                patched_modules.append(module.__name__)
+
+    assert patched_modules, "Expected at least isaaclab.cloner.cloner_utils to hold the stock resolver."
+    print(f"Patched resolve_clone_plan_source for nested clone templates in: {', '.join(sorted(patched_modules))}")
+    return True


### PR DESCRIPTION
## Summary
ObjectSet scenes with robot-mounted cameras crash during scene build; port upstream IsaacLab [#5929](https://github.com/isaac-sim/IsaacLab/pull/5929) as a runtime patch until the pinned submodule carries the fix.

## Detailed description
- Root cause: an ObjectSet forces a per-cfg clone plan, so `/World/envs/env_0/Robot/panda_link0/external_camera` is owned by both `/World/envs/env_{}/Robot` and `/World/envs/env_{}/Robot/panda_link0/external_camera`. Lab refused to process more than one path.
- During build time, it raises`ValueError: matches multiple destination templates` and aborted gym.make
- Patch the fix to resolve the path to the one with shortest suffix (`/World/envs/env_{}/Robot/panda_link0/external_camera`) as implemented in #5929.


--enbale_cameras with PI
https://github.com/user-attachments/assets/5385be49-62ef-4216-a96a-a60856161361



