### PR TITLE
Add OpenPI server port override

### DIFF
--- a/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
+++ b/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
@@ -28,8 +28,8 @@ subsequent invocations reuse the cached image. Pass ``-r`` to force a rebuild,
 ``-v pi0`` to serve the pi0 variant instead of pi05, or ``-p <port>`` to bind
 the server to a non-default port.
 
-By default, the wrapper binds to port ``8000``. If that port is already in use,
-stop the existing process or choose another port:
+By default, the wrapper binds to port ``8000``. If OpenPI reports that the
+address is already in use, stop the existing process or choose another port:
 
 .. code-block:: bash
 

--- a/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
+++ b/docs/pages/quickstart/first_experiments/running_a_real_policy/openpi.rst
@@ -22,11 +22,18 @@ upstream openpi at a pinned commit on first run) and starts the inference server
 
    ./isaaclab_arena_openpi/docker/run_openpi_server.sh
 
-The first invocation builds ``isaaclab_arena_openpi-server:latest`` (~3 min,
+The first invocation builds ``isaaclab_arena:openpi_server`` (~3 min,
 ~19 GB) and then downloads the ~11 GB checkpoint into the container on startup;
 subsequent invocations reuse the cached image. Pass ``-r`` to force a rebuild,
-``-v pi0`` to serve the pi0 variant instead of pi05, or ``-s <path>`` to build
-from a local openpi checkout.
+``-v pi0`` to serve the pi0 variant instead of pi05, or ``-p <port>`` to bind
+the server to a non-default port.
+
+By default, the wrapper binds to port ``8000``. If that port is already in use,
+stop the existing process or choose another port:
+
+.. code-block:: bash
+
+   ./isaaclab_arena_openpi/docker/run_openpi_server.sh -p 8001
 
 When you see:
 
@@ -34,7 +41,8 @@ When you see:
 
    INFO:websockets.server:server listening on 0.0.0.0:8000
 
-the server is ready. Leave the terminal running.
+the server is ready. Leave the terminal running. If you used ``-p``, the log
+will show the selected port instead.
 
 The wrapper passes ``--policy.config`` (architecture + data transforms) and
 ``--policy.dir`` (params + normalization stats) for the selected variant; see
@@ -64,7 +72,8 @@ point the arena policy runner at the server:
 
 Defaults: ``--openpi_embodiment_adapter droid``, ``--policy_variant pi05``,
 ``--remote_host localhost``, ``--remote_port 8000``. Pass ``--remote_host`` if the
-server is on a different machine.
+server is on a different machine. If terminal 1 used a non-default port, pass
+the same value with ``--remote_port``.
 
 The server terminal will start logging connection and inference events as the arena
 Kit window shows the droid arm reacting to pi0's commanded joint positions.
@@ -89,6 +98,9 @@ To measure success rates across several variations of the environment in a singl
 
 This runs nine jobs sequentially — each varying the object, background, and destination — and reports a per-job success rate.
 Each evaluation is run without restarting Isaac Sim to save on the startup time.
+If the OpenPI server uses a non-default port, override each OpenPI run's
+``policy.remote_port`` to the same value, for example
+``runs.<run_name>.policy.remote_port=8001``.
 
 .. figure:: ../../../../images/openpi_droid_3x3_grid.gif
    :width: 100%

--- a/isaaclab_arena_openpi/docker/run_openpi_server.sh
+++ b/isaaclab_arena_openpi/docker/run_openpi_server.sh
@@ -48,55 +48,6 @@ while getopts ":rp:v:h" opt; do
     esac
 done
 
-validate_port() {
-    local port_number
-
-    if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
-        echo "invalid -p port: $PORT (expected an integer from 1 to 65535)" >&2
-        exit 1
-    fi
-    port_number=$((10#$PORT))
-    if (( port_number < 1 || port_number > 65535 )); then
-        echo "invalid -p port: $PORT (expected an integer from 1 to 65535)" >&2
-        exit 1
-    fi
-    PORT="$port_number"
-}
-
-assert_port_available() {
-    if ! command -v python3 >/dev/null 2>&1; then
-        echo "python3 is required to check whether port ${PORT} is available" >&2
-        exit 1
-    fi
-
-    if ! python3 - "$PORT" <<'PY'
-import socket
-import sys
-
-port = int(sys.argv[1])
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-try:
-    sock.bind(("0.0.0.0", port))
-except OSError:
-    sys.exit(1)
-finally:
-    sock.close()
-PY
-    then
-        cat >&2 <<EOF
-OpenPI server port ${PORT} is already in use.
-Stop the process that is listening on ${PORT}, or choose another port:
-  $(basename "$0") -p <free_port>
-
-When using a non-default port, pass the same value to Arena with --remote_port.
-EOF
-        exit 1
-    fi
-}
-
-validate_port
-assert_port_available
-
 case "$VARIANT" in
     pi05)
         POLICY_CONFIG="pi05_droid_jointpos_polaris"

--- a/isaaclab_arena_openpi/docker/run_openpi_server.sh
+++ b/isaaclab_arena_openpi/docker/run_openpi_server.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./run_openpi_server.sh                              # build if missing, then run pi05
 #   ./run_openpi_server.sh -r                           # force rebuild, then run
+#   ./run_openpi_server.sh -p 8001                      # run on a non-default port
 #   ./run_openpi_server.sh -v pi0                       # run the pi0 variant
 #   ./run_openpi_server.sh -h                           # help
 #
@@ -18,6 +19,7 @@ IMAGE_NAME="isaaclab_arena"
 IMAGE_TAG="openpi_server"
 
 VARIANT="pi05"
+PORT="8000"
 FORCE_REBUILD=false
 
 print_help() {
@@ -29,20 +31,71 @@ Usage:
 
 Options:
   -r              Force rebuilding of the server image.
+  -p <port>       Port to serve on. Defaults to 8000.
   -v <variant>    Policy variant to serve: pi05 (default) or pi0.
   -h              Show this help and exit.
 EOF
 }
 
-while getopts ":rv:h" opt; do
+while getopts ":rp:v:h" opt; do
     case "$opt" in
         r) FORCE_REBUILD=true ;;
+        p) PORT="$OPTARG" ;;
         v) VARIANT="$OPTARG" ;;
         h) print_help; exit 0 ;;
         \?) echo "unknown option: -$OPTARG" >&2; print_help; exit 1 ;;
         :) echo "option -$OPTARG requires an argument" >&2; exit 1 ;;
     esac
 done
