### PR TITLE
Fix IK reachability check for relation-placed robots

### DIFF
--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -84,9 +84,9 @@ class ReachabilityValidator(PlacementValidator):
             position_threshold=self._ik_pos_threshold,
             rotation_threshold=self._ik_rot_threshold,
         )
-        robot_base_pose_w = config.embodiment.get_initial_pose()
-        self._robot_base_pos_w = robot_base_pose_w.position_xyz
-        self._robot_base_quat_w_xyzw = robot_base_pose_w.rotation_xyzw
+        self._embodiment = config.embodiment
+        # Used only when the robot is not itself relation-placed, in which case it never appears in a layout.
+        self._configured_robot_base_pose_w = config.embodiment.get_initial_pose()
         # Guards the zero-target warning so it fires once per validator, not once per candidate layout.
         self._warned_no_targets = False
         self._rerun_layer = self._make_rerun_layer()
@@ -134,7 +134,8 @@ class ReachabilityValidator(PlacementValidator):
         Rebuilds each object's world pose, builds a collision cuboid per object -- what makes them block a
         grasp when collision checking is on -- then IK-solves each target's top-down grasp against a world
         holding every other object. A layout with nothing to grasp (anchor-only, or no target present) is
-        trivially reachable.
+        trivially reachable. The robot stands where this layout puts it when it is relation-placed too,
+        so the grasps are solved from the base pose the layout would actually spawn.
 
         Args:
             positions: Solved (x, y, z) per object.
@@ -150,11 +151,14 @@ class ReachabilityValidator(PlacementValidator):
         }
         # non-anchor objects with a RequiresReachability relation
         targets = self._select_reachability_targets(objects, anchors)
+        robot_base_pose_w = self._resolve_robot_base_pose(world_poses)
+        # The robot's own body is not an obstacle: cuRobo already carries it as collision spheres.
         cuboid_per_object = {
             obj: get_aabb_collision_cuboid_for_object(
                 obj, world_poses[obj].position_xyz, world_poses[obj].rotation_xyzw
             )
             for obj in objects
+            if obj is not self._embodiment
         }
 
         if not targets:
@@ -172,20 +176,20 @@ class ReachabilityValidator(PlacementValidator):
             top_down_grasp_pose_from_world_poses(
                 world_poses[obj].position_xyz,
                 world_poses[obj].rotation_xyzw,
-                self._robot_base_pos_w,
-                self._robot_base_quat_w_xyzw,
+                robot_base_pose_w.position_xyz,
+                robot_base_pose_w.rotation_xyzw,
                 self._grasp_z_offset,
                 device=self._solver.device,
             )
             for obj in targets
         ])
