### PR TITLE
Support OpenAI URL as external endpoint

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -201,7 +201,7 @@ else
 
     # pass through the agentic env-gen endpoint selection and its API keys; values are
     # inherited from the host shell so the key never lives in the repo.
-    for AGENTIC_ENV_VAR in NV_API_KEY NVIDIA_API_KEY ARENA_INFERENCE_ENDPOINT; do
+    for AGENTIC_ENV_VAR in NV_API_KEY NVIDIA_API_KEY EXTERNAL_API_KEY ARENA_INFERENCE_ENDPOINT; do
         if [ -n "${!AGENTIC_ENV_VAR}" ]; then
             DOCKER_RUN_ARGS+=("--env" "$AGENTIC_ENV_VAR")
         fi

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -201,7 +201,7 @@ else
 
     # pass through the agentic env-gen endpoint selection and its API keys; values are
     # inherited from the host shell so the key never lives in the repo.
-    for AGENTIC_ENV_VAR in NV_API_KEY NVIDIA_API_KEY EXTERNAL_API_KEY ARENA_INFERENCE_ENDPOINT; do
+    for AGENTIC_ENV_VAR in NV_API_KEY NVIDIA_API_KEY OPENAI_API_KEY ARENA_INFERENCE_ENDPOINT; do
         if [ -n "${!AGENTIC_ENV_VAR}" ]; then
             DOCKER_RUN_ARGS+=("--env" "$AGENTIC_ENV_VAR")
         fi

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -49,13 +49,30 @@ in the shell you launch the agentic environment generation runner from.
    export ARENA_INFERENCE_ENDPOINT=internal
    export NV_API_KEY=<your-internal-api-key>
 
-A single run can override the selection with ``--inference_endpoint {internal,public}``.
+   # OpenAI API
+   export ARENA_INFERENCE_ENDPOINT=openai
+   export OPENAI_API_KEY=<your-openai-api-key>
+
+A single run can override the selection with
+``--inference_endpoint {internal,public,openai}``.
 
 Generate a key for the public endpoint at
 `build.nvidia.com API keys <https://build.nvidia.com/settings/api-keys>`_, and a key for the
 NVIDIA-internal endpoint at
 `inference.nvidia.com key management <https://inference.nvidia.com/key-management>`_
 (reachable from the NVIDIA network only).
+
+To use the direct OpenAI endpoint, create an OpenAI account, generate a secret at
+`OpenAI API keys <https://platform.openai.com/api-keys>`_, and configure payment or prepaid
+credits under
+`OpenAI billing <https://platform.openai.com/settings/organization/billing/overview>`_.
+OpenAI charges the account associated with the key according to its current API pricing and usage.
+Store the key securely and do not commit it to the repository.
+
+.. warning::
+   The ``openai`` endpoint connects directly to a third-party service operated by OpenAI, not
+   NVIDIA. Its availability, regional restrictions, data handling, pricing, and terms are
+   controlled by OpenAI. Review those terms before sending prompts or other data.
 
 Each endpoint calls a different model, and the generated environment changes with it. See
 :doc:`model_selection` for what the model decides, what Arena validates, and how to select the model.

--- a/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
@@ -49,7 +49,7 @@ resolution.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 18 30 20 15 15
+   :widths: 18 16 28 18 14 14
 
    * - ``ARENA_INFERENCE_ENDPOINT``
      - Accessibility
@@ -61,20 +61,20 @@ resolution.
      - Public (free)
      - ``openai/gpt-oss-120b``
      - ``NVIDIA_API_KEY``
-     - 10/15 (66.7%)
-     - 18.61 s
+     - 13/15 (86.7%)
+     - 22.28 s
    * - ``internal``
      - NVIDIA internal
      - ``openai/openai/gpt-5.6-terra``
      - ``NV_API_KEY``
      - 15/15 (100%)
-     - 10.78 s
+     - 12.57 s
    * - ``openai``
      - Public (charged)
      - ``gpt-5.6-terra``
      - ``OPENAI_API_KEY``
      - 15/15 (100%)
-     - 7.94 s
+     - 10.15 s
 
 .. note::
    The benchmark ran each of five documented prompts three times. Pass rate is the fraction of

--- a/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/model_selection.rst
@@ -12,7 +12,7 @@ what the environment contains. Arena only checks that the answer is admissible: 
 ``registry_name`` is registered, each relation kind exists, and each ``prim_path`` is in the
 background's prim tree. A bad answer is rejected and saved as ``invalid_<name>.yaml`` with trace
 lines, but Arena cannot fix it. The model must support OpenAI-compatible structured outputs
-(``response_format={"type": "json_schema", "strict": true}``).
+(``response_format={"type": "json_schema", ...}``).
 
 Why Spec Quality Varies
 -------------------------
@@ -49,17 +49,38 @@ resolution.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 40 40
+   :widths: 20 18 30 20 15 15
 
    * - ``ARENA_INFERENCE_ENDPOINT``
+     - Accessibility
      - Default model
      - API key variable
