### PR TITLE
Simplify Arena Experiment result collection

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment_result.py
+++ b/isaaclab_arena/evaluation/arena_experiment_result.py
@@ -60,7 +60,7 @@ ArenaExperimentResultData = dict[Literal["runs"], dict[str, ArenaExperimentRunDa
 
 
 def _require_nonempty_string(value: object, field_name: str) -> str:
-    """Return a non-empty string used in Run metadata."""
+    """Return a non-empty string used in an Experiment result."""
     assert isinstance(value, str) and value.strip(), f"{field_name} must be a non-empty string"
     return value
 
@@ -125,33 +125,19 @@ class ArenaExperimentResult:
     def _collect_run(self, run_name: str, run_metadata: Mapping[str, Any]) -> ArenaExperimentRunData:
         """Collect one declared Run's metadata and episode results."""
         self.assert_run_name_is_safe_path_component(run_name)
-        environment = run_metadata["environment"]
-        status = run_metadata["status"]
-        assert status in ("completed", "failed"), f"status for Run {run_name!r} must be 'completed' or 'failed'"
-
         run_output_directory = self.experiment_output_directory / run_name
-        if status == "completed":
-            assert (
-                run_output_directory.is_dir()
-            ), f"completed Run {run_name!r} is missing its output directory: {run_output_directory}"
-        elif run_output_directory.exists():
-            assert (
-                run_output_directory.is_dir()
-            ), f"output path for failed Run {run_name!r} must be a directory: {run_output_directory}"
-
-        rebuilds = (
-            _collect_rebuilds(run_output_directory, self.experiment_output_directory)
-            if run_output_directory.is_dir()
-            else []
-        )
+        assert (
+            not run_output_directory.exists() or run_output_directory.is_dir()
+        ), f"Run output path must be a directory: {run_output_directory}"
+        status = run_metadata["status"]
+        assert (
+            status != "completed" or run_output_directory.is_dir()
+        ), f"completed Run {run_name!r} is missing its output directory: {run_output_directory}"
         return {
-            "environment": {
-                "name": environment["name"],
-                "definition": environment["definition"],
-            },
+            "environment": run_metadata["environment"],
             "policy_variant": run_metadata["policy_variant"],
             "status": status,
-            "rebuilds": rebuilds,
+            "rebuilds": _collect_rebuilds(run_output_directory, self.experiment_output_directory),
         }
 
     def to_dict(self) -> ArenaExperimentResultData:
@@ -169,10 +155,12 @@ class ArenaExperimentResult:
         return result_path
 
 
-def build_arena_run_result_metadata(run_cfg: ArenaRunCfg) -> dict[str, Any]:
-    """Build serializable environment and policy metadata for an effective Run."""
+def run_environment_and_policy_variant_from_config(run_cfg: ArenaRunCfg) -> dict[str, Any]:
+    """Return the environment and policy variant fields stored for one Run."""
     from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 
+    # TODO(cvolk): Remove this conversion once ArenaRunCfg stores the environment identifiers and policy variant
+    # used in Arena Experiment results.
     environment_cfg = run_cfg.environment
     # TODO(cvolk): Remove this structural check once graph-YAML environments use registered typed configurations.
     if hasattr(environment_cfg, "env_spec_path"):

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -10,7 +10,10 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
-from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult, build_arena_run_result_metadata
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ArenaExperimentResult,
+    run_environment_and_policy_variant_from_config,
+)
 from isaaclab_arena.evaluation.arena_run import ArenaRunResult, build_runs_info_table
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
 from isaaclab_arena.evaluation.legacy_experiment_runner import (
@@ -74,7 +77,7 @@ def _write_arena_experiment_result(
     run_results: list[ArenaRunResult],
     experiment_output_directory: Path,
 ) -> Path:
-    """Combine every Run's metadata and episode results into one Experiment JSON file."""
+    """Combine every Run's environment, policy, status, and episodes into one Experiment JSON file."""
     run_results_by_name = {run_result.run_name: run_result for run_result in run_results}
     assert len(run_results_by_name) == len(run_results), "Experiment results must contain each Run exactly once"
     assert set(run_results_by_name) == set(
@@ -82,7 +85,7 @@ def _write_arena_experiment_result(
     ), "Experiment results must contain exactly the configured Runs"
     run_metadata_by_name = {
         run_name: {
-            **build_arena_run_result_metadata(run_cfg),
+            **run_environment_and_policy_variant_from_config(run_cfg),
             "status": run_results_by_name[run_name].status.value,
         }
         for run_name, run_cfg in experiment_cfg.runs.items()

--- a/isaaclab_arena/tests/test_arena_experiment_result.py
+++ b/isaaclab_arena/tests/test_arena_experiment_result.py
@@ -18,7 +18,7 @@ from isaaclab_arena.environment_spec import arena_env_graph_yaml_loader
 from isaaclab_arena.evaluation.arena_experiment_result import (
     ARENA_EXPERIMENT_RESULT_FILENAME,
     ArenaExperimentResult,
-    build_arena_run_result_metadata,
+    run_environment_and_policy_variant_from_config,
 )
 
 
@@ -163,7 +163,7 @@ class _RunCfg:
     policy: object
 
 
-def test_builds_graph_environment_metadata_and_preserves_an_explicit_policy_variant(monkeypatch):
+def test_gets_graph_environment_and_preserves_an_explicit_policy_variant(monkeypatch):
     monkeypatch.setattr(
         arena_env_graph_yaml_loader,
         "load_env_graph_spec_dict",
@@ -174,7 +174,7 @@ def test_builds_graph_environment_metadata_and_preserves_an_explicit_policy_vari
         policy=_PolicyCfg(policy_variant="Pi0.5-Exact"),
     )
 
-    assert build_arena_run_result_metadata(run_cfg) == {
+    assert run_environment_and_policy_variant_from_config(run_cfg) == {
         "environment": {
             "name": "banana_in_bowl",
             "definition": "configs/../tasks/banana_in_bowl.yaml",
@@ -183,7 +183,7 @@ def test_builds_graph_environment_metadata_and_preserves_an_explicit_policy_vari
     }
 
 
-def test_builds_registered_environment_and_policy_metadata(monkeypatch):
+def test_gets_registered_environment_and_policy_variant(monkeypatch):
     class _EnvironmentFactory:
         name = "registered_environment"
 
@@ -201,7 +201,7 @@ def test_builds_registered_environment_and_policy_metadata(monkeypatch):
         lambda registry, policy_cfg: _Policy,
     )
 
-    assert build_arena_run_result_metadata(_RunCfg(_EnvironmentCfg(), _PolicyCfg())) == {
+    assert run_environment_and_policy_variant_from_config(_RunCfg(_EnvironmentCfg(), _PolicyCfg())) == {
         "environment": {
             "name": "registered_environment",
             "definition": "registered_environment",

--- a/osmo/tasks/experiment_runner_task.py
+++ b/osmo/tasks/experiment_runner_task.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
-from isaaclab_arena.evaluation.arena_experiment_result import build_arena_run_result_metadata
+from isaaclab_arena.evaluation.arena_experiment_result import run_environment_and_policy_variant_from_config
 from isaaclab_arena.evaluation.arena_run import RunStatus
 from isaaclab_arena.hydra.typed_experiment_serializer import serialize_arena_experiment_to_yaml
 from osmo.tasks.base_task import BaseTask, TaskCfg
@@ -101,7 +101,7 @@ class ExperimentRunnerTask(BaseTask):
         experiment_runner_result_path = shlex.quote(f"{OSMO_TASK_OUTPUT_DIR}/{EXPERIMENT_RUNNER_RESULT_FILE_NAME}")
         run_metadata_json = shlex.quote(
             json.dumps({
-                run_name: build_arena_run_result_metadata(run_cfg)
+                run_name: run_environment_and_policy_variant_from_config(run_cfg)
                 for run_name, run_cfg in self.experiment_cfg.runs.items()
             })
         )


### PR DESCRIPTION
## Summary
Simplify Arena Experiment result collection

## Detailed description
- Follow up on #1070 by keeping `ArenaExperimentResult` focused on combining declared Run outputs while preserving the completed-Run directory check.
- Rename the configuration conversion to describe its exact output: environment fields and `policy_variant`.
- Document when that conversion can be removed. The generated JSON format does not change.

Verified with the full pre-commit suite and 54 focused result, local runner, and OSMO tests.