-        ik = self._solve_grasp_per_target(targets, grasp_poses, cuboid_per_object)
+        ik = self._solve_grasp_per_target(targets, grasp_poses, cuboid_per_object, robot_base_pose_w)
         if self._rerun_layer is not None:
             layout_index_across_batch = self._visualizer.get_layout_index_across_batch(layout_index_within_batch)
             self._rerun_layer.log_layout(
                 layout_index_across_batch=layout_index_across_batch,
-                robot_base_pos_w=self._robot_base_pos_w,
-                robot_base_quat_w_xyzw=self._robot_base_quat_w_xyzw,
+                robot_base_pos_w=robot_base_pose_w.position_xyz,
+                robot_base_quat_w_xyzw=robot_base_pose_w.rotation_xyzw,
                 target_names=[obj.name for obj in targets],
                 grasp_poses_base_frame=grasp_poses,
                 feasible=ik.feasible,
@@ -202,6 +206,7 @@ class ReachabilityValidator(PlacementValidator):
         targets: list[ObjectBase],
         grasp_poses: torch.Tensor,
         cuboid_per_object: dict[ObjectBase, AABBCollisionCuboid],
+        robot_base_pose_w: Pose,
     ) -> IKFeasibility:
         """IK-solve each target's grasp against a world holding every object but that target, and stack the results.
 
@@ -209,6 +214,7 @@ class ReachabilityValidator(PlacementValidator):
             targets: The objects whose grasps are checked, in the order they appear in ``grasp_poses``.
             grasp_poses: ``(len(targets), 4, 4)`` top-down grasp transforms in the robot base frame.
             cuboid_per_object: Collision cuboid at the layout pose, for every object in the layout.
+            robot_base_pose_w: World pose of the robot base the obstacles are re-expressed relative to.
 
         Returns:
             One ``IKFeasibility`` whose per-target entries are ordered like ``targets``.
@@ -216,7 +222,7 @@ class ReachabilityValidator(PlacementValidator):
         per_target = []
         for target_index, target in enumerate(targets):
             obstacles = [cuboid for obj, cuboid in cuboid_per_object.items() if obj is not target]
-            self._solver.update_world(obstacles, self._robot_base_pos_w, self._robot_base_quat_w_xyzw)
+            self._solver.update_world(obstacles, robot_base_pose_w.position_xyz, robot_base_pose_w.rotation_xyzw)
             per_target.append(
                 solve_ik_feasibility(
                     self._solver,
@@ -232,6 +238,14 @@ class ReachabilityValidator(PlacementValidator):
             rotation_error=torch.cat([ik.rotation_error for ik in per_target]),
             joint_positions=torch.cat([ik.joint_positions for ik in per_target]),
         )
+
+    def _resolve_robot_base_pose(self, world_poses: dict[ObjectBase, Pose]) -> Pose:
+        """World pose of the robot base under one layout.
+
+        The robot is a placement asset like any other when it carries relations, so a layout that moves it
+        must be checked from where it stands there; otherwise it keeps its configured pose.
+        """
+        return world_poses.get(self._embodiment, self._configured_robot_base_pose_w)
 
     def _select_reachability_targets(self, objects: list[ObjectBase], anchors: set[ObjectBase]) -> list[ObjectBase]:
         """Movable objects the task marked as reachability targets (carry a RequiresReachability relation)."""

--- a/isaaclab_arena_curobo/ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/ik_reachability_validator.py
@@ -151,7 +151,7 @@ class ReachabilityValidator(PlacementValidator):
         }
         # non-anchor objects with a RequiresReachability relation
         targets = self._select_reachability_targets(objects, anchors)
-        robot_base_pose_w = self._resolve_robot_base_pose(world_poses)
+        robot_base_pose_w = world_poses.get(self._embodiment, self._configured_robot_base_pose_w)
         # The robot's own body is not an obstacle: cuRobo already carries it as collision spheres.
         cuboid_per_object = {
             obj: get_aabb_collision_cuboid_for_object(
@@ -238,14 +238,6 @@ class ReachabilityValidator(PlacementValidator):
             rotation_error=torch.cat([ik.rotation_error for ik in per_target]),
             joint_positions=torch.cat([ik.joint_positions for ik in per_target]),
         )
-
-    def _resolve_robot_base_pose(self, world_poses: dict[ObjectBase, Pose]) -> Pose:
-        """World pose of the robot base under one layout.
-
-        The robot is a placement asset like any other when it carries relations, so a layout that moves it
-        must be checked from where it stands there; otherwise it keeps its configured pose.
-        """
-        return world_poses.get(self._embodiment, self._configured_robot_base_pose_w)
 
     def _select_reachability_targets(self, objects: list[ObjectBase], anchors: set[ObjectBase]) -> list[ObjectBase]:
         """Movable objects the task marked as reachability targets (carry a RequiresReachability relation)."""

--- a/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
+++ b/isaaclab_arena_curobo/tests/test_ik_reachability_validator.py
@@ -79,6 +79,7 @@ def _patch_curobo(monkeypatch, feasible_fn):
 
         def update_world(self, cuboids, base_pos, base_quat):
             self.world_cuboids = cuboids
+            captured.setdefault("base_poses_per_world_update", []).append((tuple(base_pos), tuple(base_quat)))
 
     captured = {}
 
@@ -286,6 +287,51 @@ def test_validator_accepts_when_all_grasps_feasible(monkeypatch):
     # One collision cuboid per non-target object (the desk); one grasp per target (the box).
     assert [cuboid.name for cuboid in captured["solver"].world_cuboids] == ["desk"]
     assert captured["total_grasps"] == 1
+
+
+@pytest.mark.curobo_deps
+def test_validator_uses_relation_placed_robot_pose(monkeypatch):
+    """IK uses the robot's solved layout pose instead of its configured pre-placement pose."""
+    from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, RequiresReachability, Side
+    from isaaclab_arena.tests.dummy_object import DummyObject
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+    from isaaclab_arena.utils.pose import Pose
+
+    captured = _patch_curobo(monkeypatch, feasible_fn=lambda n: [True] * n)
+    desk = DummyObject(
+        name="desk",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.5, -0.5, 0.0), max_point=(0.5, 0.5, 0.1)),
+        initial_pose=Pose.identity(),
+    )
+    desk.add_relation(IsAnchor())
+    target = DummyObject(
+        name="target",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.1, -0.1, 0.0), max_point=(0.1, 0.1, 0.2)),
+    )
+    target.add_relation(On(desk))
+    target.add_relation(RequiresReachability())
+    configured_robot_pose = Pose(position_xyz=(9.0, 9.0, 0.0))
+    robot = DummyObject(
+        name="robot",
+        bounding_box=AxisAlignedBoundingBox(min_point=(-0.2, -0.2, 0.0), max_point=(0.2, 0.2, 1.0)),
+        initial_pose=configured_robot_pose,
+    )
+    robot.add_relation(NextTo(desk, side=Side.NEGATIVE_Y))
+    validator = _make_reachability_validator(robot)
+
+    solved_robot_position = (0.0, -1.0, 0.0)
+    positions = {
+        desk: (0.0, 0.0, 0.0),
+        target: (0.0, 0.0, 0.11),
+        robot: solved_robot_position,
+    }
+    orientations = {desk: 0.0, target: 0.0, robot: 0.0}
+
+    assert validator.validate_batch([positions], [orientations], [{}], []) == [True]
+    base_position, base_orientation = captured["base_poses_per_world_update"][0]
+    assert base_position == solved_robot_position
+    assert base_position != configured_robot_pose.position_xyz
+    assert base_orientation == (0.0, 0.0, 0.0, 1.0)
 
 
 @pytest.mark.curobo_deps


### PR DESCRIPTION
## Summary
Fix IK check when robot is relation-placed

## Detailed description
- ReachabilityValidator cached the embodiment's configured base pose at construction, so relation-placed robots (e.g. kitchen `next_to` / `on floor`) were IK-checked as if still at the origin and every grasp failed
- Resolve the robot base pose from each candidate layout (fall back to configured pose when the robot has no relations); exclude the robot AABB from obstacles since cuRobo already models self-collision spheres
- Kitchen pick-and-place (`droid_pick_and_place_lightwheel_kitchen`) goes from `ik_reachable=0/43` every batch to `19/41` on the first batch