### PR TITLE
Move Dexsuite procedural cuboids out of the shared object library

### DIFF
--- a/docs/pages/example_workflows/dexsuite_lift/index.rst
+++ b/docs/pages/example_workflows/dexsuite_lift/index.rst
@@ -49,9 +49,9 @@ body states, object point cloud, and 5-step observation history.
    * - **Embodiment**
      - Kuka LBR iiwa + Allegro Hand (7 DOF arm + 16 DOF hand)
    * - **Scene**
-     - Procedural table (static background) with ground plane and lighting
+     - Env-local procedural table (static background) with ``ground_plane`` and ``light``
    * - **Objects**
-     - Procedural lift cuboid (``procedural_cube``)
+     - Env-local procedural lift cuboid (constructed via ``procedural_asset_classes()``)
    * - **Policy**
      - RSL-RL PPO (``DexsuiteKukaAllegroPPORunnerCfg``)
    * - **Training Method**

--- a/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
@@ -36,10 +36,10 @@ The environment is defined in
               from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask
               from isaaclab_arena.utils.pose import Pose, PoseRange
 
-              dexsuite_table = self.asset_registry.get_asset_by_name("procedural_table")()
+              dexsuite_table = ProceduralTable()
               dexsuite_table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
 
-              manip_object = self.asset_registry.get_asset_by_name("procedural_cube")()
+              manip_object = ProceduralCube()
               manip_object.set_initial_pose(
                   PoseRange(
                       position_xyz_min=(-0.75, -0.1, 0.35),

--- a/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
@@ -35,7 +35,9 @@ The environment is defined in
               from isaaclab_arena.scene.scene import Scene
               from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask
               from isaaclab_arena.utils.pose import Pose, PoseRange
+              from isaaclab_arena_environments.dexsuite_lift_environment import procedural_asset_classes
 
+              ProceduralTable, ProceduralCube = procedural_asset_classes()
               dexsuite_table = ProceduralTable()
               dexsuite_table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
 

--- a/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
+++ b/docs/pages/example_workflows/dexsuite_lift/step_1_environment_setup.rst
@@ -22,11 +22,12 @@ The environment is defined in
 
    .. code-block:: python
 
-      class DexsuiteLiftEnvironment(ExampleEnvironmentBase):
+      @register_environment
+      class DexsuiteLiftEnvironment(ArenaEnvironmentFactory[DexsuiteLiftEnvironmentCfg]):
 
           name: str = "dexsuite_lift"
 
-          def get_env(self, args_cli: argparse.Namespace):
+          def build(self, cfg: DexsuiteLiftEnvironmentCfg) -> IsaacLabArenaEnvironment:
               import math
 
               import isaaclab_tasks.manager_based.manipulation.dexsuite  # noqa: F401
@@ -35,13 +36,15 @@ The environment is defined in
               from isaaclab_arena.scene.scene import Scene
               from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask
               from isaaclab_arena.utils.pose import Pose, PoseRange
-              from isaaclab_arena_environments.dexsuite_lift_environment import procedural_asset_classes
 
-              ProceduralTable, ProceduralCube = procedural_asset_classes()
-              dexsuite_table = ProceduralTable()
+              # Cuboids are env-local (not AssetRegistry entries); defined lazily so
+              # package import does not pull Object → pxr before SimulationApp starts.
+              procedural_table_cls, procedural_cube_cls = procedural_asset_classes()
+
+              dexsuite_table = procedural_table_cls()
               dexsuite_table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
 
-              manip_object = ProceduralCube()
+              manip_object = procedural_cube_cls()
               manip_object.set_initial_pose(
                   PoseRange(
                       position_xyz_min=(-0.75, -0.1, 0.35),
@@ -53,25 +56,23 @@ The environment is defined in
 
               ground_plane = self.asset_registry.get_asset_by_name("ground_plane")()
               light = self.asset_registry.get_asset_by_name("light")()
-
-              embodiment = self.asset_registry.get_asset_by_name("kuka_allegro")()
+              embodiment = self.asset_registry.get_asset_by_name("kuka_allegro")(
+                  enable_cameras=cfg.enable_cameras
+              )
 
               scene = Scene(assets=[dexsuite_table, manip_object, ground_plane, light])
               task = DexsuiteLiftTask(lift_object=manip_object, background_scene=dexsuite_table)
-
-              dexsuite_rl_cfg_entry = (
-                  "isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.agents."
-                  "rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg"
-              )
 
               return IsaacLabArenaEnvironment(
                   name=self.name,
                   embodiment=embodiment,
                   scene=scene,
                   task=task,
-                  teleop_device=None,
                   rl_framework_entry_point="rsl_rl_cfg_entry_point",
-                  rl_policy_cfg=dexsuite_rl_cfg_entry,
+                  rl_policy_cfg=(
+                      "isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.agents."
+                      "rsl_rl_ppo_cfg:DexsuiteKukaAllegroPPORunnerCfg"
+                  ),
               )
 
 .. note::

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -503,9 +503,9 @@ position. Featured in the
    * - **Embodiment**
      - ``kuka_allegro`` (fixed)
    * - **Scene**
-     - ``procedural_table`` background, ``ground_plane``, ``light``
+     - Env-local procedural table (not in ``AssetRegistry``), ``ground_plane``, ``light``
    * - **Objects**
-     - ``procedural_cube`` (randomized initial pose with a wide ``PoseRange``)
+     - Env-local procedural cuboid (not in ``AssetRegistry``; wide ``PoseRange``)
    * - **Task Class**
      - ``DexsuiteLiftTask`` (object_pose command, position-only, resampled every 2–3 s)
    * - **Training Method**

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -13,7 +13,6 @@ import isaaclab.sim as sim_utils
 if TYPE_CHECKING:
     from isaaclab_arena.assets.hdr_image import HDRImage
 
-from isaaclab.assets import RigidObjectCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
@@ -1893,93 +1892,3 @@ class GreyBinRobolab(LibraryObject):
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/grey_bin.usd"
     # USD has 0.07 scale which is ignored by spawner. Setting it back again.
     scale = (0.007, 0.007, 0.007)
-
-
-# ---------------------------------------------------------------------------
-# Procedural assets (Newton-safe, single-geometry cuboids)
-# ---------------------------------------------------------------------------
-
-_PROCEDURAL_TABLE_SPAWN_CFG = sim_utils.CuboidCfg(
-    size=(0.8, 1.5, 0.04),
-    rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
-    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-    visible=False,
-)
-
-
-@register_asset
-class ProceduralTable(Object):
-    """Kinematic cuboid table (invisible collision surface). Newton-safe, single geometry."""
-
-    name = "procedural_table"
-    tags = ["background", "procedural"]
-    object_min_z: float = 0.0
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-    ):
-        resolved_name = instance_name if instance_name is not None else "table"
-        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/table"
-        super().__init__(
-            name=resolved_name,
-            prim_path=resolved_prim,
-            object_type=ObjectType.RIGID,
-            usd_path="",
-            initial_pose=initial_pose,
-        )
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_TABLE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)
-
-
-_PROCEDURAL_CUBE_SPAWN_CFG = sim_utils.CuboidCfg(
-    size=(0.05, 0.1, 0.1),
-    physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
-    rigid_props=sim_utils.RigidBodyPropertiesCfg(
-        solver_position_iteration_count=16,
-        solver_velocity_iteration_count=0,
-        disable_gravity=False,
-    ),
-    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-    mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
-)
-
-
-@register_asset
-class ProceduralCube(Object):
-    """Rigid cuboid manipuland (0.2 kg, 5x10x10 cm). Newton-safe, single geometry."""
-
-    name = "procedural_cube"
-    tags = ["object", "procedural"]
-
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-    ):
-        resolved_name = instance_name if instance_name is not None else "object"
-        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/Object"
-        super().__init__(
-            name=resolved_name,
-            prim_path=resolved_prim,
-            object_type=ObjectType.RIGID,
-            usd_path="",
-            initial_pose=initial_pose,
-        )
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_CUBE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)

