### PR TITLE
[Doc] New concept page explaining the two ways to define an Arena environment 

### DIFF
--- a/docs/images/env_spec_py_yaml.png
+++ b/docs/images/env_spec_py_yaml.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8896476e2b5f73d8065c18a803eb9b4f26c56ef241b84c875dc29bf93b81f7fc
+size 22239

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -323,8 +323,7 @@ TABLE OF CONTENTS
    :maxdepth: 1
    :caption: Concepts
 
-   pages/concepts/concept_overview
-   pages/concepts/concept_environment_compilation
+   pages/concepts/environment/index
    pages/concepts/scene/index
    pages/concepts/task/index
    pages/concepts/embodiment/index

--- a/docs/pages/concepts/concept_object_and_robot_placement.rst
+++ b/docs/pages/concepts/concept_object_and_robot_placement.rst
@@ -107,7 +107,7 @@ Use this table as a reading map:
    * - Environment compilation
      - How ``ArenaEnvBuilder`` turns an Arena environment definition into an
        Isaac Lab environment configuration
-     - :doc:`concept_environment_compilation`
+     - :doc:`environment/env_builder`
    * - Spatial relations and anchors
      - How to mark fixed references and describe intended positions and
        orientations

--- a/docs/pages/concepts/environment/env_builder.rst
+++ b/docs/pages/concepts/environment/env_builder.rst
@@ -1,5 +1,5 @@
-Environment Compilation
-=======================
+Environment Builder
+===================
 
 Environment compilation is the step that turns the three independent components —
 scene, embodiment, and task — into a runnable Isaac Lab environment.
@@ -7,7 +7,7 @@ scene, embodiment, and task — into a runnable Isaac Lab environment.
 component contributes and merging them into a single
 ``ManagerBasedRLEnvCfg``.
 
-.. figure:: ../../images/arena_env_builder.png
+.. figure:: ../../../images/arena_env_builder.png
    :width: 100%
    :alt: ArenaEnvBuilder merges Scene, Embodiment, and Task into a ManagerBasedRLEnv
    :align: center
@@ -92,5 +92,5 @@ in mimic mode.
 Next Steps
 ----------
 
-Continue to :doc:`object_placement/relations` to learn how anchors and spatial
+Continue to :doc:`../object_placement/relations` to learn how anchors and spatial
 relations describe a placement layout.

