### PR TITLE
[Doc] Add uv run & reachability validator instructions in agentic env gen

### DIFF
--- a/docs/_ext/isaaclab_arena_doc_tools.py
+++ b/docs/_ext/isaaclab_arena_doc_tools.py
@@ -66,6 +66,27 @@ def isaaclab_arena_code_link(app: Sphinx, _: Any, source: list[str]) -> None:
     source[0] = re.sub(r":isaaclab_arena_code_link:`<(?P<relative_path>.*)>`", replacer, source[0])
 
 
+def uv_run_command_replacer(app: Sphinx, _: Any, source: list[str]) -> None:
+    """Replaces uv setup command directives with code blocks."""
+
+    def uv_source_replacer(_: Any) -> str:
+        return """.. code-block:: bash
+
+           uv sync --extra dev
+           source .venv/bin/activate
+           export OMNI_KIT_ACCEPT_EULA=YES ACCEPT_EULA=Y"""
+
+    def uv_wheel_replacer(_: Any) -> str:
+        return """.. code-block:: bash
+
+           uv sync --no-default-groups --group isaaclab-from-wheel --extra dev
+           source .venv/bin/activate
+           export OMNI_KIT_ACCEPT_EULA=YES ACCEPT_EULA=Y"""
+
+    source[0] = re.sub(r":uv_run_source:", uv_source_replacer, source[0])
+    source[0] = re.sub(r":uv_run_wheel:", uv_wheel_replacer, source[0])
+
+
 def docker_run_command_replacer(app: Sphinx, _: Any, source: list[str]) -> None:
     """Replaces docker run command directives with code blocks."""
 
@@ -88,5 +109,6 @@ def docker_run_command_replacer(app: Sphinx, _: Any, source: list[str]) -> None:
 def setup(app: Sphinx) -> None:
     app.connect("source-read", isaaclab_arena_git_clone_code_block)
     app.connect("source-read", isaaclab_arena_code_link)
+    app.connect("source-read", uv_run_command_replacer)
     app.connect("source-read", docker_run_command_replacer)
     app.add_config_value("isaaclab_arena_docs_config", {}, "env")

--- a/docs/images/agentic_environment_generation/droid_kitchen_pnp_pi.gif
+++ b/docs/images/agentic_environment_generation/droid_kitchen_pnp_pi.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a18b823f4168b94a75eff72ac0756b4c80c318458d88150a9637e7344cc4fdb8
-size 1473971
+oid sha256:b1b3c5cda8b5aad241f1f3d1b4badbb15ad5408167a282011c9318e0a23f78e6
+size 11932935

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -33,9 +33,27 @@ Prerequisites
 
 Every workflow in this section shares the same setup.
 
-**Docker Container**: Base (see :doc:`../../quickstart/installation` for more details)
+Use either a native ``uv`` environment or the base Docker container (see
+:doc:`../../quickstart/installation` for more details).
 
-:docker_run_default:
+.. tab-set::
+
+   .. tab-item:: Native uv source
+      :selected:
+
+      :uv_run_source:
+
+   .. tab-item:: Native uv wheel
+
+      :uv_run_wheel:
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
+For either native ``uv`` flavor, ``isaaclab_arena_curobo`` is not installed; use
+the Docker container with ``-c`` if you need
+:doc:`cuRobo-based reachability validation </pages/concepts/object_placement/validation>`.
 
 See :doc:`../../concepts/agentic_environment_generation/index` for the system
 architecture and runner reference.

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/index.rst
@@ -28,7 +28,7 @@ Workflow
 Prerequisites
 ^^^^^^^^^^^^^
 
-See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+See :ref:`agentic-env-gen-prerequisites` for the environment and API key setup.
 The spec shown here depends on the model behind that endpoint — see
 :doc:`../../../concepts/agentic_environment_generation/model_selection`.
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_1_launch_runner.rst
@@ -1,7 +1,7 @@
 Run Agentic Environment Generation
 ----------------------------------
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this workflow.
 
 The Arena environment generation agent infers an ``ArenaEnvGraphSpec`` YAML from a user prompt.
 The agent runs in two modes:

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_open_door/step_3_use_environment.rst
@@ -18,9 +18,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
-
-:docker_run_default:
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/index.rst
@@ -28,7 +28,7 @@ Workflow
 Prerequisites
 ^^^^^^^^^^^^^
 
