### PR TITLE
Add inference endpoint switching in GUI and improve doc

### DIFF
--- a/docs/images/agentic_env_gen_gui_panel_edit.png
+++ b/docs/images/agentic_env_gen_gui_panel_edit.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac9256584907d53581f81e01f021f2ea2ff6637736402dde4d0333ccba8cea47
+size 197827

--- a/docs/images/agentic_env_gen_gui_panel_generate.png
+++ b/docs/images/agentic_env_gen_gui_panel_generate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c23b4ecb43374ce94f0e473eb6c1ed2ba892b4c68ab7b197e118fb848537f3be
+size 76114

--- a/docs/images/agentic_env_gen_gui_panel_sim_preview.png
+++ b/docs/images/agentic_env_gen_gui_panel_sim_preview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad3f8d1029d4e5243ec3bf42f221e7e1e30e86a7ca84fc0e2ea206a6dc53a9b0
+size 522222

--- a/docs/images/agentic_env_gen_gui_panel_visualize.png
+++ b/docs/images/agentic_env_gen_gui_panel_visualize.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:312a04f42528fdddd99095ed2840c4bca1fed893fc0308e851e6aeb6e9425b41
+size 227660

--- a/docs/images/agentic_env_gen_gui_panel_visualize_kitchen.png
+++ b/docs/images/agentic_env_gen_gui_panel_visualize_kitchen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64fea0b05974d1f39acca91f6895b2fbf93dcc0f676c58fec78777502efe6b05
+size 313348

--- a/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
+++ b/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
@@ -41,7 +41,8 @@ UI Panels
 The page is split into a left editing column and a right preview column.
 
 Generate from prompt
-   Enter a natural-language task and scene description, then click
+   Choose an inference endpoint (only endpoints whose API key is set are
+   listed), enter a natural-language task and scene description, then click
    ``Generate spec``. The GUI calls the environment-generation agent and loads
    the returned ``ArenaEnvGraphSpec`` YAML into the editor. When validation
    fails, the invalid YAML is still loaded into the editor and the validation

--- a/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
+++ b/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
@@ -48,12 +48,20 @@ Generate from prompt
    fails, the invalid YAML is still loaded into the editor and the validation
    traces are shown alongside it.
 
+   .. image:: ../../../images/agentic_env_gen_gui_panel_generate.png
+      :alt: Generate-from-prompt panel with inference endpoint selection
+      :width: 50%
+
 YAML editor
    Edit the generated or loaded ``ArenaEnvGraphSpec`` directly. The editor
    validates the YAML as you work and shows either a valid-spec summary or the
    parse/validation error. The ``Save YAML`` button writes the spec to
    ``<env_name>.yaml`` in the configured output directory. A searchable
    background prim-tree panel helps identify prim paths while editing.
+
+   .. image:: ../../../images/agentic_env_gen_gui_panel_edit.png
+      :alt: ArenaEnvGraphSpec YAML editor panel
+      :width: 50%
 
 Visualization
    Shows an automatically refreshed dashboard for valid YAML. The dashboard
@@ -62,19 +70,49 @@ Visualization
    :math:`+X`, green for :math:`+Y`, and blue for :math:`+Z`. If the YAML is
    invalid, the panel waits until the error is fixed before rendering.
 
+   When the spec contains an entry under ``object_references``, expand
+   **Background prim tree** to search the background USD for the referenced
+   prim. The searchable, collapsible tree helps verify or correct the
+   reference's ``prim_path``.
+
+   .. grid:: 2
+      :gutter: 2
+
+      .. grid-item::
+
+         .. image:: ../../../images/agentic_env_gen_gui_panel_visualize.png
+            :alt: Environment graph visualization panel
+            :width: 100%
+
+      .. grid-item::
+
+         .. image:: ../../../images/agentic_env_gen_gui_panel_visualize_kitchen.png
+            :alt: Kitchen environment graph visualization panel
+            :width: 100%
+
 Sim preview
-   Runs the full Arena environment construction from YAML, relation
-   solving, and zero-action rollout in a SimulationApp side process.
-   Controls let you set the number of parallel environments, zero-action steps,
-   and environment spacing. The preview uses the task's default viewer
-   configuration and displays a viewport video of the rollout.
+   Runs the full Arena environment construction from YAML, relation solving,
+   and zero-action rollout in a SimulationApp side process. Controls let you
+   set the number of parallel environments, zero-action steps, and environment
+   spacing.
+
+   .. image:: ../../../images/agentic_env_gen_gui_panel_sim_preview.png
+      :alt: Simulation preview controls and viewport recording
+      :width: 50%
+
+   .. note::
+
+      The preview uses the task's default viewer configuration and records the
+      Kit viewport camera. Increase **Zero-action steps** (``num_steps``) to
+      extend the rollout, and move the viewport camera in the Kit window to
+      change the recorded view.
 
 Editing and Update Flow
 -----------------------
 
 The main update flow is:
 
-#. Type a prompt and click ``Generate``.
+#. Type a prompt and click ``Generate spec``.
 #. The agent receives the prompt and returns an ``ArenaEnvGraphSpec``. The
    generated YAML is loaded into the editor and saved as ``<env_name>.yaml``.
 #. The user can manually edit the YAML in the editor. Once the edited YAML