+     - Pass rate
+     - Mean runtime
    * - ``public`` (default)
+     - Public (free)
      - ``openai/gpt-oss-120b``
      - ``NVIDIA_API_KEY``
+     - 10/15 (66.7%)
+     - 18.61 s
    * - ``internal``
-     - ``azure/anthropic/claude-opus-4-8``
+     - NVIDIA internal
+     - ``openai/openai/gpt-5.6-terra``
      - ``NV_API_KEY``
+     - 15/15 (100%)
+     - 10.78 s
+   * - ``openai``
+     - Public (charged)
+     - ``gpt-5.6-terra``
+     - ``OPENAI_API_KEY``
+     - 15/15 (100%)
+     - 7.94 s
+
+.. note::
+   The benchmark ran each of five documented prompts three times. Pass rate is the fraction of
+   generated specs that matched the expected structure; runtime is the mean end-to-end
+   ``generate_spec`` runtime. These results are snapshots rather than guarantees: model output is
+   non-deterministic, and service load affects runtime.
 
 Reviewing the Generated Spec
 ----------------------------

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -65,7 +65,7 @@ class EnvironmentGenerationAgent:
             max_retries: Number of additional attempts after a recoverable failure
                 (network errors, timeouts, empty responses, malformed JSON). Each
                 retry is a fresh API call.
-            endpoint: Inference endpoint name, ``internal``, ``public``, or ``external``.
+            endpoint: Inference endpoint name, ``internal``, ``public``, or ``openai``.
                 Falls back to the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
             enable_simready_search: When ``True``, search SimReady for objects the asset catalog
                 does not cover.

--- a/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
+++ b/isaaclab_arena/agentic_environment_generation/environment_generation_agent.py
@@ -65,8 +65,8 @@ class EnvironmentGenerationAgent:
             max_retries: Number of additional attempts after a recoverable failure
                 (network errors, timeouts, empty responses, malformed JSON). Each
                 retry is a fresh API call.
-            endpoint: Inference endpoint name, ``internal`` or ``public``. Falls back to
-                the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
+            endpoint: Inference endpoint name, ``internal``, ``public``, or ``external``.
+                Falls back to the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
             enable_simready_search: When ``True``, search SimReady for objects the asset catalog
                 does not cover.
             simready_config: Optional SimReady search configuration.

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -24,8 +24,8 @@ INTERNAL_MODEL = "openai/openai/gpt-5.6-terra"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 PUBLIC_MODEL = "openai/gpt-oss-120b"
 # If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
-EXTERNAL_BASE_URL = "https://api.openai.com/v1"
-EXTERNAL_MODEL = "gpt-5.6-terra"
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+OPENAI_MODEL = "gpt-5.6-terra"
 
 INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
 """Environment variable naming the inference endpoint every agentic command uses."""
