### PR TITLE
Shorten agentic env-spec CLI names

### DIFF
--- a/docs/pages/concepts/environment/env_spec.rst
+++ b/docs/pages/concepts/environment/env_spec.rst
@@ -331,7 +331,7 @@ How to spawn an environment
    * - .. code-block:: bash
 
           python isaaclab_arena/scripts/environment_runner.py \
-            --env_graph_spec_yaml \
+            --env_spec \
             isaaclab_arena_environments/robolab/tasks/banana_on_plate.yaml
 
      - .. code-block:: bash

--- a/docs/pages/concepts/environment/environment_definition.rst
+++ b/docs/pages/concepts/environment/environment_definition.rst
@@ -1,5 +1,5 @@
-Environment Spec
-================
+Environment Definition
+======================
 
 An Arena environment is three parts — scene, embodiment, and task (see the
 :doc:`section overview <index>`). This page covers the two ways to define that

--- a/docs/pages/concepts/environment/index.rst
+++ b/docs/pages/concepts/environment/index.rst
@@ -45,9 +45,10 @@ for a G1, or the kitchen for a warehouse, with no changes to the task.
 This moves us from a library of monolithic environment descriptions to a library
 of environment *parts*.
 
-The two pages below cover how you write an environment down, and how it is built:
+The two pages below cover how you define an environment, and how it is built:
 
-- :doc:`env_spec` — the two ways to specify an environment, Python or YAML.
+- :doc:`environment_definition` — the two ways to define an environment, Python
+  or YAML.
 - :doc:`env_builder` — how ``ArenaEnvBuilder`` compiles a specification into an
   Isaac Lab ``ManagerBasedRLEnv``.
 
@@ -57,5 +58,5 @@ The individual components are covered in :doc:`../scene/index`,
 .. toctree::
    :maxdepth: 1
 
-   env_spec
+   environment_definition
    env_builder

--- a/docs/pages/concepts/object_placement/solver.rst
+++ b/docs/pages/concepts/object_placement/solver.rst
@@ -142,7 +142,7 @@ Run the example with:
      --viz kit \
      --policy_type zero_action \
      --num_steps 100 \
-     --env_graph_spec_yaml \
+     --env_spec \
        isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
 
 This example uses the Droid stand footprint for geometric placement.

--- a/docs/pages/concepts/object_placement/validation.rst
+++ b/docs/pages/concepts/object_placement/validation.rst
@@ -127,7 +127,7 @@ the env's embodiment into ``reachability_config`` automatically.
 It gates only objects marked ``RequiresReachability`` — a relation that tasks
 such as ``PickAndPlaceTask`` stamp automatically. With no such relation, the
 check passes trivially. Grasp offset and IK tolerances are configurable; see
-:doc:`../environment/env_spec`.
+:doc:`../environment/environment_definition`.
 
 .. figure:: ../../../images/reachability_rerun_viz.gif
    :width: 100%
@@ -152,7 +152,7 @@ running and reported without rejecting layouts, which is the usual way to
 keep placement geometry-only.
 
 Both are set on ``ObjectPlacerParams`` in Python or the
-``placement_validators`` block in YAML; see :doc:`../environment/env_spec`
+``placement_validators`` block in YAML; see :doc:`../environment/environment_definition`
 for the field-level split.
 
 Next Steps

--- a/docs/pages/example_workflows/agentic_env_gen/gui_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/gui_runner.rst
@@ -20,7 +20,7 @@ You can also open an existing environment graph spec:
 .. code-block:: bash
 
    python isaaclab_arena_examples/agentic_environment_generation/gui_runner.py \
-      --env_graph_spec_yaml isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+      --env_spec isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
 
 By default, generated YAML files are written under
 ``isaaclab_arena_environments/agent_generated``. Use ``--out_dir`` to choose a

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_1_launch_runner.rst
@@ -49,7 +49,7 @@ That is, the task is to open the fridge door to the 0.2 openness threshold in th
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode resolve \
             --prompt "There is a floor and a fridge in the lightwheel_robocasa_kitchen kitchen. DROID is on the floor, next to the fridge with 0.1 meter distance and facing it. DROID opens the fridge door to the 0.2 openness threshold."
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_2_edit_environment_graph_spec.rst
@@ -126,7 +126,7 @@ Applying your edits
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode build \
             --viz kit \
             --num_envs 1 \

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_2_edit_environment_graph_spec.rst
@@ -131,7 +131,7 @@ Applying your edits
             --viz kit \
             --num_envs 1 \
             --num_steps 100 \
-            --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
+            --env_spec isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
 
       A spec you generated yourself is written to
       ``isaaclab_arena_environments/agent_generated/<env_name>.yaml`` instead — pass that path to build it.

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
@@ -15,7 +15,7 @@ Open one terminal and run the following command outside the Arena docker contain
 
 In the other terminal, run the following command to launch the policy runner. The commands below use the
 ready-made spec that ships with Arena; to evaluate a spec you generated yourself, point
-``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
+``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 
 **Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
