### PR TITLE
Add doc about uv supports on reachability validation

### DIFF
--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
@@ -41,6 +41,12 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
 
+      .. note::
+         Reachability validation runs only in the cuRobo-installed Docker container
+         (``./docker/run_docker.sh -c``). It is not available with a native ``uv``
+         install — see :doc:`../../../quickstart/installation` and
+         :ref:`ik-reachable-check`.
+
       If you want to ensure the robot can reach the target objects (i.e. pepsi can, bean can and mini plastic
       basket), you can use this environment in the cuRobo-installed docker container to activate the
       reachability validation.

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
@@ -42,6 +42,12 @@ yourself, point ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
 
+      .. note::
+         Reachability validation runs only in the cuRobo-installed Docker container
+         (``./docker/run_docker.sh -c``). It is not available with a native ``uv``
+         install — see :doc:`../../../quickstart/installation` and
+         :ref:`ik-reachable-check`.
+
       If you want to ensure the robot can reach the target objects (i.e. fruit and bowl), you can use this
       environment in the cuRobo-installed docker container to activate the reachability validation.
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
@@ -41,6 +41,12 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 
    .. tab-item:: Policy evaluation with reachability validation (cuRobo)
 
+      .. note::
+         Reachability validation runs only in the cuRobo-installed Docker container
+         (``./docker/run_docker.sh -c``). It is not available with a native ``uv``
+         install — see :doc:`../../../quickstart/installation` and
+         :ref:`ik-reachable-check`.
+
       If you want to ensure the robot can reach the target objects (i.e. banana and plate), you can use this
       environment in the cuRobo-installed docker container to activate the reachability validation.
 

--- a/docs/pages/quickstart/installation.rst
+++ b/docs/pages/quickstart/installation.rst
@@ -95,6 +95,13 @@ pinned by the committed lockfile.
    the activated environment rather than through ``uv run`` — a bare
    ``uv run`` re-syncs the environment back to the source flavor.
 
+.. note::
+   Native ``uv`` installs do not include the optional ``isaaclab_arena_curobo``
+   package, so :doc:`cuRobo-based reachability validation
+   </pages/concepts/object_placement/validation>` (the ``ik_reachable`` check)
+   is not available. Use the Docker workflow with ``./docker/run_docker.sh -c``
+   instead.
+
 Accept the Isaac Sim EULA so the first launch is non-interactive:
 
 .. code-block:: bash
@@ -152,6 +159,12 @@ installation options.
 :docker_run_default:
 
 The container will build (if needed) and drop you into an interactive shell.
+
+For :doc:`cuRobo-based reachability validation
+</pages/concepts/object_placement/validation>`, launch with the ``-c`` flag
+instead (native ``uv`` installs do not support this check):
+
+:docker_run_curobo:
 
 .. note::
    The run docker script mounts the following directories from the host machine if they exist:


### PR DESCRIPTION
## Summary
Add doc about uv supports on reachability validation. Link it in table-top agentic env gen workflows.