### PR TITLE
Fix post-merge uv osmo-workflow test failure

### DIFF
--- a/docs/pages/quickstart/running_a_real_policy/gr00t.rst
+++ b/docs/pages/quickstart/running_a_real_policy/gr00t.rst
@@ -6,6 +6,18 @@ foundation model. No fine-tuning or separate model download is required. The wei
 are fetched from `HuggingFace <https://huggingface.co/nvidia/GR00T-N1.6-DROID>`_
 when the policy server starts for the first time.
 
+.. note::
+
+   **uv environment:** the ``gr00t`` package is not pulled in by ``uv sync`` because
+   its declared Python constraint differs from the Arena environment. Install it once
+   before running GR00T policies or tests:
+
+   .. code-block:: bash
+
+      uv pip install --no-deps --ignore-requires-python -e submodules/Isaac-GR00T/
+
+   Docker users can skip this step — the package is already installed in the container.
+
 
 Start a GR00T policy server
 ---------------------------

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -18,8 +18,8 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import load_arena_
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 from isaaclab_arena.evaluation.legacy_graph_environment_cli import LegacyGraphEnvironmentCfg
 from isaaclab_arena.policy.zero_action_policy import ZeroActionPolicyCfg
+from isaaclab_arena.tests.utils.markers import requires_gr00t
 from isaaclab_arena_environments.pick_and_place_maple_table_environment import PickAndPlaceMapleTableEnvironmentCfg
-from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import Gr00tRemoteClosedloopPolicyCfg
 from isaaclab_arena_openpi.policy import pi0_remote_policy  # noqa: F401
 from isaaclab_arena_openpi.policy.pi0_remote_config import Pi0RemotePolicyCfg
 from osmo.submit_arena_experiment import (
@@ -40,11 +40,16 @@ from osmo.tasks.experiment_runner_task import (
     ExperimentRunnerTask,
     ExperimentRunnerTaskCfg,
 )
-from osmo.tasks.gr00t_server_task import Gr00tServerTask, Gr00tServerTaskCfg
 from osmo.tasks.pi0_server_task import Pi0ServerTask, Pi0ServerTaskCfg
 from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow
 from osmo.workflows.workflow import WorkflowCfg
 from osmo.workflows.workflow_constants import DATASET_SWIFT_URL, OSMO_TASK_OUTPUT_DIR, POLICY_SERVER_PORT
+
+try:
+    from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import Gr00tRemoteClosedloopPolicyCfg
+    from osmo.tasks.gr00t_server_task import Gr00tServerTask, Gr00tServerTaskCfg
+except ImportError:
+    pass
 
 # Composing complete Arena Experiments loads Isaac runtime modules, so these tests
 # must not share a pytest process with the persistent SimulationApp tests.
@@ -355,6 +360,7 @@ def test_mixed_pi0_variants_derive_per_run_server_checkpoints():
     assert "--policy.dir=gs://openpi-assets-simeval/pi05_droid_jointpos" in second_server_command
 
 
+@requires_gr00t
 def test_mixed_pi0_and_gr00t_experiment_fans_out_per_run_servers():
     """Derive one pi0 server and one GR00T server from a mixed Experiment; leave the local Run server-free."""
     workflow = ArenaExperimentWorkflow(
@@ -387,6 +393,7 @@ def test_mixed_pi0_and_gr00t_experiment_fans_out_per_run_servers():
     assert "remote_host" not in _embedded_experiment(local_tasks[0])["runs"]["local"]["policy"]
 
 
+@requires_gr00t
 def test_gr00t_cli_dry_run_renders_workflow(tmp_path, capsys):
     """Compose and render a derived GR00T Experiment submission through the real CLI parser."""
     experiment_path = tmp_path / "gr00t_experiment.yaml"

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -45,6 +45,8 @@ from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow
 from osmo.workflows.workflow import WorkflowCfg
 from osmo.workflows.workflow_constants import DATASET_SWIFT_URL, OSMO_TASK_OUTPUT_DIR, POLICY_SERVER_PORT
 
+# Only the @requires_gr00t tests use these names (via _mixed_experiment_cfg), so
+# it is safe to skip the import when the gr00t submodule is not installed.
 try:
     from isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy import Gr00tRemoteClosedloopPolicyCfg
     from osmo.tasks.gr00t_server_task import Gr00tServerTask, Gr00tServerTaskCfg

--- a/isaaclab_arena/tests/test_osmo_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_workflow.py
@@ -7,6 +7,10 @@
 
 import pytest
 
+# submit_evaluation_workflow → server_plus_policy_runner_workflow → gr00t_server_task → gr00t;
+# the chain fails at collection time when gr00t is absent, so the whole module must be skipped.
+pytest.importorskip("gr00t")
+
 from osmo.submit_evaluation_workflow import main
 from osmo.tasks.dreamzero_policy_runner_task import DreamZeroPolicyRunnerTaskCfg
 from osmo.tasks.pi0_server_task import Pi0ServerTask, Pi0ServerTaskCfg

--- a/isaaclab_arena/tests/utils/markers.py
+++ b/isaaclab_arena/tests/utils/markers.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared pytest skip markers for optional external dependencies."""
+
+import pytest
+
+try:
+    import gr00t  # noqa: F401
+
+    _HAS_GR00T = True
+except ImportError:
+    _HAS_GR00T = False
+
+requires_gr00t = pytest.mark.skipif(not _HAS_GR00T, reason="gr00t not installed")


### PR DESCRIPTION
## Summary
Fix post-merge uv osmo-workflow test failure

## Detailed description
- Root-cause: #991 introduced `test_osmo_workflow.py` which assume gr00t call-path to PolicyClient exists in dev env.
- Install the gr00t package from the submodule after uv sync `(--no-deps` `--ignore-requires-python)` — only the call-path to PolicyClient is needed.
- Guard the two gr00t-specific tests in `test_osmo_experiment_workflow.py` with `@requires_gr00t`  so the rest of the file runs without gr00t
- Skip `test_osmo_workflow.py` at module level via `pytest.importorskip` since its import chain transitively pulls in gr00t