--- a/docs/pages/concepts/environment/env_spec.rst
+++ b/docs/pages/concepts/environment/env_spec.rst
@@ -1,0 +1,365 @@
+Environment Spec
+================
+
+An Arena environment is three parts — scene, embodiment, and task (see the
+:doc:`section overview <index>`). This page covers the two ways to define that
+composition, and where they diverge.
+
+Both produce the same object: an ``IsaacLabArenaEnvironment``.
+:doc:`env_builder` turns that into a runnable Isaac Lab environment:
+
+.. figure:: ../../../images/env_spec_py_yaml.png
+   :alt: Python factory and Graph YAML both produce an IsaacLabArenaEnvironment, which ArenaEnvBuilder compiles into a ManagerBasedRLEnv.
+
+* **Python** — a registered ``ArenaEnvironmentFactory``. ``build()`` constructs
+  the scene, embodiment, and task in code.
+* **YAML** — an ``ArenaEnvGraphSpec``: a declarative environment graph. Nodes are
+  assets; edges are spatial relations and task parameters.
+  ``from_yaml()`` validates on load; ``to_arena_env()`` returns the same
+  ``IsaacLabArenaEnvironment``.
+
+
+The same environment, side by side
+----------------------------------
+
+Same pick-and-place setup in both columns: a DROID arm picks a Rubik's cube off a
+table and places it in a bowl. Full examples, same order, matching ``#`` markers —
+read across to see the correspondence.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - YAML
+     - Python
+   * - .. code-block:: yaml
+
+          # Environment name
+          env_name: pick_and_place_maple_table
+
+          # Embodiment
+          embodiment:
+            id: droid_abs_joint_pos
+            registry_name: droid_abs_joint_pos
+
+          # Scene (lighting injected automatically)
+          background:
+            id: maple_table
+            registry_name: maple_table_robolab
+          objects:
+          - id: cube
+            registry_name: rubiks_cube_hot3d_robolab
+          - id: bowl
+            registry_name: bowl_ycb_robolab
+
+          # Sub-asset prims
+          object_references:
+          - id: table
+            parent_id: maple_table
+            prim_path: table
+            object_type: rigid
+
+          # Layout
+          relations:
+          - kind: is_anchor
+            subject: table
+          - kind: 'on'
+            subject: cube
+            reference: table
+          - kind: 'on'
+            subject: bowl
+            reference: table
+
+          # Task
+          task:
+            composition: atomic
+            description: Pick up the Rubik's cube and place it in the bowl.
+            subtasks:
+            - kind: PickAndPlaceTask
+              params:
+                pick_up_object: cube
+                destination_location: bowl
+                background_scene: maple_table
+                episode_length_s: 20.0
+
+     - .. code-block:: python
+
+          @register_environment
+          class PickAndPlaceMapleTable(ArenaEnvironmentFactory):
+              # Identity
+              name = "pick_and_place_maple_table"
+
+              def build(self, cfg):
+                  get = self.asset_registry.get_asset_by_name
+
+                  # Embodiment
+                  embodiment = get("droid_abs_joint_pos")(
+                      enable_cameras=cfg.enable_cameras,
+                  )
+
+                  # Scene (light must be added explicitly)
+                  maple_table = get("maple_table_robolab")()
+                  cube = get("rubiks_cube_hot3d_robolab")()
+                  bowl = get("bowl_ycb_robolab")()
+                  light = get("light")()
+
+                  # Sub-asset prims
+                  table = ObjectReference(
+                      name="table",
+                      prim_path="{ENV_REGEX_NS}"
+                                "/maple_table_robolab/table",
+                      parent_asset=maple_table,
+                      object_type=ObjectType.RIGID,
+                  )
+
+                  # Layout
+                  table.add_relation(IsAnchor())
+                  table.set_initial_pose(Pose.identity())
+                  cube.add_relation(On(table))
+                  bowl.add_relation(On(table))
+
+                  # Task
+                  task = PickAndPlaceTask(
+                      pick_up_object=cube,
+                      destination_location=bowl,
+                      background_scene=maple_table,
+                      episode_length_s=20.0,
+                  )
+
+                  return IsaacLabArenaEnvironment(
+                      name=self.name,
+                      embodiment=embodiment,
+                      scene=Scene(assets=[
+                          maple_table, light, cube, bowl, table,
+                      ]),
+                      task=task,
+                  )
+
+Where the two formats differ
+----------------------------
+
+Three buckets:
+
+* Only Python
+* Only YAML
+* Same key, different behavior
+
+Only in Python
+~~~~~~~~~~~~~~
+
+``IsaacLabArenaEnvironment`` takes ten constructor arguments.
+``build_arena_env_from_graph_spec()`` fills five: ``name``, ``scene``,
+``embodiment``, ``task``, and a partial ``placer_params``. Everything else has no
+YAML key.
+
+**Teleoperation device.** YAML never sets ``env_cfg.teleop_devices``. Python can
+pass a device that drives the embodiment:
+
+.. code-block:: python
+
+   teleop_device = self.device_registry.get_device_by_name(cfg.teleop_device)()
+   return IsaacLabArenaEnvironment(..., teleop_device=teleop_device)
+
+**RL interoperability.** Gym kwargs for RL frameworks are Python-only. You cannot
+define an RL-training environment in YAML:
+
+.. code-block:: python
+
+   return IsaacLabArenaEnvironment(
+       ...,
+       rl_framework_entry_point="rsl_rl_cfg_entry_point",
+       rl_policy_cfg="my_module:RLPolicyCfg",
+   )
+
+**Patching the compiled config.** ``env_cfg_callback`` runs after Arena builds the
+``ManagerBasedRLEnvCfg``. Use it for viewport, decimation, physics, or anything
+else on that config:
+
+.. code-block:: python
+
+   def set_viewport(env_cfg):
+       env_cfg.viewer.eye = (1.5, 1.5, 1.0)
+       env_cfg.viewer.lookat = (0.0, 0.0, 0.5)
+
+   return IsaacLabArenaEnvironment(..., env_cfg_callback=set_viewport)
+
+**Extra episode recorder terms.** Per-episode signals beyond the built-ins:
+
+.. code-block:: python
+
+   return IsaacLabArenaEnvironment(
+       ...,
+       episode_recorder_terms={"cube_pose": EpisodeRecorderTermCfg(func=record_cube_pose)},
+   )
+
+**Most placement tuning.** YAML ``placement_validators`` can set only four
+``ObjectPlacerParams`` fields: ``enabled_checks``, ``required_checks``,
+``debug_visualize``, and ``debug_visualize_output_path``. Seeds, random yaw, pool
+size, resolve-on-reset, and IK reachability need Python:
+
+.. code-block:: python
+
+   placer_params = ObjectPlacerParams(
+       placement_seed=42,          # reproducible layouts
+       random_yaw_init=True,       # random yaw per object
+       resolve_on_reset=False,     # solve once, reuse across resets
+       min_unique_layouts_per_env=20,
+       reachability_config=ReachabilityConfig(...),
+   )
+   return IsaacLabArenaEnvironment(..., placer_params=placer_params)
+
+**Extra variations.** Both formats get the defaults an asset attaches in its
+constructor (a light brings intensity, color, and HDR). Anything the asset class
+does not declare needs Python:
+
+.. code-block:: python
+
+   pick_up_object.add_variation(MyCustomVariation(pick_up_object))
+
+**Calling methods on assets.** YAML ``params`` go to constructors only. Method
+calls on a live instance have no YAML form:
+
+.. code-block:: python
+
+   directional_light.set_dome_light(dome_light)
+
+Only in YAML
+~~~~~~~~~~~~
+
+**Load-time validation.** The spec is Pydantic. Registry names, node ids,
+relation arity, task params, and check subsets fail when the file loads — before
+Isaac Sim starts. Python has no equivalent; the same mistakes show up later as an
+``AttributeError`` or a broken scene:
+
+.. code-block:: text
+
+   AssertionError: Unknown asset registry_name 'rubiks_cube_hot3d'
+   AssertionError: Relation kind 'is_anchor' must not define relation.reference
+   AssertionError: composition 'atomic' requires exactly one atomic task
+
+**Automatic default lighting.** No ``light``-tagged asset and no light in the
+background USD? The loader adds a dome light and a directional light (off until a
+lighting-direction variation turns it on). In Python, no light means no light.
+
+**Scene reuse across task files.** ``external_yaml`` merges one scene into many
+task files. Pattern used in ``isaaclab_arena_environments/robolab/``:
+``scenes/*.yaml`` for layout, ``tasks/*.yaml`` for the task block only:
+
+.. code-block:: yaml
+
+   external_yaml: ../scenes/bagel_plate_banana_bowl.yaml
+   env_name: banana_on_plate
+   task:
+     composition: atomic
+     ...
+
+**Declared CLI overrides.** ``cli_override_specs`` turns a node into a CLI flag
+with no code change. Below, ``--object`` replaces that node's ``registry_name``:
+
+.. code-block:: yaml
+
+   cli_override_specs:
+   - arg: object
+     target_node_id: rubiks_cube_hot3d_robolab
+
+**Machine authoring.** Graph YAML is the output of
+:doc:`../../example_workflows/agentic_env_gen/index`: natural language in,
+validated ``ArenaEnvGraphSpec`` out. Pydantic checks registry names, node ids,
+relation arity, and task params before the simulator sees anything.
+
+Same key, different behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Skip these when porting and you will not get the same environment.
+
+**Duplicate instances need unique names.** YAML sets ``instance_name`` to the node
+id. Asset classes default it to the registry name, so two Python instances of the
+same asset share one name unless you set ``instance_name``. Prim paths, event
+terms, and observation keys all key off that name:
+
+.. code-block:: python
+
+   # Two objects, one name. Pass instance_name yourself.
+   banana_a = get("banana_ycb_robolab")(instance_name="banana_a")
+   banana_b = get("banana_ycb_robolab")(instance_name="banana_b")
+
+**An anchor without a pose.** YAML gives an ``is_anchor`` subject with no pose
+``Pose.identity()`` — the layout origin for the relation solver. Python leaves
+the anchor with no pose until you set one:
+
+.. code-block:: python
+
+   table.add_relation(IsAnchor())
+   table.set_initial_pose(Pose.identity())
+
+**Relative prim paths.** An object-reference ``prim_path`` that does not start
+with ``{ENV_REGEX_NS}/`` expands to
+``{ENV_REGEX_NS}/<background registry_name>/<prim_path>``. Always the background
+registry name — even if ``parent_id`` points elsewhere. Python takes the path
+verbatim; it must be the full runtime path.
+
+**Cameras.** YAML forwards ``enable_cameras`` into the embodiment ``params``. A
+Python factory that ignores ``cfg.enable_cameras`` builds a camera-less env even
+when the flag is set. Policies that expect images will not be amused:
+
+.. code-block:: python
+
+   embodiment = get("droid_abs_joint_pos")(enable_cameras=cfg.enable_cameras)
+
+**Openable references.** YAML picks the class from the fields: ``openable_joint_name``
+in ``params`` → ``OpenableObjectReference`` (and ``object_type: articulation``);
+otherwise → ``ObjectReference``. Python: you pick. Use the plain class for a door
+and you get a door with nothing to open.
+
+**Object set members.** YAML constructs set members with no constructor args, so
+they cannot carry a ``usd_path``. SimReady assets fail at load time and cannot be
+set members. Python ``RigidObjectSet`` takes live instances — SimReady is fine:
+
+.. code-block:: python
+
+   RigidObjectSet(name="bottles", objects=[simready_bottle, ycb_bottle])
+
+How to spawn an environment
+---------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - YAML
+     - Python
+   * - .. code-block:: bash
+
+          python isaaclab_arena/scripts/environment_runner.py \
+            --env_graph_spec_yaml \
+            isaaclab_arena_environments/robolab/tasks/banana_on_plate.yaml
+
+     - .. code-block:: bash
+
+          python isaaclab_arena/scripts/environment_runner.py \
+            pick_and_place_maple_table \
+            --embodiment droid_rel_joint_pos \
+            --pick_up_object banana_ycb_robolab \
+            --destination_location bowl_ycb_robolab
+
+Or load a graph YAML directly:
+
+.. code-block:: python
+
+   spec = ArenaEnvGraphSpec.from_yaml("path/to/env_graph.yaml")
+   environment = spec.to_arena_env()
+   env = ArenaEnvBuilder(environment, ArenaEnvBuilderCfg()).make_registered()
+
+Choosing between them
+---------------------
+
+Many assets and relations? Start with YAML as it is validated, and machine-generatable so you
+can focus on the scene layout and task definition. Reach for Python when the YAML cannot
+express what you need: RL registration, teleop, ``ManagerBasedRLEnvCfg`` patches,
+placement parameters, and so on.
+
+Next Steps
+----------
+
+:doc:`env_builder` shows how either definition becomes a runnable Isaac Lab
+environment.

--- a/docs/pages/concepts/environment/env_spec.rst
+++ b/docs/pages/concepts/environment/env_spec.rst
@@ -11,7 +11,7 @@ Both produce the same object: an ``IsaacLabArenaEnvironment``.
 .. figure:: ../../../images/env_spec_py_yaml.png
    :alt: Python factory and Graph YAML both produce an IsaacLabArenaEnvironment, which ArenaEnvBuilder compiles into a ManagerBasedRLEnv.
 
-* **Python** — a registered ``ArenaEnvironmentFactory``. ``build()`` constructs
+* **Python** — a registered ``ArenaEnvironmentCfg``. ``build()`` constructs
   the scene, embodiment, and task in code.
 * **YAML** — an ``ArenaEnvGraphSpec``: a declarative environment graph. Nodes are
   assets; edges are spatial relations and task parameters.

--- a/docs/pages/concepts/environment/index.rst
+++ b/docs/pages/concepts/environment/index.rst
@@ -1,5 +1,5 @@
-Concept Overview
-================
+Environment
+===========
 
 Isaac Lab Arena aims to simplify the creation of task/environment libraries.
 The key to achieving that goal is the use of *composition*.
@@ -9,7 +9,7 @@ Arena environments are composed of three independent sub-pieces:
 * **Embodiment**: The robot embodiment, its physical description, observations, actions, sensors etc.
 * **Task**: A definition of what is to be accomplished in the environment.
 
-.. figure:: ../../images/isaac_lab_arena_arch_overview.png
+.. figure:: ../../../images/isaac_lab_arena_arch_overview.png
    :width: 90%
    :alt: Isaac Lab Arena Workflow
    :align: center
@@ -44,3 +44,18 @@ The same pick-and-place task works with any robot on any scene: swap the Franka
 for a G1, or the kitchen for a warehouse, with no changes to the task.
 This moves us from a library of monolithic environment descriptions to a library
 of environment *parts*.
+
+The two pages below cover how you write an environment down, and how it is built:
+
+- :doc:`env_spec` — the two ways to specify an environment, Python or YAML.
+- :doc:`env_builder` — how ``ArenaEnvBuilder`` compiles a specification into an
+  Isaac Lab ``ManagerBasedRLEnv``.
+
+The individual components are covered in :doc:`../scene/index`,
+:doc:`../embodiment/index`, and :doc:`../task/index`.
+
+.. toctree::
+   :maxdepth: 1
+
+   env_spec
+   env_builder

--- a/docs/pages/concepts/policy/concept_evaluation_types.rst
+++ b/docs/pages/concepts/policy/concept_evaluation_types.rst
@@ -6,7 +6,7 @@ Isaac Lab Arena supports two main ways to run policy evaluation: a single-job
 multiple jobs in one process. This section summarizes when to use each and how
 they work. Each section below links to the relevant concept docs:
 :doc:`Policy Design <index>`,
-:doc:`Environment Design <../concept_overview>`, and
+:doc:`Environment Design <../environment/index>`, and
 :doc:`Metrics Design <../task/concept_metrics_design>`.
 
 Both runners support a **server–client** setup, where simulation runs locally
@@ -150,7 +150,7 @@ configurations (e.g. many objects or tasks) without launching multiple processes
 by hand. Persistence of the simulation application is maintained between jobs.
 
 **Design context:** For how environments are composed and how metrics are
-defined and computed, see :doc:`Environment Design <../concept_overview>`
+defined and computed, see :doc:`Environment Design <../environment/index>`
 and :doc:`Metrics Design <../task/concept_metrics_design>`. Policies used per job
 follow :doc:`Policy Design <index>`.
 

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -5,7 +5,7 @@ Isaac Lab Arena ships a catalog of ready-to-run environments under
 ``isaaclab_arena_environments/``. Environments can be provided in two ways:
 
 * **Python registered environments**: small compositions of the building blocks
-  introduced in :doc:`../concepts/concept_overview` — **Scene**,
+  introduced in :doc:`../concepts/environment/index` — **Scene**,
   **Embodiment**, and **Task** — wrapped in an ``ExampleEnvironmentBase``
   subclass and registered with the global ``EnvironmentRegistry``. The
   registered ``Task ID`` is passed as the positional ``example_environment``
@@ -626,7 +626,7 @@ microwave, followed by closing the microwave door.
 See Also
 --------
 
-- :doc:`../concepts/concept_overview` — the Scene / Embodiment / Task building blocks used by every environment listed here.
+- :doc:`../concepts/environment/index` — the Scene / Embodiment / Task building blocks used by every environment listed here.
 - :doc:`../quickstart/first_arena_env` — walkthrough of the ``pick_and_place_maple_table`` environment.
 - :doc:`../arena_in_your_repo/index` — how to register your own ``ExampleEnvironmentBase`` subclass alongside the built-in ones.
 

--- a/docs/pages/example_workflows/locomanipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_1_environment_setup.rst
@@ -171,7 +171,7 @@ See :doc:`../../concepts/task/index` for task creation details.
 
 Finally, we assemble all the pieces into a complete, runnable environment. The ``IsaacLabArenaEnvironment`` is the
 top-level container that connects your embodiment (the robot), the scene (the world) and the task (the objective).
-See :doc:`../../concepts/concept_overview` for environment composition details.
+See :doc:`../../concepts/environment/index` for environment composition details.
 
 
 Step 1: Download a test dataset

--- a/docs/pages/example_workflows/reinforcement_learning/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/reinforcement_learning/step_1_environment_setup.rst
@@ -149,7 +149,7 @@ See :doc:`../../concepts/task/index` for task creation details.
 
 Finally, we assemble all the pieces into a complete, runnable RL environment. The ``IsaacLabArenaEnvironment``
 connects the embodiment (the robot), the scene (the world), and the task (the objective and rewards).
-See :doc:`../../concepts/concept_overview` for environment composition details.
+See :doc:`../../concepts/environment/index` for environment composition details.
 
 
 Validation: Run Random Policy

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_1_environment_setup.rst
@@ -352,7 +352,7 @@ See :doc:`../../concepts/scene/index` for scene composition details.
 
 Finally, we assemble all the pieces into a complete, runnable environment. The ``IsaacLabArenaEnvironment`` is the
 top-level container that connects the embodiment (the robot), the scene (the world), and the task (the objective).
-See :doc:`../../concepts/concept_overview` for environment composition details.
+See :doc:`../../concepts/environment/index` for environment composition details.
 
 
 Step 1: Download a Test Dataset

--- a/docs/pages/example_workflows/static_manipulation/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_1_environment_setup.rst
@@ -125,7 +125,7 @@ See :doc:`../../concepts/task/index` for task creation details.
 
 Finally, we assemble all the pieces into a complete, runnable environment. The ``IsaacLabArenaEnvironment`` is the
 top-level container that connects the embodiment (the robot), the scene (the world), and the task (the objective).
-See :doc:`../../concepts/concept_overview` for environment composition details.
+See :doc:`../../concepts/environment/index` for environment composition details.
 
 
 Step 1: Download a Test Dataset

--- a/docs/pages/quickstart/first_arena_env.rst
+++ b/docs/pages/quickstart/first_arena_env.rst
@@ -153,7 +153,7 @@ Under the hood, Arena assembles this environment in seven steps:
 For more detail, see :doc:`Assets <../concepts/scene/concept_assets_design>`,
 :doc:`Scenes <../concepts/scene/index>`, :doc:`Embodiments <../concepts/embodiment/index>`,
 :doc:`Tasks <../concepts/task/index>`, and
-:doc:`Environment Compilation <../concepts/concept_environment_compilation>`.
+:doc:`Environment Builder <../concepts/environment/env_builder>`.
 
 .. dropdown:: Full source: ``pick_and_place_maple_table_environment.py``
    :animate: fade-in


### PR DESCRIPTION
## Summary
New concept page documenting the two ways to define an Arena environment — a Python ArenaEnvironmentCfg and a graph YAML ArenaEnvGraphSpec — and where they diverge.
