### PR TITLE
Support external & internal inference endpoint for agentic env gen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,9 @@ jobs:
     timeout-minutes: 80
     needs: [pre_commit]
     env:
-      # NV_API_KEY is consumed by the live-endpoint tests for agentic env gen.
-      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
+      # CI calls the public inference endpoint only for agentic env-gen tests.
+      ARENA_INFERENCE_ENDPOINT: public
+      NVIDIA_API_KEY: ${{ secrets.ARENA_PUBLIC_NVIDIA_API_KEY }}
 
     container:
       image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
@@ -379,8 +380,10 @@ jobs:
           - variant: source
             uv_flags: ""
     env:
-      # NV_API_KEY is consumed by the live-endpoint tests for agentic env gen.
-      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
+      # CI calls the public inference endpoint only; the agentic env-gen live-endpoint
+      # tests read NVIDIA_API_KEY for it.
+      ARENA_INFERENCE_ENDPOINT: public
+      NVIDIA_API_KEY: ${{ secrets.ARENA_PUBLIC_NVIDIA_API_KEY }}
       # Accept the Isaac Sim EULA so the first launch is non-interactive.
       OMNI_KIT_ACCEPT_EULA: "YES"
       ACCEPT_EULA: "Y"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,9 @@ jobs:
     timeout-minutes: 80
     needs: [pre_commit]
     env:
-      # CI calls the public inference endpoint only for agentic env-gen tests.
-      ARENA_INFERENCE_ENDPOINT: public
-      NVIDIA_API_KEY: ${{ secrets.ARENA_PUBLIC_NVIDIA_API_KEY }}
+      # CI calls the internal inference endpoint for agentic env-gen live-endpoint tests.
+      ARENA_INFERENCE_ENDPOINT: internal
+      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
 
     container:
       image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
@@ -380,10 +380,10 @@ jobs:
           - variant: source
             uv_flags: ""
     env:
-      # CI calls the public inference endpoint only; the agentic env-gen live-endpoint
-      # tests read NVIDIA_API_KEY for it.
-      ARENA_INFERENCE_ENDPOINT: public
-      NVIDIA_API_KEY: ${{ secrets.ARENA_PUBLIC_NVIDIA_API_KEY }}
+      # CI calls the internal inference endpoint; the agentic env-gen live-endpoint
+      # tests read NV_API_KEY for it.
+      ARENA_INFERENCE_ENDPOINT: internal
+      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
       # Accept the Isaac Sim EULA so the first launch is non-interactive.
       OMNI_KIT_ACCEPT_EULA: "YES"
       ACCEPT_EULA: "Y"

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -199,11 +199,13 @@ else
         fi
     fi
 
-    # pass through API keys used by the agentic env-gen prototype; values are
+    # pass through the agentic env-gen endpoint selection and its API keys; values are
     # inherited from the host shell so the key never lives in the repo.
-    if [ -n "$NV_API_KEY" ]; then
-        DOCKER_RUN_ARGS+=("--env" "NV_API_KEY")
-    fi
+    for AGENTIC_ENV_VAR in NV_API_KEY NVIDIA_API_KEY ARENA_INFERENCE_ENDPOINT; do
+        if [ -n "${!AGENTIC_ENV_VAR}" ]; then
+            DOCKER_RUN_ARGS+=("--env" "$AGENTIC_ENV_VAR")
+        fi
+    done
 
     # Allow X11 connections
     xhost +local:docker > /dev/null

--- a/docs/pages/example_workflows/agentic_env_gen/gui_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/gui_runner.rst
@@ -5,6 +5,10 @@ The agentic environment-generation GUI is a Streamlit live editor for creating,
 reviewing, editing, saving, visualizing, and simulation-previewing
 ``ArenaEnvGraphSpec`` YAML files.
 
+What comes back depends on the model behind the selected endpoint — see :doc:`model_selection`.
+Use ``--inference_endpoint`` to pick the endpoint the GUI generates with. Since the model is
+non-deterministic, it's important to review and correct what it returns.
+
 Run the GUI from inside the Isaac Lab-Arena development container:
 
 .. code-block:: bash

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -36,14 +36,29 @@ Every workflow in this section shares the same setup.
 
 :docker_run_default:
 
-The generation agent calls a remote LLM endpoint, so export your API key inside
-the container before launching the runner:
+The generation agent calls a remote LLM endpoint. Pick one and export its API key
+in the shell you launch the agentic environment generation runner from.
 
 .. code-block:: bash
 
-   export NV_API_KEY=<your-api-key>
+   # Publicly reachable build.nvidia.com endpoint (default)
+   export ARENA_INFERENCE_ENDPOINT=public
+   export NVIDIA_API_KEY=<your-ngc-api-key>
 
-.. todo:: add instructions for obtaining the NVIDIA-hosted service API key (internal and external)
+   # NVIDIA-internal endpoint
+   export ARENA_INFERENCE_ENDPOINT=internal
+   export NV_API_KEY=<your-internal-api-key>
+
+A single run can override the selection with ``--inference_endpoint {internal,public}``.
+
+Generate a key for the public endpoint at
+`build.nvidia.com API keys <https://build.nvidia.com/settings/api-keys>`_, and a key for the
+NVIDIA-internal endpoint at
+`inference.nvidia.com key management <https://inference.nvidia.com/key-management>`_
+(reachable from the NVIDIA network only).
+
+Each endpoint calls a different model, and the generated environment changes with it. See
+:doc:`model_selection` for what the model decides, what Arena validates, and how to select the model.
 
 Available Generated Environments
 --------------------------------