--- a/isaaclab_arena/tests/test_dexsuite_kuka_lift_example.py
+++ b/isaaclab_arena/tests/test_dexsuite_kuka_lift_example.py
@@ -23,32 +23,19 @@ def test_dexsuite_lift_example_in_cli_registry() -> None:
 
 
 @pytest.mark.with_newton
-def test_procedural_assets_registered() -> None:
-    pytest.importorskip(
-        "isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.dexsuite_kuka_allegro_env_cfg"
-    )
-    from isaaclab_arena.assets.registries import AssetRegistry
-
-    reg = AssetRegistry()
-    assert reg.is_registered("procedural_table")
-    assert reg.is_registered("procedural_cube")
-
-
-@pytest.mark.with_newton
 def test_dexsuite_kuka_lift_task_matches_lift_mdp_flags() -> None:
     pytest.importorskip(
         "isaaclab_tasks.manager_based.manipulation.dexsuite.config.kuka_allegro.dexsuite_kuka_allegro_env_cfg"
     )
 
-    from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.metrics.success_rate import SuccessRateMetric
     from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask, DexsuiteLiftTerminationsCfg, LiftObjectTask
     from isaaclab_arena.utils.pose import Pose, PoseRange
+    from isaaclab_arena_environments.dexsuite_lift_environment import ProceduralCube, ProceduralTable
 