@@ -58,18 +58,18 @@ INTERNAL_ENDPOINT = InferenceEndpoint(
 PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")
 """Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""
 
-EXTERNAL_ENDPOINT = InferenceEndpoint(
-    "external",
-    EXTERNAL_BASE_URL,
-    EXTERNAL_MODEL,
-    "EXTERNAL_API_KEY",
+OPENAI_ENDPOINT = InferenceEndpoint(
+    "openai",
+    OPENAI_BASE_URL,
+    OPENAI_MODEL,
+    "OPENAI_API_KEY",
     max_tokens_parameter="max_completion_tokens",
     supports_temperature=False,
     strict_json_schema=False,
 )
 """Direct OpenAI API endpoint, reached with an OpenAI API key."""
 
-INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT, EXTERNAL_ENDPOINT)}
+INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT, OPENAI_ENDPOINT)}
 DEFAULT_ENDPOINT_NAME = PUBLIC_ENDPOINT.name
 
 
@@ -128,7 +128,7 @@ class InferenceBackend:
             max_tokens: Maximum tokens in each completion response.
             max_retries: Additional attempts after a recoverable failure; must be in
                 ``[0, MAX_RETRIES_LIMIT)``.
-            endpoint: Inference endpoint name, ``internal``, ``public``, or ``external``.
+            endpoint: Inference endpoint name, ``internal``, ``public``, or ``openai``.
                 Falls back to the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
         """
         assert (

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -17,15 +17,9 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel
 
-MAX_RETRIES_LIMIT = 10
-
-INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
-INTERNAL_MODEL = "openai/openai/gpt-5.6-terra"
-PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
-PUBLIC_MODEL = "openai/gpt-oss-120b"
-# If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
-OPENAI_BASE_URL = "https://api.openai.com/v1"
-OPENAI_MODEL = "gpt-5.6-terra"
+# -----------------------------------------------------------------------------
+# Inference endpoints
+# -----------------------------------------------------------------------------
 
 INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
 """Environment variable naming the inference endpoint every agentic command uses."""
@@ -41,31 +35,34 @@ class InferenceEndpoint:
     api_key_env_var: str
     max_tokens_parameter: Literal["max_tokens", "max_completion_tokens"] = "max_tokens"
     supports_temperature: bool = True
-    strict_json_schema: bool = True
 
 
 INTERNAL_ENDPOINT = InferenceEndpoint(
-    "internal",
-    INTERNAL_BASE_URL,
-    INTERNAL_MODEL,
-    "NV_API_KEY",
+    name="internal",
+    base_url="https://inference-api.nvidia.com",
+    model="openai/openai/gpt-5.6-terra",
+    api_key_env_var="NV_API_KEY",
     max_tokens_parameter="max_completion_tokens",
     supports_temperature=False,
-    strict_json_schema=False,
 )
 """NVIDIA-internal inference endpoint, reached with an internal API key."""
 
-PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")
+PUBLIC_ENDPOINT = InferenceEndpoint(
+    name="public",
+    base_url="https://integrate.api.nvidia.com/v1",
+    # If you cannot access the model in your region, try "nvidia/nemotron-3-super-120b-a12b".
+    model="openai/gpt-oss-120b",
+    api_key_env_var="NVIDIA_API_KEY",
+)
 """Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""
 
 OPENAI_ENDPOINT = InferenceEndpoint(
-    "openai",
-    OPENAI_BASE_URL,
-    OPENAI_MODEL,
-    "OPENAI_API_KEY",
+    name="openai",
+    base_url="https://api.openai.com/v1",
+    model="gpt-5.6-terra",
+    api_key_env_var="OPENAI_API_KEY",
     max_tokens_parameter="max_completion_tokens",
     supports_temperature=False,
-    strict_json_schema=False,
 )
 """Direct OpenAI API endpoint, reached with an OpenAI API key."""
 
@@ -89,6 +86,13 @@ def resolve_inference_endpoint(name: str | None = None) -> InferenceEndpoint:
         f"{sorted(INFERENCE_ENDPOINTS)}"
     )
     return INFERENCE_ENDPOINTS[resolved]
+
+
+# -----------------------------------------------------------------------------
+# Inference backend
+# -----------------------------------------------------------------------------
+
+MAX_RETRIES_LIMIT = 10
 
 
 @dataclass(frozen=True)
@@ -196,7 +200,6 @@ class InferenceBackend:
                         "type": "json_schema",
                         "json_schema": {
                             "name": request.schema_name,
-                            "strict": self._endpoint.strict_json_schema,
                             "schema": request.schema,
                         },
                     },

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -10,17 +10,14 @@ from __future__ import annotations
 import copy
 import json
 import os
-import time
-from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from openai import OpenAI, RateLimitError
+from openai import OpenAI
 from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel
 
 MAX_RETRIES_LIMIT = 10
-EXTERNAL_RATE_LIMIT_FALLBACK_S = 20.0
 
 INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
 INTERNAL_MODEL = "openai/openai/gpt-5.6-terra"
@@ -157,7 +154,7 @@ class InferenceBackend:
         self._temperature = temperature
         self._max_tokens = max_tokens
         self._max_retries = max_retries
-        _ping(client, inference_endpoint, resolved_model, max_retries)
+        _ping(client, inference_endpoint, resolved_model)
 
     @property
     def endpoint(self) -> InferenceEndpoint:
@@ -192,10 +189,7 @@ class InferenceBackend:
             if attempt > 0:
                 print(f"[{request.retry_label}] retry {attempt}/{self._max_retries} after: {last_exc}", flush=True)
             try:
-                resp = _create_chat_completion(
-                    self._client,
-                    self._endpoint,
-                    self._max_retries,
+                resp = self._client.chat.completions.create(
                     model=self._model,
                     messages=messages,
                     response_format={
@@ -225,10 +219,6 @@ class InferenceBackend:
                 # Seen on the default azure/anthropic/claude-opus-4-8, but not DeepSeek.
                 # TODO(xinjieyao): check if other models also wrap the response in a single-key dictionary.
                 return _unwrap_provider_envelope(json.loads(text, strict=False), request.schema)
-            except RateLimitError as exc:
-                last_exc = exc
-                if self._endpoint == EXTERNAL_ENDPOINT:
-                    break
             except Exception as exc:
                 last_exc = exc
         raise RuntimeError(
@@ -263,42 +253,7 @@ def _completion_options(endpoint: InferenceEndpoint, max_tokens: int, temperatur
     return options
 
 
-def _create_chat_completion(
-    client: OpenAI,
-    endpoint: InferenceEndpoint,
-    max_retries: int,
-    **kwargs: Any,
-) -> Any:
-    """Create a completion, respecting external-endpoint Retry-After headers."""
-    for attempt in range(1 + max_retries):
-        try:
-            return client.chat.completions.create(**kwargs)
-        except RateLimitError as exc:
-            if endpoint != EXTERNAL_ENDPOINT or attempt >= max_retries:
-                raise
-            delay_s = _rate_limit_retry_delay_s(exc)
-            print(
-                f"[inference] external rate limit; retry {attempt + 1}/{max_retries} after {delay_s:g}s",
-                flush=True,
-            )
-            time.sleep(delay_s)
-    raise AssertionError("unreachable")
-
-
-def _rate_limit_retry_delay_s(exc: RateLimitError) -> float:
-    """Return the provider-requested rate-limit delay, or a conservative fallback."""
-    response = getattr(exc, "response", None)
-    headers = getattr(response, "headers", {})
-    for name, scale in (("retry-after-ms", 0.001), ("retry-after", 1.0)):
-        value = headers.get(name)
-        if value is None:
-            continue
-        with suppress(TypeError, ValueError):
-            return max(0.0, float(value) * scale)
-    return EXTERNAL_RATE_LIMIT_FALLBACK_S
-
-
-def _ping(client: OpenAI, endpoint: InferenceEndpoint, model: str, max_retries: int) -> str:
+def _ping(client: OpenAI, endpoint: InferenceEndpoint, model: str) -> str:
     """Smoke-test the endpoint + API key + model with a minimal request.
 
     Args:
@@ -306,16 +261,12 @@ def _ping(client: OpenAI, endpoint: InferenceEndpoint, model: str, max_retries: 
         endpoint: Endpoint capabilities used to construct the request.
         model: Model identifier forwarded to
             ``client.chat.completions.create(model=...)``.
-        max_retries: Additional attempts after an external rate-limit response.
 
     Returns:
         The model's response text.
     """
     # TODO(qianl): wrap with transient-error retry.
-    resp = _create_chat_completion(
-        client,
-        endpoint,
-        max_retries,
+    resp = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": "Respond with exactly: OK"}],
         **_completion_options(endpoint, 32, 0),

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -23,7 +23,7 @@ MAX_RETRIES_LIMIT = 10
 EXTERNAL_RATE_LIMIT_FALLBACK_S = 20.0
 
 INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
-INTERNAL_MODEL = "azure/anthropic/claude-opus-4-8"
+INTERNAL_MODEL = "openai/openai/gpt-5.6-terra"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 PUBLIC_MODEL = "openai/gpt-oss-120b"
 # If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
@@ -47,7 +47,15 @@ class InferenceEndpoint:
     strict_json_schema: bool = True
 
 
-INTERNAL_ENDPOINT = InferenceEndpoint("internal", INTERNAL_BASE_URL, INTERNAL_MODEL, "NV_API_KEY")
+INTERNAL_ENDPOINT = InferenceEndpoint(
+    "internal",
+    INTERNAL_BASE_URL,
+    INTERNAL_MODEL,
+    "NV_API_KEY",
+    max_tokens_parameter="max_completion_tokens",
+    supports_temperature=False,
+    strict_json_schema=False,
+)
 """NVIDIA-internal inference endpoint, reached with an internal API key."""
 
 PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -24,6 +24,8 @@ INTERNAL_MODEL = "azure/anthropic/claude-opus-4-8"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 PUBLIC_MODEL = "openai/gpt-oss-120b"
 # If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
+EXTERNAL_BASE_URL = "https://api.openai.com/v1"
+EXTERNAL_MODEL = "gpt-5.5"
 
 INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
 """Environment variable naming the inference endpoint every agentic command uses."""
@@ -45,7 +47,10 @@ INTERNAL_ENDPOINT = InferenceEndpoint("internal", INTERNAL_BASE_URL, INTERNAL_MO
 PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")
 """Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""
 
-INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT)}
+EXTERNAL_ENDPOINT = InferenceEndpoint("external", EXTERNAL_BASE_URL, EXTERNAL_MODEL, "EXTERNAL_API_KEY")
+"""Direct OpenAI API endpoint, reached with an OpenAI API key."""
+
+INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT, EXTERNAL_ENDPOINT)}
 DEFAULT_ENDPOINT_NAME = PUBLIC_ENDPOINT.name
 
 