--- a/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
+++ b/docs/pages/concepts/agentic_environment_generation/gui_runner.rst
@@ -6,17 +6,16 @@ reviewing, editing, saving, visualizing, and simulation-previewing
 ``ArenaEnvGraphSpec`` YAML files.
 
 What comes back depends on the model behind the selected endpoint — see
-:doc:`model_selection`. Use ``--inference_endpoint {internal,public,openai}``
-to pick the endpoint the GUI generates with, or set
-``ARENA_INFERENCE_ENDPOINT``. Since the model is non-deterministic, review and
-correct what it returns.
+:doc:`model_selection`. Pick the endpoint in the GUI generation panel
+(only endpoints whose API key is set are listed), or set
+``ARENA_INFERENCE_ENDPOINT`` as the default. Since the model is
+non-deterministic, review and correct what it returns.
 
 Run the GUI from inside the Isaac Lab-Arena development container:
 
 .. code-block:: bash
 
-   python isaaclab_arena_examples/agentic_environment_generation/gui_runner.py \
-      --inference_endpoint public
+   python isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
 
 You can also open an existing environment graph spec:
 

--- a/docs/pages/concepts/agentic_environment_generation/model_selection.rst
+++ b/docs/pages/concepts/agentic_environment_generation/model_selection.rst
@@ -42,8 +42,8 @@ Selecting the Model
 
 Each endpoint preset has its own default model, so switching endpoints switches models (see
 :ref:`agentic-env-gen-prerequisites`). The CLI runner overrides it per run with ``--model`` and
-``--temperature``; the GUI runner only selects the endpoint, and uses that endpoint's default
-model. For the public endpoint, any model in the
+``--temperature``; the GUI runner selects the endpoint in the generation panel and uses that
+endpoint's default model. For the public endpoint, any model in the
 `NVIDIA NIM LLM API reference <https://docs.api.nvidia.com/nim/reference/llm-apis>`_ works, as long
 as it supports strict structured outputs — a larger context window buys more reliable prim path
 resolution.

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -43,7 +43,7 @@ container. This step is required only once per host environment.
 
 .. tab-set::
 
-   .. tab-item:: Public NVIDIA API
+   .. tab-item:: NVIDIA Public Endpoint
       :selected:
 
       Generate an NGC API key at
@@ -54,7 +54,7 @@ container. This step is required only once per host environment.
 
          export NVIDIA_API_KEY=<your-ngc-api-key>
 
-   .. tab-item:: NVIDIA-internal API
+   .. tab-item:: NVIDIA Internal Endpoint
 
       From the NVIDIA network, generate an internal API key at
       `inference.nvidia.com key management <https://inference.nvidia.com/key-management>`_,
@@ -68,7 +68,7 @@ container. This step is required only once per host environment.
 
          This endpoint is accessible by NVIDIA employees only and counts into your Inference Hub token usage.
 
-   .. tab-item:: OpenAI API
+   .. tab-item:: OpenAI Endpoint
 
       Create an OpenAI account, generate a secret at
       `OpenAI API keys <https://platform.openai.com/api-keys>`_, and configure
@@ -131,11 +131,15 @@ the Docker container with ``-c`` if you need
 Available Generated Environments
 --------------------------------
 
-The ``isaaclab_arena_environments/robolab`` subfolder contains Arena environments for
-RoboLab scenes and tasks. Scene YAMLs live in ``robolab/scenes/``; task YAMLs in
-``robolab/tasks/`` include their scene via a top-level ``external_yaml:`` path. See
-:doc:`../robolab_task_catalog` for the list of RoboLab tasks currently supported in Arena.
-Each environment is generated from a natural-language prompt and can be used for policy evaluation.
+The generated environment catalogs cover tabletop and room-scale manipulation
+and can be used directly for policy evaluation:
+
+* **RoboLab-style tabletop manipulation** — diverse tabletop scenes, objects,
+  and manipulation tasks. See the :doc:`RoboLab Task Catalog
+  <../robolab_task_catalog>`.
+* **Room-scale kitchen benchmark** — object manipulation and articulated
+  appliance tasks across room-scale kitchen scenes. See the :doc:`Kitchen
+  Benchmark Catalog <../kitchen_bench_catalog>`.
 
 .. warning::
    Agentic environment generation is experimental and changing quickly. The

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -75,8 +75,9 @@ in the shell you launch the agentic environment generation runner from.
    export ARENA_INFERENCE_ENDPOINT=openai
    export OPENAI_API_KEY=<your-openai-api-key>
 
-A single run can override the selection with
-``--inference_endpoint {internal,public,openai}``.
+The CLI runner can override the selection per run with
+``--inference_endpoint {internal,public,openai}``. The GUI runner selects the
+endpoint in the generation panel instead.
 
 Generate a key for the public endpoint at
 `build.nvidia.com API keys <https://build.nvidia.com/settings/api-keys>`_, and a key for the

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -33,6 +33,79 @@ Prerequisites
 
 Every workflow in this section shares the same setup.
 
