### PR TITLE
Fix getting-started episode results

### DIFF
--- a/isaaclab_arena/tests/test_environment_cfgs.py
+++ b/isaaclab_arena/tests/test_environment_cfgs.py
@@ -87,7 +87,7 @@ def test_every_registered_cli_adapter_uses_its_typed_cfg_defaults():
 
 def test_generated_cli_arguments_and_cfg_validation():
     """Keep list, boolean, and scalar parsing while configs validate domain values."""
-    assert PickAndPlaceMapleTableEnvironmentCfg().episode_length_s is None
+    assert PickAndPlaceMapleTableEnvironmentCfg().episode_length_s == 70.0
 
     test_cases = [
         (

--- a/isaaclab_arena/tests/test_environment_cfgs.py
+++ b/isaaclab_arena/tests/test_environment_cfgs.py
@@ -87,6 +87,8 @@ def test_every_registered_cli_adapter_uses_its_typed_cfg_defaults():
 
 def test_generated_cli_arguments_and_cfg_validation():
     """Keep list, boolean, and scalar parsing while configs validate domain values."""
+    assert PickAndPlaceMapleTableEnvironmentCfg().episode_length_s is None
+
     test_cases = [
         (
             GR1PutAndCloseDoorEnvironment,
@@ -98,8 +100,20 @@ def test_generated_cli_arguments_and_cfg_validation():
         (GR1TableMultiObjectNoCollisionEnvironment, ["--mode", "heterogeneous"], {"mode": "heterogeneous"}),
         (
             PickAndPlaceMapleTableEnvironment,
-            ["--light_intensity", "750", "--additional_table_objects", "apple", "banana"],
-            {"light_intensity": 750.0, "additional_table_objects": ["apple", "banana"]},
+            [
+                "--light_intensity",
+                "750",
+                "--additional_table_objects",
+                "apple",
+                "banana",
+                "--episode_length_s",
+                "1.5",
+            ],
+            {
+                "light_intensity": 750.0,
+                "additional_table_objects": ["apple", "banana"],
+                "episode_length_s": 1.5,
+            },
         ),
     ]
 
@@ -112,6 +126,13 @@ def test_generated_cli_arguments_and_cfg_validation():
     invalid_mode_args = _parse_legacy_arguments(GR1TableMultiObjectNoCollisionEnvironment, ["--mode", "unsupported"])
     with pytest.raises(AssertionError, match="Unsupported placement mode"):
         _environment_cfg_from_cli(GR1TableMultiObjectNoCollisionEnvironment, invalid_mode_args)
+
+    invalid_episode_length_args = _parse_legacy_arguments(
+        PickAndPlaceMapleTableEnvironment,
+        ["--episode_length_s", "0"],
+    )
+    with pytest.raises(AssertionError, match="episode_length_s must be greater than zero"):
+        _environment_cfg_from_cli(PickAndPlaceMapleTableEnvironment, invalid_episode_length_args)
 
 
 def test_build_environment_from_cli_calls_typed_build(monkeypatch):

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -60,25 +60,23 @@ def test_getting_started_experiment_composes_typed_runs():
     assert list(runs) == [
         "baseline",
         "swap_objects",
-        "change_background_hdr",
-        "parallel_envs",
     ]
     assert runs["baseline"].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
         hdr="home_office_robolab",
+        episode_length_s=1.5,
     )
     assert runs["swap_objects"].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
         pick_up_object="mustard_bottle_hot3d_robolab",
         destination_location="wooden_bowl_hot3d_robolab",
         hdr="home_office_robolab",
+        episode_length_s=1.5,
     )
-    assert runs["change_background_hdr"].environment.hdr == "billiard_hall_robolab"
-    assert runs["parallel_envs"].environment.hdr == "home_office_robolab"
     assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
-    assert [run.environment_builder.num_envs for run in runs.values()] == [1, 1, 1, 64]
-    assert runs["parallel_envs"].environment_builder.env_spacing == 2.5
-    assert [run.rollout_limit.num_steps for run in runs.values()] == [50, 50, 50, 100]
+    assert all(run.environment_builder.num_envs == 1 for run in runs.values())
+    assert all(run.rollout_limit.num_steps is None for run in runs.values())
+    assert all(run.rollout_limit.num_episodes == 1 for run in runs.values())
 
 
 def test_experiment_composition_preserves_caller_owned_hydra_context():

--- a/isaaclab_arena/tests/test_experiment_hydra.py
+++ b/isaaclab_arena/tests/test_experiment_hydra.py
@@ -60,6 +60,8 @@ def test_getting_started_experiment_composes_typed_runs():
     assert list(runs) == [
         "baseline",
         "swap_objects",
+        "change_background_hdr",
+        "parallel_envs",
     ]
     assert runs["baseline"].environment == PickAndPlaceMapleTableEnvironmentCfg(
         embodiment="droid_rel_joint_pos",
@@ -73,8 +75,12 @@ def test_getting_started_experiment_composes_typed_runs():
         hdr="home_office_robolab",
         episode_length_s=1.5,
     )
+    assert runs["change_background_hdr"].environment.hdr == "billiard_hall_robolab"
+    assert runs["parallel_envs"].environment.hdr == "home_office_robolab"
+    assert all(run.environment.episode_length_s == 1.5 for run in runs.values())
     assert all(run.policy == ZeroActionPolicyCfg() for run in runs.values())
-    assert all(run.environment_builder.num_envs == 1 for run in runs.values())
+    assert [run.environment_builder.num_envs for run in runs.values()] == [1, 1, 1, 64]
+    assert runs["parallel_envs"].environment_builder.env_spacing == 2.5
     assert all(run.rollout_limit.num_steps is None for run in runs.values())
     assert all(run.rollout_limit.num_episodes == 1 for run in runs.values())
 

--- a/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
@@ -28,3 +28,12 @@ runs:
     environment:
       pick_up_object: mustard_bottle_hot3d_robolab
       destination_location: wooden_bowl_hot3d_robolab
+
+  change_background_hdr:
+    environment:
+      hdr: billiard_hall_robolab
+
+  parallel_envs:
+    environment_builder:
+      num_envs: 64
+      env_spacing: 2.5

--- a/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml
@@ -14,10 +14,12 @@ shared:
     pick_up_object: rubiks_cube_hot3d_robolab
     destination_location: bowl_ycb_robolab
     hdr: home_office_robolab
+    # Short demo timeout in simulated time, not wall-clock time.
+    episode_length_s: 1.5
   policy:
     type: zero_action
   rollout_limit:
-    num_steps: 50
+    num_episodes: 1
 
 runs:
   baseline: {}
@@ -26,14 +28,3 @@ runs:
     environment:
       pick_up_object: mustard_bottle_hot3d_robolab
       destination_location: wooden_bowl_hot3d_robolab
-
-  change_background_hdr:
-    environment:
-      hdr: billiard_hall_robolab
-
-  parallel_envs:
-    environment_builder:
-      num_envs: 64
-      env_spacing: 2.5
-    rollout_limit:
-      num_steps: 100

--- a/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
+++ b/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
@@ -26,6 +26,13 @@ class PickAndPlaceMapleTableEnvironmentCfg(ArenaEnvironmentCfg):
     pick_up_object: str = "rubiks_cube_hot3d_robolab"
     destination_location: str = "bowl_ycb_robolab"
     additional_table_objects: list[str] = field(default_factory=list)
+    episode_length_s: float | None = None
+    """Override the maximum episode duration; use the task default when unset."""
+
+    def __post_init__(self) -> None:
+        assert (
+            self.episode_length_s is None or self.episode_length_s > 0.0
+        ), "episode_length_s must be greater than zero"
 
 
 @register_environment
@@ -99,7 +106,7 @@ class PickAndPlaceMapleTableEnvironment(ArenaEnvironmentFactory[PickAndPlaceMapl
             pick_up_object=pick_up_object,
             destination_location=destination_location,
             background_scene=background,
-            episode_length_s=70.0,
+            episode_length_s=cfg.episode_length_s,
         )
 
         # Set viewport camera to match the robolab droid view

--- a/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
+++ b/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
@@ -26,13 +26,10 @@ class PickAndPlaceMapleTableEnvironmentCfg(ArenaEnvironmentCfg):
     pick_up_object: str = "rubiks_cube_hot3d_robolab"
     destination_location: str = "bowl_ycb_robolab"
     additional_table_objects: list[str] = field(default_factory=list)
-    episode_length_s: float | None = None
-    """Override the maximum episode duration; use the task default when unset."""
+    episode_length_s: float = 70.0
 
     def __post_init__(self) -> None:
-        assert (
-            self.episode_length_s is None or self.episode_length_s > 0.0
-        ), "episode_length_s must be greater than zero"
+        assert self.episode_length_s > 0.0, "episode_length_s must be greater than zero"
 
 
 @register_environment


### PR DESCRIPTION
The Getting Started example printed `num_episodes: 0`, `object_moved_rate: nan`, and wrote an empty report:

```
======================================================================
METRICS SUMMARY
======================================================================

baseline:
  num_episodes                            0
  object_moved_rate                     nan
  success_rate                       0.0000

swap_objects:
  num_episodes                            0
  object_moved_rate                     nan
  success_rate                       0.0000
======================================================================

Wrote evaluation report with 0 task(s), 0 run(s) and 0 episode(s) to: /workspaces/isaaclab_arena/outputs/2026-08-10_16-42-10/index.html (+0 linked page(s))
```



- Reason: The 50-step limit stopped each run before the 70-second episode ended, so no episode results were exported.
- Fix: Keep all four runs, use a 1.5-second simulated timeout for the example, and complete one episode per run while retaining the environment's 70-second default.