@@ -104,8 +109,8 @@ class InferenceBackend:
             max_tokens: Maximum tokens in each completion response.
             max_retries: Additional attempts after a recoverable failure; must be in
                 ``[0, MAX_RETRIES_LIMIT)``.
-            endpoint: Inference endpoint name, ``internal`` or ``public``. Falls back to
-                the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
+            endpoint: Inference endpoint name, ``internal``, ``public``, or ``external``.
+                Falls back to the ``ARENA_INFERENCE_ENDPOINT`` environment variable.
         """
         assert (
             0 <= max_retries < MAX_RETRIES_LIMIT

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 import copy
 import json
 import os
+import time
+from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
-from openai import OpenAI
+from openai import OpenAI, RateLimitError
 from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel
 
 MAX_RETRIES_LIMIT = 10
+EXTERNAL_RATE_LIMIT_FALLBACK_S = 20.0
 
 INTERNAL_BASE_URL = "https://inference-api.nvidia.com"
 INTERNAL_MODEL = "azure/anthropic/claude-opus-4-8"
@@ -25,7 +28,7 @@ PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 PUBLIC_MODEL = "openai/gpt-oss-120b"
 # If you cannot access the model in your region, you can try the "nvidia/nemotron-3-super-120b-a12b" model.
 EXTERNAL_BASE_URL = "https://api.openai.com/v1"
-EXTERNAL_MODEL = "gpt-5.5"
+EXTERNAL_MODEL = "gpt-5.6-terra"
 
 INFERENCE_ENDPOINT_ENV_VAR = "ARENA_INFERENCE_ENDPOINT"
 """Environment variable naming the inference endpoint every agentic command uses."""
@@ -39,6 +42,9 @@ class InferenceEndpoint:
     base_url: str
     model: str
     api_key_env_var: str
+    max_tokens_parameter: Literal["max_tokens", "max_completion_tokens"] = "max_tokens"
+    supports_temperature: bool = True
+    strict_json_schema: bool = True
 
 
 INTERNAL_ENDPOINT = InferenceEndpoint("internal", INTERNAL_BASE_URL, INTERNAL_MODEL, "NV_API_KEY")
@@ -47,7 +53,15 @@ INTERNAL_ENDPOINT = InferenceEndpoint("internal", INTERNAL_BASE_URL, INTERNAL_MO
 PUBLIC_ENDPOINT = InferenceEndpoint("public", PUBLIC_BASE_URL, PUBLIC_MODEL, "NVIDIA_API_KEY")
 """Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""
 