+
+validate_port() {
+    local port_number
+
+    if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+        echo "invalid -p port: $PORT (expected an integer from 1 to 65535)" >&2
+        exit 1
+    fi
+    port_number=$((10#$PORT))
+    if (( port_number < 1 || port_number > 65535 )); then
+        echo "invalid -p port: $PORT (expected an integer from 1 to 65535)" >&2
+        exit 1
+    fi
+    PORT="$port_number"
+}
+
+assert_port_available() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "python3 is required to check whether port ${PORT} is available" >&2
+        exit 1
+    fi
+
+    if ! python3 - "$PORT" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    sock.bind(("0.0.0.0", port))
+except OSError:
+    sys.exit(1)
+finally:
+    sock.close()
+PY
+    then
+        cat >&2 <<EOF
+OpenPI server port ${PORT} is already in use.
+Stop the process that is listening on ${PORT}, or choose another port:
+  $(basename "$0") -p <free_port>
+
+When using a non-default port, pass the same value to Arena with --remote_port.
+EOF
+        exit 1
+    fi
+}
+
+validate_port
+assert_port_available
 
 case "$VARIANT" in
     pi05)
@@ -80,7 +133,7 @@ else
     echo "Image ${IMAGE_NAME}:${IMAGE_TAG} already exists. Not rebuilding (use -r to force)."
 fi
 
-echo "Running ${IMAGE_NAME}:${IMAGE_TAG} (variant: ${VARIANT})"
+echo "Running ${IMAGE_NAME}:${IMAGE_TAG} (variant: ${VARIANT}, port: ${PORT})"
 
 mkdir -p "$OPENPI_CACHE_DIR"
 SERVER_RAN=true
@@ -90,6 +143,6 @@ docker run --rm -it --gpus all --network=host \
     -e XLA_PYTHON_CLIENT_MEM_FRACTION=0.5 \
     -v "${OPENPI_CACHE_DIR}:/cache/openpi" \
     "${IMAGE_NAME}:${IMAGE_TAG}" \
-    uv run scripts/serve_policy.py policy:checkpoint \
+    uv run scripts/serve_policy.py --port="${PORT}" policy:checkpoint \
         --policy.config="${POLICY_CONFIG}" \
         --policy.dir="${POLICY_DIR}"


### PR DESCRIPTION
## Summary
Add OpenPI server port override

## Detailed description
- Add a -p option and pass the selected port to serve_policy.py.
- Keep OpenPI's native bind/argument errors instead of adding wrapper preflight checks.
- Document matching non-default server ports with Arena remote_port.
- Merge this to main first, then cherry-pick the landed commit to release/0.3.0-prerelease.