### PR TITLE
Switch to publicly hosted usd-randomizer kitchens

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -11,7 +11,7 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
 from isaaclab_arena.assets.background import Background
 from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
-from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR
+from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR, ISAAC_STAGING_NUCLEUS_DIR
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
 
@@ -227,8 +227,6 @@ class TableOakRobolab(LibraryBackground):
 # Replicator kitchen backgrounds
 # -----------------------------------------------------------------------------
 
-_REPLICATOR_KITCHEN_ROOT = f"{ARENA_NUCLEUS_DIR}/Arena/assets/background_library/replicator_kitchen"
-
 
 class ReplicatorKitchenBackground(LibraryBackground):
     """Base class for Replicator-generated kitchen floorplans."""
@@ -246,7 +244,7 @@ class ReplicatorKitchenGShape(ReplicatorKitchenBackground):
     """Replicator G-shaped kitchen."""
 
     name = "replicator_kitchen_g_shape"
-    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_g_shape.usda"
+    usd_path = f"{ISAAC_STAGING_NUCLEUS_DIR}/Environments/replicator_kitchen/kitchen_g_shape.usda"
 
 
 @register_asset
@@ -254,7 +252,7 @@ class ReplicatorKitchenLIsland(ReplicatorKitchenBackground):
     """Replicator L-shaped kitchen with an island."""
 
     name = "replicator_kitchen_l_island"
-    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_l_island.usda"
+    usd_path = f"{ISAAC_STAGING_NUCLEUS_DIR}/Environments/replicator_kitchen/kitchen_l_island.usda"
 
 
 @register_asset
@@ -262,7 +260,7 @@ class ReplicatorKitchenLShape(ReplicatorKitchenBackground):
     """Replicator L-shaped kitchen."""
 
     name = "replicator_kitchen_l_shape"
-    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_l_shape.usda"
+    usd_path = f"{ISAAC_STAGING_NUCLEUS_DIR}/Environments/replicator_kitchen/kitchen_l_shape.usda"
 
 
 @register_asset
@@ -270,7 +268,7 @@ class ReplicatorKitchenPeninsula(ReplicatorKitchenBackground):
     """Replicator kitchen with a peninsula."""
 
     name = "replicator_kitchen_peninsula"
-    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_peninsula.usda"
+    usd_path = f"{ISAAC_STAGING_NUCLEUS_DIR}/Environments/replicator_kitchen/kitchen_peninsula.usda"
 
 
 @register_asset
@@ -278,4 +276,4 @@ class ReplicatorKitchenUShape(ReplicatorKitchenBackground):
     """Replicator U-shaped kitchen."""
 
     name = "replicator_kitchen_u_shape"
-    usd_path = f"{_REPLICATOR_KITCHEN_ROOT}/kitchen_u_shape.usda"
+    usd_path = f"{ISAAC_STAGING_NUCLEUS_DIR}/Environments/replicator_kitchen/kitchen_u_shape.usda"

--- a/isaaclab_arena/assets/nucleus.py
+++ b/isaaclab_arena/assets/nucleus.py
@@ -12,5 +12,5 @@ from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 # TODO(2026.07.14, Point Arena assets to the production bucket before release)
 ARENA_NUCLEUS_DIR: str = ISAACLAB_NUCLEUS_DIR.replace("omniverse-content-production", "omniverse-content-staging")
-# Replicator kitchens need to fill a request to be synced to the production bucket
+# TODO(2026.08.12, Fill request to sync Replicator kitchens to the production bucket once Sim 6.1 is released)
 ISAAC_STAGING_NUCLEUS_DIR: str = ISAAC_NUCLEUS_DIR.replace("omniverse-content-production", "omniverse-content-staging")

--- a/isaaclab_arena/assets/nucleus.py
+++ b/isaaclab_arena/assets/nucleus.py
@@ -8,7 +8,9 @@
 Points to staging bucket before release and to production bucket after
 """
 
-from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
 
 # TODO(2026.07.14, Point Arena assets to the production bucket before release)
 ARENA_NUCLEUS_DIR: str = ISAACLAB_NUCLEUS_DIR.replace("omniverse-content-production", "omniverse-content-staging")
+# Replicator kitchens need to fill a request to be synced to the production bucket
+ISAAC_STAGING_NUCLEUS_DIR: str = ISAAC_NUCLEUS_DIR.replace("omniverse-content-production", "omniverse-content-staging")


### PR DESCRIPTION
## Summary
USD randomizer made kitchens have been hosted on Sim 6.0 staging bucket. `test_kitchen_bench_yaml_env.py` test existence of those assets live.