@@ -30,7 +30,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
       --enable_cameras \
       --num_envs 1 \
       --num_episodes 2 \
-      --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
+      --env_spec isaaclab_arena_environments/kitchen_bench/droid_open_fridge_lightwheel_kitchen.yaml
 
 .. figure:: ../../../../images/droid_kitchen_open_door_pi.gif
    :width: 100%

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_1_launch_runner.rst
@@ -71,7 +71,7 @@ kitchen the robot is placed in the scene rather than mounted on the task surface
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode resolve \
             --prompt "There is a center-right counter top and a floor in the lightwheel_robocasa_kitchen background. DROID picks up a mustard bottle on the counter top and places it in a bowl. DROID is next to the counter top and on the floor."
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_2_edit_environment_graph_spec.rst
@@ -117,7 +117,7 @@ surfaces. List them from the background prim tree — the set of prims the agent
 
          python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
             --mode prim_tree \
-            --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml \
+            --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml \
             | grep counter
 
       It prints each line as a ``prim_path`` candidate with its ``object_type``, plus the joint names when the prim
@@ -195,7 +195,7 @@ Applying your edits
             --viz kit \
             --num_envs 1 \
             --num_steps 100 \
-            --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+            --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
 
       A spec you generated yourself is written to
       ``isaaclab_arena_environments/agent_generated/<env_name>.yaml`` instead — pass that path to build it.

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_2_edit_environment_graph_spec.rst
@@ -115,7 +115,7 @@ surfaces. List them from the background prim tree — the set of prims the agent
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode prim_tree \
             --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml \
             | grep counter
@@ -190,7 +190,7 @@ Applying your edits
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode build \
             --viz kit \
             --num_envs 1 \

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -15,7 +15,7 @@ Open one terminal and run the following command outside the Arena docker contain
 
 In the other terminal, run the following command to launch the policy runner. The commands below use the
 ready-made spec that ships with Arena; to evaluate a spec you generated yourself, point
-``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
+``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 
 **Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
@@ -30,7 +30,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
       --enable_cameras \
       --num_envs 1 \
       --num_episodes 2 \
-      --env_graph_spec_yaml isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+      --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
 
 .. figure:: ../../../../images/droid_kitchen_pnp_pi.gif
    :width: 100%

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_1_launch_runner.rst
@@ -54,7 +54,7 @@ for assets that match the prompt, if assets are not found in the Arena asset lib
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode resolve \
             --enable_simready_search \
             --prompt "Droid picks up the pepsi can and the bean can from the maple table and places them into the mini plastic basket. There is a hammer next to the pepsi can and a tuna can on the table, and the bean can sits next to the basket."

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
@@ -155,7 +155,7 @@ Applying your edits
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode build \
             --viz kit \
             --num_envs 1 \

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_2_edit_environment_graph_spec.rst
@@ -160,7 +160,7 @@ Applying your edits
             --viz kit \
             --num_envs 1 \
             --num_steps 100 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
 
       A spec you generated yourself is written to
       ``isaaclab_arena_environments/agent_generated/<env_name>.yaml`` — named after ``env_name``, without the

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
@@ -17,7 +17,7 @@ Open one terminal and run the following command outside the Arena docker contain
 
 In the other terminal, run the following command to launch the policy runner. The commands below use the
 ready-made spec that ships with Arena; to evaluate a spec you generated yourself, point
-``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
+``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 .. tab-set::
 
@@ -36,7 +36,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --enable_cameras \
             --num_envs 1 \
             --num_episodes 3 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
 
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
@@ -59,7 +59,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --enable_cameras \
             --num_envs 1 \
             --num_episodes 3 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
 
       While the environment builds, every batch of candidate layouts reports how many of them passed each
       check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the rejection rate to watch:

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_1_launch_runner.rst
@@ -51,7 +51,7 @@ say that it varies across environments. That is the cue for the agent to emit an
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode resolve \
             --prompt "Droid picks up a fruit from the maple table and places it into the bowl on the table. Each environment should get a different fruit."
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
@@ -133,7 +133,7 @@ Applying your edits
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode build \
             --viz kit \
             --num_envs 4 \

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_2_edit_environment_graph_spec.rst
@@ -138,7 +138,7 @@ Applying your edits
             --viz kit \
             --num_envs 4 \
             --num_steps 100 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
 
       A spec you generated yourself is written to
       ``isaaclab_arena_environments/agent_generated/<env_name>.yaml`` instead — pass that path to build it.

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
@@ -18,7 +18,7 @@ Open one terminal and run the following command outside the Arena docker contain
 In the other terminal, run the following command to launch the policy runner.
 Keep ``--num_envs`` above one so the policy is evaluated against a different fruit per environment.
 The commands below use the ready-made spec that ships with Arena; to evaluate a spec you generated
-yourself, point ``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
+yourself, point ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 .. tab-set::
 