@@ -79,3 +94,4 @@ Warnings
    kitchen_pick_and_place/index
    kitchen_open_door/index
    gui_runner
+   model_selection

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/index.rst
@@ -29,6 +29,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+The spec shown here depends on the model behind that endpoint — see :doc:`../model_selection`.
 
 Workflow Steps
 ^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/index.rst
@@ -29,6 +29,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+The spec shown here depends on the model behind that endpoint — see :doc:`../model_selection`.
 
 Workflow Steps
 ^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
@@ -1,0 +1,83 @@
+.. _agentic-env-gen-model-choice:
+
+Inference Model and Spec Quality
+================================
+
+How Arena Uses the Model
+-------------------------
+
+Arena does not reason about the scene. It builds a prompt from the catalogs, asks the model for a
+JSON object matching the ``ArenaEnvGraphSpec`` schema, and validates the result. The model decides
+what the environment contains. Arena only checks that the answer is admissible: each
+``registry_name`` is registered, each relation kind exists, and each ``prim_path`` is in the
+background's prim tree. A bad answer is rejected and saved as ``invalid_<name>.yaml`` with trace
+lines, but Arena cannot fix it. The model must support OpenAI-compatible structured outputs
+(``response_format={"type": "json_schema", "strict": true}``).
+
+Why Spec Quality Varies
+-------------------------
+
+Spec quality tracks model capability. Context length is usually the limiting factor: each pass
+sends the full catalog in one request, and a model that cannot hold it answers from the part it
+saw. This shows up as an unregistered asset name or an out-of-tree ``prim_path``, not as a length
+error. Weaker models also:
+
+* invent asset names
+* drop objects
+* anchor the scene to the background instead of the counter
+* collapse five parallel pick-and-places into one atomic task
+* pick a plausible-but-wrong prim out of several similar ones
+
+Prompt Size at Scale
+----------------------
+
+Spec inference sends roughly 15 000 characters of catalogs. Prim path resolution sends the
+background's entire prim tree — about 30 000 characters (10 000 tokens) for
+``lightwheel_robocasa_kitchen`` (886 prims) — so a short-context model fails on that pass first.
+Print the current catalog with ``--mode catalog``.
+
+Selecting the Model
+-------------------
+
+Each endpoint preset has its own default model, so switching endpoints switches models (see
+:ref:`agentic-env-gen-prerequisites`). The CLI runner overrides it per run with ``--model`` and
+``--temperature``; the GUI runner only selects the endpoint, and uses that endpoint's default
+model. For the public endpoint, any model in the
+`NVIDIA NIM LLM API reference <https://docs.api.nvidia.com/nim/reference/llm-apis>`_ works, as long
+as it supports strict structured outputs — a larger context window buys more reliable prim path
+resolution.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - ``ARENA_INFERENCE_ENDPOINT``
+     - Default model
+     - API key variable
+   * - ``public`` (default)
+     - ``openai/gpt-oss-120b``
+     - ``NVIDIA_API_KEY``
+   * - ``internal``
+     - ``azure/anthropic/claude-opus-4-8``
+     - ``NV_API_KEY``
+
+Reviewing the Generated Spec
+----------------------------
+
+Output is non-deterministic, even at ``--temperature 0``. Validation only proves a spec is
+admissible, not that it is the environment you asked for. Review every generated spec in the
+:doc:`GUI live editor <gui_runner>` before generating data or evaluating a policy against it:
+
+* **Objects** — every object the prompt asked for is there, with no invented extras, and each
+  ``registry_name`` is the asset you meant rather than a same-sounding sibling.
+* **Anchor and relations** — the ``is_anchor`` subject is what the scene should be built around
+  (the counter, not the background), and each ``on`` / ``next_to`` reference points at the
+  intended node. This decides where the robot ends up.
+* **Task** — the composition (``atomic`` / ``sequential`` / ``parallel``) matches the prompt, with
+  one subtask per action and ``pick_up_object`` / ``destination_location`` not swapped.
+* **Object references** — the resolved ``prim_path`` is the right prim out of the several similar
+  ones a background offers, and an opened articulation carries the correct ``openable_joint_name``.
+* **Sim preview** — run it. Objects intersecting geometry, or a robot that cannot reach the task
+  objects, show up here and nowhere in validation.
+
+The reviewed YAML can be used to reproduce the environment, but re-running the prompt to create the environment is not.

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/index.rst
@@ -34,6 +34,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+The spec shown here depends on the model behind that endpoint — see :doc:`../model_selection`.
 
 Workflow Steps
 ^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
@@ -1,8 +1,10 @@
 Edit the Environment Graph Spec
 -------------------------------
 