-See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+See :ref:`agentic-env-gen-prerequisites` for the environment and API key setup.
 The spec shown here depends on the model behind that endpoint — see
 :doc:`../../../concepts/agentic_environment_generation/model_selection`.
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_1_launch_runner.rst
@@ -1,7 +1,7 @@
 Run Agentic Environment Generation
 ----------------------------------
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this workflow.
 
 The Arena environment generation agent infers an ``ArenaEnvGraphSpec`` YAML from a user prompt.
 The agent runs in two modes:

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -18,9 +18,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
-
-:docker_run_default:
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -81,5 +81,6 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
    :alt: PI policy controlling DROID for mustard-bottle pick and place in the kitchen
    :align: center
 
-   PI controls DROID to pick up the mustard bottle and place it in the bowl in
-   the agentically generated kitchen environment.
+   Policy evaluation of the generated kitchen environment using the OpenPI
+   policy with reachability validation. The robot picks up the mustard bottle
+   and places it into the bowl.

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -63,7 +63,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
 
       While the environment builds, every batch of candidate layouts reports how many of them passed each
-      check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the rejection rate to watch:
+      check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the pass rate to watch:
 
       .. code-block:: text
 

--- a/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/kitchen_pick_and_place/step_3_use_environment.rst
@@ -2,6 +2,8 @@ Use the Generated Environment
 -----------------------------
 
 Once you are satisfied with the environment, you can use it to evaluate a policy on the environment.
+The base container runs the environment as it was generated. The cuRobo-installed container additionally
+gates object placement on whether the robot can reach the target objects.
 
 For example, you can use the policy runner to evaluate a PI policy on the
 environment. For other policy types, see
@@ -17,18 +19,62 @@ In the other terminal, run the following command to launch the policy runner. Th
 ready-made spec that ships with Arena; to evaluate a spec you generated yourself, point
 ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/<env_name>.yaml``.
 
+.. tab-set::
 
-Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
+   .. tab-item:: Policy evaluation (without reachability validation)
+      :selected:
 
-.. code-block:: bash
+      .. code-block:: bash
 
-   python isaaclab_arena/evaluation/policy_runner.py \
-      --viz kit \
-      --policy_type isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy \
-      --enable_cameras \
-      --num_envs 1 \
-      --num_episodes 2 \
-      --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+         python isaaclab_arena/evaluation/policy_runner.py \
+            --viz kit \
+            --policy_type isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy \
+            --enable_cameras \
+            --num_envs 1 \
+            --num_episodes 2 \
+            --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+
+
+   .. tab-item:: Policy evaluation (with cuRobo-based reachability validation)
+
+      .. note::
+         Reachability validation runs only in the cuRobo-installed Docker container
+         (``./docker/run_docker.sh -c``). It is not available with a native ``uv``
+         install — see :doc:`../../../quickstart/installation` and
+         :ref:`ik-reachable-check`.
+
+      If you want to ensure the robot can reach the target objects (i.e. mustard bottle and bowl), you can
+      use this environment in the cuRobo-installed docker container to activate the reachability validation.
+
+      **Docker Container**: Curobo-installed Base (see :doc:`../../../quickstart/installation` for more details)
+
+      :docker_run_curobo:
+
+      Now only the layouts the robot can reach are used:
+
+      .. code-block:: bash
+
+         python isaaclab_arena/evaluation/policy_runner.py \
+            --viz kit \
+            --policy_type isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy \
+            --enable_cameras \
+            --num_envs 1 \
+            --num_episodes 2 \
+            --env_spec isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml
+
+      While the environment builds, every batch of candidate layouts reports how many of them passed each
+      check. ``ik_reachable`` is the cuRobo verdict, so its ratio is the rejection rate to watch:
+
+      .. code-block:: text
+
+         [placement] Validated 50 candidate layout(s); passed per check: on_relation=49/50, next_to=45/50, not_next_to=50/50, face_to=50/50, no_overlap=50/50, ik_reachable=15/44
+
+      A low ``ik_reachable`` ratio means most sampled layouts put the mustard bottle or the bowl outside the
+      arm's workspace, and the placer keeps resampling.
+      When an environment finds no reachable layout at all, it falls back to its lowest-loss layout.
+
+      See :ref:`ik-reachable-check` for how this check is registered, what it requires, and how to tune
+      or disable it.
 
 .. figure:: ../../../../images/agentic_environment_generation/droid_kitchen_pnp_pi.gif
    :width: 100%

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/index.rst
@@ -33,7 +33,7 @@ Workflow
 Prerequisites
 ^^^^^^^^^^^^^
 