@@ -37,7 +37,7 @@ yourself, point ``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent
             --enable_cameras \
             --num_envs 12 \
             --num_episodes 12 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
 
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
@@ -59,7 +59,7 @@ yourself, point ``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent
             --enable_cameras \
             --num_envs 12 \
             --num_episodes 12 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
 
       While the environment builds, every batch of candidate layouts reports how many of them passed each
       check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the rejection rate to watch:

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_1_launch_runner.rst
@@ -48,7 +48,7 @@ The agent runs in two modes:
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode resolve \
             --prompt "Droid picks up the banana from the maple table and places it on the plate. There are two bagels and one bowl on the table."
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
@@ -135,7 +135,7 @@ Applying your edits
             --viz kit \
             --num_envs 1 \
             --num_steps 100 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
 
       A spec you generated yourself is written to
       ``isaaclab_arena_environments/agent_generated/<env_name>.yaml`` instead — pass that path to build it.

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_2_edit_environment_graph_spec.rst
@@ -130,7 +130,7 @@ Applying your edits
 
       .. code-block:: bash
 
-         python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \
+         python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \
             --mode build \
             --viz kit \
             --num_envs 1 \

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
@@ -17,7 +17,7 @@ Open one terminal and run the following command outside the Arena docker contain
 
 In the other terminal, run the following command to launch the policy runner. The commands below use the
 ready-made spec that ships with Arena; to evaluate a spec you generated yourself, point