-EXTERNAL_ENDPOINT = InferenceEndpoint("external", EXTERNAL_BASE_URL, EXTERNAL_MODEL, "EXTERNAL_API_KEY")
+EXTERNAL_ENDPOINT = InferenceEndpoint(
+    "external",
+    EXTERNAL_BASE_URL,
+    EXTERNAL_MODEL,
+    "EXTERNAL_API_KEY",
+    max_tokens_parameter="max_completion_tokens",
+    supports_temperature=False,
+    strict_json_schema=False,
+)
 """Direct OpenAI API endpoint, reached with an OpenAI API key."""
 
 INFERENCE_ENDPOINTS = {endpoint.name: endpoint for endpoint in (INTERNAL_ENDPOINT, PUBLIC_ENDPOINT, EXTERNAL_ENDPOINT)}
@@ -135,7 +149,7 @@ class InferenceBackend:
         self._temperature = temperature
         self._max_tokens = max_tokens
         self._max_retries = max_retries
-        _ping(client, resolved_model)
+        _ping(client, inference_endpoint, resolved_model, max_retries)
 
     @property
     def endpoint(self) -> InferenceEndpoint:
@@ -170,19 +184,21 @@ class InferenceBackend:
             if attempt > 0:
                 print(f"[{request.retry_label}] retry {attempt}/{self._max_retries} after: {last_exc}", flush=True)
             try:
-                resp = self._client.chat.completions.create(
+                resp = _create_chat_completion(
+                    self._client,
+                    self._endpoint,
+                    self._max_retries,
                     model=self._model,
                     messages=messages,
                     response_format={
                         "type": "json_schema",
                         "json_schema": {
                             "name": request.schema_name,
-                            "strict": True,
+                            "strict": self._endpoint.strict_json_schema,
                             "schema": request.schema,
                         },
                     },
-                    temperature=self._temperature,
-                    max_tokens=self._max_tokens,
+                    **_completion_options(self._endpoint, self._max_tokens, self._temperature),
                 )
                 choices = getattr(resp, "choices", None) or []
                 assert choices, (
@@ -201,6 +217,10 @@ class InferenceBackend:
                 # Seen on the default azure/anthropic/claude-opus-4-8, but not DeepSeek.
                 # TODO(xinjieyao): check if other models also wrap the response in a single-key dictionary.
                 return _unwrap_provider_envelope(json.loads(text, strict=False), request.schema)
+            except RateLimitError as exc:
+                last_exc = exc
+                if self._endpoint == EXTERNAL_ENDPOINT:
+                    break
             except Exception as exc:
                 last_exc = exc
         raise RuntimeError(
@@ -227,23 +247,70 @@ def build_strict_schema(model_cls: type[BaseModel]) -> dict[str, Any]:
     return schema
 
 
-def _ping(client: OpenAI, model: str) -> str:
+def _completion_options(endpoint: InferenceEndpoint, max_tokens: int, temperature: float) -> dict[str, int | float]:
+    """Return completion arguments supported by the selected endpoint."""
+    options: dict[str, int | float] = {endpoint.max_tokens_parameter: max_tokens}
+    if endpoint.supports_temperature:
+        options["temperature"] = temperature
+    return options
+
+
+def _create_chat_completion(
+    client: OpenAI,
+    endpoint: InferenceEndpoint,
+    max_retries: int,
+    **kwargs: Any,
+) -> Any:
+    """Create a completion, respecting external-endpoint Retry-After headers."""
+    for attempt in range(1 + max_retries):
+        try:
+            return client.chat.completions.create(**kwargs)
+        except RateLimitError as exc:
+            if endpoint != EXTERNAL_ENDPOINT or attempt >= max_retries:
+                raise
+            delay_s = _rate_limit_retry_delay_s(exc)
+            print(
+                f"[inference] external rate limit; retry {attempt + 1}/{max_retries} after {delay_s:g}s",
+                flush=True,
+            )
+            time.sleep(delay_s)
+    raise AssertionError("unreachable")
+
+
+def _rate_limit_retry_delay_s(exc: RateLimitError) -> float:
+    """Return the provider-requested rate-limit delay, or a conservative fallback."""
+    response = getattr(exc, "response", None)
+    headers = getattr(response, "headers", {})
+    for name, scale in (("retry-after-ms", 0.001), ("retry-after", 1.0)):
+        value = headers.get(name)
+        if value is None:
+            continue
+        with suppress(TypeError, ValueError):
+            return max(0.0, float(value) * scale)
+    return EXTERNAL_RATE_LIMIT_FALLBACK_S
+
+
+def _ping(client: OpenAI, endpoint: InferenceEndpoint, model: str, max_retries: int) -> str:
     """Smoke-test the endpoint + API key + model with a minimal request.
 
     Args:
         client: An OpenAI-compatible client (typically ``openai.OpenAI``).
+        endpoint: Endpoint capabilities used to construct the request.
         model: Model identifier forwarded to
             ``client.chat.completions.create(model=...)``.
+        max_retries: Additional attempts after an external rate-limit response.
 
     Returns:
         The model's response text.
     """
     # TODO(qianl): wrap with transient-error retry.
-    resp = client.chat.completions.create(
+    resp = _create_chat_completion(
+        client,
+        endpoint,
+        max_retries,
         model=model,
         messages=[{"role": "user", "content": "Respond with exactly: OK"}],
-        temperature=0,
-        max_tokens=8,
+        **_completion_options(endpoint, 32, 0),
     )
     choices = getattr(resp, "choices", None) or []
     assert choices, (

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -8,10 +8,9 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from openai import RateLimitError
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
     EXTERNAL_ENDPOINT,
@@ -166,36 +165,6 @@ class TestRunJson:
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
         assert kwargs["response_format"]["json_schema"]["strict"] is False
-
-    def test_external_endpoint_honors_retry_after_ms(self, stub_openai):
-        _, client = stub_openai
-        backend = InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name, max_retries=1)
-        client.chat.completions.create.reset_mock()
-        response = MagicMock()
-        response.headers = {"retry-after-ms": "250"}
-        rate_limit_error = RateLimitError("rate limited", response=response, body=None)
-        client.chat.completions.create.side_effect = [
-            rate_limit_error,
-            chat_response(content='{"ok": true}'),
-        ]
-        with patch("isaaclab_arena.agentic_environment_generation.inference_backend.time.sleep") as sleep:
-            assert backend.run_json(_request()) == {"ok": True}
-        sleep.assert_called_once_with(0.25)
-        assert client.chat.completions.create.call_count == 2
-
-    def test_external_ping_honors_retry_after_seconds(self, stub_openai):
-        _, client = stub_openai
-        response = MagicMock()
-        response.headers = {"retry-after": "2"}
-        rate_limit_error = RateLimitError("rate limited", response=response, body=None)
-        client.chat.completions.create.side_effect = [
-            rate_limit_error,
-            chat_response(content="OK"),
-        ]
-        with patch("isaaclab_arena.agentic_environment_generation.inference_backend.time.sleep") as sleep:
-            InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name, max_retries=1)
-        sleep.assert_called_once_with(2.0)
-        assert client.chat.completions.create.call_count == 2
 
     def test_tolerates_unescaped_control_chars(self, stub_openai):
         _, client = stub_openai

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -13,9 +13,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
-    EXTERNAL_ENDPOINT,
     INFERENCE_ENDPOINT_ENV_VAR,
     INTERNAL_ENDPOINT,
+    OPENAI_ENDPOINT,
     PUBLIC_ENDPOINT,
     InferenceBackend,
     StructuredOutputRequest,
@@ -51,7 +51,7 @@ def clean_endpoint_env(monkeypatch):
     monkeypatch.delenv(INFERENCE_ENDPOINT_ENV_VAR, raising=False)
     monkeypatch.delenv(INTERNAL_ENDPOINT.api_key_env_var, raising=False)
     monkeypatch.delenv(PUBLIC_ENDPOINT.api_key_env_var, raising=False)
-    monkeypatch.delenv(EXTERNAL_ENDPOINT.api_key_env_var, raising=False)
+    monkeypatch.delenv(OPENAI_ENDPOINT.api_key_env_var, raising=False)
 
 
 class TestResolveInferenceEndpoint:
@@ -111,13 +111,13 @@ class TestInit:
         with pytest.raises(AssertionError, match=f"set {INTERNAL_ENDPOINT.api_key_env_var}"):
             InferenceBackend(endpoint=INTERNAL_ENDPOINT.name)
 
-    def test_external_endpoint_sets_base_url_model_and_key(self, monkeypatch, stub_openai):
+    def test_openai_endpoint_sets_base_url_model_and_key(self, monkeypatch, stub_openai):
         mock_cls, client = stub_openai
-        monkeypatch.setenv(EXTERNAL_ENDPOINT.api_key_env_var, "external-key")
-        backend = InferenceBackend(endpoint=EXTERNAL_ENDPOINT.name)
-        assert backend.endpoint == EXTERNAL_ENDPOINT
-        assert backend.model == EXTERNAL_ENDPOINT.model
-        mock_cls.assert_called_once_with(api_key="external-key", base_url=EXTERNAL_ENDPOINT.base_url)
+        monkeypatch.setenv(OPENAI_ENDPOINT.api_key_env_var, "openai-key")
+        backend = InferenceBackend(endpoint=OPENAI_ENDPOINT.name)
+        assert backend.endpoint == OPENAI_ENDPOINT
+        assert backend.model == OPENAI_ENDPOINT.model
+        mock_cls.assert_called_once_with(api_key="openai-key", base_url=OPENAI_ENDPOINT.base_url)
         ping_kwargs = client.chat.completions.create.call_args.kwargs
         assert ping_kwargs["max_completion_tokens"] == 32
         assert "max_tokens" not in ping_kwargs
@@ -142,9 +142,9 @@ class TestRunJson:
         assert "max_completion_tokens" not in kwargs
         assert kwargs["response_format"]["json_schema"]["strict"] is True
 
-    def test_external_endpoint_uses_openai_completion_options(self, stub_openai):
+    def test_openai_endpoint_uses_openai_completion_options(self, stub_openai):
         _, client = stub_openai
-        backend = InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name)
+        backend = InferenceBackend(api_key="test-key", endpoint=OPENAI_ENDPOINT.name)
         client.chat.completions.create.reset_mock()
         client.chat.completions.create.return_value = chat_response(content='{"ok": true}')
         backend.run_json(_request())

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -155,6 +155,18 @@ class TestRunJson:
         assert "temperature" not in kwargs
         assert kwargs["response_format"]["json_schema"]["strict"] is False
 
+    def test_internal_gpt_uses_openai_completion_options(self, stub_openai):
+        _, client = stub_openai
+        backend = InferenceBackend(api_key="test-key", endpoint=INTERNAL_ENDPOINT.name)
+        client.chat.completions.create.reset_mock()
+        client.chat.completions.create.return_value = chat_response(content='{"ok": true}')
+        backend.run_json(_request())
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 4096
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["response_format"]["json_schema"]["strict"] is False
+
     def test_external_endpoint_honors_retry_after_ms(self, stub_openai):
         _, client = stub_openai
         backend = InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name, max_retries=1)

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -140,7 +140,6 @@ class TestRunJson:
         assert kwargs["max_tokens"] == 4096
         assert kwargs["temperature"] == 0.2
         assert "max_completion_tokens" not in kwargs
-        assert kwargs["response_format"]["json_schema"]["strict"] is True
 
     def test_openai_endpoint_uses_openai_completion_options(self, stub_openai):
         _, client = stub_openai
@@ -152,7 +151,6 @@ class TestRunJson:
         assert kwargs["max_completion_tokens"] == 4096
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert kwargs["response_format"]["json_schema"]["strict"] is False
 
     def test_internal_gpt_uses_openai_completion_options(self, stub_openai):
         _, client = stub_openai
@@ -164,7 +162,6 @@ class TestRunJson:
         assert kwargs["max_completion_tokens"] == 4096
         assert "max_tokens" not in kwargs
         assert "temperature" not in kwargs
-        assert kwargs["response_format"]["json_schema"]["strict"] is False
 
     def test_tolerates_unescaped_control_chars(self, stub_openai):
         _, client = stub_openai

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -8,9 +8,10 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from openai import RateLimitError
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
     EXTERNAL_ENDPOINT,
@@ -112,12 +113,16 @@ class TestInit:
             InferenceBackend(endpoint=INTERNAL_ENDPOINT.name)
 
     def test_external_endpoint_sets_base_url_model_and_key(self, monkeypatch, stub_openai):
-        mock_cls, _ = stub_openai
+        mock_cls, client = stub_openai
         monkeypatch.setenv(EXTERNAL_ENDPOINT.api_key_env_var, "external-key")
         backend = InferenceBackend(endpoint=EXTERNAL_ENDPOINT.name)
         assert backend.endpoint == EXTERNAL_ENDPOINT
         assert backend.model == EXTERNAL_ENDPOINT.model
         mock_cls.assert_called_once_with(api_key="external-key", base_url=EXTERNAL_ENDPOINT.base_url)
+        ping_kwargs = client.chat.completions.create.call_args.kwargs
+        assert ping_kwargs["max_completion_tokens"] == 32
+        assert "max_tokens" not in ping_kwargs
+        assert "temperature" not in ping_kwargs
 
     def test_custom_model_and_base_url(self, stub_openai):
         mock_cls, _ = stub_openai
@@ -127,6 +132,59 @@ class TestInit:
 
 
 class TestRunJson:
+    def test_public_endpoint_uses_legacy_completion_options(self, stub_openai):
+        _, client = stub_openai
+        backend = inference_backend(stub_openai)
+        client.chat.completions.create.return_value = chat_response(content='{"ok": true}')
+        backend.run_json(_request())
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 4096
+        assert kwargs["temperature"] == 0.2
+        assert "max_completion_tokens" not in kwargs
+        assert kwargs["response_format"]["json_schema"]["strict"] is True
+
+    def test_external_endpoint_uses_openai_completion_options(self, stub_openai):
+        _, client = stub_openai
+        backend = InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name)
+        client.chat.completions.create.reset_mock()
+        client.chat.completions.create.return_value = chat_response(content='{"ok": true}')
+        backend.run_json(_request())
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 4096
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["response_format"]["json_schema"]["strict"] is False
+
+    def test_external_endpoint_honors_retry_after_ms(self, stub_openai):
+        _, client = stub_openai
+        backend = InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name, max_retries=1)
+        client.chat.completions.create.reset_mock()
+        response = MagicMock()
+        response.headers = {"retry-after-ms": "250"}
+        rate_limit_error = RateLimitError("rate limited", response=response, body=None)
+        client.chat.completions.create.side_effect = [
+            rate_limit_error,
+            chat_response(content='{"ok": true}'),
+        ]
+        with patch("isaaclab_arena.agentic_environment_generation.inference_backend.time.sleep") as sleep:
+            assert backend.run_json(_request()) == {"ok": True}
+        sleep.assert_called_once_with(0.25)
+        assert client.chat.completions.create.call_count == 2
+
+    def test_external_ping_honors_retry_after_seconds(self, stub_openai):
+        _, client = stub_openai
+        response = MagicMock()
+        response.headers = {"retry-after": "2"}
+        rate_limit_error = RateLimitError("rate limited", response=response, body=None)
+        client.chat.completions.create.side_effect = [
+            rate_limit_error,
+            chat_response(content="OK"),
+        ]
+        with patch("isaaclab_arena.agentic_environment_generation.inference_backend.time.sleep") as sleep:
+            InferenceBackend(api_key="test-key", endpoint=EXTERNAL_ENDPOINT.name, max_retries=1)
+        sleep.assert_called_once_with(2.0)
+        assert client.chat.completions.create.call_count == 2
+
     def test_tolerates_unescaped_control_chars(self, stub_openai):
         _, client = stub_openai
         backend = inference_backend(stub_openai)

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    EXTERNAL_ENDPOINT,
     INFERENCE_ENDPOINT_ENV_VAR,
     INTERNAL_ENDPOINT,
     PUBLIC_ENDPOINT,
