### PR TITLE
Harden agentic env-gen against weak public models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,8 @@ jobs:
     timeout-minutes: 80
     needs: [pre_commit]
     env:
-      # CI calls the internal inference endpoint for agentic env-gen live-endpoint tests.
-      ARENA_INFERENCE_ENDPOINT: internal
-      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
+      ARENA_INFERENCE_ENDPOINT: public
+      NVIDIA_API_KEY: ${{ secrets.ARENA_NVIDIA_API_KEY }}
 
     container:
       image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
@@ -380,10 +379,8 @@ jobs:
           - variant: source
             uv_flags: ""
     env:
-      # CI calls the internal inference endpoint; the agentic env-gen live-endpoint
-      # tests read NV_API_KEY for it.
-      ARENA_INFERENCE_ENDPOINT: internal
-      NV_API_KEY: ${{ secrets.ARENA_NV_API_KEY }}
+      ARENA_INFERENCE_ENDPOINT: public
+      NVIDIA_API_KEY: ${{ secrets.ARENA_NVIDIA_API_KEY }}
       # Accept the Isaac Sim EULA so the first launch is non-interactive.
       OMNI_KIT_ACCEPT_EULA: "YES"
       ACCEPT_EULA: "Y"

--- a/isaaclab_arena/agentic_environment_generation/catalogues.py
+++ b/isaaclab_arena/agentic_environment_generation/catalogues.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent prompt catalogues built from the live asset, relation, and task registries."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, get_args, get_type_hints
+
+from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
+from isaaclab_arena.relations.relations import RelationBase
+
+# Constructor kwargs already expressed as top-level ArenaEnvGraphTypes fields (not as
+# TaskSpec.params / SpatialRelationSpec.params). Keep them out of the agent catalogues.
+_TASK_CATALOGUE_EXCLUDED_PARAMS = frozenset({"task_description"})  # CompositeTaskSpec.description
+_RELATION_CATALOGUE_EXCLUDED_PARAMS = frozenset({"parent"})  # SpatialRelationSpec.reference
+
+
+# ---------------------------------------------------------------------------
+# Asset catalogue (AssetRegistry → user-prompt blocks)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AssetCatalogue:
+    """Registered asset vocabulary grouped for the agent prompt."""
+
+    # A list of embodiment names and their tags for agent to choose from.
+    embodiments: list[dict[str, Any]] = field(default_factory=list)
+    # A list of background names and their tags for agent to choose from.
+    backgrounds: list[dict[str, Any]] = field(default_factory=list)
+    # A list of object names, object types, and tags for agent to choose from.
+    objects: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_catalog_string(self) -> str:
+        """Format this catalogue as the user-message vocabulary block."""
+        embodiment_lines = "\n".join(
+            f"- {e['name']}  tags={e['tags']}" for e in sorted(self.embodiments, key=lambda e: e["name"])
+        )
+        background_lines = "\n".join(
+            f"- {b['name']}  tags={b['tags']}" for b in sorted(self.backgrounds, key=lambda b: b["name"])
+        )
+        object_lines = "\n".join(
+            f"- {o['name']}  type={o['object_type']}  tags={o['tags']}"
+            for o in sorted(self.objects, key=lambda o: o["name"])
+        )
+        return (
+            f"EMBODIMENTS ({len(self.embodiments)}):\n{embodiment_lines}\n\n"
+            f"BACKGROUNDS ({len(self.backgrounds)}):\n{background_lines}\n\n"
+            f"OBJECTS ({len(self.objects)}):\n{object_lines}"
+        )
+
+
+def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalogue:
+    """Collect registered embodiments, backgrounds, and pick-up objects from ``AssetRegistry``."""
+    registry = registry or AssetRegistry()
+    catalogue = AssetCatalogue()
+    # TODO(qianl): handle optional lights and hdr images.
+    # TODO(qianl): add tag to filter out validated/agent-ready assets only.
+    # Classify by registry tags, not issubclass(Background/Object/EmbodimentBase): importing those
+    # types pulls in pxr before SimulationApp and breaks unit tests.
+    for name in registry.get_all_keys():
+        cls = registry.get_asset_by_name(name)
+        tags = getattr(cls, "tags", None) or []
+        if "embodiment" in tags:
+            catalogue.embodiments.append({"name": name, "tags": [t for t in tags if t != "embodiment"]})
+        elif "background" in tags:
+            catalogue.backgrounds.append({"name": name, "tags": [t for t in tags if t != "background"]})
+        # Only assets existed in the catalogue are exposed.
+        elif "object" in tags:
+            # Exposed so the agent can honour type constraints, e.g. object-set members must be rigid.
+            object_type = getattr(cls, "object_type", None)
+            catalogue.objects.append({
+                "name": name,
+                "tags": [t for t in tags if t != "object"],
+                "object_type": object_type.value if object_type else "unknown",
+            })
+    return catalogue
+
+
+# ---------------------------------------------------------------------------
+# Relation catalogue (ObjectRelationLibraryRegistry → user-prompt blocks)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RelationCatalogueEntry:
+    """One registered spatial relation exposed to the agent."""
+
+    name: str
+    unary: bool
+    required_params: list[str]
+    optional_params: list[str]
+    enum_options: dict[str, list[str]]
+    summary: str
+
+
+@dataclass
+class RelationCatalogue:
+    """Registered object-relation vocabulary for the agent prompt."""
+
+    relations: list[RelationCatalogueEntry] = field(default_factory=list)
+
+    def to_catalog_string(self) -> str:
+        """Format this catalogue as the user-message RELATIONS block."""
+        lines = []
+        for entry in sorted(self.relations, key=lambda r: r.name):
+            arity = "unary" if entry.unary else "binary"
+
+            def _format_param(name: str) -> str:
+                options = entry.enum_options.get(name)
+                return f"{name}={{{', '.join(options)}}}" if options else name
+
+            required = ", ".join(_format_param(name) for name in entry.required_params)
+            optional = ", ".join(_format_param(name) for name in entry.optional_params)
+            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
+            lines.append(f"- {entry.name} ({arity}; {params}): {entry.summary}")
+        return f"RELATIONS ({len(self.relations)}):\n" + "\n".join(lines)
+
+
+def build_relation_catalogue(
+    registry: ObjectRelationLibraryRegistry | None = None,
+) -> RelationCatalogue:
+    """Collect agent-ready object relations from ``ObjectRelationLibraryRegistry``."""
+    registry = registry or ObjectRelationLibraryRegistry()
+    catalogue = RelationCatalogue()
+    for name in registry.get_all_keys():
+        relation_cls = registry.get_object_relation_by_name(name)
+        assert issubclass(relation_cls, RelationBase), f"{name!r} is not a RelationBase subclass"
+        if not getattr(relation_cls, "agent_ready", False):
+            continue
+        required_params, optional_params, enum_options = _collect_init_params(
+            relation_cls,
+            excluded_params=set(_RELATION_CATALOGUE_EXCLUDED_PARAMS),
+        )
+        catalogue.relations.append(
+            RelationCatalogueEntry(
+                name=name,
+                unary=relation_cls.is_unary(),
+                required_params=required_params,
+                optional_params=optional_params,
+                enum_options=enum_options,
+                summary=_first_docstring_line(relation_cls),
+            )
+        )
+    return catalogue
+
+
+# ---------------------------------------------------------------------------
+# Task catalogue (TaskRegistry → user-prompt blocks)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaskCatalogueEntry:
+    """One agent_ready task exposed to the agent."""
+
+    name: str
+    required_params: list[str]
+    optional_params: list[str]
+    enum_options: dict[str, list[str]]
+    summary: str
+
+
+@dataclass
+class TaskCatalogue:
+    """Agent-ready task vocabulary for the agent prompt."""
+
+    tasks: list[TaskCatalogueEntry] = field(default_factory=list)
+
+    def to_catalog_string(self) -> str:
+        """Format this catalogue as the user-message TASKS block."""
+        lines = []
+        for entry in sorted(self.tasks, key=lambda t: t.name):
+
+            def _format_param(name: str) -> str:
+                options = entry.enum_options.get(name)
+                return f"{name}={{{', '.join(options)}}}" if options else name
+
+            required = ", ".join(_format_param(name) for name in entry.required_params)
+            optional = ", ".join(_format_param(name) for name in entry.optional_params)
+            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
+            lines.append(f"- {entry.name} ({params}): {entry.summary}")
+        return f"TASKS ({len(self.tasks)}):\n" + "\n".join(lines)
+
+
+def agent_ready_task_names(registry: TaskRegistry | None = None) -> frozenset[str]:
+    """Return ``TaskRegistry`` keys for tasks marked with ``@agent_ready``."""
+    registry = registry or TaskRegistry()
+    return frozenset(
+        name for name in registry.get_all_keys() if getattr(registry.get_task_by_name(name), "agent_ready", False)
+    )
+
+
+def build_task_catalogue(registry: TaskRegistry | None = None) -> TaskCatalogue:
+    """Collect agent_ready tasks from ``TaskRegistry``."""
+    registry = registry or TaskRegistry()
+    catalogue = TaskCatalogue()
+    for name in sorted(agent_ready_task_names(registry)):
+        task_cls = registry.get_task_by_name(name)
+        required_params, optional_params, enum_options = _collect_init_params(
+            task_cls,
+            excluded_params=set(_TASK_CATALOGUE_EXCLUDED_PARAMS),
+        )
+        catalogue.tasks.append(
+            TaskCatalogueEntry(
+                name=name,
+                required_params=required_params,
+                optional_params=optional_params,
+                enum_options=enum_options,
+                summary=_first_docstring_line(task_cls),
+            )
+        )
+    return catalogue
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _first_docstring_line(cls: type) -> str:
+    doc = cls.__doc__ or ""
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _collect_init_params(
+    cls: type,
+    excluded_params: set[str],
+) -> tuple[list[str], list[str], dict[str, list[str]]]:
+    """Collect required, optional, and Enum-valued constructor parameters."""
+    signature = inspect.signature(cls.__init__)
+    params = {
+        name: param
+        for name, param in signature.parameters.items()
+        if name != "self"
+        and name not in excluded_params
+        and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    required = [name for name, param in params.items() if param.default is inspect.Parameter.empty]
+    optional = [name for name, param in params.items() if param.default is not inspect.Parameter.empty]
+    try:
+        type_hints = get_type_hints(cls.__init__)
+    except (NameError, TypeError):
+        module_globals = vars(sys.modules[cls.__module__])
+        type_hints = {}
+        for name, param in params.items():
+            type_hints[name] = _resolve_annotation(param.annotation, module_globals)
+    enum_options = {
+        name: [str(member.value) for member in enum_type]
+        for name, annotation in type_hints.items()
+        if name in params and (enum_type := _find_enum_type(annotation)) is not None
+    }
+    return required, optional, enum_options
+
+
+def _find_enum_type(annotation: Any) -> type[Enum] | None:
+    """Return the Enum type contained in an annotation, including union annotations."""
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return annotation
+    for argument in get_args(annotation):
+        if (enum_type := _find_enum_type(argument)) is not None:
+            return enum_type
+    return None
+
+
+def _resolve_annotation(annotation: Any, module_globals: dict[str, Any]) -> Any:
+    """Resolve one trusted internal string annotation when its names are available."""
+    if not isinstance(annotation, str):
+        return annotation
+    try:
+        return eval(annotation, module_globals)  # noqa: S307 — trusted internal annotations
+    except (NameError, SyntaxError, TypeError):
+        return annotation

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -7,13 +7,18 @@
 
 from __future__ import annotations
 
-import inspect
 import logging
-import sys
-from dataclasses import dataclass, field, replace
-from enum import Enum
-from typing import Any, get_args, get_type_hints
+from dataclasses import replace
+from typing import Any
 
+from isaaclab_arena.agentic_environment_generation.catalogues import (
+    AssetCatalogue,
+    RelationCatalogue,
+    TaskCatalogue,
+    build_asset_catalogue,
+    build_relation_catalogue,
+    build_task_catalogue,
+)
 from isaaclab_arena.agentic_environment_generation.inference_backend import InferenceBackend
 from isaaclab_arena.agentic_environment_generation.missing_object_inference import MissingObjectInference
 from isaaclab_arena.agentic_environment_generation.prim_path_inference import PrimPathInference
@@ -22,16 +27,10 @@ from isaaclab_arena.agentic_environment_generation.simready_asset_search import 
     search_simready_objects,
 )
 from isaaclab_arena.agentic_environment_generation.spec_inference import SpecInference