-You may want to review or edit the spec before building the environment. The agent infers the spec from the
-prompt using a LLM model, and may be mistaken in its choices.
+Review the spec before building the environment. The agent infers it from the prompt with an
+LLM, so what comes back is non-deterministic: the same prompt can return a different spec on
+the next run, and a spec that validates can still be mistaken in its choices. See
+:doc:`../model_selection` for more details.
 For a composite task, check that the subtask list covers every pick and place pair you asked for, and that the SimReady hits are the assets you expected.
 
 Understanding the YAML

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/index.rst
@@ -35,6 +35,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+The spec shown here depends on the model behind that endpoint — see :doc:`../model_selection`.
 
 Workflow Steps
 ^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
@@ -1,8 +1,10 @@
 Edit the Environment Graph Spec
 -------------------------------
 
-You may want to review or edit the spec before building the environment. The agent infers the spec from the
-prompt using a LLM model, and may be mistaken in its choices.
+Review the spec before building the environment. The agent infers it from the prompt with an
+LLM, so what comes back is non-deterministic: the same prompt can return a different spec on
+the next run, and a spec that validates can still be mistaken in its choices. See
+:doc:`../model_selection` for more details.
 For an object set, check that the members are the assets you expected as those are added based on semantic similarity by the agent.
 
 Understanding the YAML

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/index.rst
@@ -28,6 +28,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+The spec shown here depends on the model behind that endpoint — see :doc:`../model_selection`.
 
 Workflow Steps
 ^^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
@@ -1,8 +1,10 @@
 Edit the Environment Graph Spec
 -------------------------------
 
-You may want to review or edit the spec before building the environment. The agent infers the spec from the
-prompt using a LLM model, and could be mistaken in its choices.
+Review the spec before building the environment. The agent infers it from the prompt with an
+LLM, so what comes back is non-deterministic: the same prompt can return a different spec on
+the next run, and a spec that validates can still be mistaken in its choices. See
+:doc:`../model_selection` for more details.
 You could add or remove objects or change the spatial relationships between objects.
 
 Understanding the YAML

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -43,6 +43,7 @@ class EnvironmentGenerationAgent:
         temperature: float = 0.2,
         max_tokens: int = 4096,
         max_retries: int = 3,
+        endpoint: str | None = None,
         *,
         enable_simready_search: bool = False,
         simready_config: SimReadySearchConfig | None = None,
@@ -50,8 +51,8 @@ class EnvironmentGenerationAgent:
         """Configure the OpenAI-compatible client and validate the model.
 
         Args:
-            api_key: API token for the inference endpoint. Falls back
-                to the ``NV_API_KEY`` environment variable.
+            api_key: API token for the inference endpoint. Falls back to the environment
+                variable the selected endpoint reads.
             model: Model identifier at the inference endpoint.
                 Must support OpenAI-compatible structured outputs.
             base_url: OpenAI-compatible inference endpoint.
@@ -63,6 +64,8 @@ class EnvironmentGenerationAgent:
             max_retries: Number of additional attempts after a recoverable failure
                 (network errors, timeouts, empty responses, malformed JSON). Each
                 retry is a fresh API call.
+            endpoint: Inference endpoint name, ``internal`` or ``public``. Falls back to
+                the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
             enable_simready_search: When ``True``, search SimReady for objects the asset catalog
                 does not cover.
             simready_config: Optional SimReady search configuration.
@@ -74,6 +77,7 @@ class EnvironmentGenerationAgent:
             temperature=temperature,
             max_tokens=max_tokens,
             max_retries=max_retries,
+            endpoint=endpoint,
         )
         self.spec_inference = SpecInference(inference_backend)
         self.missing_object_inference = MissingObjectInference(inference_backend)

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -19,9 +19,51 @@ from pydantic import BaseModel
 
 MAX_RETRIES_LIMIT = 10
 
-# TODO(qianl): This is currently Nvidia internal. Switch to public endpoint.
-DEFAULT_BASE_URL = "https://inference-api.nvidia.com"
-DEFAULT_MODEL = "azure/anthropic/claude-opus-4-8"
+INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
+INTERNAL_MODEL = "azure/anthropic/claude-opus-4-8"
+PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
+PUBLIC_MODEL = "openai/gpt-oss-120b"
+
+INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
+"""Environment variable naming the inference endpoint every agentic command uses."""
+
+
+@dataclass(frozen=True)
+class InferenceEndpoint:
+    """One named inference endpoint: where to call, which model, and which API key to read."""
+
+    name: str
+    base_url: str
+    model: str
+    api_key_env_var: str
+
+
+INTERNAL_ENDPOINT = InferenceEndpoint("internal", INTERNAL_BASE_URL, INTERNAL_MODEL, "NV_API_KEY")
+"""NVIDIA-internal inference endpoint, reached with an internal API key."""
+
+PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")
+"""Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""
+
+INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT)}
+DEFAULT_ENDPOINT_NAME = PUBLIC_ENDPOINT.name
+
+
+def resolve_inference_endpoint(name: str | None = None) -> InferenceEndpoint:
+    """Return the inference endpoint named by ``name``, the environment, or the default.
+
+    Args:
+        name: Endpoint name, or ``None`` to read ``ARENA_INFERENCE_ENDPOINT`` and fall back
+            to the public endpoint.
+
+    Returns:
+        The selected endpoint preset.
+    """
+    resolved = name or os.getenv(INFERENCE_ENDPOINT_ENV_VAR) or DEFAULT_ENDPOINT_NAME
+    assert resolved in INFERENCE_ENDPOINTS, (
+        f"Unknown inference endpoint {resolved!r}: set {INFERENCE_ENDPOINT_ENV_VAR} to one of "
+        f"{sorted(INFERENCE_ENDPOINTS)}"
+    )
+    return INFERENCE_ENDPOINTS[resolved]
 
 
 @dataclass(frozen=True)