-    reg = AssetRegistry()
-    lift = reg.get_asset_by_name("procedural_cube")()
+    lift = ProceduralCube()
     lift.set_initial_pose(PoseRange(position_xyz_min=(-0.75, -0.1, 0.35), position_xyz_max=(-0.35, 0.3, 0.75)))
-    table = reg.get_asset_by_name("procedural_table")()
+    table = ProceduralTable()
     table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
     task = DexsuiteLiftTask(lift_object=lift, background_scene=table)
     assert isinstance(task, LiftObjectTask)

--- a/isaaclab_arena/tests/test_dexsuite_kuka_lift_example.py
+++ b/isaaclab_arena/tests/test_dexsuite_kuka_lift_example.py
@@ -31,11 +31,12 @@ def test_dexsuite_kuka_lift_task_matches_lift_mdp_flags() -> None:
     from isaaclab_arena.metrics.success_rate import SuccessRateMetric
     from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask, DexsuiteLiftTerminationsCfg, LiftObjectTask
     from isaaclab_arena.utils.pose import Pose, PoseRange
-    from isaaclab_arena_environments.dexsuite_lift_environment import ProceduralCube, ProceduralTable
+    from isaaclab_arena_environments.dexsuite_lift_environment import procedural_asset_classes
 
-    lift = ProceduralCube()
+    procedural_table_cls, procedural_cube_cls = procedural_asset_classes()
+    lift = procedural_cube_cls()
     lift.set_initial_pose(PoseRange(position_xyz_min=(-0.75, -0.1, 0.35), position_xyz_max=(-0.35, 0.3, 0.75)))
-    table = ProceduralTable()
+    table = procedural_table_cls()
     table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
     task = DexsuiteLiftTask(lift_object=lift, background_scene=table)
     assert isinstance(task, LiftObjectTask)

--- a/isaaclab_arena/tests/test_physics_settle.py
+++ b/isaaclab_arena/tests/test_physics_settle.py
@@ -149,7 +149,7 @@ def _build_parallel_layout_env(num_envs, expected_settled):
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
     from isaaclab_arena.scene.scene import Scene
     from isaaclab_arena.utils.pose import Pose, PosePerEnv
-    from isaaclab_arena_environments.dexsuite_lift_environment import ProceduralTable
+    from isaaclab_arena_environments.dexsuite_lift_environment import procedural_asset_classes
 
     floor_top_z = 0.02  # ProceduralTable is 0.04 thick, centered at z=0.
     rest_z = floor_top_z + 0.1  # Sphere radius is 0.1, so this rests it on the floor.