-``--env_graph_spec_yaml`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
+``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 .. tab-set::
 
@@ -36,7 +36,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --enable_cameras \
             --num_envs 1 \
             --num_episodes 3 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
 
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
@@ -58,7 +58,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --enable_cameras \
             --num_envs 1 \
             --num_episodes 3 \
-            --env_graph_spec_yaml isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
+            --env_spec isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
 
       While the environment builds, every batch of candidate layouts reports how many of them passed each
       check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the rejection rate to watch:

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -12,7 +12,7 @@ Isaac Lab Arena ships a catalog of ready-to-run environments under
   argument to scripts such as ``isaaclab_arena/evaluation/policy_runner.py``.
 * **Environment graph YAML specs**: ``ArenaEnvGraphSpec`` files that describe the same
   scene, embodiment, task, objects, and relations declaratively. These are
-  passed with ``--env_graph_spec_yaml`` and can be generated from prompts by the
+  passed with ``--env_spec`` and can be generated from prompts by the
   :doc:`agentic_env_gen/index` workflow.
 
 The metadata below follows the same structure as the **Key Specifications**
@@ -29,7 +29,7 @@ Agentically Generated Graph Specs
 
 RoboLab environment graph YAMLs live under
 ``isaaclab_arena_environments/robolab/``. They are generated from natural-language
-prompts and consumed with ``--env_graph_spec_yaml`` instead of the positional
+prompts and consumed with ``--env_spec`` instead of the positional
 ``example_environment`` name.
 
 See :doc:`robolab_task_catalog` for the list of RoboLab tasks

--- a/docs/pages/example_workflows/kitchen_bench_catalog.rst
+++ b/docs/pages/example_workflows/kitchen_bench_catalog.rst
@@ -3,7 +3,7 @@ Kitchen Benchmark Catalog
 
 The kitchen benchmark contains 17 DROID tasks defined as environment graph
 YAML specs under ``isaaclab_arena_environments/kitchen_bench/``. Pass a spec
-to ``policy_runner.py`` with ``--env_graph_spec_yaml`` to run that environment.
+to ``policy_runner.py`` with ``--env_spec`` to run that environment.
 Each row links to the source YAML and shows a Pi policy execution recorded from
 the maintained DROID external camera.
 

--- a/isaaclab_arena/cli/isaaclab_arena_cli.py
+++ b/isaaclab_arena/cli/isaaclab_arena_cli.py
@@ -119,7 +119,7 @@ def add_env_graph_spec_cli_args(parser: argparse.ArgumentParser) -> None:
         "Environment Graph Spec Arguments", "Arguments specific to environment graph spec"
     )
     env_graph_spec_group.add_argument(
-        "--env_graph_spec_yaml",
+        "--env_spec",
         type=str,
         default=None,
         help=(

--- a/isaaclab_arena/evaluation/legacy_environment_cli_args.py
+++ b/isaaclab_arena/evaluation/legacy_environment_cli_args.py
@@ -28,7 +28,7 @@ def legacy_environment_args_to_cli_args(args: dict[str, Any]) -> list[str]:
 
     environment = str(args["environment"])
     if environment.endswith((".yaml", ".yml")):
-        cli_args.extend(("--env_graph_spec_yaml", environment))
+        cli_args.extend(("--env_spec", environment))
     else:
         cli_args.append(environment)
 

--- a/isaaclab_arena/evaluation/legacy_eval_config.py
+++ b/isaaclab_arena/evaluation/legacy_eval_config.py
@@ -156,7 +156,7 @@ def _graph_environment_cfg_from_legacy_args(
 ) -> LegacyGraphEnvironmentCfg:
     """Create the temporary graph-YAML compatibility config from legacy arguments."""
     return LegacyGraphEnvironmentCfg(
-        env_graph_spec_yaml_path=str(arena_env_args["environment"]),
+        env_spec_path=str(arena_env_args["environment"]),
         per_run_overrides={
             field_name: value for field_name, value in arena_env_args.items() if field_name != "environment"
         },

--- a/isaaclab_arena/evaluation/legacy_graph_environment_cli.py
+++ b/isaaclab_arena/evaluation/legacy_graph_environment_cli.py
@@ -27,10 +27,10 @@ if TYPE_CHECKING:
 class LegacyGraphEnvironmentCfg(ArenaEnvironmentCfg):
     """Environment config for graph-YAML environments
 
-    The environment is stored as env_graph_spec_yaml_path and the per-run overrides.
+    The environment is stored as env_spec_path and the per-run overrides.
     """
 
-    env_graph_spec_yaml_path: str = ""
+    env_spec_path: str = ""
     """Graph-spec YAML path the environment was loaded from; serialized as the environment ``type``."""
 
     per_run_overrides: dict[str, Any] = field(default_factory=dict)
@@ -48,11 +48,9 @@ def build_arena_builder_from_legacy_graph(
     """Build a graph-YAML environment through the existing argparse adapter."""
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
-    assert cfg.env_graph_spec_yaml_path.endswith((".yaml", ".yml")), "legacy graph config must select a graph YAML"
-    arena_env_args = legacy_environment_args_to_cli_args(
-        {"environment": cfg.env_graph_spec_yaml_path, **cfg.per_run_overrides}
-    )
+    assert cfg.env_spec_path.endswith((".yaml", ".yml")), "legacy graph config must select a graph YAML"
+    arena_env_args = legacy_environment_args_to_cli_args({"environment": cfg.env_spec_path, **cfg.per_run_overrides})
     parser = get_isaaclab_arena_environments_cli_parser()
     args_cli = parser.parse_args(arena_env_args)
-    arena_env = arena_env_from_graph_spec(args_cli.env_graph_spec_yaml, args_cli)
+    arena_env = arena_env_from_graph_spec(args_cli.env_spec, args_cli)
     return ArenaEnvBuilder(arena_env, environment_builder, hydra_overrides=hydra_overrides)

--- a/isaaclab_arena/hydra/typed_experiment_loader.py
+++ b/isaaclab_arena/hydra/typed_experiment_loader.py
@@ -281,11 +281,11 @@ def _build_environment_cfg_from_yaml_values(
     argparse compatibility path; otherwise the type selects a registered typed config.
     """
     if _is_environment_graph_yaml_spec(environment_values):
-        env_graph_spec_yaml_path = _graph_spec_yaml_path(environment_values)
+        env_spec_path = _graph_spec_yaml_path(environment_values)
         per_run_overrides = {
             field_name: value for field_name, value in environment_values.items() if field_name != "type"
         }
-        return _graph_environment_cfg_from_yaml_values(env_graph_spec_yaml_path, per_run_overrides)
+        return _graph_environment_cfg_from_yaml_values(env_spec_path, per_run_overrides)
     else:
         return _compose_typed_config_from_yaml_selector(
             config_store,
@@ -301,7 +301,7 @@ def _build_environment_cfg_from_yaml_values(
 # TODO(cvolk, 2026-07-07): [typed-config-migration] Delete this factory when graph-YAML
 # environments have a typed configuration and no longer use the argparse compatibility path.
 def _graph_environment_cfg_from_yaml_values(
-    env_graph_spec_yaml_path: str,
+    env_spec_path: str,
     per_run_overrides: dict[str, Any],
 ) -> LegacyGraphEnvironmentCfg:
     """Create the temporary graph-YAML compatibility config from typed YAML Run values.
@@ -313,7 +313,7 @@ def _graph_environment_cfg_from_yaml_values(
     """
     return LegacyGraphEnvironmentCfg(
         enable_cameras=bool(per_run_overrides.get("enable_cameras", False)),
-        env_graph_spec_yaml_path=env_graph_spec_yaml_path,
+        env_spec_path=env_spec_path,
         per_run_overrides=dict(per_run_overrides),
     )
 

--- a/isaaclab_arena/hydra/typed_experiment_serializer.py
+++ b/isaaclab_arena/hydra/typed_experiment_serializer.py
@@ -61,7 +61,7 @@ def _environment_yaml_values(
 ) -> dict[str, Any]:
     """Return one Run's environment section."""
     if isinstance(run_cfg.environment, LegacyGraphEnvironmentCfg):
-        return {"type": run_cfg.environment.env_graph_spec_yaml_path, **run_cfg.environment.per_run_overrides}
+        return {"type": run_cfg.environment.env_spec_path, **run_cfg.environment.per_run_overrides}
     else:
         environment_type = environment_registry.get_factory_type_for_cfg(run_cfg.environment)
         return {"type": environment_type.name, **dumped_environment_values}

--- a/isaaclab_arena/scripts/environment_runner.py
+++ b/isaaclab_arena/scripts/environment_runner.py
@@ -18,7 +18,7 @@ Run a registered environment:
 Run an environment graph spec:
 
     python isaaclab_arena/scripts/environment_runner.py \
-        --env_graph_spec_yaml isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
+        --env_spec isaaclab_arena_environments/robolab/tasks/banana_in_bowl.yaml
 """
 
 from __future__ import annotations

--- a/isaaclab_arena/scripts/run_placement_pool_validation.py
+++ b/isaaclab_arena/scripts/run_placement_pool_validation.py
@@ -16,7 +16,7 @@ Run inside the container (example with a registered example environment):
 Or against a graph spec:
 
     /isaac-sim/python.sh isaaclab_arena/scripts/run_placement_pool_validation.py --headless \\
-        --num_envs 4 --env_graph_spec_yaml path/to/spec.yaml
+        --num_envs 4 --env_spec path/to/spec.yaml
 """
 
 from __future__ import annotations

--- a/isaaclab_arena/tests/test_arena_env_graph_conversion.py
+++ b/isaaclab_arena/tests/test_arena_env_graph_conversion.py
@@ -82,9 +82,9 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
 
     yaml_path = str(TEST_DATA_DIR / "pick_and_place_maple_table_env_graph.yaml")
 
-    # --env_graph_spec_yaml with no example-environment subcommand: parses (subcommand is
+    # --env_spec with no example-environment subcommand: parses (subcommand is
     # optional) and the runner builds the env from the graph spec instead of the registry.
-    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path]
+    sys.argv = ["policy_runner.py", "--env_spec", yaml_path]
     args = get_isaaclab_arena_environments_cli_parser().parse_args()
 
     builder = get_arena_builder_from_cli(args)
@@ -93,7 +93,7 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     # The flags the YAML declares under `cli_override_specs` are registered dynamically by the
     # environments parser (not hardcoded). Confirm --object parses through that real parser
     # path and that apply_cli_override_args swaps the declared target asset's registry_name.
-    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", yaml_path, "--object", "dex_cube"]
+    sys.argv = ["policy_runner.py", "--env_spec", yaml_path, "--object", "dex_cube"]
     args = get_isaaclab_arena_environments_cli_parser().parse_args()
     assert args.object == "dex_cube"
     spec = ArenaEnvGraphSpec.from_yaml(yaml_path)
@@ -101,17 +101,17 @@ def _test_get_arena_builder_from_cli_builds_env_from_graph_yaml(simulation_app):
     cube = next(obj for obj in spec.objects if obj.id == "rubiks_cube_hot3d_robolab")
     assert cube.registry_name == "dex_cube"
 
-    # A non-existent --env_graph_spec_yaml fails with a clear "not found" assertion from the YAML
+    # A non-existent --env_spec fails with a clear "not found" assertion from the YAML
     # loader, not an opaque FileNotFoundError. The parser hits it while building, when it reads the
     # graph's declared override flags.
-    sys.argv = ["policy_runner.py", "--env_graph_spec_yaml", "/no/such/env_graph.yaml"]
+    sys.argv = ["policy_runner.py", "--env_spec", "/no/such/env_graph.yaml"]
     with pytest.raises(AssertionError, match="not found"):
         get_isaaclab_arena_environments_cli_parser()
 
     # Neither source, or both at once, is rejected by the exactly-one-source assert.
     for bad in (
-        argparse.Namespace(env_graph_spec_yaml=None, example_environment=None),
-        argparse.Namespace(env_graph_spec_yaml=yaml_path, example_environment="lift_object"),
+        argparse.Namespace(env_spec=None, example_environment=None),
+        argparse.Namespace(env_spec=yaml_path, example_environment="lift_object"),
     ):
         with pytest.raises(AssertionError):
             get_arena_builder_from_cli(bad)

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -112,7 +112,7 @@ runs:
     assert isinstance(run.environment, LegacyGraphEnvironmentCfg)
     # Only environment values are stored (and later become CLI tokens at execution); the
     # environment_builder section stays typed and reaches the argparse path directly.
-    assert run.environment.env_graph_spec_yaml_path == "robolab/tasks/banana_in_bowl.yaml"
+    assert run.environment.env_spec_path == "robolab/tasks/banana_in_bowl.yaml"
     assert run.environment.per_run_overrides == {"enable_cameras": True, "pick_up_object": "banana"}
     assert run.environment_builder.num_envs == 2
     assert run.environment_builder.device == "cuda:1"
@@ -165,7 +165,7 @@ def test_typed_graph_camera_run_requires_prelaunch_camera_flag():
     run_cfg = ArenaRunCfg(
         name="graph_run",
         environment=LegacyGraphEnvironmentCfg(
-            env_graph_spec_yaml_path="robolab/tasks/banana_in_bowl.yaml",
+            env_spec_path="robolab/tasks/banana_in_bowl.yaml",
             enable_cameras=True,
         ),
         policy=ZeroActionPolicyCfg(),

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -319,7 +319,7 @@ def test_graph_spec_yaml_environment_builds_legacy_cfg(tmp_path):
     run = experiment_cfg.runs["graph_run"]
 
     assert run.environment == LegacyGraphEnvironmentCfg(
-        env_graph_spec_yaml_path="robolab/tasks/banana_in_bowl.yaml",
+        env_spec_path="robolab/tasks/banana_in_bowl.yaml",
         per_run_overrides={"pick_up_object": "banana"},
     )
     assert run.policy == ZeroActionPolicyCfg()

--- a/isaaclab_arena/tests/test_legacy_eval_config.py
+++ b/isaaclab_arena/tests/test_legacy_eval_config.py
@@ -90,7 +90,7 @@ def test_legacy_graph_environment_stays_in_the_existing_cli_path():
     (run,) = run_cfgs_from_legacy_eval_config(legacy_config, device="cpu")
 
     assert isinstance(run.environment, LegacyGraphEnvironmentCfg)
-    assert run.environment.env_graph_spec_yaml_path == str(graph_path)
+    assert run.environment.env_spec_path == str(graph_path)
     assert run.environment.per_run_overrides == {"enable_cameras": True, "object": "dex_cube"}
 
 
@@ -108,7 +108,7 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
         },
         device="cuda:1",
     )
-    parsed_args = SimpleNamespace(env_graph_spec_yaml=str(graph_path))
+    parsed_args = SimpleNamespace(env_spec=str(graph_path))
     expected_arena_env = object()
     expected_builder = object()
     captured = {}
@@ -120,8 +120,8 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
 
     monkeypatch.setattr(legacy_graph_environment_cli, "get_isaaclab_arena_environments_cli_parser", lambda: _Parser())
 
-    def get_arena_env(env_graph_spec_yaml, args_cli):
-        captured["env_graph_spec_yaml"] = env_graph_spec_yaml
+    def get_arena_env(env_spec, args_cli):
+        captured["env_spec"] = env_spec
         captured["args_cli"] = args_cli
         return expected_arena_env
 
@@ -145,10 +145,10 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
 
     assert builder is expected_builder
     assert captured["arguments"] == legacy_environment_args_to_cli_args(
-        {"environment": run.environment.env_graph_spec_yaml_path, **run.environment.per_run_overrides}
+        {"environment": run.environment.env_spec_path, **run.environment.per_run_overrides}
     )
     assert captured["args_cli"] is parsed_args
-    assert captured["env_graph_spec_yaml"] == str(graph_path)
+    assert captured["env_spec"] == str(graph_path)
     # The Run's typed builder config crosses the boundary directly, so device and
     # language_instruction never round-trip through the argparse namespace.
     assert captured["builder_cfg"] is run.environment_builder

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -632,8 +632,7 @@ def test_embedded_graph_environment_experiment_composes_through_experiment_runne
     run_cfg = experiment_cfg.runs["graph_run"]
     assert isinstance(run_cfg.environment, LegacyGraphEnvironmentCfg)
     assert (
-        run_cfg.environment.env_graph_spec_yaml_path
-        == "isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml"
+        run_cfg.environment.env_spec_path == "isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml"
     )
     assert run_cfg.environment.per_run_overrides == {"enable_cameras": True}
     assert run_cfg.environment_builder.num_envs == 4

--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -47,10 +47,10 @@ def run_policy_runner(
         args.append("--enable_cameras")
     # automatically detect if the env source is a graph spec yaml or an example-environment name
     # and pass the appropriate argument.
-    # NOTE: --env_graph_spec_yaml takes the next arg as its value, so example_environment must be
+    # NOTE: --env_spec takes the next arg as its value, so example_environment must be
     # appended directly after it. Do not insert any other arg between these two lines.
     if example_environment.endswith((".yaml", ".yml")):
-        args.append("--env_graph_spec_yaml")
+        args.append("--env_spec")
     args.append(example_environment)
     if embodiment is not None:
         args.append("--embodiment")

--- a/isaaclab_arena_environments/cli.py
+++ b/isaaclab_arena_environments/cli.py
@@ -158,10 +158,10 @@ def add_example_environments_cli_args(args_parser: argparse.ArgumentParser) -> a
 
     # A graph spec YAML may declare its own swappable flags under `cli_override_specs`. Register them
     # here, before parsing, so they appear in --help and parse like any other flag.
-    env_graph_spec_yaml = getattr(args, "env_graph_spec_yaml", None)
-    if env_graph_spec_yaml is not None:
+    env_spec = getattr(args, "env_spec", None)
+    if env_spec is not None:
         # The env comes from the graph spec, so don't register the example-environment subparsers.
-        cli_override_specs_from_yaml = ArenaEnvGraphSpec.read_cli_override_specs(env_graph_spec_yaml)
+        cli_override_specs_from_yaml = ArenaEnvGraphSpec.read_cli_override_specs(env_spec)
         add_cli_override_args(args_parser, cli_override_specs_from_yaml)
         return args_parser
 
@@ -206,28 +206,28 @@ def get_arena_builder_from_cli(
     """
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
-    # The env comes from exactly one source: a graph spec YAML (--env_graph_spec_yaml) or a
+    # The env comes from exactly one source: a graph spec YAML (--env_spec) or a
     # registered example-environment name (subcommand).
-    env_graph_spec_yaml = getattr(args_cli, "env_graph_spec_yaml", None)
+    env_spec = getattr(args_cli, "env_spec", None)
     example_environment = getattr(args_cli, "example_environment", None)
-    assert (env_graph_spec_yaml is None) != (example_environment is None), (
-        "Specify exactly one environment source: an example-environment name or --env_graph_spec_yaml"
-        f" (got example_environment={example_environment!r}, env_graph_spec_yaml={env_graph_spec_yaml!r})"
+    assert (env_spec is None) != (example_environment is None), (
+        "Specify exactly one environment source: an example-environment name or --env_spec"
+        f" (got example_environment={example_environment!r}, env_spec={env_spec!r})"
     )
 
     # Either env graph spec yaml OR example env name
     arena_env = (
-        arena_env_from_graph_spec(env_graph_spec_yaml, args_cli)
-        if env_graph_spec_yaml is not None
+        arena_env_from_graph_spec(env_spec, args_cli)
+        if env_spec is not None
         else _arena_env_from_example_name(example_environment, args_cli)
     )
     builder_cfg = arena_env_builder_cfg_from_argparse(args_cli)
     return ArenaEnvBuilder(arena_env, builder_cfg, hydra_overrides=hydra_overrides)
 
 
-def arena_env_from_graph_spec(env_graph_spec_yaml: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
+def arena_env_from_graph_spec(env_spec: str, args_cli: argparse.Namespace) -> IsaacLabArenaEnvironment:
     """Build the arena env from a graph spec YAML, applying any CLI node overrides."""
-    spec = ArenaEnvGraphSpec.from_yaml(env_graph_spec_yaml)
+    spec = ArenaEnvGraphSpec.from_yaml(env_spec)
     spec.apply_cli_override_args(args_cli)
     # cameras are enabled in embodiment, need to pass along to the env
     return spec.to_arena_env(enable_cameras=args_cli.enable_cameras)

--- a/isaaclab_arena_examples/agentic_environment_generation/cli_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/cli_runner.py
@@ -8,24 +8,24 @@
 Usage::
 
     # Print the Pydantic ArenaEnvGraphSpec JSON schema (no agent call, no Isaac Sim):
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode schema
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py --mode schema
 
     # Print the catalog sent to the agent (no agent call, no Isaac Sim):
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode catalog
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py --mode catalog
 
     # Print the background prim tree of a graph spec (no agent call, no Isaac Sim):
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \\
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \\
         --mode prim_tree --env_spec <env>_env_graph.yaml
 
     # Resolve a prompt into an environment graph spec YAML (no Isaac Sim):
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode resolve --prompt ...
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py --mode resolve --prompt ...
 
     # Build a gym env from a graph spec YAML and run the zero-action policy:
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode build --headless \\
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py --mode build --headless \\
         --num_envs 1 --env_spec <env>_env_graph.yaml
 
     # Resolve and build in one process:
-    python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode full --headless \\
+    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py --mode full --headless \\
         --num_envs 1 --prompt ...
 """
 

--- a/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py
@@ -15,14 +15,14 @@ Usage::
 
     # Print the background prim tree of a graph spec (no agent call, no Isaac Sim):
     python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py \\
-        --mode prim_tree --env_graph_spec_yaml <env>_env_graph.yaml
+        --mode prim_tree --env_spec <env>_env_graph.yaml
 
     # Resolve a prompt into an environment graph spec YAML (no Isaac Sim):
     python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode resolve --prompt ...
 
     # Build a gym env from a graph spec YAML and run the zero-action policy:
     python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode build --headless \\
-        --num_envs 1 --env_graph_spec_yaml <env>_env_graph.yaml
+        --num_envs 1 --env_spec <env>_env_graph.yaml
 
     # Resolve and build in one process:
     python isaaclab_arena_examples/agentic_environment_generation/environment_generation_runner.py --mode full --headless \\
@@ -67,9 +67,9 @@ def add_agentic_env_gen_runner_cli_args(parser: argparse.ArgumentParser) -> None
         help=(
             "Which phases to run: 'schema' (print the spec JSON schema and exit), "
             "'catalog' (print the agent catalog and exit), "
-            "'prim_tree' (print the background prim tree of --env_graph_spec_yaml and exit), "
+            "'prim_tree' (print the background prim tree of --env_spec and exit), "
             "'resolve' (prompt -> spec YAML, no Isaac Sim), "
-            "'build' (needs --env_graph_spec_yaml), or 'full' (resolve and build in one process; default). "
+            "'build' (needs --env_spec), or 'full' (resolve and build in one process; default). "
             "'schema', 'catalog', and 'prim_tree' make no agent call."
         ),
     )
@@ -344,8 +344,8 @@ def build_env_and_run_policy(env_graph_spec_path: Path, args_cli: argparse.Names
 
 
 def _resolved_graph_spec_yaml(args_cli: argparse.Namespace) -> Path:
-    path_arg = args_cli.env_graph_spec_yaml
-    assert path_arg is not None, f"--mode {args_cli.mode} requires --env_graph_spec_yaml"
+    path_arg = args_cli.env_spec
+    assert path_arg is not None, f"--mode {args_cli.mode} requires --env_spec"
     path = Path(path_arg)
     assert path.is_file(), f"env graph spec YAML not found: {path}"
     return path

--- a/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
@@ -12,7 +12,7 @@ Usage::
 
     # Open an existing spec:
     python isaaclab_arena_examples/agentic_environment_generation/gui_runner.py \\
-        --env_graph_spec_yaml isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
+        --env_spec isaaclab_arena/tests/test_data/pick_and_place_maple_table_env_graph.yaml
 
     # Custom port:
     python isaaclab_arena_examples/agentic_environment_generation/gui_runner.py --port 8600
@@ -54,7 +54,7 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--env_graph_spec_yaml",
+        "--env_spec",
         type=Path,
         default=None,
         help="Optional ArenaEnvGraphSpec YAML to open in the editor.",
@@ -85,7 +85,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     serve_live_editor(
-        args.env_graph_spec_yaml,
+        args.env_spec,
         out_dir=args.out_dir,
         port=args.port,
         inference_endpoint=args.inference_endpoint,
@@ -147,7 +147,7 @@ def serve_live_editor(
             "--",
         ]
         if yaml_path is not None:
-            cmd.extend(["--env_graph_spec_yaml", str(yaml_path.resolve())])
+            cmd.extend(["--env_spec", str(yaml_path.resolve())])
         cmd.extend(["--out_dir", str(out_dir.resolve())])
 
         print(f"[review_gui] launching Streamlit live editor: {' '.join(cmd)}", file=sys.stderr)

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/streamlit_ui.py
@@ -37,7 +37,7 @@ def parse_args() -> argparse.Namespace:
     """Parse Streamlit CLI args forwarded after ``--`` by gui_runner."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--env_graph_spec_yaml",
+        "--env_spec",
         type=Path,
         default=None,
         help="Optional path to an ArenaEnvGraphSpec YAML to open in the editor.",
@@ -93,7 +93,7 @@ def main() -> None:
     )
 
     args = parse_args()
-    yaml_path = args.env_graph_spec_yaml.resolve() if args.env_graph_spec_yaml is not None else None
+    yaml_path = args.env_spec.resolve() if args.env_spec is not None else None
     if yaml_path is not None and not yaml_path.exists():
         st.error(f"YAML file not found: {yaml_path}", icon="🛑")
         st.stop()

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -233,14 +233,14 @@ class TestParseArgs:
     def test_defaults_to_none_spec_path(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["streamlit_ui.py"])
         args = parse_args()
-        assert args.env_graph_spec_yaml is None
+        assert args.env_spec is None
 
-    def test_parses_env_graph_spec_yaml(self, monkeypatch, tmp_path: Path):
+    def test_parses_env_spec(self, monkeypatch, tmp_path: Path):
         spec_path = tmp_path / "spec.yaml"
         spec_path.write_text("env_name: x\n", encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", ["streamlit_ui.py", "--env_graph_spec_yaml", str(spec_path)])
+        monkeypatch.setattr(sys, "argv", ["streamlit_ui.py", "--env_spec", str(spec_path)])
         args = parse_args()
-        assert args.env_graph_spec_yaml == spec_path
+        assert args.env_spec == spec_path
 
     def test_parses_out_dir(self, monkeypatch, tmp_path: Path):
         monkeypatch.setattr(sys, "argv", ["streamlit_ui.py", "--out_dir", str(tmp_path / "generated")])

--- a/osmo/tasks/policy_runner_task.py
+++ b/osmo/tasks/policy_runner_task.py
@@ -98,8 +98,8 @@ class PolicyRunnerTask(BaseTask):
         The ``--arena_env`` value chooses the environment source and is resolved as follows:
 
         - Registered example-environment pass by name: kitchen_pick_and_place
-        - A graph-spec YAML path is preceded by the flag: --env_graph_spec_yaml robolab/tasks/mustard_above_raisin.yaml``.
+        - A graph-spec YAML path is preceded by the flag: --env_spec robolab/tasks/mustard_above_raisin.yaml``.
         """
         if self.task_cfg.arena_env.endswith((".yaml", ".yml")):
-            return f"--env_graph_spec_yaml {self.task_cfg.arena_env}"
+            return f"--env_spec {self.task_cfg.arena_env}"
         return self.task_cfg.arena_env


### PR DESCRIPTION
## Summary
Rename agentic env-spec CLI flag and runner

## Detailed description
- Long `--env_graph_spec_yaml` / `environment_generation_runner` names made docs and CLI usage harder to scan
- Renamed the flag to `--env_spec` and the script to `cli_runner.py`, updating runners, hydra/OSMO paths, tests, and workflow docs
- Breaking CLI change for anyone still passing `--env_graph_spec_yaml`