@@ -46,33 +88,53 @@ class InferenceBackend:
         temperature: float = 0.2,
         max_tokens: int = 4096,
         max_retries: int = 3,
+        endpoint: str | None = None,
     ):
         """Configure an OpenAI-compatible structured-output client.
 
         Args:
-            api_key: API token for the inference endpoint. Falls back to the
-                ``NV_API_KEY`` environment variable.
-            model: Model identifier passed to the chat completion API.
-            base_url: OpenAI-compatible inference endpoint.
+            api_key: API token for the inference endpoint. Falls back to the environment
+                variable the selected endpoint reads.
+            model: Model identifier passed to the chat completion API. Defaults to the
+                selected endpoint's model.
+            base_url: OpenAI-compatible inference endpoint. Defaults to the selected
+                endpoint's base URL.
             temperature: Sampling temperature for completion requests.
             max_tokens: Maximum tokens in each completion response.
             max_retries: Additional attempts after a recoverable failure; must be in
                 ``[0, MAX_RETRIES_LIMIT)``.
+            endpoint: Inference endpoint name, ``internal`` or ``public``. Falls back to
+                the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
         """
         assert (
             0 <= max_retries < MAX_RETRIES_LIMIT
         ), f"max_retries must be in [0, {MAX_RETRIES_LIMIT}), got {max_retries}"
-        resolved_api_key = api_key or os.getenv("NV_API_KEY")
-        assert resolved_api_key, "API key required: set NV_API_KEY or pass api_key."
-        resolved_base_url = base_url or DEFAULT_BASE_URL
-        resolved_model = model or DEFAULT_MODEL
+        inference_endpoint = resolve_inference_endpoint(endpoint)
+        resolved_api_key = api_key or os.getenv(inference_endpoint.api_key_env_var)
+        assert resolved_api_key, (
+            f"API key required for the {inference_endpoint.name!r} inference endpoint: set "
+            f"{inference_endpoint.api_key_env_var} or pass api_key. Select another endpoint with "
+            f"{INFERENCE_ENDPOINT_ENV_VAR}."
+        )
+        resolved_base_url = base_url or inference_endpoint.base_url
+        resolved_model = model or inference_endpoint.model
+        print(
+            f"[inference] endpoint {inference_endpoint.name!r} model {resolved_model!r} at {resolved_base_url}",
+            flush=True,
+        )
         client = OpenAI(api_key=resolved_api_key, base_url=resolved_base_url)
         self._client: OpenAI = client
+        self._endpoint = inference_endpoint
         self._model = resolved_model
         self._temperature = temperature
         self._max_tokens = max_tokens
         self._max_retries = max_retries
         _ping(client, resolved_model)
+
+    @property
+    def endpoint(self) -> InferenceEndpoint:
+        """Inference endpoint preset the client was configured from."""
+        return self._endpoint
 
     @property
     def model(self) -> str:

--- a/isaaclab_arena/agentic_environment_generation/spec_io.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_io.py
@@ -7,12 +7,17 @@
 
 from __future__ import annotations
 
+import json
 import re
+import yaml
 from pathlib import Path
+from typing import Any
 
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 DEFAULT_AGENTIC_OUTPUT_DIR = Path("isaaclab_arena_environments/agent_generated")
+INVALID_SPEC_FILENAME_PREFIX = "invalid_"
+"""Filename prefix marking a written spec as one that failed validation."""
 
 
 def safe_filename_stem(name: str) -> str:
@@ -31,4 +36,31 @@ def write_env_graph_spec(graph_spec: ArenaEnvGraphSpec, out_dir: Path) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     path = env_graph_spec_path(graph_spec.env_name, out_dir)
     graph_spec.write_yaml(path)
