### PR TITLE
Avoid Warp CUDA initialization before Fabric startup

### DIFF
--- a/isaaclab_arena/relations/object_placer.py
+++ b/isaaclab_arena/relations/object_placer.py
@@ -87,6 +87,7 @@ class ObjectPlacer:
         objects: list[PlaceableAsset],
         num_envs: int = 1,
         collision_objects: list[CollisionObject] | None = None,
+        device: torch.device | str | None = None,
     ) -> list[PlacementResult]:
         """Place objects according to their spatial relations.
 
@@ -102,6 +103,7 @@ class ObjectPlacer:
                 placement (one layout per env).
             collision_objects: Optional fixed background obstacles avoided during
                 placement but never optimized or relation-constrained.
+            device: Solver device. Defaults to CUDA when available, otherwise CPU.
 
         Returns:
             One PlacementResult per environment.
@@ -117,6 +119,7 @@ class ObjectPlacer:
             attempts_per_result=max_attempts,
             generator=generator,
             collision_objects=collision_objects,
+            device=device,
         )
         results_per_env = [env_results[0] for env_results in ranked_results_per_env]
 
@@ -141,6 +144,7 @@ class ObjectPlacer:
         num_envs: int,
         results_per_env: int,
         collision_objects: list[CollisionObject] | None = None,
+        device: torch.device | str | None = None,
     ) -> list[list[PlacementResult]]:
         """Return ranked placement candidates per env.
 
@@ -153,6 +157,7 @@ class ObjectPlacer:
         Args:
             collision_objects: Optional fixed background obstacles avoided during
                 placement but never optimized or relation-constrained.
+            device: Solver device. Defaults to CUDA when available, otherwise CPU.
         """
         collision_objects = collision_objects or []
         assert results_per_env > 0, f"results_per_env must be positive, got {results_per_env}"
@@ -166,6 +171,7 @@ class ObjectPlacer:
             attempts_per_result=max_attempts,
             generator=generator,
             collision_objects=collision_objects,
+            device=device,
         )
 
         return [ranked_results[:results_per_env] for ranked_results in ranked_results_per_env]
@@ -213,6 +219,7 @@ class ObjectPlacer:
         attempts_per_result: int,
         generator: torch.Generator | None,
         collision_objects: list[CollisionObject] | None = None,
+        device: torch.device | str | None = None,
     ) -> list[list[PlacementResult]]:
         """Solve and rank placement candidates per environment.
 
@@ -254,6 +261,7 @@ class ObjectPlacer:
             env_bboxes_include_yaw=any(orientations for orientations in orientations_per_candidate),
             orientations=orientations_per_candidate,
             collision_objects=collision_objects,
+            device=device,
         )
         self._apply_face_to_orientations(all_positions, orientations_per_candidate)
         # FaceTo yaw is only known after solving, so rebuild from unrotated boxes before validation.

--- a/isaaclab_arena/relations/pooled_object_placer.py
+++ b/isaaclab_arena/relations/pooled_object_placer.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.bounding_box_helpers import has_heterogeneous_objects
+from isaaclab_arena.relations.collision_mode import object_uses_mesh_collision
 from isaaclab_arena.relations.object_placer import ObjectPlacer
 from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_result import PlacementResult
@@ -98,7 +99,14 @@ class PooledObjectPlacer:
         self._env_rngs = get_rngs(self._num_envs, placer_params.placement_seed)
         self._env_pools: list[EnvLayoutPool] = [EnvLayoutPool([]) for _ in range(self._num_envs)]
 
-        self._solve_and_store(pool_size)
+        default_collision_mode = placer_params.solver_params.collision_mode
+        uses_mesh_collision = any(
+            object_uses_mesh_collision(obj, default_collision_mode)
+            for obj in [*self._objects, *self._collision_objects]
+        )
+        # Build-time CUDA Warp initialization can corrupt PhysX Fabric GPU-interoperable rendering.
+        # Runtime refills occur after PhysX/Fabric initialization and can use the default CUDA device.
+        self._solve_and_store(pool_size, device="cpu" if uses_mesh_collision else None)
         for cur_env, pool in enumerate(self._env_pools):
             if not pool.layouts:
                 raise RuntimeError(
@@ -130,7 +138,7 @@ class PooledObjectPlacer:
         self._placer.params.placement_seed = self._base_placement_seed + self._next_seed_offset
         self._next_seed_offset += num_candidates
 
-    def _solve_and_store(self, num_layouts: int) -> None:
+    def _solve_and_store(self, num_layouts: int, device: torch.device | str | None = None) -> None:
         """Solve and store layouts until every env has target_num_layouts_per_env unread layouts.
 
         Bounded by max_placement_attempts; raises if the target cannot be met.
@@ -146,7 +154,7 @@ class PooledObjectPlacer:
 
             batch_size = max_missing * self._num_envs
             allow_fallback = self._allow_best_loss_fallbacks and batch_idx == max_solve_batches - 1
-            ranked_results_per_env, layouts_per_env = self._solve_env_ranked_layouts(batch_size)
+            ranked_results_per_env, layouts_per_env = self._solve_env_ranked_layouts(batch_size, device=device)
             self._store_env_matched_results(
                 ranked_results_per_env,
                 layouts_per_env,
@@ -162,7 +170,9 @@ class PooledObjectPlacer:
             f"{max_solve_batches} solve batches. Available per env: {self._available_per_env()}."
         )
 
-    def _solve_env_ranked_layouts(self, num_layouts: int) -> tuple[list[list[PlacementResult]], int]:
+    def _solve_env_ranked_layouts(
+        self, num_layouts: int, device: torch.device | str | None = None
+    ) -> tuple[list[list[PlacementResult]], int]:
         """Solve ranked layouts tied to each env's actual object geometry.
 
         Returns ranked candidate lists per real env so the pool can store
@@ -181,6 +191,7 @@ class PooledObjectPlacer:
                 num_envs=self._num_envs,
                 results_per_env=layouts_per_env,
                 collision_objects=self._collision_objects,
+                device=device,
             )
 
         return ranked_results_per_env, layouts_per_env