-from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
 from isaaclab_arena.assets.simready_constants import SIMREADY_USD_OBJECT_REGISTRY_NAME
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
-from isaaclab_arena.relations.relations import RelationBase
 
 _logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Environment generation agent
-# ---------------------------------------------------------------------------
 
 
 class EnvironmentGenerationAgent:
@@ -222,266 +221,3 @@ class EnvironmentGenerationAgent:
             self._simready_usd_paths[asset_cls.name] = candidate.usd_path
             _logger.info("catalogued %r for %r: %s", asset_cls.name, candidate.search_phrase, candidate.usd_path)
         return extended
-
-
-# ---------------------------------------------------------------------------
-# Asset catalogue (AssetRegistry → user-prompt blocks)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class AssetCatalogue:
-    """Registered asset vocabulary grouped for the agent prompt."""
-
-    # A list of embodiment names and their tags for agent to choose from.
-    embodiments: list[dict[str, Any]] = field(default_factory=list)
-    # A list of background names and their tags for agent to choose from.
-    backgrounds: list[dict[str, Any]] = field(default_factory=list)
-    # A list of object names, object types, and tags for agent to choose from.
-    objects: list[dict[str, Any]] = field(default_factory=list)
-
-    def to_catalog_string(self) -> str:
-        """Format this catalogue as the user-message vocabulary block."""
-        embodiment_lines = "\n".join(
-            f"- {e['name']}  tags={e['tags']}" for e in sorted(self.embodiments, key=lambda e: e["name"])
-        )
-        background_lines = "\n".join(
-            f"- {b['name']}  tags={b['tags']}" for b in sorted(self.backgrounds, key=lambda b: b["name"])
-        )
-        object_lines = "\n".join(
-            f"- {o['name']}  type={o['object_type']}  tags={o['tags']}"
-            for o in sorted(self.objects, key=lambda o: o["name"])
-        )
-        return (
-            f"EMBODIMENTS ({len(self.embodiments)}):\n{embodiment_lines}\n\n"
-            f"BACKGROUNDS ({len(self.backgrounds)}):\n{background_lines}\n\n"
-            f"OBJECTS ({len(self.objects)}):\n{object_lines}"
-        )
-
-
-def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalogue:
-    """Collect registered embodiments, backgrounds, and pick-up objects from ``AssetRegistry``."""
-    registry = registry or AssetRegistry()
-    catalogue = AssetCatalogue()
-    # TODO(qianl): handle optional lights and hdr images.
-    # TODO(qianl): add tag to filter out validated/agent-ready assets only.
-    # Classify by registry tags, not issubclass(Background/Object/EmbodimentBase): importing those
-    # types pulls in pxr before SimulationApp and breaks unit tests.
-    for name in registry.get_all_keys():
-        cls = registry.get_asset_by_name(name)
-        tags = getattr(cls, "tags", None) or []
-        if "embodiment" in tags:
-            catalogue.embodiments.append({"name": name, "tags": [t for t in tags if t != "embodiment"]})
-        elif "background" in tags:
-            catalogue.backgrounds.append({"name": name, "tags": [t for t in tags if t != "background"]})
-        # Only assets existed in the catalogue are exposed.
-        elif "object" in tags:
-            # Exposed so the agent can honour type constraints, e.g. object-set members must be rigid.
-            object_type = getattr(cls, "object_type", None)
-            catalogue.objects.append({
-                "name": name,
-                "tags": [t for t in tags if t != "object"],
-                "object_type": object_type.value if object_type else "unknown",
-            })
-    return catalogue
-
-
-# ---------------------------------------------------------------------------
-# Relation catalogue (ObjectRelationLibraryRegistry → user-prompt blocks)
-# ---------------------------------------------------------------------------
-
-
-def _first_docstring_line(cls: type) -> str:
-    doc = cls.__doc__ or ""
-    for line in doc.splitlines():
-        stripped = line.strip()
-        if stripped:
-            return stripped
-    return ""
-
-
-# Constructor kwargs already expressed as top-level ArenaEnvGraphTypes fields (not as
-# TaskSpec.params / SpatialRelationSpec.params). Keep them out of the agent catalogues.
-_TASK_CATALOGUE_EXCLUDED_PARAMS = frozenset({"task_description"})  # CompositeTaskSpec.description
-_RELATION_CATALOGUE_EXCLUDED_PARAMS = frozenset({"parent"})  # SpatialRelationSpec.reference
-
-
-@dataclass
-class RelationCatalogueEntry:
-    """One registered spatial relation exposed to the agent."""
-
-    name: str
-    unary: bool
-    required_params: list[str]
-    optional_params: list[str]
-    enum_options: dict[str, list[str]]
-    summary: str
-
-
-@dataclass
-class RelationCatalogue:
-    """Registered object-relation vocabulary for the agent prompt."""
-
-    relations: list[RelationCatalogueEntry] = field(default_factory=list)
-
-    def to_catalog_string(self) -> str:
-        """Format this catalogue as the user-message RELATIONS block."""
-        lines = []
-        for entry in sorted(self.relations, key=lambda r: r.name):
-            arity = "unary" if entry.unary else "binary"
-
-            def _format_param(name: str) -> str:
-                options = entry.enum_options.get(name)
-                return f"{name}={{{', '.join(options)}}}" if options else name
-
-            required = ", ".join(_format_param(name) for name in entry.required_params)
-            optional = ", ".join(_format_param(name) for name in entry.optional_params)
-            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
-            lines.append(f"- {entry.name} ({arity}; {params}): {entry.summary}")
-        return f"RELATIONS ({len(self.relations)}):\n" + "\n".join(lines)
-
-
-def build_relation_catalogue(
-    registry: ObjectRelationLibraryRegistry | None = None,
-) -> RelationCatalogue:
-    """Collect agent-ready object relations from ``ObjectRelationLibraryRegistry``."""
-    registry = registry or ObjectRelationLibraryRegistry()
-    catalogue = RelationCatalogue()
-    for name in registry.get_all_keys():
-        relation_cls = registry.get_object_relation_by_name(name)
-        assert issubclass(relation_cls, RelationBase), f"{name!r} is not a RelationBase subclass"
-        if not getattr(relation_cls, "agent_ready", False):
-            continue
-        required_params, optional_params, enum_options = _collect_init_params(
-            relation_cls,
-            excluded_params=set(_RELATION_CATALOGUE_EXCLUDED_PARAMS),
-        )
-        catalogue.relations.append(
-            RelationCatalogueEntry(
-                name=name,
-                unary=relation_cls.is_unary(),
-                required_params=required_params,
-                optional_params=optional_params,
-                enum_options=enum_options,
-                summary=_first_docstring_line(relation_cls),
-            )
-        )
-    return catalogue
-
-
-def _collect_init_params(
-    cls: type,
-    excluded_params: set[str],
-) -> tuple[list[str], list[str], dict[str, list[str]]]:
-    """Collect required, optional, and Enum-valued constructor parameters."""
-    signature = inspect.signature(cls.__init__)
-    params = {
-        name: param
-        for name, param in signature.parameters.items()
-        if name != "self"
-        and name not in excluded_params
-        and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
-    }
-    required = [name for name, param in params.items() if param.default is inspect.Parameter.empty]
-    optional = [name for name, param in params.items() if param.default is not inspect.Parameter.empty]
-    try:
-        type_hints = get_type_hints(cls.__init__)
-    except (NameError, TypeError):
-        module_globals = vars(sys.modules[cls.__module__])
-        type_hints = {}
-        for name, param in params.items():
-            type_hints[name] = _resolve_annotation(param.annotation, module_globals)
-    enum_options = {
-        name: [str(member.value) for member in enum_type]
-        for name, annotation in type_hints.items()
-        if name in params and (enum_type := _find_enum_type(annotation)) is not None
-    }
-    return required, optional, enum_options
-
-
-def _find_enum_type(annotation: Any) -> type[Enum] | None:
-    """Return the Enum type contained in an annotation, including union annotations."""
-    if isinstance(annotation, type) and issubclass(annotation, Enum):
-        return annotation
-    for argument in get_args(annotation):
-        if (enum_type := _find_enum_type(argument)) is not None:
-            return enum_type
-    return None
-
-
-def _resolve_annotation(annotation: Any, module_globals: dict[str, Any]) -> Any:
-    """Resolve one trusted internal string annotation when its names are available."""
-    if not isinstance(annotation, str):
-        return annotation
-    try:
-        return eval(annotation, module_globals)  # noqa: S307 — trusted internal annotations
-    except (NameError, SyntaxError, TypeError):
-        return annotation
-
-
-# ---------------------------------------------------------------------------
-# Task catalogue (TaskRegistry → user-prompt blocks)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class TaskCatalogueEntry:
-    """One agent_ready task exposed to the agent."""
-
-    name: str
-    required_params: list[str]
-    optional_params: list[str]
-    enum_options: dict[str, list[str]]
-    summary: str
-
-
-@dataclass
-class TaskCatalogue:
-    """Agent-ready task vocabulary for the agent prompt."""
-
-    tasks: list[TaskCatalogueEntry] = field(default_factory=list)
-
-    def to_catalog_string(self) -> str:
-        """Format this catalogue as the user-message TASKS block."""
-        lines = []
-        for entry in sorted(self.tasks, key=lambda t: t.name):
-
-            def _format_param(name: str) -> str:
-                options = entry.enum_options.get(name)
-                return f"{name}={{{', '.join(options)}}}" if options else name
-
-            required = ", ".join(_format_param(name) for name in entry.required_params)
-            optional = ", ".join(_format_param(name) for name in entry.optional_params)
-            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
-            lines.append(f"- {entry.name} ({params}): {entry.summary}")
-        return f"TASKS ({len(self.tasks)}):\n" + "\n".join(lines)
-
-
-def agent_ready_task_names(registry: TaskRegistry | None = None) -> frozenset[str]:
-    """Return ``TaskRegistry`` keys for tasks marked with ``@agent_ready``."""
-    registry = registry or TaskRegistry()
-    return frozenset(
-        name for name in registry.get_all_keys() if getattr(registry.get_task_by_name(name), "agent_ready", False)
-    )
-
-
-def build_task_catalogue(registry: TaskRegistry | None = None) -> TaskCatalogue:
-    """Collect agent_ready tasks from ``TaskRegistry``."""
-    registry = registry or TaskRegistry()
-    catalogue = TaskCatalogue()
-    for name in sorted(agent_ready_task_names(registry)):
-        task_cls = registry.get_task_by_name(name)
-        required_params, optional_params, enum_options = _collect_init_params(
-            task_cls,
-            excluded_params=set(_TASK_CATALOGUE_EXCLUDED_PARAMS),
-        )
-        catalogue.tasks.append(
-            TaskCatalogueEntry(
-                name=name,
-                required_params=required_params,
-                optional_params=optional_params,
-                enum_options=enum_options,
-                summary=_first_docstring_line(task_cls),
-            )
-        )
-    return catalogue

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -300,6 +300,12 @@ def _first_docstring_line(cls: type) -> str:
     return ""
 
 