+    return path
+
+
+def rejected_env_graph_spec_path(env_name: str, out_dir: Path) -> Path:
+    """Return the graph-spec YAML path for a rejected ``env_name`` under ``out_dir``."""
+    return out_dir / f"{INVALID_SPEC_FILENAME_PREFIX}{safe_filename_stem(env_name)}.yaml"
+
+
+def write_rejected_env_graph_spec(graph_spec_data: dict[str, Any], out_dir: Path, traces: tuple[str, ...] = ()) -> Path:
+    """Dump a rejected environment graph spec to YAML under ``out_dir``, named as invalid.
+    Args:
+        graph_spec_data: Rejected spec as the agent returned it.
+        out_dir: Directory to write into, created when missing.
+        traces: Validation failures, written above the spec as YAML comments.
+
+    Returns:
+        The path written.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    env_name = graph_spec_data.get("env_name")
+    path = rejected_env_graph_spec_path(env_name if isinstance(env_name, str) else "", out_dir)
+    header = "".join(f"# {line}\n" for line in ("this spec failed validation:", *traces))
+    # A rejected spec can hold whatever the model returned, so render the values YAML cannot.
+    plain_data = json.loads(json.dumps(graph_spec_data, default=str))
+    with path.open("w", encoding="utf-8") as f:
+        f.write(header)
+        yaml.safe_dump(plain_data, f, sort_keys=False, default_flow_style=False)
     return path

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import os
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +30,7 @@ from isaaclab_arena.tests.utils.agentic_environment_generation import (
     kitchen_resolve_response,
     minimal_spec_dict,
     relation_catalog,
+    skip_without_live_endpoint_key,
 )
 from isaaclab_arena.tests.utils.agentic_environment_generation import task_catalog as make_task_catalog
 
@@ -361,7 +361,7 @@ def _assert_five_bananas_parallel_pick_and_place_spec(spec: ArenaEnvGraphSpec) -
 
 # Marked flaky to absorb intermittent wire-level hiccups on the inference endpoint.
 # TODO(qianl): drop the flaky marker once production-side retry is implemented.
-@pytest.mark.skipif(not os.environ.get("NV_API_KEY"), reason="live endpoint test requires NV_API_KEY")
+@skip_without_live_endpoint_key()
 @pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_generate_spec_atomic_pick_and_place_against_live_endpoint():
     """Live test: avocado into bowl yields an atomic pick-and-place task."""
@@ -372,7 +372,7 @@ def test_generate_spec_atomic_pick_and_place_against_live_endpoint():
     _assert_atomic_pick_and_place_spec(spec)
 
 
-@pytest.mark.skipif(not os.environ.get("NV_API_KEY"), reason="live endpoint test requires NV_API_KEY")
+@skip_without_live_endpoint_key()
 @pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_generate_spec_five_bananas_parallel_pick_and_place_against_live_endpoint():
     """Live test: five bananas into one bin yields a parallel composite task."""
@@ -383,7 +383,7 @@ def test_generate_spec_five_bananas_parallel_pick_and_place_against_live_endpoin
     _assert_five_bananas_parallel_pick_and_place_spec(spec)
 
 
-@pytest.mark.skipif(not os.environ.get("NV_API_KEY"), reason="live endpoint test requires NV_API_KEY")
+@skip_without_live_endpoint_key()
 @pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_resolve_usd_prim_robocasa_kitchen_counter_and_fridge():
     """End-to-end pass-1 + pass-2 prim resolution for Robocasa kitchen counter and fridge."""

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -13,9 +13,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
-    DEFAULT_BASE_URL,
+    INFERENCE_ENDPOINT_ENV_VAR,
+    INTERNAL_ENDPOINT,
+    PUBLIC_ENDPOINT,
     InferenceBackend,
     StructuredOutputRequest,
+    resolve_inference_endpoint,
 )
 from isaaclab_arena.tests.utils.agentic_environment_generation import chat_response, inference_backend
 
@@ -41,23 +44,70 @@ def _spec_request() -> StructuredOutputRequest:
     )
 
 
+@pytest.fixture(autouse=True)
+def clean_endpoint_env(monkeypatch):
+    """Keep the developer's endpoint selection out of endpoint-resolution tests."""
+    monkeypatch.delenv(INFERENCE_ENDPOINT_ENV_VAR, raising=False)
+    monkeypatch.delenv(INTERNAL_ENDPOINT.api_key_env_var, raising=False)
+    monkeypatch.delenv(PUBLIC_ENDPOINT.api_key_env_var, raising=False)
+
+
+class TestResolveInferenceEndpoint:
+    def test_defaults_to_the_public_endpoint(self):
+        assert resolve_inference_endpoint() == PUBLIC_ENDPOINT
+
+    def test_reads_the_environment_variable(self, monkeypatch):
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, INTERNAL_ENDPOINT.name)
+        assert resolve_inference_endpoint() == INTERNAL_ENDPOINT
+
+    def test_explicit_name_overrides_the_environment_variable(self, monkeypatch):
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, INTERNAL_ENDPOINT.name)
+        assert resolve_inference_endpoint(PUBLIC_ENDPOINT.name) == PUBLIC_ENDPOINT
+
+    def test_raises_on_an_unknown_name(self):
+        with pytest.raises(AssertionError, match="Unknown inference endpoint"):
+            resolve_inference_endpoint("staging")
+
+
 class TestInit:
     def test_explicit_api_key_overrides_env(self, monkeypatch, stub_openai):
         mock_cls, _ = stub_openai
-        monkeypatch.setenv("NV_API_KEY", "env-key")
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "env-key")
         InferenceBackend(api_key="explicit-key")
-        mock_cls.assert_called_once_with(api_key="explicit-key", base_url=DEFAULT_BASE_URL)
+        mock_cls.assert_called_once_with(api_key="explicit-key", base_url=PUBLIC_ENDPOINT.base_url)
 
     def test_falls_back_to_env_var(self, monkeypatch, stub_openai):
         mock_cls, _ = stub_openai