--- a/isaaclab_arena/relations/relation_solver.py
+++ b/isaaclab_arena/relations/relation_solver.py
@@ -189,6 +189,7 @@ class RelationSolver:
         env_bboxes_include_yaw: bool = False,
         orientations: list[dict[PlaceableAsset, float]] | None = None,
         collision_objects: list[CollisionObject] | None = None,
+        device: torch.device | str | None = None,
     ) -> list[dict[PlaceableAsset, tuple[float, float, float]]]:
         """Solve for optimal positions of all objects.
 
@@ -209,12 +210,13 @@ class RelationSolver:
             collision_objects: Optional fixed background obstacles included in the
                 no-overlap collision term only. They are not optimized and carry no
                 relation constraints.
+            device: Solver device. Defaults to CUDA when available, otherwise CPU.
 
         Returns:
             List of dicts (one per env) mapping objects to their solved (x, y, z) positions.
         """
         assert not env_bboxes_include_yaw or env_bboxes is not None, "env_bboxes_include_yaw=True requires env_bboxes."
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
         state = RelationSolverState(
             objects, initial_positions, device=device, env_bboxes=env_bboxes, collision_objects=collision_objects
         )

--- a/isaaclab_arena/tests/test_mesh_collision.py
+++ b/isaaclab_arena/tests/test_mesh_collision.py
@@ -773,6 +773,27 @@ def test_object_collision_mode_can_enable_mesh_in_bbox_solver():
 
 
 @requires_warp
+def test_pooled_mesh_placement_initializes_solver_on_cpu():
+    """Build-time pooled MESH placement avoids CUDA initialization before PhysX Fabric starts."""
+    from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
+    from isaaclab_arena.relations.pooled_object_placer import PooledObjectPlacer
+
+    table = _make_table()
+    a = _make_cylinder("a", radius=0.05)
+    b = _make_cylinder("b", radius=0.05)
+    a.add_relation(On(table))
+    b.add_relation(On(table))
+    params = ObjectPlacerParams(
+        solver_params=RelationSolverParams(collision_mode=CollisionMode.MESH, max_iters=20, verbose=False)
+    )
+
+    pool = PooledObjectPlacer(objects=[table, a, b], placer_params=params, pool_size=1)
+
+    assert pool._placer._solver._mesh_manager is not None
+    assert pool._placer._solver._mesh_manager.device == "cpu"
+
+
+@requires_warp
 def test_mixed_mesh_aabb_uses_per_env_bbox_proxy():
     """AABB-only subjects paired with mesh targets use the candidate/env bbox, not the default bbox."""
     table = _make_table()


### PR DESCRIPTION
## Summary
Avoid Warp CUDA initialization before Fabric startup

## Detailed description
- Initial GPU MESH placement could corrupt PhysX Fabric rendering, causing background geometry and robot parts to disappear.
- Run the initial pooled MESH solve on CPU, while retaining CUDA for runtime pool refills after Fabric initializes.
- Add explicit solver-device propagation and regression coverage.
- Confirmed correct rendering with Fabric GPU interop enabled.

## Benchmark

Replicator kitchen, synchronized `RelationSolver.solve` wall time, batch size 50 (num_envs=1).
isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml"
Before mode used CUDA for every solve; after mode used CPU initially and CUDA for refills.

- Initial: 3.107 s → 8.278 s
- Refill 1: 2.788 s → 3.017 s
- Refill 2: 2.743 s → 2.845 s
- Refill 3: 2.780 s → 2.843 s

The fix adds approximately 5.17 seconds at startup. Runtime refills remain close to the previous CUDA performance.

For batch size 200 (num_envs=4), CPU initial uses ~12s while GPU unchanges. Refills are similar to batch=50.