+Inference API key setup
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The generation agent calls a remote LLM endpoint. Export one or more API keys
+in the host environment **before** launching a native ``uv`` runner or starting the
+Docker container. Docker forwards the configured keys when it creates the
+container. This step is required only once per host environment.
+
+.. tab-set::
+
+   .. tab-item:: Public NVIDIA API
+      :selected:
+
+      Generate an NGC API key at
+      `build.nvidia.com API keys <https://build.nvidia.com/settings/api-keys>`_,
+      then export it for the publicly reachable endpoint:
+
+      .. code-block:: bash
+
+         export NVIDIA_API_KEY=<your-ngc-api-key>
+
+   .. tab-item:: NVIDIA-internal API
+
+      From the NVIDIA network, generate an internal API key at
+      `inference.nvidia.com key management <https://inference.nvidia.com/key-management>`_,
+      then export it:
+
+      .. code-block:: bash
+
+         export NV_API_KEY=<your-internal-api-key>
+
+      .. note::
+
+         This endpoint is accessible by NVIDIA employees only and counts into your Inference Hub token usage.
+
+   .. tab-item:: OpenAI API
+
+      Create an OpenAI account, generate a secret at
+      `OpenAI API keys <https://platform.openai.com/api-keys>`_, and configure
+      payment or prepaid credits under
+      `OpenAI billing <https://platform.openai.com/settings/organization/billing/overview>`_.
+      OpenAI charges the account associated with the key according to its
+      current API pricing and usage. Store the key securely and do not commit it
+      to the repository.
+
+      .. code-block:: bash
+
+         export OPENAI_API_KEY=<your-openai-api-key>
+
+      .. note::
+
+         The ``openai`` endpoint connects directly to a third-party service
+         operated by OpenAI, not NVIDIA. Its availability, regional
+         restrictions, data handling, pricing, and terms are controlled by
+         OpenAI. Review those terms before sending prompts or other data.
+
+Set ``ARENA_INFERENCE_ENDPOINT`` to choose the default endpoint:
+
+.. code-block:: bash
+
+   export ARENA_INFERENCE_ENDPOINT=public  # internal, public, or openai
+
+The CLI runner can override the selection per run with
+``--inference_endpoint {internal,public,openai}``. The GUI runner selects among
+the endpoints whose API keys are available in the generation panel.
+
+Each endpoint calls a different model, and the generated environment changes with it. See
+:doc:`../../concepts/agentic_environment_generation/model_selection` for what the model decides,
+what Arena validates, and how to select the model.
+
+Start uv or Docker
+~~~~~~~~~~~~~~~~~~
+
 Use either a native ``uv`` environment or the base Docker container (see
 :doc:`../../quickstart/installation` for more details).
 
@@ -55,52 +128,6 @@ For either native ``uv`` flavor, ``isaaclab_arena_curobo`` is not installed; use
 the Docker container with ``-c`` if you need
 :doc:`cuRobo-based reachability validation </pages/concepts/object_placement/validation>`.
 
-See :doc:`../../concepts/agentic_environment_generation/index` for the system
-architecture and runner reference.
-
-The generation agent calls a remote LLM endpoint. Pick one and export its API key
-in the shell you launch the agentic environment generation runner from.
-
-.. code-block:: bash
-
-   # Publicly reachable build.nvidia.com endpoint (default)
-   export ARENA_INFERENCE_ENDPOINT=public
-   export NVIDIA_API_KEY=<your-ngc-api-key>
-
-   # NVIDIA-internal endpoint
-   export ARENA_INFERENCE_ENDPOINT=internal
-   export NV_API_KEY=<your-internal-api-key>
-
-   # OpenAI API
-   export ARENA_INFERENCE_ENDPOINT=openai
-   export OPENAI_API_KEY=<your-openai-api-key>
-
-The CLI runner can override the selection per run with
-``--inference_endpoint {internal,public,openai}``. The GUI runner selects the
-endpoint in the generation panel instead.
-
-Generate a key for the public endpoint at
-`build.nvidia.com API keys <https://build.nvidia.com/settings/api-keys>`_, and a key for the
-NVIDIA-internal endpoint at
-`inference.nvidia.com key management <https://inference.nvidia.com/key-management>`_
-(reachable from the NVIDIA network only).
-
-To use the direct OpenAI endpoint, create an OpenAI account, generate a secret at
-`OpenAI API keys <https://platform.openai.com/api-keys>`_, and configure payment or prepaid
-credits under
-`OpenAI billing <https://platform.openai.com/settings/organization/billing/overview>`_.
-OpenAI charges the account associated with the key according to its current API pricing and usage.
-Store the key securely and do not commit it to the repository.
-
-.. warning::
-   The ``openai`` endpoint connects directly to a third-party service operated by OpenAI, not
-   NVIDIA. Its availability, regional restrictions, data handling, pricing, and terms are
-   controlled by OpenAI. Review those terms before sending prompts or other data.
-
-Each endpoint calls a different model, and the generated environment changes with it. See
-:doc:`../../concepts/agentic_environment_generation/model_selection` for what the model decides,
-what Arena validates, and how to select the model.
-
 Available Generated Environments
 --------------------------------
 
@@ -110,10 +137,7 @@ RoboLab scenes and tasks. Scene YAMLs live in ``robolab/scenes/``; task YAMLs in
 :doc:`../robolab_task_catalog` for the list of RoboLab tasks currently supported in Arena.
 Each environment is generated from a natural-language prompt and can be used for policy evaluation.
 
-Warnings
---------
-
-.. note::
+.. warning::
    Agentic environment generation is experimental and changing quickly. The
    current prompt formats, generated spec structure, GUI behavior, and policy
    evaluation integrations may change across releases.