-        monkeypatch.setenv("NV_API_KEY", "env-key")
-        InferenceBackend()
-        mock_cls.assert_called_once_with(api_key="env-key", base_url=DEFAULT_BASE_URL)
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "env-key")
+        backend = InferenceBackend()
+        assert backend.model == PUBLIC_ENDPOINT.model
+        mock_cls.assert_called_once_with(api_key="env-key", base_url=PUBLIC_ENDPOINT.base_url)
 
-    def test_raises_when_no_key_anywhere(self, monkeypatch, stub_openai):
-        monkeypatch.delenv("NV_API_KEY", raising=False)
-        with pytest.raises(AssertionError, match="API key required"):
+    def test_raises_when_no_key_anywhere(self, stub_openai):
+        with pytest.raises(AssertionError, match=f"set {PUBLIC_ENDPOINT.api_key_env_var}"):
             InferenceBackend()
+
+    def test_selected_endpoint_sets_base_url_model_and_key(self, monkeypatch, stub_openai):
+        mock_cls, _ = stub_openai
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, INTERNAL_ENDPOINT.name)
+        monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
+        backend = InferenceBackend()
+        assert backend.endpoint == INTERNAL_ENDPOINT
+        assert backend.model == INTERNAL_ENDPOINT.model
+        mock_cls.assert_called_once_with(api_key="internal-key", base_url=INTERNAL_ENDPOINT.base_url)
+
+    def test_endpoint_argument_overrides_env_var(self, monkeypatch, stub_openai):
+        mock_cls, _ = stub_openai
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, INTERNAL_ENDPOINT.name)
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
+        backend = InferenceBackend(endpoint=PUBLIC_ENDPOINT.name)
+        assert backend.model == PUBLIC_ENDPOINT.model
+        mock_cls.assert_called_once_with(api_key="public-key", base_url=PUBLIC_ENDPOINT.base_url)
+
+    def test_key_of_the_other_endpoint_is_not_used(self, monkeypatch, stub_openai):
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
+        with pytest.raises(AssertionError, match=f"set {INTERNAL_ENDPOINT.api_key_env_var}"):
+            InferenceBackend(endpoint=INTERNAL_ENDPOINT.name)
 
     def test_custom_model_and_base_url(self, stub_openai):
         mock_cls, _ = stub_openai

--- a/isaaclab_arena/tests/test_missing_object_inference.py
+++ b/isaaclab_arena/tests/test_missing_object_inference.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 
 import pytest
 
@@ -19,7 +18,11 @@ from isaaclab_arena.agentic_environment_generation.missing_object_inference impo
     MissingObjectInference,
 )
 from isaaclab_arena.tests.utils.agentic_environment_generation import catalog as make_catalog
-from isaaclab_arena.tests.utils.agentic_environment_generation import chat_response, inference_backend
+from isaaclab_arena.tests.utils.agentic_environment_generation import (
+    chat_response,
+    inference_backend,
+    skip_without_live_endpoint_key,
+)
 
 INFERENCE_LOGGER = "isaaclab_arena.agentic_environment_generation.missing_object_inference"
 """Where this pass reports what it found; the agent's traces carry only errors."""
