### PR TITLE
Kitchen experiment files.

### DIFF
--- a/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_17_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_17_tasks_pi0_and_cosmos.yaml
@@ -1,0 +1,294 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs every kitchen_bench task with both the OpenPI (pi0) and Cosmos policies (17 tasks x 2 policies
+# = 34 runs). On OSMO the inference server for each Run is derived from its policy type (pi0 servers
+# for *_pi0 Runs, Cosmos servers for *_cosmos Runs).
+runs:
+
+  droid_open_fridge_lightwheel_kitchen_pi0:
+    environment: &droid_open_fridge_lightwheel_kitchen_env
+      type: isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
+      enable_cameras: true
+    policy: &openpi_policy
+      type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
+      policy_variant: pi05
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+      openpi_embodiment_adapter: droid
+    environment_builder: &pi0_builder
+      num_envs: 25
+    rollout_limit:
+      num_episodes: 100
+
+  droid_open_fridge_lightwheel_kitchen_cosmos:
+    environment: *droid_open_fridge_lightwheel_kitchen_env
+    policy: &cosmos_policy
+      type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
+      cosmos_embodiment_adapter: droid
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+    environment_builder: &cosmos_builder
+      num_envs: 25
+    rollout_limit:
+      num_episodes: 100
+
+  droid_open_microwave_lightwheel_kitchen_pi0:
+    environment: &droid_open_microwave_lightwheel_kitchen_env
+      type: isaaclab_arena_environments/kitchen_bench/droid_open_microwave_lightwheel_kitchen.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  droid_open_microwave_lightwheel_kitchen_cosmos:
+    environment: *droid_open_microwave_lightwheel_kitchen_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  droid_pick_and_place_lightwheel_kitchen_pi0:
+    environment: &droid_pick_and_place_lightwheel_kitchen_env
+      type: isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  droid_pick_and_place_lightwheel_kitchen_cosmos:
+    environment: *droid_pick_and_place_lightwheel_kitchen_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_banana_bowl_pi0:
+    environment: &replicator_kitchen_g_shape_banana_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_banana_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_banana_bowl_cosmos:
+    environment: *replicator_kitchen_g_shape_banana_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_bowl_sink_pi0:
+    environment: &replicator_kitchen_g_shape_bowl_sink_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_bowl_sink.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_bowl_sink_cosmos:
+    environment: *replicator_kitchen_g_shape_bowl_sink_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_mustard_bowl_pi0:
+    environment: &replicator_kitchen_g_shape_mustard_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_mustard_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_g_shape_mustard_bowl_cosmos:
+    environment: *replicator_kitchen_g_shape_mustard_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_banana_bowl_pi0:
+    environment: &replicator_kitchen_l_island_banana_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_banana_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_banana_bowl_cosmos:
+    environment: *replicator_kitchen_l_island_banana_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_bowl_sink_pi0:
+    environment: &replicator_kitchen_l_island_bowl_sink_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_bowl_sink.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_bowl_sink_cosmos:
+    environment: *replicator_kitchen_l_island_bowl_sink_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_mustard_bowl_pi0:
+    environment: &replicator_kitchen_l_island_mustard_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_island_mustard_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_island_mustard_bowl_cosmos:
+    environment: *replicator_kitchen_l_island_mustard_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_banana_bowl_pi0:
+    environment: &replicator_kitchen_l_shape_banana_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_banana_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_banana_bowl_cosmos:
+    environment: *replicator_kitchen_l_shape_banana_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_bowl_sink_pi0:
+    environment: &replicator_kitchen_l_shape_bowl_sink_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_bowl_sink.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_bowl_sink_cosmos:
+    environment: *replicator_kitchen_l_shape_bowl_sink_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_mustard_bowl_pi0:
+    environment: &replicator_kitchen_l_shape_mustard_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_mustard_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_mustard_bowl_cosmos:
+    environment: *replicator_kitchen_l_shape_mustard_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_peninsula_bowl_sink_pi0:
+    environment: &replicator_kitchen_peninsula_bowl_sink_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_bowl_sink.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_peninsula_bowl_sink_cosmos:
+    environment: *replicator_kitchen_peninsula_bowl_sink_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_peninsula_mustard_bowl_pi0:
+    environment: &replicator_kitchen_peninsula_mustard_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_peninsula_mustard_bowl_cosmos:
+    environment: *replicator_kitchen_peninsula_mustard_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_banana_bowl_pi0:
+    environment: &replicator_kitchen_u_shape_banana_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_banana_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_banana_bowl_cosmos:
+    environment: *replicator_kitchen_u_shape_banana_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_bowl_sink_pi0:
+    environment: &replicator_kitchen_u_shape_bowl_sink_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_bowl_sink.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_bowl_sink_cosmos:
+    environment: *replicator_kitchen_u_shape_bowl_sink_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_mustard_bowl_pi0:
+    environment: &replicator_kitchen_u_shape_mustard_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_u_shape_mustard_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_u_shape_mustard_bowl_cosmos:
+    environment: *replicator_kitchen_u_shape_mustard_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100

--- a/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_17_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_17_tasks_pi0_and_cosmos.yaml
@@ -3,9 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Runs every kitchen_bench task with both the OpenPI (pi0) and Cosmos policies (17 tasks x 2 policies
-# = 34 runs). On OSMO the inference server for each Run is derived from its policy type (pi0 servers
-# for *_pi0 Runs, Cosmos servers for *_cosmos Runs).
+# Runs every kitchen_bench task with both the OpenPI (pi0) and Cosmos policies (17 tasks x 2 policies = 34 runs).
 runs:
 
   droid_open_fridge_lightwheel_kitchen_pi0:

--- a/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_2_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_2_tasks_pi0_and_cosmos.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs two kitchen_bench tasks with both the OpenPI (pi0) and Cosmos policies (4 runs). On OSMO the
+# inference server for each Run is derived from its policy type (pi0 servers for *_pi0 Runs, Cosmos
+# servers for *_cosmos Runs).
+runs:
+
+  droid_pick_and_place_lightwheel_kitchen_pi0:
+    environment: &droid_pick_and_place_lightwheel_kitchen_env
+      type: isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+      enable_cameras: true
+    policy: &openpi_policy
+      type: isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy
+      policy_variant: pi05
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+      openpi_embodiment_adapter: droid
+    environment_builder: &pi0_builder
+      num_envs: 25
+    rollout_limit:
+      num_episodes: 100
+
+  droid_pick_and_place_lightwheel_kitchen_cosmos:
+    environment: *droid_pick_and_place_lightwheel_kitchen_env
+    policy: &cosmos_policy
+      type: isaaclab_arena_cosmos.policy.cosmos_remote_policy.CosmosRemotePolicy
+      cosmos_embodiment_adapter: droid
+      policy_device: cuda:0
+      remote_host: 127.0.0.1
+      remote_port: 8000
+    environment_builder: &cosmos_builder
+      num_envs: 25
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_banana_bowl_pi0:
+    environment: &replicator_kitchen_l_shape_banana_bowl_env
+      type: isaaclab_arena_environments/kitchen_bench/replicator_kitchen_l_shape_banana_bowl.yaml
+      enable_cameras: true
+    policy: *openpi_policy
+    environment_builder: *pi0_builder
+    rollout_limit:
+      num_episodes: 100
+
+  replicator_kitchen_l_shape_banana_bowl_cosmos:
+    environment: *replicator_kitchen_l_shape_banana_bowl_env
+    policy: *cosmos_policy
+    environment_builder: *cosmos_builder
+    rollout_limit:
+      num_episodes: 100

--- a/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_2_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/experiment_configs/kitchen_bench_2_tasks_pi0_and_cosmos.yaml
@@ -3,9 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Runs two kitchen_bench tasks with both the OpenPI (pi0) and Cosmos policies (4 runs). On OSMO the
-# inference server for each Run is derived from its policy type (pi0 servers for *_pi0 Runs, Cosmos
-# servers for *_cosmos Runs).
+# Runs two kitchen_bench tasks with both the OpenPI (pi0) and Cosmos policies (4 runs).
 runs:
 
   droid_pick_and_place_lightwheel_kitchen_pi0:

--- a/osmo/workflows/workflow.py
+++ b/osmo/workflows/workflow.py
@@ -55,7 +55,7 @@ class WorkflowCfg:
     gpus: int = 1
     """Requested GPUs."""
 
-    memory: str = "128Gi"
+    memory: str = "120Gi"
     """Requested memory."""
 
     storage: str = "200Gi"


### PR DESCRIPTION
## Summary
Add experiment files to run kitchen_bench experiments on main.

## Detailed description
- Adds two files, one for a small (2 task) experiment, and one for a larger (17 task, i.e. all task) experiment.
- reduce default CPU memory to `120Gb` so we can run `l40`s without modification.