@@ -162,7 +162,8 @@ def _build_parallel_layout_env(num_envs, expected_settled):
             poses.append(Pose(position_xyz=(x, 0.0, z), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
         return PosePerEnv(poses=poses)
 
-    floor = ProceduralTable(instance_name="floor")
+    procedural_table_cls, _ = procedural_asset_classes()
+    floor = procedural_table_cls(instance_name="floor")
     floor.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
 
     sphere_a = Sphere(instance_name="sphere_a")

--- a/isaaclab_arena/tests/test_physics_settle.py
+++ b/isaaclab_arena/tests/test_physics_settle.py
@@ -143,12 +143,13 @@ def _build_parallel_layout_env(num_envs, expected_settled):
     Returns the gym-wrapped env (already reset) and the two sphere names (the floor is excluded, like a
     background/anchor object would be in a real settle check).
     """
-    from isaaclab_arena.assets.object_library import ProceduralTable, Sphere
+    from isaaclab_arena.assets.object_library import Sphere
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
     from isaaclab_arena.scene.scene import Scene
     from isaaclab_arena.utils.pose import Pose, PosePerEnv
+    from isaaclab_arena_environments.dexsuite_lift_environment import ProceduralTable
 
     floor_top_z = 0.02  # ProceduralTable is 0.04 thick, centered at z=0.
     rest_z = floor_top_z + 0.1  # Sphere radius is 0.1, so this rests it on the floor.

--- a/isaaclab_arena_environments/dexsuite_lift_environment.py
+++ b/isaaclab_arena_environments/dexsuite_lift_environment.py
@@ -9,98 +9,117 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-import isaaclab.sim as sim_utils
-from isaaclab.assets import RigidObjectCfg
-
-from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.register import register_environment
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
-from isaaclab_arena.utils.pose import Pose
 
 if TYPE_CHECKING:
+    from isaaclab_arena.assets.object import Object
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 
-_PROCEDURAL_TABLE_SPAWN_CFG = sim_utils.CuboidCfg(
-    size=(0.8, 1.5, 0.04),
-    rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
-    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-    visible=False,
-)
+# Cached after first call to :func:`procedural_asset_classes` (Object/pxr stay unloaded until then).
+_procedural_table_cls: type[Object] | None = None
+_procedural_cube_cls: type[Object] | None = None
 
 
-class ProceduralTable(Object):
-    """Kinematic cuboid table (invisible collision surface). Newton-safe, single geometry."""
+def procedural_asset_classes() -> tuple[type[Object], type[Object]]:
+    """Return ProceduralTable/ProceduralCube, defining them on first use.
 
-    tags = ["background", "procedural"]
-    object_min_z: float = 0.0
+    Kept off the module import path so ``isaaclab_arena_environments`` package init
+    (which imports every ``*_environment`` module) does not pull ``Object`` → ``pxr``
+    before ``SimulationApp`` starts.
+    """
+    global _procedural_table_cls, _procedural_cube_cls
+    if _procedural_table_cls is not None and _procedural_cube_cls is not None:
+        return _procedural_table_cls, _procedural_cube_cls
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-    ):
-        resolved_name = instance_name if instance_name is not None else "table"
-        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/table"
-        super().__init__(
-            name=resolved_name,
-            prim_path=resolved_prim,
-            object_type=ObjectType.RIGID,
-            usd_path="",
-            initial_pose=initial_pose,
-        )
+    import isaaclab.sim as sim_utils
+    from isaaclab.assets import RigidObjectCfg
 
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_TABLE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.utils.pose import Pose
 
+    table_spawn_cfg = sim_utils.CuboidCfg(
+        size=(0.8, 1.5, 0.04),
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+        collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+        visible=False,
+    )
 
-_PROCEDURAL_CUBE_SPAWN_CFG = sim_utils.CuboidCfg(
-    size=(0.05, 0.1, 0.1),
-    physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
-    rigid_props=sim_utils.RigidBodyPropertiesCfg(
-        solver_position_iteration_count=16,
-        solver_velocity_iteration_count=0,
-        disable_gravity=False,
-    ),
-    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-    mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
-)
+    class ProceduralTable(Object):
+        """Kinematic cuboid table (invisible collision surface). Newton-safe, single geometry."""
 
+        tags = ["background", "procedural"]
+        object_min_z: float = 0.0
 
-class ProceduralCube(Object):
-    """Rigid cuboid manipuland (0.2 kg, 5x10x10 cm). Newton-safe, single geometry."""
+        def __init__(
+            self,
+            instance_name: str | None = None,
+            prim_path: str | None = None,
+            initial_pose: Pose | None = None,
+        ):
+            resolved_name = instance_name if instance_name is not None else "table"
+            resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/table"
+            super().__init__(
+                name=resolved_name,
+                prim_path=resolved_prim,
+                object_type=ObjectType.RIGID,
+                usd_path="",
+                initial_pose=initial_pose,
+            )
 
-    tags = ["object", "procedural"]
+        def _generate_rigid_cfg(self) -> RigidObjectCfg:
+            cfg = RigidObjectCfg(
+                prim_path=self.prim_path,
+                spawn=table_spawn_cfg,
+                **self.asset_cfg_addon,
+            )
+            return self._add_initial_pose_to_cfg(cfg)
 
-    def __init__(
-        self,
-        instance_name: str | None = None,
-        prim_path: str | None = None,
-        initial_pose: Pose | None = None,
-    ):
-        resolved_name = instance_name if instance_name is not None else "object"
-        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/Object"
-        super().__init__(
-            name=resolved_name,
-            prim_path=resolved_prim,
-            object_type=ObjectType.RIGID,
-            usd_path="",
-            initial_pose=initial_pose,
-        )
+    cube_spawn_cfg = sim_utils.CuboidCfg(
+        size=(0.05, 0.1, 0.1),
+        physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            solver_position_iteration_count=16,
+            solver_velocity_iteration_count=0,
+            disable_gravity=False,
+        ),
+        collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+        mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
+    )
 
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_CUBE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)
+    class ProceduralCube(Object):
+        """Rigid cuboid manipuland (0.2 kg, 5x10x10 cm). Newton-safe, single geometry."""
+
+        tags = ["object", "procedural"]
+
+        def __init__(
+            self,
+            instance_name: str | None = None,
+            prim_path: str | None = None,
+            initial_pose: Pose | None = None,
+        ):
+            resolved_name = instance_name if instance_name is not None else "object"
+            resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/Object"
+            super().__init__(
+                name=resolved_name,
+                prim_path=resolved_prim,
+                object_type=ObjectType.RIGID,
+                usd_path="",
+                initial_pose=initial_pose,
+            )
+
+        def _generate_rigid_cfg(self) -> RigidObjectCfg:
+            cfg = RigidObjectCfg(
+                prim_path=self.prim_path,
+                spawn=cube_spawn_cfg,
+                **self.asset_cfg_addon,
+            )
+            return self._add_initial_pose_to_cfg(cfg)
+
+    _procedural_table_cls = ProceduralTable
+    _procedural_cube_cls = ProceduralCube
+    return ProceduralTable, ProceduralCube
 
 
 @dataclass
@@ -127,12 +146,14 @@ class DexsuiteLiftEnvironment(ArenaEnvironmentFactory[DexsuiteLiftEnvironmentCfg
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.scene.scene import Scene
         from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask
-        from isaaclab_arena.utils.pose import PoseRange
+        from isaaclab_arena.utils.pose import Pose, PoseRange
 
-        dexsuite_table = ProceduralTable()
+        procedural_table_cls, procedural_cube_cls = procedural_asset_classes()
+
+        dexsuite_table = procedural_table_cls()
         dexsuite_table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
 
-        manip_object = ProceduralCube()
+        manip_object = procedural_cube_cls()
         manip_object.set_initial_pose(
             PoseRange(
                 position_xyz_min=(-0.75, -0.1, 0.35),

--- a/isaaclab_arena_environments/dexsuite_lift_environment.py
+++ b/isaaclab_arena_environments/dexsuite_lift_environment.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -16,109 +17,75 @@ if TYPE_CHECKING:
     from isaaclab_arena.assets.object import Object
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
 
-# Cached after first call to :func:`procedural_asset_classes` (Object/pxr stay unloaded until then).
-_procedural_table_cls: type[Object] | None = None
-_procedural_cube_cls: type[Object] | None = None
 
-
+@functools.lru_cache(maxsize=1)
 def procedural_asset_classes() -> tuple[type[Object], type[Object]]:
     """Return ProceduralTable/ProceduralCube, defining them on first use.
 
     Kept off the module import path so ``isaaclab_arena_environments`` package init
-    (which imports every ``*_environment`` module) does not pull ``Object`` → ``pxr``
-    before ``SimulationApp`` starts.
+    does not pull ``Object`` → ``pxr`` before ``SimulationApp`` starts.
     """
-    global _procedural_table_cls, _procedural_cube_cls
-    if _procedural_table_cls is not None and _procedural_cube_cls is not None:
-        return _procedural_table_cls, _procedural_cube_cls
-
     import isaaclab.sim as sim_utils
-    from isaaclab.assets import RigidObjectCfg
 
     from isaaclab_arena.assets.object import Object
     from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.utils.pose import Pose
 
-    table_spawn_cfg = sim_utils.CuboidCfg(
-        size=(0.8, 1.5, 0.04),
-        rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
-        collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-        visible=False,
-    )
+    class _ProceduralCuboid(Object):
+        """Rigid cuboid spawned from a CuboidCfg (no USD)."""
 
-    class ProceduralTable(Object):
+        tags: list[str]
+        _default_name: str
+        _default_prim: str
+        _spawn_cfg: sim_utils.CuboidCfg
+
+        def __init__(
+            self,
+            instance_name: str | None = None,
+            prim_path: str | None = None,
+            initial_pose: Pose | None = None,
+        ):
+            super().__init__(
+                name=instance_name or self._default_name,
+                prim_path=prim_path or self._default_prim,
+                object_type=ObjectType.RIGID,
+                tags=self.tags,
+                initial_pose=initial_pose,
+                spawner_cfg=self._spawn_cfg,
+            )
+
+    class ProceduralTable(_ProceduralCuboid):
         """Kinematic cuboid table (invisible collision surface). Newton-safe, single geometry."""
 
         tags = ["background", "procedural"]
         object_min_z: float = 0.0
+        _default_name = "table"
+        _default_prim = "{ENV_REGEX_NS}/table"
+        _spawn_cfg = sim_utils.CuboidCfg(
+            size=(0.8, 1.5, 0.04),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+            collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+            visible=False,
+        )
 
-        def __init__(
-            self,
-            instance_name: str | None = None,
-            prim_path: str | None = None,
-            initial_pose: Pose | None = None,
-        ):
-            resolved_name = instance_name if instance_name is not None else "table"
-            resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/table"
-            super().__init__(
-                name=resolved_name,
-                prim_path=resolved_prim,
-                object_type=ObjectType.RIGID,
-                usd_path="",
-                initial_pose=initial_pose,
-            )
-
-        def _generate_rigid_cfg(self) -> RigidObjectCfg:
-            cfg = RigidObjectCfg(
-                prim_path=self.prim_path,
-                spawn=table_spawn_cfg,
-                **self.asset_cfg_addon,
-            )
-            return self._add_initial_pose_to_cfg(cfg)
-
-    cube_spawn_cfg = sim_utils.CuboidCfg(
-        size=(0.05, 0.1, 0.1),
-        physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
-        rigid_props=sim_utils.RigidBodyPropertiesCfg(
-            solver_position_iteration_count=16,
-            solver_velocity_iteration_count=0,
-            disable_gravity=False,
-        ),
-        collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
-        mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
-    )
-
-    class ProceduralCube(Object):
+    class ProceduralCube(_ProceduralCuboid):
         """Rigid cuboid manipuland (0.2 kg, 5x10x10 cm). Newton-safe, single geometry."""
 
         tags = ["object", "procedural"]
+        _default_name = "object"
+        _default_prim = "{ENV_REGEX_NS}/Object"
+        _spawn_cfg = sim_utils.CuboidCfg(
+            size=(0.05, 0.1, 0.1),
+            physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
+            rigid_props=sim_utils.RigidBodyPropertiesCfg(
+                solver_position_iteration_count=16,
+                solver_velocity_iteration_count=0,
+                disable_gravity=False,
+            ),
+            collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+            mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
+        )
 
-        def __init__(
-            self,
-            instance_name: str | None = None,
-            prim_path: str | None = None,
-            initial_pose: Pose | None = None,
-        ):
-            resolved_name = instance_name if instance_name is not None else "object"
-            resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/Object"
-            super().__init__(
-                name=resolved_name,
-                prim_path=resolved_prim,
-                object_type=ObjectType.RIGID,
-                usd_path="",
-                initial_pose=initial_pose,
-            )
-
-        def _generate_rigid_cfg(self) -> RigidObjectCfg:
-            cfg = RigidObjectCfg(
-                prim_path=self.prim_path,
-                spawn=cube_spawn_cfg,
-                **self.asset_cfg_addon,
-            )
-            return self._add_initial_pose_to_cfg(cfg)
-
-    _procedural_table_cls = ProceduralTable
-    _procedural_cube_cls = ProceduralCube
     return ProceduralTable, ProceduralCube
 
 

--- a/isaaclab_arena_environments/dexsuite_lift_environment.py
+++ b/isaaclab_arena_environments/dexsuite_lift_environment.py
@@ -9,11 +9,98 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import isaaclab.sim as sim_utils
+from isaaclab.assets import RigidObjectCfg
+
+from isaaclab_arena.assets.object import Object
+from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.register import register_environment
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+from isaaclab_arena.utils.pose import Pose
 
 if TYPE_CHECKING:
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+_PROCEDURAL_TABLE_SPAWN_CFG = sim_utils.CuboidCfg(
+    size=(0.8, 1.5, 0.04),
+    rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+    visible=False,
+)
+
+
+class ProceduralTable(Object):
+    """Kinematic cuboid table (invisible collision surface). Newton-safe, single geometry."""
+
+    tags = ["background", "procedural"]
+    object_min_z: float = 0.0
+
+    def __init__(
+        self,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | None = None,
+    ):
+        resolved_name = instance_name if instance_name is not None else "table"
+        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/table"
+        super().__init__(
+            name=resolved_name,
+            prim_path=resolved_prim,
+            object_type=ObjectType.RIGID,
+            usd_path="",
+            initial_pose=initial_pose,
+        )
+
+    def _generate_rigid_cfg(self) -> RigidObjectCfg:
+        cfg = RigidObjectCfg(
+            prim_path=self.prim_path,
+            spawn=_PROCEDURAL_TABLE_SPAWN_CFG,
+            **self.asset_cfg_addon,
+        )
+        return self._add_initial_pose_to_cfg(cfg)
+
+
+_PROCEDURAL_CUBE_SPAWN_CFG = sim_utils.CuboidCfg(
+    size=(0.05, 0.1, 0.1),
+    physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
+    rigid_props=sim_utils.RigidBodyPropertiesCfg(
+        solver_position_iteration_count=16,
+        solver_velocity_iteration_count=0,
+        disable_gravity=False,
+    ),
+    collision_props=sim_utils.CollisionPropertiesCfg(contact_offset=0.005),
+    mass_props=sim_utils.MassPropertiesCfg(mass=0.2),
+)
+
+
+class ProceduralCube(Object):
+    """Rigid cuboid manipuland (0.2 kg, 5x10x10 cm). Newton-safe, single geometry."""
+
+    tags = ["object", "procedural"]
+
+    def __init__(
+        self,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | None = None,
+    ):
+        resolved_name = instance_name if instance_name is not None else "object"
+        resolved_prim = prim_path if prim_path is not None else "{ENV_REGEX_NS}/Object"
+        super().__init__(
+            name=resolved_name,
+            prim_path=resolved_prim,
+            object_type=ObjectType.RIGID,
+            usd_path="",
+            initial_pose=initial_pose,
+        )
+
+    def _generate_rigid_cfg(self) -> RigidObjectCfg:
+        cfg = RigidObjectCfg(
+            prim_path=self.prim_path,
+            spawn=_PROCEDURAL_CUBE_SPAWN_CFG,
+            **self.asset_cfg_addon,
+        )
+        return self._add_initial_pose_to_cfg(cfg)
 
 
 @dataclass
@@ -40,12 +127,12 @@ class DexsuiteLiftEnvironment(ArenaEnvironmentFactory[DexsuiteLiftEnvironmentCfg
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.scene.scene import Scene
         from isaaclab_arena.tasks.lift_object_task import DexsuiteLiftTask
-        from isaaclab_arena.utils.pose import Pose, PoseRange
+        from isaaclab_arena.utils.pose import PoseRange
 
-        dexsuite_table = self.asset_registry.get_asset_by_name("procedural_table")()
+        dexsuite_table = ProceduralTable()
         dexsuite_table.set_initial_pose(Pose(position_xyz=(-0.55, 0.0, 0.235)))
 
-        manip_object = self.asset_registry.get_asset_by_name("procedural_cube")()
+        manip_object = ProceduralCube()
         manip_object.set_initial_pose(
             PoseRange(
                 position_xyz_min=(-0.75, -0.1, 0.35),


### PR DESCRIPTION

## Summary
Remove dexsuite procedure object from registry to avoid agent usage.

## Detailed description
- Keep Newton-only table/cube assets local to the Dexsuite lift example and construct them directly instead of registering them globally.
- This excludes them from the env gen agent visible asset catalog.