@@ -91,7 +94,7 @@ _LIVE_CATALOG = (
 
 
 # Marked flaky to absorb intermittent wire-level hiccups on the inference endpoint.
-@pytest.mark.skipif(not os.environ.get("NV_API_KEY"), reason="live endpoint test requires NV_API_KEY")
+@skip_without_live_endpoint_key()
 @pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_infer_names_the_uncatalogued_object_against_live_endpoint():
     """Live test: the one object the catalog has no match for comes back as a search phrase."""
@@ -103,7 +106,7 @@ def test_infer_names_the_uncatalogued_object_against_live_endpoint():
     assert any("watering can" in phrase.lower() for phrase in phrases), f"got {phrases!r}"
 
 
-@pytest.mark.skipif(not os.environ.get("NV_API_KEY"), reason="live endpoint test requires NV_API_KEY")
+@skip_without_live_endpoint_key()
 @pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_infer_names_nothing_when_the_catalog_covers_the_prompt_against_live_endpoint():
     """Live test: a prompt every object of which is catalogued searches for nothing."""

--- a/isaaclab_arena/tests/test_spec_io.py
+++ b/isaaclab_arena/tests/test_spec_io.py
@@ -5,7 +5,13 @@
 
 from __future__ import annotations
 
-from isaaclab_arena.agentic_environment_generation.spec_io import safe_filename_stem
+import yaml
+
+from isaaclab_arena.agentic_environment_generation.spec_io import (
+    rejected_env_graph_spec_path,
+    safe_filename_stem,
+    write_rejected_env_graph_spec,
+)
 
 
 class TestSafeFilenameStem:
@@ -16,3 +22,19 @@ class TestSafeFilenameStem:
     def test_empty_or_all_unsafe_falls_back(self):
         assert safe_filename_stem("") == "unnamed_env"
         assert safe_filename_stem("///") == "unnamed_env"
+
+
+class TestWriteRejectedEnvGraphSpec:
+    def test_writes_invalid_prefixed_yaml_with_traces(self, tmp_path):
+        data = {"env_name": "droid pick place", "objects": [{"id": "bowl", "registry_name": "not_a_real_asset"}]}
+        path = write_rejected_env_graph_spec(data, tmp_path, ("objects.0: Unknown asset registry_name",))
+        assert path == rejected_env_graph_spec_path("droid pick place", tmp_path)
+        assert path.name == "invalid_droid_pick_place.yaml"
+        text = path.read_text(encoding="utf-8")
+        assert "# objects.0: Unknown asset registry_name" in text
+        assert yaml.safe_load(text) == data
+
+    def test_writes_unnamed_spec_holding_unserializable_values(self, tmp_path):
+        path = write_rejected_env_graph_spec({"objects": [{"id": object()}]}, tmp_path)
+        assert path.name == "invalid_unnamed_env.yaml"
+        assert isinstance(yaml.safe_load(path.read_text(encoding="utf-8"))["objects"][0]["id"], str)

--- a/isaaclab_arena/tests/utils/agentic_environment_generation.py
+++ b/isaaclab_arena/tests/utils/agentic_environment_generation.py
@@ -45,6 +45,19 @@ def stub_openai():
         yield mock_cls, client
 
 
+def skip_without_live_endpoint_key() -> pytest.MarkDecorator:
+    """Return a skip marker for tests that call the selected inference endpoint for real."""
+    import os
+
+    from isaaclab_arena.agentic_environment_generation.inference_backend import resolve_inference_endpoint
+
+    endpoint = resolve_inference_endpoint()
+    return pytest.mark.skipif(
+        not os.environ.get(endpoint.api_key_env_var),
+        reason=f"live endpoint test requires {endpoint.api_key_env_var} for the {endpoint.name!r} endpoint",
+    )
+
+
 def inference_backend(stub_openai, *, model: str = "test-model", max_retries: int = 3) -> InferenceBackend:
     """Build an ``InferenceBackend`` against the patched OpenAI client from ``stub_openai``."""
     from isaaclab_arena.agentic_environment_generation.inference_backend import InferenceBackend

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -32,13 +32,18 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import DEFAULT_ENDPOINT_NAME, INFERENCE_ENDPOINTS
-from isaaclab_arena.agentic_environment_generation.spec_io import DEFAULT_AGENTIC_OUTPUT_DIR, write_env_graph_spec
+from isaaclab_arena.agentic_environment_generation.spec_io import (
+    DEFAULT_AGENTIC_OUTPUT_DIR,
+    write_env_graph_spec,
+    write_rejected_env_graph_spec,
+)
 from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 
@@ -175,7 +180,7 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path | None:
     if args_cli.inference_endpoint:
         agent_kwargs["endpoint"] = args_cli.inference_endpoint
     agent = EnvironmentGenerationAgent(**agent_kwargs)
-    env_graph_spec, _ = agent.generate_spec(
+    env_graph_spec, rejected = agent.generate_spec(
         args_cli.prompt,
         asset_catalog=asset_catalog,
         relation_catalog=relation_catalog,
@@ -185,10 +190,15 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path | None:
     #   "embodiment.registry_name: Unknown asset registry_name 'not_a_real_asset'"
     #   "Task 'PickAndPlaceTask' is missing required param 'pick_up_object'"
     if env_graph_spec is None:
-        print("\n[runner] the agent returned an invalid spec. Nothing was written.", flush=True)
+        print("\n[runner] the agent returned an invalid spec.", flush=True)
         print("\n[runner] validation traces:", flush=True)
         for line in agent.traces:
             print(f"  {line}", flush=True)
+        # Print and write the rejected response so it can be read, or fixed by hand, without
+        # re-running the prompt.
+        print(f"\n[runner] rejected spec:\n{json.dumps(rejected, indent=2, default=str)}", flush=True)
+        rejected_path = write_rejected_env_graph_spec(rejected or {}, args_cli.out_dir, agent.traces)
+        print(f"\n[runner] wrote rejected environment graph spec → {rejected_path}", flush=True)
         return None
     # The spec is valid either way: an object no asset was found for was never offered to spec
     # inference, so it was built without it. Say so, or the substitution goes unnoticed.
@@ -211,8 +221,6 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path | None:
 
 def print_schema() -> None:
     """Print the Pydantic ArenaEnvGraphSpec JSON schema."""
-    import json
-
     from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
     print(json.dumps(ArenaEnvGraphSpec.model_json_schema(), indent=2))

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -37,6 +37,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from isaaclab_arena.agentic_environment_generation.inference_backend import DEFAULT_ENDPOINT_NAME, INFERENCE_ENDPOINTS
 from isaaclab_arena.agentic_environment_generation.spec_io import DEFAULT_AGENTIC_OUTPUT_DIR, write_env_graph_spec
 from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
@@ -78,6 +79,16 @@ def add_agentic_env_gen_runner_cli_args(parser: argparse.ArgumentParser) -> None
         type=str,
         default=None,
         help="Override the LLM model id (default: agent's built-in default).",
+    )
+    group.add_argument(
+        "--inference_endpoint",
+        type=str,
+        choices=tuple(INFERENCE_ENDPOINTS),
+        default=None,
+        help=(
+            "Inference endpoint to call (default: the ARENA_INFERENCE_ENDPOINT environment variable, "
+            f"else '{DEFAULT_ENDPOINT_NAME}')."
+        ),
     )
     group.add_argument(
         "--temperature",
@@ -161,6 +172,8 @@ def resolve_env_spec(args_cli: argparse.Namespace) -> Path | None:
     }
     if args_cli.model:
         agent_kwargs["model"] = args_cli.model
+    if args_cli.inference_endpoint:
+        agent_kwargs["endpoint"] = args_cli.inference_endpoint
     agent = EnvironmentGenerationAgent(**agent_kwargs)
     env_graph_spec, _ = agent.generate_spec(
         args_cli.prompt,

--- a/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
@@ -31,6 +31,11 @@ import sys
 import tempfile
 from pathlib import Path
 
+from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    DEFAULT_ENDPOINT_NAME,
+    INFERENCE_ENDPOINT_ENV_VAR,
+    INFERENCE_ENDPOINTS,
+)
 from isaaclab_arena.agentic_environment_generation.spec_io import DEFAULT_AGENTIC_OUTPUT_DIR
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
     SIMAPP_SOCKET_ENV,
@@ -68,12 +73,41 @@ def main() -> None:
         default=8501,
         help="Streamlit server port (default: 8501).",
     )
+    parser.add_argument(
+        "--inference_endpoint",
+        type=str,
+        choices=tuple(INFERENCE_ENDPOINTS),
+        default=None,
+        help=(
+            "Inference endpoint the generation agent calls (default: the ARENA_INFERENCE_ENDPOINT "
+            f"environment variable, else '{DEFAULT_ENDPOINT_NAME}')."
+        ),
+    )
     args = parser.parse_args()
-    serve_live_editor(args.env_graph_spec_yaml, out_dir=args.out_dir, port=args.port)
+    serve_live_editor(
+        args.env_graph_spec_yaml,
+        out_dir=args.out_dir,
+        port=args.port,
+        inference_endpoint=args.inference_endpoint,
+    )
 
 
-def serve_live_editor(yaml_path: Path | None, *, out_dir: Path = DEFAULT_AGENTIC_OUTPUT_DIR, port: int = 8501) -> None:
-    """Start the SimApp server, spawn Streamlit, and supervise both until exit."""
+def serve_live_editor(
+    yaml_path: Path | None,
+    *,
+    out_dir: Path = DEFAULT_AGENTIC_OUTPUT_DIR,
+    port: int = 8501,
+    inference_endpoint: str | None = None,
+) -> None:
+    """Start the SimApp server, spawn Streamlit, and supervise both until exit.
+
+    Args:
+        yaml_path: Optional spec YAML to open in the editor.
+        out_dir: Directory the editor writes generated spec YAML into.
+        port: Streamlit server port.
+        inference_endpoint: Inference endpoint name handed to the Streamlit process, or ``None``
+            to leave the environment's own selection in place.
+    """
     app_path = _REVIEW_GUI_DIR / "streamlit_ui.py"
     assert app_path.exists(), f"Streamlit app not found at {app_path} — installation is incomplete."
 
@@ -95,6 +129,8 @@ def serve_live_editor(yaml_path: Path | None, *, out_dir: Path = DEFAULT_AGENTIC
         env = os.environ.copy()
         if active_socket is not None:
             env[SIMAPP_SOCKET_ENV] = str(active_socket)
+        if inference_endpoint is not None:
+            env[INFERENCE_ENDPOINT_ENV_VAR] = inference_endpoint
 
         cmd = [
             sys.executable,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -21,6 +21,7 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
     build_relation_catalogue,
     build_task_catalogue,
 )
+from isaaclab_arena.agentic_environment_generation.inference_backend import resolve_inference_endpoint
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadySearchConfig,
     SimReadySourceKind,
@@ -70,7 +71,7 @@ def _simready_config_from_session() -> SimReadySearchConfig:
 
 
 def _get_generation_agent() -> EnvironmentGenerationAgent | None:
-    """Lazy-init the LLM agent when ``NV_API_KEY`` is available."""
+    """Lazy-init the LLM agent when the selected inference endpoint's API key is available."""
     if st.session_state.get("generation_agent_error"):
         return None
     simready_enabled = bool(st.session_state.get("enable_simready_search", False))
@@ -150,7 +151,7 @@ def run_generation_pipeline(prompt: str) -> tuple[bool, str]:
     if agent is None:
         err = st.session_state.get(
             "generation_agent_error",
-            "Set NV_API_KEY in the environment before generating specs.",
+            f"Set {resolve_inference_endpoint().api_key_env_var} in the environment before generating specs.",
         )
         return False, err
 


### PR DESCRIPTION
## Summary
Support external & internal inference endpoint

## Detailed description
- Add both internal and public endpoints and mechanism to switch. Tape CI to use public endpoint with my personal key.
- Logged invalid spec to disk with a prefix "invalid_" and log on terminals how it's invalid against  the catalogue.
- Added doc to inform how to choose model/endpoint and Arena is not in charge of the model quality.
- CI still using internal endpoint. Support to enable current sampling workflows with the public endpoint will come a follow up PR.