+# Constructor kwargs already expressed as top-level ArenaEnvGraphTypes fields (not as
+# TaskSpec.params / SpatialRelationSpec.params). Keep them out of the agent catalogues.
+_TASK_CATALOGUE_EXCLUDED_PARAMS = frozenset({"task_description"})  # CompositeTaskSpec.description
+_RELATION_CATALOGUE_EXCLUDED_PARAMS = frozenset({"parent"})  # SpatialRelationSpec.reference
+
+
 @dataclass
 class RelationCatalogueEntry:
     """One registered spatial relation exposed to the agent."""
@@ -348,7 +354,7 @@ def build_relation_catalogue(
             continue
         required_params, optional_params, enum_options = _collect_init_params(
             relation_cls,
-            excluded_params={"parent"} if not relation_cls.is_unary() else set(),
+            excluded_params=set(_RELATION_CATALOGUE_EXCLUDED_PARAMS),
         )
         catalogue.relations.append(
             RelationCatalogueEntry(
@@ -465,7 +471,10 @@ def build_task_catalogue(registry: TaskRegistry | None = None) -> TaskCatalogue:
     catalogue = TaskCatalogue()
     for name in sorted(agent_ready_task_names(registry)):
         task_cls = registry.get_task_by_name(name)
-        required_params, optional_params, enum_options = _collect_init_params(task_cls, excluded_params=set())
+        required_params, optional_params, enum_options = _collect_init_params(
+            task_cls,
+            excluded_params=set(_TASK_CATALOGUE_EXCLUDED_PARAMS),
+        )
         catalogue.tasks.append(
             TaskCatalogueEntry(
                 name=name,

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -7,9 +7,12 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
+import sys
 from dataclasses import dataclass, field, replace
-from typing import Any
+from enum import Enum
+from typing import Any, get_args, get_type_hints
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import InferenceBackend
 from isaaclab_arena.agentic_environment_generation.missing_object_inference import MissingObjectInference
@@ -304,6 +307,9 @@ class RelationCatalogueEntry:
 
     name: str
     unary: bool
+    required_params: list[str]
+    optional_params: list[str]
+    enum_options: dict[str, list[str]]
     summary: str
 
 
@@ -318,27 +324,94 @@ class RelationCatalogue:
         lines = []
         for entry in sorted(self.relations, key=lambda r: r.name):
             arity = "unary" if entry.unary else "binary"
-            lines.append(f"- {entry.name} ({arity}): {entry.summary}")
+
+            def _format_param(name: str) -> str:
+                options = entry.enum_options.get(name)
+                return f"{name}={{{', '.join(options)}}}" if options else name
+
+            required = ", ".join(_format_param(name) for name in entry.required_params)
+            optional = ", ".join(_format_param(name) for name in entry.optional_params)
+            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
+            lines.append(f"- {entry.name} ({arity}; {params}): {entry.summary}")
         return f"RELATIONS ({len(self.relations)}):\n" + "\n".join(lines)
 
 
 def build_relation_catalogue(
     registry: ObjectRelationLibraryRegistry | None = None,
 ) -> RelationCatalogue:
-    """Collect registered object relations from ``ObjectRelationLibraryRegistry``."""
+    """Collect agent-ready object relations from ``ObjectRelationLibraryRegistry``."""
     registry = registry or ObjectRelationLibraryRegistry()
     catalogue = RelationCatalogue()
     for name in registry.get_all_keys():
         relation_cls = registry.get_object_relation_by_name(name)
         assert issubclass(relation_cls, RelationBase), f"{name!r} is not a RelationBase subclass"
+        if not getattr(relation_cls, "agent_ready", False):
+            continue
+        required_params, optional_params, enum_options = _collect_init_params(
+            relation_cls,
+            excluded_params={"parent"} if not relation_cls.is_unary() else set(),
+        )
         catalogue.relations.append(
             RelationCatalogueEntry(
                 name=name,
                 unary=relation_cls.is_unary(),
+                required_params=required_params,
+                optional_params=optional_params,
+                enum_options=enum_options,
                 summary=_first_docstring_line(relation_cls),
             )
         )
     return catalogue
+
+
+def _collect_init_params(
+    cls: type,
+    excluded_params: set[str],
+) -> tuple[list[str], list[str], dict[str, list[str]]]:
+    """Collect required, optional, and Enum-valued constructor parameters."""
+    signature = inspect.signature(cls.__init__)
+    params = {
+        name: param
+        for name, param in signature.parameters.items()
+        if name != "self"
+        and name not in excluded_params
+        and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    }
+    required = [name for name, param in params.items() if param.default is inspect.Parameter.empty]
+    optional = [name for name, param in params.items() if param.default is not inspect.Parameter.empty]
+    try:
+        type_hints = get_type_hints(cls.__init__)
+    except (NameError, TypeError):
+        module_globals = vars(sys.modules[cls.__module__])
+        type_hints = {}
+        for name, param in params.items():
+            type_hints[name] = _resolve_annotation(param.annotation, module_globals)
+    enum_options = {
+        name: [str(member.value) for member in enum_type]
+        for name, annotation in type_hints.items()
+        if name in params and (enum_type := _find_enum_type(annotation)) is not None
+    }
+    return required, optional, enum_options
+
+
+def _find_enum_type(annotation: Any) -> type[Enum] | None:
+    """Return the Enum type contained in an annotation, including union annotations."""
+    if isinstance(annotation, type) and issubclass(annotation, Enum):
+        return annotation
+    for argument in get_args(annotation):
+        if (enum_type := _find_enum_type(argument)) is not None:
+            return enum_type
+    return None
+
+
+def _resolve_annotation(annotation: Any, module_globals: dict[str, Any]) -> Any:
+    """Resolve one trusted internal string annotation when its names are available."""
+    if not isinstance(annotation, str):
+        return annotation
+    try:
+        return eval(annotation, module_globals)  # noqa: S307 — trusted internal annotations
+    except (NameError, SyntaxError, TypeError):
+        return annotation
 
 
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -22,7 +22,6 @@ from isaaclab_arena.agentic_environment_generation.simready_asset_search import 
     search_simready_objects,
 )
 from isaaclab_arena.agentic_environment_generation.spec_inference import SpecInference
-from isaaclab_arena.agentic_environment_generation.spec_validation import required_task_init_param_names
 from isaaclab_arena.assets.registries import AssetRegistry, ObjectRelationLibraryRegistry, TaskRegistry
 from isaaclab_arena.assets.simready_constants import SIMREADY_USD_OBJECT_REGISTRY_NAME
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -425,6 +424,8 @@ class TaskCatalogueEntry:
 
     name: str
     required_params: list[str]
+    optional_params: list[str]
+    enum_options: dict[str, list[str]]
     summary: str
 
 
@@ -438,7 +439,14 @@ class TaskCatalogue:
         """Format this catalogue as the user-message TASKS block."""
         lines = []
         for entry in sorted(self.tasks, key=lambda t: t.name):
-            params = ", ".join(entry.required_params)
+
+            def _format_param(name: str) -> str:
+                options = entry.enum_options.get(name)
+                return f"{name}={{{', '.join(options)}}}" if options else name
+
+            required = ", ".join(_format_param(name) for name in entry.required_params)
+            optional = ", ".join(_format_param(name) for name in entry.optional_params)
+            params = f"required: {required or 'none'}; optional: {optional or 'none'}"
             lines.append(f"- {entry.name} ({params}): {entry.summary}")
         return f"TASKS ({len(self.tasks)}):\n" + "\n".join(lines)
 
@@ -457,10 +465,13 @@ def build_task_catalogue(registry: TaskRegistry | None = None) -> TaskCatalogue:
     catalogue = TaskCatalogue()
     for name in sorted(agent_ready_task_names(registry)):
         task_cls = registry.get_task_by_name(name)
+        required_params, optional_params, enum_options = _collect_init_params(task_cls, excluded_params=set())
         catalogue.tasks.append(
             TaskCatalogueEntry(
                 name=name,
-                required_params=required_task_init_param_names(task_cls),
+                required_params=required_params,
+                optional_params=optional_params,
+                enum_options=enum_options,
                 summary=_first_docstring_line(task_cls),
             )
         )

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -23,6 +23,7 @@ INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
 INTERNAL_MODEL = "azure/anthropic/claude-opus-4-8"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 PUBLIC_MODEL = "openai/gpt-oss-120b"
+# If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
 
 INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
 """Environment variable naming the inference endpoint every agentic command uses."""

--- a/isaaclab_arena/agentic_environment_generation/prim_path_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/prim_path_inference.py
@@ -18,6 +18,7 @@ from isaaclab_arena.agentic_environment_generation.inference_backend import (
     build_strict_schema,
 )
 from isaaclab_arena.agentic_environment_generation.spec_validation import format_validation_error
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 from isaaclab_arena.environment_spec.arena_env_graph_types import ObjectReferenceSpec
 
@@ -55,6 +56,7 @@ class PrimPathInference:
         # Defer pxr import until call time to avoid conflict with SimulationApp.
         from isaaclab_arena.utils.usd_prim_tree import load_usd_prim_tree
 
+        spec = _enforce_object_reference_types(spec)
         usd_path = spec.background.resolve_usd_path()
         prim_tree = load_usd_prim_tree(usd_path)
         data = self._inference_backend.run_json(
@@ -92,8 +94,10 @@ GUIDANCE:
 - Pick prim_path only from those full relative_path values.
 - prim_path must be a relative suffix under the parent background — never include
   {ENV_REGEX_NS} or the background registry name.
-- Respect each input object_reference object_type: pick a prim_path whose object_type in
-  BACKGROUND PRIM TREE matches the object_type from the input spec. Do not change object_type.
+- When the input object_type is articulation or rigid, pick a prim_path whose object_type in
+  BACKGROUND PRIM TREE matches it exactly. Do not change object_type.
+- When the input object_type is base, the prim tree object_type may be base, rigid, or articulation;
+  pick the prim that semantically represents the referenced static fixture or surface.
 - When the input object_type is articulation, pick the articulation root prim (the line that
   lists joint names), not a rigid child mesh or collision prim under it.
 - When the input object_type is base, pick an anchor-surface prim (counter top, shelf, etc.).
@@ -169,11 +173,47 @@ class ResolvedObjectReferences(BaseModel):
     )
 
 
+def _enforce_object_reference_types(spec: ArenaEnvGraphSpec) -> ArenaEnvGraphSpec:
+    """Set object-reference types from their task roles.
+
+    Open/close-door targets are articulations, pick-and-place pick-up objects are rigid,
+    and every other reference is a static base.
+    """
+    if spec.object_references is None:
+        return spec
+    openable_ids = {
+        task.params.get("openable_object")
+        for task in spec.task.subtasks
+        if task.kind in {"OpenDoorTask", "CloseDoorTask"}
+    }
+    pick_up_ids = {task.params.get("pick_up_object") for task in spec.task.subtasks if task.kind == "PickAndPlaceTask"}
+    updated_references: list[ObjectReferenceSpec] = []
+    for reference in spec.object_references:
+        if reference.id in openable_ids:
+            required_type = ObjectType.ARTICULATION
+            reason = "openable_object in an open/close door task"
+        elif reference.id in pick_up_ids:
+            required_type = ObjectType.RIGID
+            reason = "pick_up_object in a pick-and-place task"
+        else:
+            required_type = ObjectType.BASE
+            reason = "not used as an openable_object or pick_up_object"
+        if reference.object_type != required_type:
+            print(
+                f"[resolve_usd_prim] enforced object reference {reference.id!r} type "
+                f"{reference.object_type.value!r} -> {required_type.value!r}: {reason}",
+                flush=True,
+            )
+            reference = reference.model_copy(update={"object_type": required_type})
+        updated_references.append(reference)
+    return spec.model_copy(update={"object_references": updated_references})
+
+
 def _validate_against_prim_tree(
     object_references: list[ObjectReferenceSpec],
     prim_tree: list[UsdPrimRecord],
 ) -> None:
-    """Validate resolved object references against the background USD prim tree."""
+    """Validate paths and reject type upcasts from rigid or articulation references."""
     records_by_path = {record.relative_path: record for record in prim_tree}
     for ref in object_references:
         assert ref.prim_path is not None, f"Object reference '{ref.id}' requires a prim_path"
@@ -182,10 +222,11 @@ def _validate_against_prim_tree(
         assert (
             record is not None
         ), f"Object reference '{ref.id}' prim_path {prim_path!r} is not in the background prim tree"
-        assert ref.object_type == record.object_type, (
-            f"Object reference '{ref.id}' object_type {ref.object_type!r} does not match prim tree "
-            f"object_type {record.object_type!r} for {prim_path!r}"
-        )
+        if ref.object_type != ObjectType.BASE:
+            assert ref.object_type == record.object_type, (
+                f"Object reference '{ref.id}' object_type {ref.object_type!r} does not match prim tree "
+                f"object_type {record.object_type!r} for {prim_path!r}"
+            )
 
 
 def _merge_resolved_object_references(

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -155,5 +155,8 @@ GUIDANCE:
 - For each ``object_reference``, leave ``prim_path`` empty.
 - REQUIRED: include an ``is_anchor`` relation on the resting surface (background or an
   ``object_reference`` within it).
+- REQUIRED: every ``object_reference`` must have an ``is_anchor`` relation.
+- For every relation, include all parameters marked ``required`` in the RELATIONS catalog in
+  that relation's ``params``.
 - All objects need an ``on`` relation with that anchor as ``reference``.
 """

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -143,6 +143,7 @@ Convert a natural-language prompt into an ArenaEnvGraphSpec.
 
 GUIDANCE:
 - Follow the per-field ``description`` strings in the schema.
+- REQUIRED: leave ``placement_validators`` and ``cli_override_specs`` null.
 - Use only exact names from the catalog for ``registry_name``:
   EMBODIMENTS for ``embodiment``, BACKGROUNDS for ``background``, and OBJECTS for ``objects``.
 - Do NOT hallucinate asset names — every ``registry_name`` must appear verbatim in the catalog.

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -159,6 +159,8 @@ GUIDANCE:
 - Only populate ``object_references`` when the prompt explicitly mentions surfaces or appliances
   inside the background; otherwise leave it unset.
 - For each ``object_reference``, leave ``prim_path`` empty.
+- Task parameters referring to an asest (object, background or object reference) must use the ID (NOT registry_name).
+- Relation subject and references must use the asset ID (NOT registry_name).
 - REQUIRED: include an ``is_anchor`` relation on the resting surface (background or an
   ``object_reference`` within it).
 - REQUIRED: every ``object_reference`` must have an ``is_anchor`` relation.

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -156,13 +156,24 @@ GUIDANCE:
   suffixes in ``id``.
 - Use ``object_sets`` only when one object varies across environments; list its variants as ``members``.
   Every member must be an OBJECTS entry marked ``type=rigid``.
-- Only populate ``object_references`` when the prompt explicitly mentions surfaces or appliances
-  inside the background; otherwise leave it unset.
+- An ``object_reference`` names a prim inside the background. Add one for every surface or appliance
+  the prompt names that the background merely contains — the floor the robot stands on, a counter top,
+  a sink, a fridge, a microwave. Name it after the appliance or surface itself, never after the moving
+  part the task acts on — a prompt opening "the fridge door" still names the reference ``fridge``.
+- REQUIRED: never add an ``object_reference`` for a surface that IS the background, such as "the table"
+  when ``registry_name`` names a table. Use the background id for it. Leave ``object_references`` unset
+  when the background itself is every surface the prompt names.
+- REQUIRED: a task or relation param naming part of the background must use that
+  ``object_reference`` id, never the background id.
 - For each ``object_reference``, leave ``prim_path`` empty.
+- REQUIRED: pick ``task.composition`` from the number of subtasks you emit. One subtask is
+  ``atomic``. Two or more is ``parallel`` when the prompt says the order does not matter, and
+  ``sequential`` when the prompt fixes an order. ``atomic`` never has more than one subtask.
 - Task parameters referring to an asest (object, background or object reference) must use the ID (NOT registry_name).
 - Relation subject and references must use the asset ID (NOT registry_name).
-- REQUIRED: include an ``is_anchor`` relation on the resting surface (background or an
-  ``object_reference`` within it).
+- REQUIRED: include an ``is_anchor`` relation on the resting surface. That is the
+  ``object_reference`` for the surface the prompt names inside the background; use the background id
+  only when the prompt names no surface inside it.
 - REQUIRED: every ``object_reference`` must have an ``is_anchor`` relation.
 - For every relation, include all parameters marked ``required`` in the RELATIONS catalog in
   that relation's ``params``.

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from pydantic import ValidationError
@@ -21,6 +22,9 @@ from isaaclab_arena.agentic_environment_generation.spec_validation import (
     format_validation_error,
 )
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+
+MAX_SPEC_INFERENCE_CALLS = 3
+"""Maximum generation calls, including critic retries after validation failures."""
 
 
 class SpecInference:
@@ -52,27 +56,65 @@ class SpecInference:
             parsed model JSON. On failure, ``spec`` is ``None`` and ``data`` is the raw
             response object.
         """
-        data = self._inference_backend.run_json(
-            StructuredOutputRequest(
-                schema_name="ArenaEnvGraphSpec",
-                schema=self._schema,
-                system=self._system_prompt(),
-                user=self._user_message(
-                    prompt,
-                    asset_catalog,
-                    relation_catalog,
-                    task_catalog,
-                ),
-                retry_label="generate_spec",
-            )
+        base_user_message = self._user_message(
+            prompt,
+            asset_catalog,
+            relation_catalog,
+            task_catalog,
         )
-        try:
-            spec = ArenaEnvGraphSpec.model_validate(data)
-        except ValidationError as exc:
-            traces.extend(format_validation_error(exc))
-            return None, data
-        traces.extend(collect_agent_ready_task_validation_traces(spec))
-        return spec, data
+        user_message = base_user_message
+        data: dict[str, Any] = {}
+        for call_index in range(MAX_SPEC_INFERENCE_CALLS):
+            data = self._inference_backend.run_json(
+                StructuredOutputRequest(
+                    schema_name="ArenaEnvGraphSpec",
+                    schema=self._schema,
+                    system=self._system_prompt(),
+                    user=user_message,
+                    retry_label="generate_spec",
+                )
+            )
+            try:
+                spec = ArenaEnvGraphSpec.model_validate(data)
+                validation_traces = collect_agent_ready_task_validation_traces(spec)
+            except ValidationError as exc:
+                spec = None
+                validation_traces = format_validation_error(exc)
+            if spec is not None and not validation_traces:
+                return spec, data
+            if call_index + 1 < MAX_SPEC_INFERENCE_CALLS:
+                print(
+                    f"[generate_spec] critic retry {call_index + 1}/{MAX_SPEC_INFERENCE_CALLS - 1} "
+                    f"after validation failed: {'; '.join(validation_traces)}",
+                    flush=True,
+                )
+                user_message = self._critic_user_message(base_user_message, data, validation_traces)
+                continue
+            traces.extend(validation_traces)
+        return None, data
+
+    @staticmethod
+    def _critic_user_message(
+        previous_user_message: str,
+        rejected_data: dict[str, Any],
+        validation_traces: list[str],
+    ) -> str:
+        """Append rejected output and validation feedback for another complete generation."""
+        errors = "\n".join(f"- {trace}" for trace in validation_traces)
+        rejected = json.dumps(rejected_data, indent=2, default=str)
+        return f"""\
+{previous_user_message}
+
+CRITIC FEEDBACK:
+The previous response failed validation. Regenerate the complete ArenaEnvGraphSpec, correcting
+every error below. Return only the corrected structured response.
+
+VALIDATION ERRORS:
+{errors}
+
+REJECTED RESPONSE:
+{rejected}
+"""
 
     @staticmethod
     def _user_message(

--- a/isaaclab_arena/agentic_environment_generation/spec_inference.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_inference.py
@@ -18,7 +18,7 @@ from isaaclab_arena.agentic_environment_generation.inference_backend import (
     build_strict_schema,
 )
 from isaaclab_arena.agentic_environment_generation.spec_validation import (
-    collect_agent_ready_task_validation_traces,
+    collect_agent_ready_validation_trace,
     format_validation_error,
 )
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -76,7 +76,12 @@ class SpecInference:
             )
             try:
                 spec = ArenaEnvGraphSpec.model_validate(data)
-                validation_traces = collect_agent_ready_task_validation_traces(spec)
+                validation_traces = collect_agent_ready_validation_trace(
+                    spec,
+                    asset_catalog=asset_catalog,
+                    task_catalog=task_catalog,
+                    relation_catalog=relation_catalog,
+                )
             except ValidationError as exc:
                 spec = None
                 validation_traces = format_validation_error(exc)

--- a/isaaclab_arena/agentic_environment_generation/spec_validation.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_validation.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
 if TYPE_CHECKING:
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+    from isaaclab_arena.agentic_environment_generation.catalogues import (
         AssetCatalogue,
         RelationCatalogue,
         TaskCatalogue,
@@ -49,18 +49,23 @@ def collect_agent_ready_validation_trace(
 ) -> list[str]:
     """Return spec violations against the exact catalogues exposed to the agent."""
     traces: list[str] = []
+
+    # Check every registry_name against the asset catalogue the agent was given.
     asset_names = {
         "EMBODIMENTS": {entry["name"] for entry in asset_catalog.embodiments},
         "BACKGROUNDS": {entry["name"] for entry in asset_catalog.backgrounds},
         "OBJECTS": {entry["name"] for entry in asset_catalog.objects},
     }
+    # Embodiment and background are required singles; flag any name outside the catalogue.
     if spec.embodiment.registry_name not in asset_names["EMBODIMENTS"]:
         traces.append(f"Embodiment registry_name {spec.embodiment.registry_name!r} is not in the EMBODIMENTS catalog")
     if spec.background.registry_name not in asset_names["BACKGROUNDS"]:
         traces.append(f"Background registry_name {spec.background.registry_name!r} is not in the BACKGROUNDS catalog")
+    # Each movable object must resolve to a known OBJECTS entry.
     for obj in spec.objects:
         if obj.registry_name not in asset_names["OBJECTS"]:
             traces.append(f"Object {obj.id!r} registry_name {obj.registry_name!r} is not in the OBJECTS catalog")
+    # Object-set members are registry names too; validate each one the same way.
     for object_set in spec.object_sets or []:
         for member in object_set.members:
             if member not in asset_names["OBJECTS"]:
@@ -68,12 +73,15 @@ def collect_agent_ready_validation_trace(
                     f"Object set {object_set.id!r} member registry_name {member!r} is not in the OBJECTS catalog"
                 )
 
+    # Check each subtask kind and its params against the task catalogue.
     task_entries = {entry.name: entry for entry in task_catalog.tasks}
     for task in spec.task.subtasks:
         entry = task_entries.get(task.kind)
+        # Unknown task kinds cannot be repaired via params; skip further checks.
         if entry is None:
             traces.append(f"Task {task.kind!r} is not in the TASKS catalog")
             continue
+        # Required params must be present; anything outside required|optional is rejected.
         for required_param in entry.required_params:
             if required_param not in task.params:
                 traces.append(f"Task {task.kind!r} is missing required param {required_param!r}")
@@ -84,9 +92,11 @@ def collect_agent_ready_validation_trace(
                 f"supported params are {sorted(supported_params)!r}"
             )
 
+    # Check each relation kind and its params against the relation catalogue.
     relation_entries = {entry.name: entry for entry in relation_catalog.relations}
     for relation in spec.relations:
         entry = relation_entries.get(relation.kind)
+        # Same pattern as tasks: unknown kinds first, then required/unsupported params.
         if entry is None:
             traces.append(f"Relation {relation.kind!r} is not in the RELATIONS catalog")
             continue

--- a/isaaclab_arena/agentic_environment_generation/spec_validation.py
+++ b/isaaclab_arena/agentic_environment_generation/spec_validation.py
@@ -7,26 +7,18 @@
 
 from __future__ import annotations
 
-import inspect
+from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
-from isaaclab_arena.assets.registries import TaskRegistry
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
 
-
-def required_task_init_param_names(task_cls: type) -> list[str]:
-    """Return required ``__init__`` parameter names for a task class."""
-    sig = inspect.signature(task_cls.__init__)
-    required: list[str] = []
-    for name, param in sig.parameters.items():
-        if name == "self":
-            continue
-        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
-            continue
-        if param.default is inspect.Parameter.empty:
-            required.append(name)
-    return required
+if TYPE_CHECKING:
+    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+        AssetCatalogue,
+        RelationCatalogue,
+        TaskCatalogue,
+    )
 
 
 _ASSERTION_FAILED_PREFIX = "Assertion failed, "
@@ -49,15 +41,62 @@ def format_validation_error(exc: ValidationError) -> list[str]:
     return lines
 
 
-def collect_agent_ready_task_validation_traces(spec: ArenaEnvGraphSpec) -> list[str]:
-    """Return agent-only task constraint violations not enforced by ``ArenaEnvGraphSpec``."""
+def collect_agent_ready_validation_trace(
+    spec: ArenaEnvGraphSpec,
+    asset_catalog: AssetCatalogue,
+    task_catalog: TaskCatalogue,
+    relation_catalog: RelationCatalogue,
+) -> list[str]:
+    """Return spec violations against the exact catalogues exposed to the agent."""
     traces: list[str] = []
-    task_registry = TaskRegistry()
+    asset_names = {
+        "EMBODIMENTS": {entry["name"] for entry in asset_catalog.embodiments},
+        "BACKGROUNDS": {entry["name"] for entry in asset_catalog.backgrounds},
+        "OBJECTS": {entry["name"] for entry in asset_catalog.objects},
+    }
+    if spec.embodiment.registry_name not in asset_names["EMBODIMENTS"]:
+        traces.append(f"Embodiment registry_name {spec.embodiment.registry_name!r} is not in the EMBODIMENTS catalog")
+    if spec.background.registry_name not in asset_names["BACKGROUNDS"]:
+        traces.append(f"Background registry_name {spec.background.registry_name!r} is not in the BACKGROUNDS catalog")
+    for obj in spec.objects:
+        if obj.registry_name not in asset_names["OBJECTS"]:
+            traces.append(f"Object {obj.id!r} registry_name {obj.registry_name!r} is not in the OBJECTS catalog")
+    for object_set in spec.object_sets or []:
+        for member in object_set.members:
+            if member not in asset_names["OBJECTS"]:
+                traces.append(
+                    f"Object set {object_set.id!r} member registry_name {member!r} is not in the OBJECTS catalog"
+                )
+
+    task_entries = {entry.name: entry for entry in task_catalog.tasks}
     for task in spec.task.subtasks:
-        task_cls = task_registry.get_task_by_name(task.kind)
-        if not getattr(task_cls, "agent_ready", False):
-            traces.append(f"Task {task.kind!r} is not agent-ready")
-        for required_param in required_task_init_param_names(task_cls):
+        entry = task_entries.get(task.kind)
+        if entry is None:
+            traces.append(f"Task {task.kind!r} is not in the TASKS catalog")
+            continue
+        for required_param in entry.required_params:
             if required_param not in task.params:
                 traces.append(f"Task {task.kind!r} is missing required param {required_param!r}")
+        supported_params = set(entry.required_params) | set(entry.optional_params)
+        for unsupported_param in sorted(set(task.params) - supported_params):
+            traces.append(
+                f"Task {task.kind!r} has unsupported param {unsupported_param!r}; "
+                f"supported params are {sorted(supported_params)!r}"
+            )
+
+    relation_entries = {entry.name: entry for entry in relation_catalog.relations}
+    for relation in spec.relations:
+        entry = relation_entries.get(relation.kind)
+        if entry is None:
+            traces.append(f"Relation {relation.kind!r} is not in the RELATIONS catalog")
+            continue
+        for required_param in entry.required_params:
+            if required_param not in relation.params:
+                traces.append(f"Relation {relation.kind!r} is missing required param {required_param!r}")
+        supported_params = set(entry.required_params) | set(entry.optional_params)
+        for unsupported_param in sorted(set(relation.params) - supported_params):
+            traces.append(
+                f"Relation {relation.kind!r} has unsupported param {unsupported_param!r}; "
+                f"supported params are {sorted(supported_params)!r}"
+            )
     return traces

--- a/isaaclab_arena/assets/register.py
+++ b/isaaclab_arena/assets/register.py
@@ -103,7 +103,7 @@ def register_task(cls):
 
 
 def agent_ready(cls):
-    """Mark a task class as available to the environment-generation agent."""
+    """Mark a registered class as available to the environment-generation agent."""
     cls.agent_ready = True
     return cls
 

--- a/isaaclab_arena/environment_spec/arena_env_graph_spec.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_spec.py
@@ -109,13 +109,15 @@ class ArenaEnvGraphSpec(BaseModel):
     def _assert_relation_references(relations: list[SpatialRelationSpec], known_ids: set[str]) -> None:
         """Ensure relation subject/reference endpoints name known asset ids."""
         for index, relation in enumerate(relations):
-            assert (
-                relation.subject in known_ids
-            ), f"Relation[{index}] kind '{relation.kind}' references unknown subject '{relation.subject}'"
+            assert relation.subject in known_ids, (
+                f"Relation[{index}] kind '{relation.kind}' references unknown subject"
+                f" '{relation.subject}'. Add it to 'objects' or 'object_references'."
+            )
             if relation.reference is not None:
-                assert (
-                    relation.reference in known_ids
-                ), f"Relation[{index}] kind '{relation.kind}' references unknown reference '{relation.reference}'"
+                assert relation.reference in known_ids, (
+                    f"Relation[{index}] kind '{relation.kind}' references unknown reference"
+                    f" '{relation.reference}'. Add it to 'objects' or 'object_references'."
+                )
 
     @staticmethod
     def _assert_task_param_references(subtasks: list[TaskSpec], known_ids: set[str]) -> None:
@@ -123,9 +125,10 @@ class ArenaEnvGraphSpec(BaseModel):
         for task in subtasks:
             for param_name, param_value in task.params.items():
                 if isinstance(param_value, str):
-                    assert (
-                        param_value in known_ids
-                    ), f"Task '{task.kind}' param '{param_name}' references unknown node '{param_value}'"
+                    assert param_value in known_ids, (
+                        f"Task '{task.kind}' param '{param_name}' references unknown node"
+                        f" '{param_value}'. Add it to 'objects' or 'object_references'."
+                    )
 
     def summary(self) -> str:
         """Return a one-line summary of object, task, and relation counts."""

--- a/isaaclab_arena/environment_spec/arena_env_graph_spec.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_spec.py
@@ -49,11 +49,11 @@ class ArenaEnvGraphSpec(BaseModel):
     relations: list[SpatialRelationSpec] = Field(
         default_factory=list, description="Spatial layout relations across all assets."
     )
+    task: CompositeTaskSpec = Field(description="Root task the robot performs to manipulate the objects.")
     placement_validators: PlacementValidatorSpec | None = Field(
         default=None,
         description="Per-env placement validators; none runs all build-time checks.",
     )
-    task: CompositeTaskSpec = Field(description="Root task the robot performs to manipulate the objects.")
     cli_override_specs: list[CliOverrideSpec] | None = Field(
         default=None, description="Optional authoring-time CLI flags that swap an asset's registry_name; usually empty."
     )

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -214,7 +214,10 @@ class CompositeTaskSpec(BaseModel):
     @model_validator(mode="after")
     def _validate_composition_task_count(self) -> CompositeTaskSpec:
         if self.composition is TaskCompositionType.ATOMIC:
-            assert len(self.subtasks) == 1, "composition 'atomic' requires exactly one atomic task"
+            assert len(self.subtasks) == 1, (
+                f"composition 'atomic' requires exactly one atomic task, got {len(self.subtasks)}."
+                " Use parallel (order does not matter) or sequential (ordered) as composition instead."
+            )
         else:
             assert len(self.subtasks) >= 2, (
                 f"composition '{self.composition.value}' requires at least two atomic tasks, got {len(self.subtasks)}."

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -155,9 +155,9 @@ class ObjectReferenceSpec(BaseModel):
     object_type: ObjectType = Field(
         description=(
             "Physics type for the referenced prim. Use the first matching value:\n"
-            "- articulation: door or other articulated prim in open/close door tasks\n"
-            "- rigid: manipulable prim in pick-and-place tasks\n"
-            "- base: static anchor prim (e.g. table surface) in is_anchor or placement relations"
+            "- articulation: openable prim (door, drawer) used as openable_object in a open/close door task\n"
+            "- rigid: manipulable prim used as pick_up_object in a pick-and-place task\n"
+            "- base: default for everything else not mentioned above\n"
         ),
     )
     params: dict[str, Any] = Field(default_factory=dict)

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -216,9 +216,10 @@ class CompositeTaskSpec(BaseModel):
         if self.composition is TaskCompositionType.ATOMIC:
             assert len(self.subtasks) == 1, "composition 'atomic' requires exactly one atomic task"
         else:
-            assert (
-                len(self.subtasks) >= 2
-            ), f"composition '{self.composition.value}' requires at least two atomic tasks, got {len(self.subtasks)}"
+            assert len(self.subtasks) >= 2, (
+                f"composition '{self.composition.value}' requires at least two atomic tasks, got {len(self.subtasks)}."
+                " Use atomic as composition instead."
+            )
         return self
 
 

--- a/isaaclab_arena/environment_spec/arena_env_graph_types.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_types.py
@@ -253,6 +253,14 @@ class SpatialRelationSpec(BaseModel):
         description="Optional kind-specific parameters; leave empty by default.",
     )
 
+    @field_validator("reference", mode="before")
+    @classmethod
+    def _none_if_empty_reference(cls, value: Any) -> Any:
+        """Normalize an empty optional reference to None before arity validation."""
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
+
     @model_validator(mode="after")
     def _validate_kind_and_arity(self) -> SpatialRelationSpec:
         registry = ObjectRelationLibraryRegistry()

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from isaaclab.utils.math import euler_xyz_from_quat
 
-from isaaclab_arena.assets.register import register_object_relation
+from isaaclab_arena.assets.register import agent_ready, register_object_relation
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.utils.pose import PoseRange  # runtime: constructed in to_pose_range_centered_at()
 
@@ -77,7 +77,6 @@ class Relation(RelationBase):
         self.relation_loss_weight = relation_loss_weight
 
 
-@register_object_relation
 class FaceTo(RelationBase):
     """Relates an object's local +X heading to a target object's world-XY direction.
 
@@ -127,6 +126,7 @@ class FaceTo(RelationBase):
             ), f"FaceTo parent '{self.parent.name}' cannot randomize XY."
 
 
+@agent_ready
 @register_object_relation
 class NextTo(Relation):
     """Represents a 'next to' relationship between objects.
@@ -142,18 +142,18 @@ class NextTo(Relation):
     def __init__(
         self,
         parent: PlaceableAsset,
+        side: Side | str,
         relation_loss_weight: float = 1.0,
         distance_m: float = 0.05,
-        side: Side | str = Side.POSITIVE_X,
         cross_position_ratio: float = 0.0,
         tolerance_m: float = 1e-2,
     ):
         """
         Args:
             parent: The parent asset that this object should be placed next to.
+            side: Which axis direction to place the object.
             relation_loss_weight: Weight for the relationship loss function.
             distance_m: Target distance from parent's boundary in meters (default: 5cm).
-            side: Which axis direction to place object (default: Side.POSITIVE_X).
             cross_position_ratio: Where to place the child along the parent's perpendicular
                 (cross) axis, from -1.0 (min edge) through 0.0 (centered) to 1.0 (max edge).
                 The cross axis depends on the side: for POSITIVE_X / NEGATIVE_X
@@ -175,6 +175,7 @@ class NextTo(Relation):
         self.tolerance_m = tolerance_m
 
 
+@agent_ready
 @register_object_relation
 class On(Relation):
     """Represents an 'on top of' relationship between objects.
@@ -214,6 +215,7 @@ class On(Relation):
         self.edge_margin_m = edge_margin_m
 
 
+@agent_ready
 @register_object_relation
 class NotNextTo(Relation):
     """Forbids placing the child next to the parent on the given side.
@@ -249,6 +251,7 @@ class NotNextTo(Relation):
         self.tolerance_m = tolerance_m
 
 
+@agent_ready
 @register_object_relation
 class IsAnchor(RelationBase):
     """Marker indicating this object is an anchor for relation solving.
@@ -265,7 +268,7 @@ class IsAnchor(RelationBase):
         chair.add_relation(IsAnchor())  # Another anchor
 
         mug.add_relation(On(table))
-        bin.add_relation(NextTo(chair))
+        bin.add_relation(NextTo(chair, side=Side.POSITIVE_X))
     """
 
     name = "is_anchor"
@@ -391,6 +394,7 @@ class RandomAroundSolution(RelationBase):
         )
 
 
+@agent_ready
 @register_object_relation
 class RotateAroundSolution(RelationBase):
     """Marker specifying an explicit rotation to apply on top of the solver solution.

--- a/isaaclab_arena/relations/relations.py
+++ b/isaaclab_arena/relations/relations.py
@@ -77,6 +77,7 @@ class Relation(RelationBase):
         self.relation_loss_weight = relation_loss_weight
 
 
+@register_object_relation
 class FaceTo(RelationBase):
     """Relates an object's local +X heading to a target object's world-XY direction.
 

--- a/isaaclab_arena/tests/test_arena_env_graph_spec.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_spec.py
@@ -353,6 +353,16 @@ def test_graph_spec_accepts_missing_object_reference_prim_path():
     assert spec.object_references[0].prim_path is None
 
 
+@pytest.mark.parametrize("empty_reference", ["", "   "])
+def test_graph_spec_normalizes_empty_unary_relation_reference(empty_reference):
+    data = _minimal_env_graph_data()
+    data["relations"][0]["reference"] = empty_reference
+
+    spec = ArenaEnvGraphSpec.from_dict(data)
+
+    assert spec.relations[0].reference is None
+
+
 def _minimal_env_graph_data():
     return {
         "env_name": "minimal_env_graph",

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -13,6 +13,7 @@ import pytest
 from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
     EnvironmentGenerationAgent,
     build_asset_catalogue,
+    build_relation_catalogue,
 )
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadyCandidateCatalogue,
@@ -46,6 +47,29 @@ def agent(stub_openai):
     a = EnvironmentGenerationAgent(api_key="test-key")
     client.chat.completions.create.reset_mock()
     return a, client
+
+
+def test_relation_catalogue_collects_required_optional_and_enum_params():
+    catalogue = build_relation_catalogue()
+    entries = {entry.name: entry for entry in catalogue.relations}
+
+    assert set(entries) == {
+        "face_to",
+        "is_anchor",
+        "next_to",
+        "not_next_to",
+        "on",
+        "rotate_around_solution",
+    }
+    assert entries["next_to"].required_params == ["side"]
+    assert entries["next_to"].optional_params == [
+        "relation_loss_weight",
+        "distance_m",
+        "cross_position_ratio",
+        "tolerance_m",
+    ]
+    assert entries["next_to"].enum_options == {"side": ["positive_x", "negative_x", "positive_y", "negative_y"]}
+    assert "parent" not in entries["next_to"].required_params + entries["next_to"].optional_params
 
 
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+    AssetCatalogue,
     EnvironmentGenerationAgent,
     build_asset_catalogue,
     build_relation_catalogue,
@@ -83,12 +84,21 @@ def test_task_catalogue_collects_required_optional_and_enum_params():
     )
 
 
+def test_task_catalogue_excludes_structural_graph_fields():
+    """Params already expressed on CompositeTaskSpec (e.g. description) stay out of TASKS."""
+    catalogue = build_task_catalogue()
+    entries = {entry.name: entry for entry in catalogue.tasks}
+
+    assert "PickAndPlaceTask" in entries
+    pick_params = entries["PickAndPlaceTask"].required_params + entries["PickAndPlaceTask"].optional_params
+    assert "task_description" not in pick_params
+
+
 def test_relation_catalogue_collects_required_optional_and_enum_params():
     catalogue = build_relation_catalogue()
     entries = {entry.name: entry for entry in catalogue.relations}
 
     assert set(entries) == {
-        "face_to",
         "is_anchor",
         "next_to",
         "not_next_to",
@@ -103,7 +113,8 @@ def test_relation_catalogue_collects_required_optional_and_enum_params():
         "tolerance_m",
     ]
     assert entries["next_to"].enum_options == {"side": ["positive_x", "negative_x", "positive_y", "negative_y"]}
-    assert "parent" not in entries["next_to"].required_params + entries["next_to"].optional_params
+    for entry in entries.values():
+        assert "parent" not in entry.required_params + entry.optional_params
 
 
 # ---------------------------------------------------------------------------
@@ -446,14 +457,17 @@ def test_generate_spec_five_bananas_parallel_pick_and_place_against_live_endpoin
 def test_resolve_usd_prim_robocasa_kitchen_counter_and_fridge():
     """End-to-end pass-1 + pass-2 prim resolution for Robocasa kitchen counter and fridge."""
     agent = EnvironmentGenerationAgent()
-    asset_catalog = catalog(
-        "EMBODIMENTS:\n- droid_abs_joint_pos  tags=[default]\n\n"
-        "BACKGROUNDS: lightwheel_robocasa_kitchen\n\n"
-        "OBJECTS:\n"
-        "- avocado01_fruits_veggies_robolab  tags=[]\n"
-        "- plate_large_vomp_robolab  tags=[]\n"
-        "- broccoli  tags=[]\n"
-        "- sweet_potato  tags=[]"
+    # Keep structured entries in sync with the prompt: catalog validation checks
+    # AssetCatalogue.objects, not a to_catalog_string override.
+    asset_catalog = AssetCatalogue(
+        embodiments=[{"name": "droid_abs_joint_pos", "tags": ["default"]}],
+        backgrounds=[{"name": "lightwheel_robocasa_kitchen", "tags": []}],
+        objects=[
+            {"name": "avocado01_fruits_veggies_robolab", "object_type": "rigid", "tags": []},
+            {"name": "plate_large_vomp_robolab", "object_type": "rigid", "tags": []},
+            {"name": "broccoli", "object_type": "rigid", "tags": []},
+            {"name": "sweet_potato", "object_type": "rigid", "tags": []},
+        ],
     )
     tasks = make_task_catalog(
         "TASKS (2):\n"

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from enum import Enum
 from unittest.mock import patch
 
 import pytest
@@ -14,6 +15,7 @@ from isaaclab_arena.agentic_environment_generation.environment_generation_agent 
     EnvironmentGenerationAgent,
     build_asset_catalogue,
     build_relation_catalogue,
+    build_task_catalogue,
 )
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadyCandidateCatalogue,
@@ -40,6 +42,29 @@ from isaaclab_arena.tests.utils.agentic_environment_generation import task_catal
 # ---------------------------------------------------------------------------
 
 
+class _TestTaskMode(Enum):
+    FAST = "fast"
+    PRECISE = "precise"
+
+
+class _TestTask:
+    """Test task."""
+
+    agent_ready = True
+
+    def __init__(self, target, mode: _TestTaskMode = _TestTaskMode.FAST, retries: int = 1):
+        pass
+
+
+class _TestTaskRegistry:
+    def get_all_keys(self):
+        return ["TestTask"]
+
+    def get_task_by_name(self, name):
+        assert name == "TestTask"
+        return _TestTask
+
+
 @pytest.fixture
 def agent(stub_openai):
     """A constructed ``EnvironmentGenerationAgent`` with a fully mocked openai client."""
@@ -47,6 +72,15 @@ def agent(stub_openai):
     a = EnvironmentGenerationAgent(api_key="test-key")
     client.chat.completions.create.reset_mock()
     return a, client
+
+
+def test_task_catalogue_collects_required_optional_and_enum_params():
+    catalogue = build_task_catalogue(_TestTaskRegistry())
+
+    assert (
+        catalogue.to_catalog_string()
+        == "TASKS (1):\n- TestTask (required: target; optional: mode={fast, precise}, retries): Test task."
+    )
 
 
 def test_relation_catalogue_collects_required_optional_and_enum_params():

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -11,13 +11,13 @@ from unittest.mock import patch
 
 import pytest
 
-from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+from isaaclab_arena.agentic_environment_generation.catalogues import (
     AssetCatalogue,
-    EnvironmentGenerationAgent,
     build_asset_catalogue,
     build_relation_catalogue,
     build_task_catalogue,
 )
+from isaaclab_arena.agentic_environment_generation.environment_generation_agent import EnvironmentGenerationAgent
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadyCandidateCatalogue,
     SimReadyObjectCandidate,

--- a/isaaclab_arena/tests/test_prim_path_inference.py
+++ b/isaaclab_arena/tests/test_prim_path_inference.py
@@ -12,9 +12,15 @@ from unittest.mock import patch
 
 import pytest
 
-from isaaclab_arena.agentic_environment_generation.prim_path_inference import PrimPathInference, _prim_tree_catalog
+from isaaclab_arena.agentic_environment_generation.prim_path_inference import (
+    PrimPathInference,
+    _enforce_object_reference_types,
+    _prim_tree_catalog,
+    _validate_against_prim_tree,
+)
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.environment_spec.arena_env_graph_types import ObjectReferenceSpec
 from isaaclab_arena.tests.utils.agentic_environment_generation import (
     chat_response,
     inference_backend,
@@ -35,6 +41,69 @@ def test_prim_tree_catalog_nested_format():
         _prim_tree_catalog(tree)
         == "BACKGROUND PRIM TREE:\ncab_1_main_group (articulation right_door_joint)\n  corpus (rigid)\n    back (base)"
     )
+
+
+@pytest.mark.parametrize("prim_type", list(ObjectType))
+def test_validate_against_prim_tree_allows_base_reference_to_any_prim_type(prim_type):
+    reference = ObjectReferenceSpec(
+        id="target",
+        parent_id="background",
+        prim_path="target",
+        object_type=ObjectType.BASE,
+    )
+    _validate_against_prim_tree([reference], [UsdPrimRecord("target", prim_type)])
+
+
+@pytest.mark.parametrize(
+    ("reference_type", "prim_type"),
+    [
+        (ObjectType.RIGID, ObjectType.BASE),
+        (ObjectType.RIGID, ObjectType.ARTICULATION),
+        (ObjectType.ARTICULATION, ObjectType.BASE),
+        (ObjectType.ARTICULATION, ObjectType.RIGID),
+    ],
+)
+def test_validate_against_prim_tree_rejects_non_base_type_mismatch(reference_type, prim_type):
+    reference = ObjectReferenceSpec(
+        id="target",
+        parent_id="background",
+        prim_path="target",
+        object_type=reference_type,
+    )
+    with pytest.raises(AssertionError, match="does not match prim tree"):
+        _validate_against_prim_tree([reference], [UsdPrimRecord("target", prim_type)])
+
+
+def test_enforce_object_reference_types_uses_task_roles(capsys):
+    data = kitchen_pass1_dict()
+    references = {reference["id"]: reference for reference in data["object_references"]}
+    references["counter_top"]["object_type"] = "articulation"
+    references["fridge"]["object_type"] = "rigid"
+    data["object_references"].append({
+        "id": "floor",
+        "parent_id": "lightwheel_robocasa_kitchen",
+        "object_type": "rigid",
+    })
+    data["task"]["subtasks"][0]["params"]["pick_up_object"] = "counter_top"
+    spec = ArenaEnvGraphSpec.model_validate(data)
+
+    updated = _enforce_object_reference_types(spec)
+
+    types = {reference.id: reference.object_type for reference in updated.object_references}
+    assert types == {
+        "counter_top": ObjectType.RIGID,
+        "fridge": ObjectType.ARTICULATION,
+        "floor": ObjectType.BASE,
+    }
+    assert {reference.id: reference.object_type for reference in spec.object_references} == {
+        "counter_top": ObjectType.ARTICULATION,
+        "fridge": ObjectType.RIGID,
+        "floor": ObjectType.RIGID,
+    }
+    output = capsys.readouterr().out
+    assert "'counter_top' type 'articulation' -> 'rigid'" in output
+    assert "'fridge' type 'rigid' -> 'articulation'" in output
+    assert "'floor' type 'rigid' -> 'base'" in output
 
 
 @patch("isaaclab_arena.utils.usd_prim_tree.load_usd_prim_tree")

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -83,6 +83,18 @@ def test_infer_user_message_contains_catalog_and_prompt(spec_inference):
     assert "user wants avocado on kitchen" in user_msg
 
 
+def test_system_prompt_requires_object_references_to_be_anchors():
+    system_prompt = SpecInference._system_prompt()
+
+    assert "every ``object_reference`` must have an ``is_anchor`` relation" in system_prompt
+
+
+def test_system_prompt_requires_all_required_relation_params():
+    system_prompt = SpecInference._system_prompt()
+
+    assert "For every relation, include all parameters marked ``required`` in the RELATIONS catalog" in system_prompt
+
+
 def test_infer_retries_after_api_error_then_succeeds(spec_inference):
     inference, client = spec_inference
     client.chat.completions.create.side_effect = [

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -106,6 +106,44 @@ def test_infer_returns_none_with_validation_traces_on_invalid_spec(spec_inferenc
     assert data["embodiment"]["registry_name"] == "not_a_real_asset"
     assert traces
     assert any("registry_name" in line for line in traces)
+    assert client.chat.completions.create.call_count == 3
+
+
+def test_infer_feeds_validation_errors_back_and_recovers(spec_inference):
+    inference, client = spec_inference
+    invalid = dict(minimal_spec_dict())
+    invalid["embodiment"]["registry_name"] = "not_a_real_asset"
+    client.chat.completions.create.side_effect = [
+        chat_response(content=json.dumps(invalid)),
+        chat_response(content=json.dumps(minimal_spec_dict())),
+    ]
+    traces: list[str] = []
+    spec, data = _infer(inference, client, traces=traces)
+    assert isinstance(spec, ArenaEnvGraphSpec)
+    assert data["embodiment"]["registry_name"] == "franka_ik"
+    assert traces == []
+    assert client.chat.completions.create.call_count == 2
+    critic_message = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "CRITIC FEEDBACK" in critic_message
+    assert "not_a_real_asset" in critic_message
+    assert "registry_name" in critic_message
+
+
+def test_infer_retries_agent_ready_task_validation_errors(spec_inference):
+    inference, client = spec_inference
+    invalid = minimal_spec_dict()
+    del invalid["task"]["subtasks"][0]["params"]["pick_up_object"]
+    client.chat.completions.create.side_effect = [
+        chat_response(content=json.dumps(invalid)),
+        chat_response(content=json.dumps(minimal_spec_dict())),
+    ]
+    traces: list[str] = []
+    spec, _ = _infer(inference, client, traces=traces)
+    assert isinstance(spec, ArenaEnvGraphSpec)
+    assert traces == []
+    assert client.chat.completions.create.call_count == 2
+    critic_message = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "missing required param 'pick_up_object'" in critic_message
 
 
 def test_infer_never_mentions_the_asset_search(spec_inference):

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -141,6 +141,25 @@ def test_infer_feeds_validation_errors_back_and_recovers(spec_inference):
     assert "registry_name" in critic_message
 
 
+def test_infer_feeds_catalog_validation_errors_back_and_recovers(spec_inference):
+    inference, client = spec_inference
+    assets = make_catalog("ASSETS")
+    assets.embodiments = [{"name": "droid_abs_joint_pos", "tags": []}]
+    corrected = minimal_spec_dict()
+    corrected["embodiment"]["registry_name"] = "droid_abs_joint_pos"
+    client.chat.completions.create.side_effect = [
+        chat_response(content=json.dumps(minimal_spec_dict())),
+        chat_response(content=json.dumps(corrected)),
+    ]
+
+    spec, _ = _infer(inference, client, asset_catalog=assets)
+
+    assert isinstance(spec, ArenaEnvGraphSpec)
+    assert client.chat.completions.create.call_count == 2
+    critic_message = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+    assert "Embodiment registry_name 'franka_ik' is not in the EMBODIMENTS catalog" in critic_message
+
+
 def test_infer_retries_agent_ready_task_validation_errors(spec_inference):
     inference, client = spec_inference
     invalid = minimal_spec_dict()

--- a/isaaclab_arena/tests/test_spec_validation.py
+++ b/isaaclab_arena/tests/test_spec_validation.py
@@ -5,7 +5,7 @@
 
 """Unit tests for agent-generated spec validation."""
 
-from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+from isaaclab_arena.agentic_environment_generation.catalogues import (
     AssetCatalogue,
     RelationCatalogue,
     RelationCatalogueEntry,

--- a/isaaclab_arena/tests/test_spec_validation.py
+++ b/isaaclab_arena/tests/test_spec_validation.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for agent-generated spec validation."""
+
+from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+    AssetCatalogue,
+    RelationCatalogue,
+    RelationCatalogueEntry,
+    TaskCatalogue,
+)
+from isaaclab_arena.agentic_environment_generation.spec_validation import collect_agent_ready_validation_trace
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+from isaaclab_arena.tests.utils.agentic_environment_generation import (
+    catalog,
+    minimal_spec_dict,
+    relation_catalog,
+    task_catalog,
+)
+
+
+def _minimal_spec() -> ArenaEnvGraphSpec:
+    return ArenaEnvGraphSpec.model_validate(minimal_spec_dict())
+
+
+def test_collect_agent_ready_validation_trace_accepts_catalogued_spec():
+    traces = collect_agent_ready_validation_trace(
+        _minimal_spec(),
+        asset_catalog=catalog("ASSETS"),
+        task_catalog=task_catalog("TASKS"),
+        relation_catalog=relation_catalog("RELATIONS"),
+    )
+
+    assert traces == []
+
+
+def test_collect_agent_ready_validation_trace_rejects_assets_outside_subcatalogs():
+    traces = collect_agent_ready_validation_trace(
+        _minimal_spec(),
+        asset_catalog=AssetCatalogue(),
+        task_catalog=task_catalog("TASKS"),
+        relation_catalog=relation_catalog("RELATIONS"),
+    )
+
+    assert "Embodiment registry_name 'franka_ik' is not in the EMBODIMENTS catalog" in traces
+    assert "Background registry_name 'maple_table_robolab' is not in the BACKGROUNDS catalog" in traces
+    assert "Object 'rubiks_cube_hot3d_robolab' registry_name 'rubiks_cube_hot3d_robolab'" in " ".join(traces)
+    assert "Object 'bowl_ycb_robolab' registry_name 'bowl_ycb_robolab'" in " ".join(traces)
+
+
+def test_collect_agent_ready_validation_trace_rejects_unknown_missing_and_unsupported_task_params():
+    spec = _minimal_spec()
+    task = spec.task.subtasks[0]
+
+    unknown_traces = collect_agent_ready_validation_trace(
+        spec,
+        asset_catalog=catalog("ASSETS"),
+        task_catalog=TaskCatalogue(),
+        relation_catalog=relation_catalog("RELATIONS"),
+    )
+    assert "Task 'PickAndPlaceTask' is not in the TASKS catalog" in unknown_traces
+
+    del task.params["pick_up_object"]
+    task.params["hallucinated_param"] = True
+    param_traces = collect_agent_ready_validation_trace(
+        spec,
+        asset_catalog=catalog("ASSETS"),
+        task_catalog=task_catalog("TASKS"),
+        relation_catalog=relation_catalog("RELATIONS"),
+    )
+    assert "Task 'PickAndPlaceTask' is missing required param 'pick_up_object'" in param_traces
+    assert any("Task 'PickAndPlaceTask' has unsupported param 'hallucinated_param'" in trace for trace in param_traces)
+
+
+def test_collect_agent_ready_validation_trace_rejects_unknown_missing_and_unsupported_relation_params():
+    spec = _minimal_spec()
+    unknown_traces = collect_agent_ready_validation_trace(
+        spec,
+        asset_catalog=catalog("ASSETS"),
+        task_catalog=task_catalog("TASKS"),
+        relation_catalog=RelationCatalogue(),
+    )
+    assert "Relation 'is_anchor' is not in the RELATIONS catalog" in unknown_traces
+    assert "Relation 'on' is not in the RELATIONS catalog" in unknown_traces
+
+    spec.relations[1].params["hallucinated_param"] = True
+    relations = RelationCatalogue(
+        relations=[
+            RelationCatalogueEntry("is_anchor", True, [], [], {}, ""),
+            RelationCatalogueEntry("on", False, ["distance_m"], [], {}, ""),
+        ]
+    )
+    param_traces = collect_agent_ready_validation_trace(
+        spec,
+        asset_catalog=catalog("ASSETS"),
+        task_catalog=task_catalog("TASKS"),
+        relation_catalog=relations,
+    )
+    assert "Relation 'on' is missing required param 'distance_m'" in param_traces
+    assert any("Relation 'on' has unsupported param 'hallucinated_param'" in trace for trace in param_traces)

--- a/isaaclab_arena/tests/utils/agentic_environment_generation.py
+++ b/isaaclab_arena/tests/utils/agentic_environment_generation.py
@@ -23,7 +23,7 @@ import pytest
 # because of this modules appearance in pytest_plugins. This causes issues with the packaging
 # tests, which run in a bare venv with only pytest installed.
 if TYPE_CHECKING:
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+    from isaaclab_arena.agentic_environment_generation.catalogues import (
         AssetCatalogue,
         RelationCatalogue,
         TaskCatalogue,
@@ -130,7 +130,7 @@ def chat_response(
 
 def catalog(text: str) -> AssetCatalogue:
     """Return an asset catalogue that renders ``text`` in the user message."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import AssetCatalogue
+    from isaaclab_arena.agentic_environment_generation.catalogues import AssetCatalogue
 
     catalogue = AssetCatalogue(
         embodiments=[
@@ -154,10 +154,7 @@ def catalog(text: str) -> AssetCatalogue:
 
 def relation_catalog(text: str) -> RelationCatalogue:
     """Return a relation catalogue that renders ``text`` in the user message."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
-        RelationCatalogue,
-        RelationCatalogueEntry,
-    )
+    from isaaclab_arena.agentic_environment_generation.catalogues import RelationCatalogue, RelationCatalogueEntry
 
     catalogue = RelationCatalogue(
         relations=[
@@ -171,10 +168,7 @@ def relation_catalog(text: str) -> RelationCatalogue:
 
 def task_catalog(text: str) -> TaskCatalogue:
     """Return a task catalogue that renders ``text`` in the user message."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
-        TaskCatalogue,
-        TaskCatalogueEntry,
-    )
+    from isaaclab_arena.agentic_environment_generation.catalogues import TaskCatalogue, TaskCatalogueEntry
 
     catalogue = TaskCatalogue(
         tasks=[

--- a/isaaclab_arena/tests/utils/agentic_environment_generation.py
+++ b/isaaclab_arena/tests/utils/agentic_environment_generation.py
@@ -132,24 +132,74 @@ def catalog(text: str) -> AssetCatalogue:
     """Return an asset catalogue that renders ``text`` in the user message."""
     from isaaclab_arena.agentic_environment_generation.environment_generation_agent import AssetCatalogue
 
-    catalogue = AssetCatalogue()
+    catalogue = AssetCatalogue(
+        embodiments=[
+            {"name": "franka_ik", "tags": []},
+            {"name": "droid_abs_joint_pos", "tags": []},
+        ],
+        backgrounds=[
+            {"name": "maple_table_robolab", "tags": []},
+            {"name": "lightwheel_robocasa_kitchen", "tags": []},
+        ],
+        objects=[
+            {"name": "rubiks_cube_hot3d_robolab", "object_type": "rigid", "tags": []},
+            {"name": "bowl_ycb_robolab", "object_type": "rigid", "tags": []},
+            {"name": "avocado01_fruits_veggies_robolab", "object_type": "rigid", "tags": []},
+            {"name": "plate_large_vomp_robolab", "object_type": "rigid", "tags": []},
+        ],
+    )
     catalogue.to_catalog_string = lambda: text  # type: ignore[method-assign]
     return catalogue
 
 
 def relation_catalog(text: str) -> RelationCatalogue:
     """Return a relation catalogue that renders ``text`` in the user message."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import RelationCatalogue
+    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+        RelationCatalogue,
+        RelationCatalogueEntry,
+    )
 
-    catalogue = RelationCatalogue()
+    catalogue = RelationCatalogue(
+        relations=[
+            RelationCatalogueEntry("is_anchor", True, [], [], {}, ""),
+            RelationCatalogueEntry("on", False, [], [], {}, ""),
+        ]
+    )
     catalogue.to_catalog_string = lambda: text  # type: ignore[method-assign]
     return catalogue
 
 
 def task_catalog(text: str) -> TaskCatalogue:
     """Return a task catalogue that renders ``text`` in the user message."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import TaskCatalogue
+    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+        TaskCatalogue,
+        TaskCatalogueEntry,
+    )
 
-    catalogue = TaskCatalogue()
+    catalogue = TaskCatalogue(
+        tasks=[
+            TaskCatalogueEntry(
+                "PickAndPlaceTask",
+                ["pick_up_object", "destination_location", "background_scene"],
+                [
+                    "destination_object",
+                    "episode_length_s",
+                    "force_threshold",
+                    "velocity_threshold",
+                    "max_separation",
+                    "mimic_env_cfg_factory",
+                ],
+                {},
+                "",
+            ),
+            TaskCatalogueEntry(
+                "OpenDoorTask",
+                ["openable_object"],
+                ["openness_threshold", "reset_openness", "episode_length_s"],
+                {},
+                "",
+            ),
+        ]
+    )
     catalogue.to_catalog_string = lambda: text  # type: ignore[method-assign]
     return catalogue

--- a/isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
+++ b/isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
@@ -57,11 +57,13 @@ relations:
 - kind: next_to
   subject: bean_can
   reference: mini_plastic_basket
-  params: {}
+  params:
+    side: positive_x
 - kind: next_to
   subject: hammer
   reference: pepsi_can
-  params: {}
+  params:
+    side: positive_x
 task:
   composition: parallel
   description: Pick up the pepsi can and bean can from the maple table and place them

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -147,12 +147,12 @@ def add_agentic_env_gen_runner_cli_args(parser: argparse.ArgumentParser) -> None
 
 def resolve_env_spec(args_cli: argparse.Namespace) -> Path | None:
     """Resolve a prompt into an environment graph spec YAML, or None when the prompt cannot be met."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
-        EnvironmentGenerationAgent,
+    from isaaclab_arena.agentic_environment_generation.catalogues import (
         build_asset_catalogue,
         build_relation_catalogue,
         build_task_catalogue,
     )
+    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import EnvironmentGenerationAgent
     from isaaclab_arena.agentic_environment_generation.simready_asset_search import simready_search_config_from_cli
 
     # The generation passes log what they searched for and found; this is a console tool, so show
@@ -228,7 +228,7 @@ def print_schema() -> None:
 
 def print_catalog() -> None:
     """Print the asset, relation, and task catalogs sent to the agent."""
-    from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+    from isaaclab_arena.agentic_environment_generation.catalogues import (
         build_asset_catalogue,
         build_relation_catalogue,
         build_task_catalogue,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -12,15 +12,15 @@ from pathlib import Path
 
 import streamlit as st
 
-from isaaclab_arena.agentic_environment_generation.environment_generation_agent import (
+from isaaclab_arena.agentic_environment_generation.catalogues import (
     AssetCatalogue,
-    EnvironmentGenerationAgent,
     RelationCatalogue,
     TaskCatalogue,
     build_asset_catalogue,
     build_relation_catalogue,
     build_task_catalogue,
 )
+from isaaclab_arena.agentic_environment_generation.environment_generation_agent import EnvironmentGenerationAgent
 from isaaclab_arena.agentic_environment_generation.inference_backend import resolve_inference_endpoint
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadySearchConfig,


### PR DESCRIPTION
## Summary
Harden agentic env-gen against weak public models

## Detailed description
- Public endpoint models more often emit invalid specs (wrong node refs, empty relations, invented params); harden generation so those failures are recoverable and less common
- Retry rejected specs with validation feedback; expand catalog/validation coverage for tasks and relations; normalize empty relation references
- Clarify Node ID vs registry_name in prompts/schema; leave placement_validators and cli_override_specs empty
- Fix prim_path object_type matching by rule-based clean up in input spec, and relaxed post-validation against prim tree to allow downcasting.
- Adds/extends unit tests for inference, validation, and generation agent paths