### PR TITLE
Fix kitchen scene corrupt rendering with fabric due to Warp BVH

### DIFF
--- a/isaaclab_arena/relations/warp_mesh_manager.py
+++ b/isaaclab_arena/relations/warp_mesh_manager.py
@@ -235,6 +235,7 @@ class WarpMeshAndSphereCache:
             indices = wp.array(
                 np.asarray(work_mesh.faces, dtype=np.int32).flatten(), dtype=wp.int32, device=self._device
             )
+            # Default lbvh mode leads to corrupt rendering with Fabric for kitchen_bench envs. Use SAH avoids it.
             self._warp_mesh_cache[key] = wp.Mesh(points=vertices, indices=indices, bvh_constructor="sah")
         return self._warp_mesh_cache[key]
 

--- a/isaaclab_arena/relations/warp_mesh_manager.py
+++ b/isaaclab_arena/relations/warp_mesh_manager.py
@@ -235,7 +235,7 @@ class WarpMeshAndSphereCache:
             indices = wp.array(
                 np.asarray(work_mesh.faces, dtype=np.int32).flatten(), dtype=wp.int32, device=self._device
             )
-            self._warp_mesh_cache[key] = wp.Mesh(points=vertices, indices=indices)
+            self._warp_mesh_cache[key] = wp.Mesh(points=vertices, indices=indices, bvh_constructor="sah")
         return self._warp_mesh_cache[key]
 
     def get_query_spheres(self, mesh: trimesh.Trimesh, obj: CollisionObject | None = None) -> torch.Tensor:


### PR DESCRIPTION
## Summary
Avoid Fabric corruption from Warp LBVH builds by switching to SAH

## Detailed description
- Replicator scenes using GPU MESH placement rendered missing or displaced background and robot geometry; CPU placement and disabling Fabric GPU interop both avoided the issue.
- The reproducer isolated the trigger to constructing the large kitchen CUDA BVH before Fabric initialization: array upload was safe, while BVH construction alone reproduced the corruption without SDF queries.
- CUDA LBVH reproduced the issue consistently, while CUDA SAH and median remained clean, identifying Warp’s pre-Fabric LBVH construction as the trigger.
- Use SAH for Arena collision-mesh BVHs. Isolated one-time BVH construction is about 5.7 ms slower. Batch-50 placement solving time remained unchanged.

Replicator Before (fridge displaced) / After
/isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py --viz kit --policy_type zero_action --num_episodes 1  --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_mustard_bowl.yaml

<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/36594fd0-8457-43b2-97ed-ea6ab5d46516" />
<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/e72d1edc-e803-4468-bacf-f617d3081874" />

Lightwheel Before (stand disappear) / After
/isaac-sim/python.sh isaaclab_arena/evaluation/policy_runner.py --viz kit --policy_type zero_action --num_episodes 1  --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml

<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/60ee0c9b-8897-4fd3-bbe1-a0269b46c48f" />
<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/f75c1c78-d8c2-4e4d-a643-6f837523aa15" />