--- a/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/gui_runner.py
@@ -31,11 +31,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-from isaaclab_arena.agentic_environment_generation.inference_backend import (
-    DEFAULT_ENDPOINT_NAME,
-    INFERENCE_ENDPOINT_ENV_VAR,
-    INFERENCE_ENDPOINTS,
-)
 from isaaclab_arena.agentic_environment_generation.spec_io import DEFAULT_AGENTIC_OUTPUT_DIR
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
     SIMAPP_SOCKET_ENV,
@@ -73,22 +68,11 @@ def main() -> None:
         default=8501,
         help="Streamlit server port (default: 8501).",
     )
-    parser.add_argument(
-        "--inference_endpoint",
-        type=str,
-        choices=tuple(INFERENCE_ENDPOINTS),
-        default=None,
-        help=(
-            "Inference endpoint the generation agent calls (default: the ARENA_INFERENCE_ENDPOINT "
-            f"environment variable, else '{DEFAULT_ENDPOINT_NAME}')."
-        ),
-    )
     args = parser.parse_args()
     serve_live_editor(
         args.env_spec,
         out_dir=args.out_dir,
         port=args.port,
-        inference_endpoint=args.inference_endpoint,
     )
 
 
@@ -97,7 +81,6 @@ def serve_live_editor(
     *,
     out_dir: Path = DEFAULT_AGENTIC_OUTPUT_DIR,
     port: int = 8501,
-    inference_endpoint: str | None = None,
 ) -> None:
     """Start the SimApp server, spawn Streamlit, and supervise both until exit.
 
@@ -105,8 +88,6 @@ def serve_live_editor(
         yaml_path: Optional spec YAML to open in the editor.
         out_dir: Directory the editor writes generated spec YAML into.
         port: Streamlit server port.
-        inference_endpoint: Inference endpoint name handed to the Streamlit process, or ``None``
-            to leave the environment's own selection in place.
     """
     app_path = _REVIEW_GUI_DIR / "streamlit_ui.py"
     assert app_path.exists(), f"Streamlit app not found at {app_path} — installation is incomplete."