@@ -50,6 +51,7 @@ def clean_endpoint_env(monkeypatch):
     monkeypatch.delenv(INFERENCE_ENDPOINT_ENV_VAR, raising=False)
     monkeypatch.delenv(INTERNAL_ENDPOINT.api_key_env_var, raising=False)
     monkeypatch.delenv(PUBLIC_ENDPOINT.api_key_env_var, raising=False)
+    monkeypatch.delenv(EXTERNAL_ENDPOINT.api_key_env_var, raising=False)
 
 
 class TestResolveInferenceEndpoint:
@@ -108,6 +110,14 @@ class TestInit:
         monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
         with pytest.raises(AssertionError, match=f"set {INTERNAL_ENDPOINT.api_key_env_var}"):
             InferenceBackend(endpoint=INTERNAL_ENDPOINT.name)
+
+    def test_external_endpoint_sets_base_url_model_and_key(self, monkeypatch, stub_openai):
+        mock_cls, _ = stub_openai
+        monkeypatch.setenv(EXTERNAL_ENDPOINT.api_key_env_var, "external-key")
+        backend = InferenceBackend(endpoint=EXTERNAL_ENDPOINT.name)
+        assert backend.endpoint == EXTERNAL_ENDPOINT
+        assert backend.model == EXTERNAL_ENDPOINT.model
+        mock_cls.assert_called_once_with(api_key="external-key", base_url=EXTERNAL_ENDPOINT.base_url)
 
     def test_custom_model_and_base_url(self, stub_openai):
         mock_cls, _ = stub_openai

--- a/isaaclab_arena/tests/test_spec_inference.py
+++ b/isaaclab_arena/tests/test_spec_inference.py
@@ -59,7 +59,6 @@ def test_infer_sets_response_format_to_json_schema(spec_inference):
     kwargs = client.chat.completions.create.call_args.kwargs
     assert kwargs["response_format"]["type"] == "json_schema"
     assert kwargs["response_format"]["json_schema"]["name"] == "ArenaEnvGraphSpec"
-    assert kwargs["response_format"]["json_schema"]["strict"] is True
     assert kwargs["response_format"]["json_schema"]["schema"] is inference._schema
 
 


### PR DESCRIPTION
## Summary
Add a direct OpenAI inference endpoint.

## Detailed description
- Support GPT-5.6 request parameters while preserving NVIDIA endpoint compatibility.
- Add endpoint-specific tests and switch the internal preset to GPT-5.6 Terra.
- Document API keys, billing, accessibility, and benchmark results.