### PR TITLE
Enable agentic env gen workflow in uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
         run: |
           # Fix dubious ownership issues in cache
           git config --global --add safe.directory '*'
-          uv sync ${{ matrix.uv_flags }}
+          uv sync ${{ matrix.uv_flags }} --extra dev
 
       - name: Run in-process Newton tests
         shell: bash

--- a/docs/pages/quickstart/installation.rst
+++ b/docs/pages/quickstart/installation.rst
@@ -11,7 +11,9 @@ or from source inside a Docker container.
      - Evaluation
      - Imitation learning
      - Reinforcement learning
+     - Agentic environment generation
    * - Docker
+     - ✓
      - ✓
      - ✓
      - ✓
@@ -19,10 +21,12 @@ or from source inside a Docker container.
      - ✓
      - ✓
      - ✓
+     - ✓
    * - uv (Isaac Lab from wheel)
      - ✓
      - ✗
      - ✗
+     - ✓
 
 Supported Systems
 -----------------
@@ -65,14 +69,14 @@ workflow:
 
       .. code-block:: bash
 
-          uv sync
+          uv sync --extra dev
           source .venv/bin/activate
 
    .. tab-item:: Wheel
 
       .. code-block:: bash
 
-          uv sync --no-default-groups --group isaaclab-from-wheel
+          uv sync --no-default-groups --group isaaclab-from-wheel --extra dev
           source .venv/bin/activate
 
       .. note::
@@ -87,7 +91,10 @@ workflow:
 ``.python-version``), installs Isaac Lab Arena and Isaac Lab (editable from
 ``submodules/IsaacLab`` in the source flavor, or from the published wheel),
 and pulls the matching Isaac Sim, PyTorch, and Newton wheels at the versions
-pinned by the committed lockfile.
+pinned by the committed lockfile. The ``dev`` extra installs the Streamlit and
+SimReady search dependencies used by the
+:doc:`agentic environment generation workflow
+</pages/concepts/agentic_environment_generation/index>`.
 
 .. note::
    The two flavors are mutually exclusive within the single ``.venv``: syncing

--- a/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
+++ b/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
@@ -11,12 +11,13 @@ import torch
 import traceback
 from contextlib import nullcontext, suppress
 
-import omni.kit.app
 from isaaclab.app import AppLauncher
 
 
 def get_isaac_sim_version() -> str:
     """Get the version of Isaac Sim."""
+    import omni.kit.app
+
     return omni.kit.app.get_app().get_app_version()
 
 


### PR DESCRIPTION
## Summary
Document uv support for agentic workflows

## Detailed description
- Install the dev extra for both uv installation flavors.
- Include required Streamlit and SimReady dependencies.
- Mark agentic environment generation as supported by all installation methods.
- Delay the Omni import until Isaac Lab initializes the pip-installed Isaac Sim runtime so GUI simulation previews can start in uv. gui_runner.py is verified working in uv source installed path.