@@ -129,8 +110,6 @@ def serve_live_editor(
         env = os.environ.copy()
         if active_socket is not None:
             env[SIMAPP_SOCKET_ENV] = str(active_socket)
-        if inference_endpoint is not None:
-            env[INFERENCE_ENDPOINT_ENV_VAR] = inference_endpoint
 
         cmd = [
             sys.executable,

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -26,7 +26,6 @@ from isaaclab_arena.agentic_environment_generation.inference_backend import (
     DEFAULT_ENDPOINT_NAME,
     INFERENCE_ENDPOINT_ENV_VAR,
     INFERENCE_ENDPOINTS,
-    resolve_inference_endpoint,
 )
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadySearchConfig,
@@ -81,6 +80,11 @@ def available_inference_endpoints() -> list[str]:
     return [name for name, endpoint in INFERENCE_ENDPOINTS.items() if os.getenv(endpoint.api_key_env_var)]
 
 
+def _inference_api_key_env_vars_text() -> str:
+    """Comma-separated API-key env var names for user-facing error messages."""
+    return ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
+
+
 def _default_inference_endpoint(available: list[str]) -> str:
     """Pick ``ARENA_INFERENCE_ENDPOINT`` / the public default when that option is available."""
     preferred = os.getenv(INFERENCE_ENDPOINT_ENV_VAR) or DEFAULT_ENDPOINT_NAME
@@ -89,15 +93,15 @@ def _default_inference_endpoint(available: list[str]) -> str:
     return available[0]
 
 
-def _selected_inference_endpoint() -> str | None:
-    """Return the endpoint currently selected in the generation panel, if any key is set."""
+def _ensure_selected_inference_endpoint() -> str | None:
+    """Normalize session endpoint selection; return ``None`` when no API key is set."""
     available = available_inference_endpoints()
     if not available:
+        st.session_state.pop("inference_endpoint", None)
         return None
-    current = st.session_state.get("inference_endpoint")
-    if current in available:
-        return current
-    return _default_inference_endpoint(available)
+    if st.session_state.get("inference_endpoint") not in available:
+        st.session_state["inference_endpoint"] = _default_inference_endpoint(available)
+    return st.session_state["inference_endpoint"]
 
 
 def _generation_agent_cache_key(
@@ -137,10 +141,11 @@ def _get_generation_agent() -> EnvironmentGenerationAgent | None:
     Failed inits are recorded for the UI banner, but each call retries so a fixed key or
     transient outage does not require changing the endpoint radio.
     """
-    endpoint_name = _selected_inference_endpoint()
+    endpoint_name = _ensure_selected_inference_endpoint()
     if endpoint_name is None:
-        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
-        st.session_state["generation_agent_error"] = f"No inference API key is set. Export one of: {key_vars}."
+        st.session_state["generation_agent_error"] = (
+            f"No inference API key is set. Export one of: {_inference_api_key_env_vars_text()}."
+        )
         return None
     simready_enabled = bool(st.session_state.get("enable_simready_search", False))
     simready_config = _simready_config_from_session()
@@ -159,11 +164,10 @@ def _get_generation_agent() -> EnvironmentGenerationAgent | None:
             enable_simready_search=simready_enabled,
             simready_config=simready_config,
         )
-    except AssertionError as exc:
-        st.session_state["generation_agent_error"] = str(exc)
-        return None
     except Exception as exc:
-        st.session_state["generation_agent_error"] = f"{type(exc).__name__}: {exc}"
+        st.session_state["generation_agent_error"] = (
+            str(exc) if isinstance(exc, AssertionError) else f"{type(exc).__name__}: {exc}"
+        )
         return None
     _clear_orphaned_generation_agents(keep=agent_key)
     st.session_state[agent_key] = agent
@@ -217,17 +221,7 @@ def run_generation_pipeline(prompt: str) -> tuple[bool, str]:
 
     agent = _get_generation_agent()
     if agent is None:
-        endpoint_name = _selected_inference_endpoint()
-        key_env = (
-            INFERENCE_ENDPOINTS[endpoint_name].api_key_env_var
-            if endpoint_name is not None
-            else resolve_inference_endpoint().api_key_env_var
-        )
-        err = st.session_state.get(
-            "generation_agent_error",
-            f"Set {key_env} in the environment before generating specs.",
-        )
-        return False, err
+        return False, st.session_state.get("generation_agent_error", "LLM agent unavailable.")
 
     try:
         catalogues = get_catalogue_bundle()
@@ -290,16 +284,13 @@ def render_generation_panel() -> None:
     st.caption("Calls the env-generation agent (LLM) and loads the returned environment graph spec.")
 
     available = available_inference_endpoints()
-    if not available:
-        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
+    endpoint_name = _ensure_selected_inference_endpoint()
+    if endpoint_name is None:
         st.warning(
-            f"No inference endpoint is available. Export one of: {key_vars}.",
+            f"No inference endpoint is available. Export one of: {_inference_api_key_env_vars_text()}.",
             icon="⚠️",
         )
-        st.session_state.pop("inference_endpoint", None)
     else:
-        if st.session_state.get("inference_endpoint") not in available:
-            st.session_state["inference_endpoint"] = _default_inference_endpoint(available)
         st.radio(
             "Inference endpoint",
             options=available,
@@ -312,7 +303,7 @@ def render_generation_panel() -> None:
                 f"Default comes from {INFERENCE_ENDPOINT_ENV_VAR} when that endpoint is available."
             ),
         )
-        endpoint = INFERENCE_ENDPOINTS[st.session_state["inference_endpoint"]]
+        endpoint = INFERENCE_ENDPOINTS[endpoint_name]
         st.caption(f"Model: `{endpoint.model}` at `{endpoint.base_url}`")
 
     prompt = st.text_area(

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -82,7 +82,7 @@ def available_inference_endpoints() -> list[str]:
 
 
 def _default_inference_endpoint(available: list[str]) -> str:
-    """Pick the CLI/default endpoint when it is among the available options."""
+    """Pick ``ARENA_INFERENCE_ENDPOINT`` / the public default when that option is available."""
     preferred = os.getenv(INFERENCE_ENDPOINT_ENV_VAR) or DEFAULT_ENDPOINT_NAME
     if preferred in available:
         return preferred
@@ -100,23 +100,14 @@ def _selected_inference_endpoint() -> str | None:
     return _default_inference_endpoint(available)
 
 
-def _on_inference_endpoint_change() -> None:
-    """Drop a stale agent error when the user switches endpoints."""
-    st.session_state.pop("generation_agent_error", None)
-
-
-def _get_generation_agent() -> EnvironmentGenerationAgent | None:
-    """Lazy-init the LLM agent when the selected inference endpoint's API key is available."""
-    if st.session_state.get("generation_agent_error"):
-        return None
-    endpoint_name = _selected_inference_endpoint()
-    if endpoint_name is None:
-        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
-        st.session_state["generation_agent_error"] = f"No inference API key is set. Export one of: {key_vars}."
-        return None
-    simready_enabled = bool(st.session_state.get("enable_simready_search", False))
-    simready_config = _simready_config_from_session()
-    agent_key = (
+def _generation_agent_cache_key(
+    endpoint_name: str,
+    *,
+    simready_enabled: bool,
+    simready_config: SimReadySearchConfig,
+) -> tuple:
+    """Session-state key for a generation agent bound to one endpoint and SimReady settings."""
+    return (
         "generation_agent",
         endpoint_name,
         simready_enabled,
@@ -125,8 +116,42 @@ def _get_generation_agent() -> EnvironmentGenerationAgent | None:
         simready_config.service_url,
         simready_config.max_results_per_object,
     )
+
+
+def _clear_orphaned_generation_agents(*, keep: tuple | None = None) -> None:
+    """Drop cached generation agents other than ``keep`` from session state."""
+    for key in list(st.session_state.keys()):
+        if isinstance(key, tuple) and key and key[0] == "generation_agent" and key != keep:
+            st.session_state.pop(key, None)
+
+
+def _on_inference_endpoint_change() -> None:
+    """Drop a stale agent error and cached agents when the user switches endpoints."""
+    st.session_state.pop("generation_agent_error", None)
+    _clear_orphaned_generation_agents()
+
+
+def _get_generation_agent() -> EnvironmentGenerationAgent | None:
+    """Lazy-init the LLM agent when the selected inference endpoint's API key is available.
+
+    Failed inits are recorded for the UI banner, but each call retries so a fixed key or
+    transient outage does not require changing the endpoint radio.
+    """
+    endpoint_name = _selected_inference_endpoint()
+    if endpoint_name is None:
+        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
+        st.session_state["generation_agent_error"] = f"No inference API key is set. Export one of: {key_vars}."
+        return None
+    simready_enabled = bool(st.session_state.get("enable_simready_search", False))
+    simready_config = _simready_config_from_session()
+    agent_key = _generation_agent_cache_key(
+        endpoint_name,
+        simready_enabled=simready_enabled,
+        simready_config=simready_config,
+    )
     agent = st.session_state.get(agent_key)
     if agent is not None:
+        st.session_state.pop("generation_agent_error", None)
         return agent
     try:
         agent = EnvironmentGenerationAgent(
@@ -140,6 +165,7 @@ def _get_generation_agent() -> EnvironmentGenerationAgent | None:
     except Exception as exc:
         st.session_state["generation_agent_error"] = f"{type(exc).__name__}: {exc}"
         return None
+    _clear_orphaned_generation_agents(keep=agent_key)
     st.session_state[agent_key] = agent
     st.session_state.pop("generation_agent_error", None)
     return agent

--- a/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/review_gui/generation_panel.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 import traceback
 import yaml
 from dataclasses import dataclass
@@ -21,7 +22,12 @@ from isaaclab_arena.agentic_environment_generation.catalogues import (
     build_task_catalogue,
 )
 from isaaclab_arena.agentic_environment_generation.environment_generation_agent import EnvironmentGenerationAgent
-from isaaclab_arena.agentic_environment_generation.inference_backend import resolve_inference_endpoint
+from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    DEFAULT_ENDPOINT_NAME,
+    INFERENCE_ENDPOINT_ENV_VAR,
+    INFERENCE_ENDPOINTS,
+    resolve_inference_endpoint,
+)
 from isaaclab_arena.agentic_environment_generation.simready_asset_search import (
     SimReadySearchConfig,
     SimReadySourceKind,
@@ -70,14 +76,49 @@ def _simready_config_from_session() -> SimReadySearchConfig:
     )
 
 
+def available_inference_endpoints() -> list[str]:
+    """Return endpoint names whose API-key environment variable is set."""
+    return [name for name, endpoint in INFERENCE_ENDPOINTS.items() if os.getenv(endpoint.api_key_env_var)]
+
+
+def _default_inference_endpoint(available: list[str]) -> str:
+    """Pick the CLI/default endpoint when it is among the available options."""
+    preferred = os.getenv(INFERENCE_ENDPOINT_ENV_VAR) or DEFAULT_ENDPOINT_NAME
+    if preferred in available:
+        return preferred
+    return available[0]
+
+
+def _selected_inference_endpoint() -> str | None:
+    """Return the endpoint currently selected in the generation panel, if any key is set."""
+    available = available_inference_endpoints()
+    if not available:
+        return None
+    current = st.session_state.get("inference_endpoint")
+    if current in available:
+        return current
+    return _default_inference_endpoint(available)
+
+
+def _on_inference_endpoint_change() -> None:
+    """Drop a stale agent error when the user switches endpoints."""
+    st.session_state.pop("generation_agent_error", None)
+
+
 def _get_generation_agent() -> EnvironmentGenerationAgent | None:
     """Lazy-init the LLM agent when the selected inference endpoint's API key is available."""
     if st.session_state.get("generation_agent_error"):
+        return None
+    endpoint_name = _selected_inference_endpoint()
+    if endpoint_name is None:
+        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
+        st.session_state["generation_agent_error"] = f"No inference API key is set. Export one of: {key_vars}."
         return None
     simready_enabled = bool(st.session_state.get("enable_simready_search", False))
     simready_config = _simready_config_from_session()
     agent_key = (
         "generation_agent",
+        endpoint_name,
         simready_enabled,
         simready_config.source.value,
         simready_config.s3_url,
@@ -89,6 +130,7 @@ def _get_generation_agent() -> EnvironmentGenerationAgent | None:
         return agent
     try:
         agent = EnvironmentGenerationAgent(
+            endpoint=endpoint_name,
             enable_simready_search=simready_enabled,
             simready_config=simready_config,
         )
@@ -149,9 +191,15 @@ def run_generation_pipeline(prompt: str) -> tuple[bool, str]:
 
     agent = _get_generation_agent()
     if agent is None:
+        endpoint_name = _selected_inference_endpoint()
+        key_env = (
+            INFERENCE_ENDPOINTS[endpoint_name].api_key_env_var
+            if endpoint_name is not None
+            else resolve_inference_endpoint().api_key_env_var
+        )
         err = st.session_state.get(
             "generation_agent_error",
-            f"Set {resolve_inference_endpoint().api_key_env_var} in the environment before generating specs.",
+            f"Set {key_env} in the environment before generating specs.",
         )
         return False, err
 
@@ -215,6 +263,32 @@ def render_generation_panel() -> None:
     st.subheader("Generate from prompt")
     st.caption("Calls the env-generation agent (LLM) and loads the returned environment graph spec.")
 
+    available = available_inference_endpoints()
+    if not available:
+        key_vars = ", ".join(sorted({endpoint.api_key_env_var for endpoint in INFERENCE_ENDPOINTS.values()}))
+        st.warning(
+            f"No inference endpoint is available. Export one of: {key_vars}.",
+            icon="⚠️",
+        )
+        st.session_state.pop("inference_endpoint", None)
+    else:
+        if st.session_state.get("inference_endpoint") not in available:
+            st.session_state["inference_endpoint"] = _default_inference_endpoint(available)
+        st.radio(
+            "Inference endpoint",
+            options=available,
+            horizontal=True,
+            key="inference_endpoint",
+            on_change=_on_inference_endpoint_change,
+            format_func=lambda name: f"{name} ({INFERENCE_ENDPOINTS[name].api_key_env_var})",
+            help=(
+                "Only endpoints with their API key set in the environment are listed. "
+                f"Default comes from {INFERENCE_ENDPOINT_ENV_VAR} when that endpoint is available."
+            ),
+        )
+        endpoint = INFERENCE_ENDPOINTS[st.session_state["inference_endpoint"]]
+        st.caption(f"Model: `{endpoint.model}` at `{endpoint.base_url}`")
+
     prompt = st.text_area(
         "Prompt",
         value=st.session_state.get("generation_prompt", DEFAULT_GENERATION_PROMPT),
@@ -263,7 +337,8 @@ def render_generation_panel() -> None:
         else:
             st.caption("Searches the Isaac Sim 6.0 GA SimReady library — no further configuration needed.")
 
-    if st.button("Generate spec", type="primary", width="stretch"):
+    generate_disabled = not available
+    if st.button("Generate spec", type="primary", width="stretch", disabled=generate_disabled):
         with st.spinner("Generating spec (LLM call)…"):
             ok, message = run_generation_pipeline(st.session_state["generation_prompt"])
         if ok:

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -15,6 +15,7 @@ import pytest
 
 from isaaclab_arena.agentic_environment_generation.inference_backend import (
     INFERENCE_ENDPOINT_ENV_VAR,
+    INFERENCE_ENDPOINTS,
     INTERNAL_ENDPOINT,
     OPENAI_ENDPOINT,
     PUBLIC_ENDPOINT,
@@ -355,9 +356,8 @@ class TestInferenceEndpointSelection:
     @pytest.fixture(autouse=True)
     def clean_endpoint_env(self, monkeypatch):
         monkeypatch.delenv(INFERENCE_ENDPOINT_ENV_VAR, raising=False)
-        monkeypatch.delenv(INTERNAL_ENDPOINT.api_key_env_var, raising=False)
-        monkeypatch.delenv(PUBLIC_ENDPOINT.api_key_env_var, raising=False)
-        monkeypatch.delenv(OPENAI_ENDPOINT.api_key_env_var, raising=False)
+        for endpoint in INFERENCE_ENDPOINTS.values():
+            monkeypatch.delenv(endpoint.api_key_env_var, raising=False)
 
     def test_available_endpoints_omit_unset_keys(self, monkeypatch):
         monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
@@ -392,12 +392,13 @@ class TestInferenceEndpointSelection:
         public_key = _generation_agent_cache_key(PUBLIC_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
         internal_key = _generation_agent_cache_key(INTERNAL_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
         assert public_key != internal_key
-        assert public_key[1] == PUBLIC_ENDPOINT.name
-        assert internal_key[1] == INTERNAL_ENDPOINT.name
+        assert PUBLIC_ENDPOINT.name in public_key
+        assert INTERNAL_ENDPOINT.name in internal_key
 
     def test_clear_orphaned_generation_agents_keeps_requested_key(self, session_state):
-        keep = ("generation_agent", PUBLIC_ENDPOINT.name, False, "isaac-sim-ga", None, None, 1)
-        other = ("generation_agent", INTERNAL_ENDPOINT.name, False, "isaac-sim-ga", None, None, 1)
+        cfg = SimReadySearchConfig()
+        keep = _generation_agent_cache_key(PUBLIC_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
+        other = _generation_agent_cache_key(INTERNAL_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
         session_state[keep] = object()
         session_state[other] = object()
         session_state["unrelated"] = "keep-me"

--- a/isaaclab_arena_examples/tests/test_review_gui.py
+++ b/isaaclab_arena_examples/tests/test_review_gui.py
@@ -13,6 +13,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    INFERENCE_ENDPOINT_ENV_VAR,
+    INTERNAL_ENDPOINT,
+    OPENAI_ENDPOINT,
+    PUBLIC_ENDPOINT,
+)
+from isaaclab_arena.agentic_environment_generation.simready_asset_search import SimReadySearchConfig
 from isaaclab_arena.agentic_environment_generation.spec_io import env_graph_spec_path, write_env_graph_spec
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
@@ -25,6 +32,11 @@ from isaaclab_arena_examples.agentic_environment_generation.review_gui.editor_pa
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.generation_panel import (
     DEFAULT_GENERATION_PROMPT,
     _apply_generated_yaml,
+    _clear_orphaned_generation_agents,
+    _default_inference_endpoint,
+    _generation_agent_cache_key,
+    _get_generation_agent,
+    available_inference_endpoints,
     run_generation_pipeline,
 )
 from isaaclab_arena_examples.agentic_environment_generation.review_gui.simapp.client import (
@@ -327,7 +339,7 @@ class TestApplyGeneratedYaml:
         assert "_validation_result" not in session_state
 
 
-def _patch_generation_agent(agent: MagicMock):
+def _patch_generation_agent(agent: MagicMock | None):
     """Stub the panel's agent accessor.
 
     The real one caches the agent under a key built from the SimReady settings, so seeding a
@@ -339,6 +351,78 @@ def _patch_generation_agent(agent: MagicMock):
     )
 
 
+class TestInferenceEndpointSelection:
+    @pytest.fixture(autouse=True)
+    def clean_endpoint_env(self, monkeypatch):
+        monkeypatch.delenv(INFERENCE_ENDPOINT_ENV_VAR, raising=False)
+        monkeypatch.delenv(INTERNAL_ENDPOINT.api_key_env_var, raising=False)
+        monkeypatch.delenv(PUBLIC_ENDPOINT.api_key_env_var, raising=False)
+        monkeypatch.delenv(OPENAI_ENDPOINT.api_key_env_var, raising=False)
+
+    def test_available_endpoints_omit_unset_keys(self, monkeypatch):
+        monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
+        assert available_inference_endpoints() == [INTERNAL_ENDPOINT.name]
+
+    def test_available_endpoints_include_every_set_key(self, monkeypatch):
+        monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
+        monkeypatch.setenv(OPENAI_ENDPOINT.api_key_env_var, "openai-key")
+        assert available_inference_endpoints() == [
+            INTERNAL_ENDPOINT.name,
+            PUBLIC_ENDPOINT.name,
+            OPENAI_ENDPOINT.name,
+        ]
+
+    def test_default_falls_back_when_preferred_key_missing(self, monkeypatch):
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, PUBLIC_ENDPOINT.name)
+        monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
+        available = available_inference_endpoints()
+        assert PUBLIC_ENDPOINT.name not in available
+        assert _default_inference_endpoint(available) == INTERNAL_ENDPOINT.name
+
+    def test_default_prefers_arena_inference_endpoint_when_available(self, monkeypatch):
+        monkeypatch.setenv(INFERENCE_ENDPOINT_ENV_VAR, OPENAI_ENDPOINT.name)
+        monkeypatch.setenv(INTERNAL_ENDPOINT.api_key_env_var, "internal-key")
+        monkeypatch.setenv(OPENAI_ENDPOINT.api_key_env_var, "openai-key")
+        available = available_inference_endpoints()
+        assert _default_inference_endpoint(available) == OPENAI_ENDPOINT.name
+
+    def test_cache_key_includes_endpoint(self):
+        cfg = SimReadySearchConfig()
+        public_key = _generation_agent_cache_key(PUBLIC_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
+        internal_key = _generation_agent_cache_key(INTERNAL_ENDPOINT.name, simready_enabled=False, simready_config=cfg)
+        assert public_key != internal_key
+        assert public_key[1] == PUBLIC_ENDPOINT.name
+        assert internal_key[1] == INTERNAL_ENDPOINT.name
+
+    def test_clear_orphaned_generation_agents_keeps_requested_key(self, session_state):
+        keep = ("generation_agent", PUBLIC_ENDPOINT.name, False, "isaac-sim-ga", None, None, 1)
+        other = ("generation_agent", INTERNAL_ENDPOINT.name, False, "isaac-sim-ga", None, None, 1)
+        session_state[keep] = object()
+        session_state[other] = object()
+        session_state["unrelated"] = "keep-me"
+        _clear_orphaned_generation_agents(keep=keep)
+        assert keep in session_state
+        assert other not in session_state
+        assert session_state["unrelated"] == "keep-me"
+
+    def test_get_generation_agent_retries_after_failed_init(self, session_state, monkeypatch):
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
+        session_state["inference_endpoint"] = PUBLIC_ENDPOINT.name
+        session_state["generation_agent_error"] = "previous failure"
+        mock_agent = MagicMock(name="generation-agent")
+        with patch(
+            "isaaclab_arena_examples.agentic_environment_generation.review_gui.generation_panel.EnvironmentGenerationAgent",
+            side_effect=[AssertionError("transient"), mock_agent],
+        ) as mock_cls:
+            assert _get_generation_agent() is None
+            assert session_state["generation_agent_error"] == "transient"
+            assert _get_generation_agent() is mock_agent
+        assert mock_cls.call_count == 2
+        assert "generation_agent_error" not in session_state
+        assert mock_cls.call_args.kwargs["endpoint"] == PUBLIC_ENDPOINT.name
+
+
 class TestRunGenerationPipeline:
     def test_rejects_empty_prompt(self, session_state):
         ok, message = run_generation_pipeline("   ")
@@ -347,7 +431,8 @@ class TestRunGenerationPipeline:
 
     def test_fails_when_agent_unavailable(self, session_state):
         session_state["generation_agent_error"] = "missing key"
-        ok, message = run_generation_pipeline("pick up a cube")
+        with _patch_generation_agent(None):
+            ok, message = run_generation_pipeline("pick up a cube")
         assert not ok
         assert "missing key" in message
 


### PR DESCRIPTION
## Summary
Add GUI inference endpoint switching. Improves doc for endpoint setup and for GUI.

## Detailed description
- Replace the GUI endpoint CLI flag with a radio showing endpoints whose API keys are configured. This allows switching endpoint inside the GUI without restarting the app.
- Retry failed agent initialization, isolate endpoint caches, and add unit coverage
- Improve agentic env gen pre-requisite doc: move endpoint API key instruction before uv/docker; add tabs for the endpoint API key setup instruction. Cleanup the generated environment catalogs session to include kitchen bench. 
- Update agentic env gen concept doc GUI page with new per-panel screenshots, and rephrasing to match latest GUI behavior.

Updated GUI view for endpoint switch:
<img width="433" height="374" alt="image" src="https://github.com/user-attachments/assets/d0ae6364-6e09-4cd6-a112-262727b84e27" />

Updated agentic env gen sample pre-requisite doc:
<img width="495" height="902" alt="image" src="https://github.com/user-attachments/assets/18385e72-c9e7-4487-8d5d-949633c598f3" />
