### PR TITLE
Fix agentic workflow policy documentation links

### DIFF
--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
@@ -5,7 +5,7 @@ Once you are satisfied with the environment, you can use it to evaluate a policy
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
-:doc:`Running a Real Policy <../../../quickstart/first_experiments/running_a_real_policy/index>`.
+:doc:`Running a Real Policy <../../../quickstart/running_a_real_policy/index>`.
 
 Open one terminal and run the following command outside the Arena docker container to launch the PI policy server:
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -5,7 +5,7 @@ Once you are satisfied with the environment, you can use it to evaluate a policy
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
-:doc:`Running a Real Policy <../../../quickstart/first_experiments/running_a_real_policy/index>`.
+:doc:`Running a Real Policy <../../../quickstart/running_a_real_policy/index>`.
 
 Open one terminal and run the following command outside the Arena docker container to launch the PI policy server:
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
@@ -7,7 +7,7 @@ gates object placement on whether the robot can reach the target objects.
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
-:doc:`Running a Real Policy <../../../quickstart/first_experiments/running_a_real_policy/index>`.
+:doc:`Running a Real Policy <../../../quickstart/running_a_real_policy/index>`.
 
 Open one terminal and run the following command outside the Arena docker container to launch the PI policy server:
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
@@ -7,7 +7,7 @@ gates object placement on whether the robot can reach the target objects.
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
-:doc:`Running a Real Policy <../../../quickstart/first_experiments/running_a_real_policy/index>`.
+:doc:`Running a Real Policy <../../../quickstart/running_a_real_policy/index>`.
 
 Open one terminal and run the following command outside the Arena docker container to launch the PI policy server:
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
@@ -7,7 +7,7 @@ gates object placement on whether the robot can reach the target objects.
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
-:doc:`Running a Real Policy <../../../quickstart/first_experiments/running_a_real_policy/index>`.
+:doc:`Running a Real Policy <../../../quickstart/running_a_real_policy/index>`.
 
 Open one terminal and run the following command outside the Arena docker container to launch the PI policy server:
 


### PR DESCRIPTION
Point generated-environment workflows at the relocated policy guide so strict documentation builds succeed.
This was caused by conflict between [#1068](https://github.com/isaac-sim/IsaacLab-Arena/pull/1068) and [#1033](https://github.com/isaac-sim/IsaacLab-Arena/pull/1033) 