-See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+See :ref:`agentic-env-gen-prerequisites` for the environment and API key setup.
 The spec shown here depends on the model behind that endpoint — see
 :doc:`../../../concepts/agentic_environment_generation/model_selection`.
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_1_launch_runner.rst
@@ -1,7 +1,7 @@
 Run Agentic Environment Generation
 ----------------------------------
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this workflow.
 
 The Arena environment generation agent infers an ``ArenaEnvGraphSpec`` YAML from a user prompt.
 The agent runs in two modes:

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_composite_task/step_3_use_environment.rst
@@ -21,12 +21,10 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 
 .. tab-set::
 
-   .. tab-item:: Policy evaluation (base)
+   .. tab-item:: Policy evaluation (without reachability validation)
       :selected:
 
-      **Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
-
-      :docker_run_default:
+      Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
 
       .. code-block:: bash
 
@@ -39,7 +37,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --env_spec isaaclab_arena_environments/maple_table_top/simready_droid_pick_place_cans_hammer_maple_table.yaml
 
 
-   .. tab-item:: Policy evaluation with reachability validation (cuRobo)
+   .. tab-item:: Policy evaluation (with cuRobo-based reachability validation)
 
       .. note::
          Reachability validation runs only in the cuRobo-installed Docker container

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/index.rst
@@ -34,7 +34,7 @@ Workflow
 Prerequisites
 ^^^^^^^^^^^^^
 
-See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+See :ref:`agentic-env-gen-prerequisites` for the environment and API key setup.
 The spec shown here depends on the model behind that endpoint — see
 :doc:`../../../concepts/agentic_environment_generation/model_selection`.
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_1_launch_runner.rst
@@ -1,7 +1,7 @@
 Run Agentic Environment Generation
 ----------------------------------
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this workflow.
 
 The Arena environment generation agent infers an ``ArenaEnvGraphSpec`` YAML from a user prompt.
 The agent runs in two modes:

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_heterogeneous_object/step_3_use_environment.rst
@@ -22,12 +22,10 @@ yourself, point ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/
 
 .. tab-set::
 
-   .. tab-item:: Policy evaluation (base)
+   .. tab-item:: Policy evaluation (without reachability validation)
       :selected:
 
-      **Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
-
-      :docker_run_default:
+      Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
 
       .. code-block:: bash
 
@@ -40,7 +38,7 @@ yourself, point ``--env_spec`` at ``isaaclab_arena_environments/agent_generated/
             --env_spec isaaclab_arena_environments/maple_table_top/droid_pick_fruit_into_bowl_maple_table.yaml
 
 
-   .. tab-item:: Policy evaluation with reachability validation (cuRobo)
+   .. tab-item:: Policy evaluation (with cuRobo-based reachability validation)
 
       .. note::
          Reachability validation runs only in the cuRobo-installed Docker container

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/index.rst
@@ -27,7 +27,7 @@ Workflow
 Prerequisites
 ^^^^^^^^^^^^^
 
-See :ref:`agentic-env-gen-prerequisites` for the container and API key setup.
+See :ref:`agentic-env-gen-prerequisites` for the environment and API key setup.
 The spec shown here depends on the model behind that endpoint — see
 :doc:`../../../concepts/agentic_environment_generation/model_selection`.
 

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_1_launch_runner.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_1_launch_runner.rst
@@ -1,7 +1,7 @@
 Run Agentic Environment Generation
 ----------------------------------
 
-**Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
+Complete the shared :ref:`agentic-env-gen-prerequisites` before running this workflow.
 
 The Arena environment generation agent infers an ``ArenaEnvGraphSpec`` YAML from a user prompt.
 The agent runs in two modes:

--- a/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/tabletop_pnp_homogenous_object/step_3_use_environment.rst
@@ -21,12 +21,10 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
 
 .. tab-set::
 
-   .. tab-item:: Policy evaluation (base)
+   .. tab-item:: Policy evaluation (without reachability validation)
       :selected:
 
-      **Docker Container**: Base (see :doc:`../../../quickstart/installation` for more details)
-
-      :docker_run_default:
+      Complete the shared :ref:`agentic-env-gen-prerequisites` before running this command.
 
       .. code-block:: bash
 
@@ -39,7 +37,7 @@ ready-made spec that ships with Arena; to evaluate a spec you generated yourself
             --env_spec isaaclab_arena_environments/maple_table_top/droid_banana_on_plate_maple_table.yaml
 
 
-   .. tab-item:: Policy evaluation with reachability validation (cuRobo)
+   .. tab-item:: Policy evaluation (with cuRobo-based reachability validation)
 
       .. note::
          Reachability validation runs only in the cuRobo-installed Docker container


### PR DESCRIPTION
## Summary
Add uv run in pre-reqs in agentic env gen index, reachability validator instructions in kitchen PnP. Replace kitchen PnP gif to reachable layouts.

