### PR TITLE
Update docs overview navigation and editing

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -242,7 +242,7 @@ to simplify the creation of simulation environments, and for running them *fast*
 
 
 | **Teleoperation**
-| Teleoperate robots in Arena-defined environments.
+| Teleoperate robots using IsaacTeleop in Arena-defined environments.
 
 .. container:: image-gallery
 
@@ -285,16 +285,20 @@ TABLE OF CONTENTS
 
 .. toctree::
    :maxdepth: 1
-   :caption: Set Up
 
-   pages/quickstart/installation
-
+   Home <self>
 
 .. toctree::
    :maxdepth: 1
-   :caption: Why is Isaac Lab Arena needed?
+   :caption: Isaac Lab Arena Overview
 
    pages/motivation/motivation
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Set Up
+
+   pages/quickstart/installation
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Welcome to Isaac Lab Arena!
 ===========================
 
 Isaac Lab Arena extends `Isaac Lab <https://isaac-sim.github.io/IsaacLab/main/index.html>`_
-to simplify the creation of simulation environments, and for running them *fast*.
+with composable tools for creating robotics simulation environments and running them efficiently at scale.
 
 .. note::
    This is the development version of IsaacLab Arena. It contains the newest features but may not be fully tested yet.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Swappable assets**
-| Swap registered objects, backgrounds, robots, and targets through configuration or graph YAML overrides while task logic continues to address the same scene roles. Object sets can assign different variants across parallel environments, so one evaluation can cover many assets without rewriting the task.
+| Run-time swapping of building blocks such as target objects and backgrounds allows parallel evaluation covering many variations of one task without code changes.
 
 .. container:: image-gallery gallery-3col
 
@@ -119,7 +119,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Parallel Evaluation**
-| Evaluate a policy across many parallel environments, aggregating metrics over completed rollouts. Arena can record per-episode results and camera videos, then produce an HTML report for reviewing success, progress, and rollout media.
+| Evaluate a policy across many parallel environments with aggregated metrics for high-level summary as well as per-episode recording for detailed analysis.
 
 .. container:: image-gallery
 
@@ -153,7 +153,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Agentic environment creation**
-| Turn a natural-language task request into an editable specification, then review it in the GUI or run it end-to-end from the CLI.
+| Turn a natural-language task request into a runnable Arena environment. Edit the environment specification and review the randomized layouts in a GUI interactively.
 
 .. container:: image-gallery
 
@@ -192,7 +192,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Environmental Variations**
-| Enable build-time and run-time variations to sample controlled changes such as HDR backgrounds, light properties, camera intrinsic and extrinsic parameters, and object mass. Variation samples are recorded per episode so evaluation results stay tied to the conditions that produced them.
+| Enable build-time and run-time variations to sample controlled changes such as but not limited to HDR backgrounds, light properties, camera intrinsic and extrinsic parameters, and object mass.
 
 .. container:: image-gallery
 
@@ -226,7 +226,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Multi-node Evaluation**
-| Submit Arena experiments to OSMO so independent runs, policy servers, and result collection can execute across a cluster. The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
+| Scale-out evaluation across multiple compute nodes.
 
 .. figure:: images/teaser_page/multinode_evaluation/multinode_evaluation.png
    :width: 80%
@@ -234,7 +234,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Sensitivity Analysis**
-| Convert variation sweeps into reports that show which environment factors are associated with policy success or failure.
+| Analyze which environment factors are associated with policy success or failure.
 
 .. figure:: images/sensitivity_report_200_trails.png
    :width: 100%

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Swappable assets**
-| Swap registered objects, backgrounds, robots, and targets through configuration or graph YAML overrides while task logic continues to address the same scene roles.
-| Object sets can assign different variants across parallel environments, so one evaluation can cover many assets without rewriting the task.
+| Swap registered objects, backgrounds, robots, and targets through configuration or graph YAML overrides while task logic continues to address the same scene roles. Object sets can assign different variants across parallel environments, so one evaluation can cover many assets without rewriting the task.
 
 .. container:: image-gallery gallery-3col
 
@@ -87,8 +86,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Automatic Object Placement**
-| Define layouts with semantic spatial relations rather than hand-coded poses.
-| Arena solves and validates candidate placements against object geometry, collisions, and task constraints.
+| Define layouts with semantic spatial relations rather than hand-coded poses. Arena solves and validates candidate placements against object geometry, collisions, and task constraints.
 
 
 .. grid:: 1 1 2 2
@@ -121,8 +119,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Parallel Evaluation**
-| Evaluate a policy across many parallel environments, aggregating metrics over completed rollouts.
-| Arena can record per-episode results and camera videos, then produce an HTML report for reviewing success, progress, and rollout media.
+| Evaluate a policy across many parallel environments, aggregating metrics over completed rollouts. Arena can record per-episode results and camera videos, then produce an HTML report for reviewing success, progress, and rollout media.
 
 .. container:: image-gallery
 
@@ -195,8 +192,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Environmental Variations**
-| Enable build-time and run-time variations to sample controlled changes such as HDR backgrounds, light properties, camera intrinsic and extrinsic parameters, and object mass.
-| Variation samples are recorded per episode so evaluation results stay tied to the conditions that produced them.
+| Enable build-time and run-time variations to sample controlled changes such as HDR backgrounds, light properties, camera intrinsic and extrinsic parameters, and object mass. Variation samples are recorded per episode so evaluation results stay tied to the conditions that produced them.
 
 .. container:: image-gallery
 
@@ -230,8 +226,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Multi-node Evaluation**
-| Submit Arena experiment YAML files to OSMO so independent runs, policy servers, and result collection can execute across a cluster.
-| The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
+| Submit Arena experiment YAML files to OSMO so independent runs, policy servers, and result collection can execute across a cluster. The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
 
 .. figure:: images/teaser_page/multinode_evaluation/multinode_evaluation.png
    :width: 80%

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -226,7 +226,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Multi-node Evaluation**
-| Submit Arena experiment YAML files to OSMO so independent runs, policy servers, and result collection can execute across a cluster. The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
+| Submit Arena experiments to OSMO so independent runs, policy servers, and result collection can execute across a cluster. The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
 
 .. figure:: images/teaser_page/multinode_evaluation/multinode_evaluation.png
    :width: 80%

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,11 +5,11 @@ Isaac Lab Arena extends `Isaac Lab <https://isaac-sim.github.io/IsaacLab/main/in
 with composable tools for creating robotics simulation environments and running them efficiently at scale.
 
 .. note::
-   This is the development version of IsaacLab Arena. It contains the newest features but may not be fully tested yet.
+   This is the development version of Isaac Lab Arena. It contains the newest features but may not be fully tested yet.
    For the tested version, please refer to the `release/0.2.1 branch <https://isaac-sim.github.io/IsaacLab-Arena/release/0.2.1/index.html>`_.
 
 | **Modular Environments**
-| Compose environments from reusable parts.
+| Compose scenes, embodiments, and tasks as reusable building blocks instead of duplicating full environment definitions.
 
 .. figure:: images/variation_axis_web.webp
    :width: 80%
@@ -17,7 +17,8 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Swappable assets**
-| Easily switch the assets in an environment without rewriting the environment code.
+| Swap registered objects, backgrounds, robots, and targets through configuration or graph YAML overrides while task logic continues to address the same scene roles.
+| Object sets can assign different variants across parallel environments, so one evaluation can cover many assets without rewriting the task.
 
 .. container:: image-gallery gallery-3col
 
@@ -86,7 +87,8 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Automatic Object Placement**
-| Objects are placed automatically at run-time based on semantic spatial relationships.
+| Define layouts with semantic spatial relations rather than hand-coded poses.
+| Arena solves and validates candidate placements against object geometry, collisions, and task constraints.
 
 
 .. grid:: 1 1 2 2
@@ -119,7 +121,8 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Parallel Evaluation**
-| Evaluate policies in multiple parallel environments *fast*.
+| Evaluate a policy across many parallel environments, aggregating metrics over completed rollouts.
+| Arena can record per-episode results and camera videos, then produce an HTML report for reviewing success, progress, and rollout media.
 
 .. container:: image-gallery
 
@@ -153,7 +156,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Agentic environment creation**
-| Work with an agent to create environments with randomization.
+| Turn a natural-language task request into an editable specification, then review it in the GUI or run it end-to-end from the CLI.
 
 .. container:: image-gallery
 
@@ -168,7 +171,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Built-in Evaluation Environments**
-| Test policies out of the box with a set of pre-defined environments.
+| Run policies against built-in registered environments.
 
 .. container:: image-gallery gallery-3col
 
@@ -192,7 +195,8 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Environmental Variations**
-| Inject controlled sources of randomness into the environment at run-time.
+| Enable build-time and run-time variations to sample controlled changes such as HDR backgrounds, light properties, camera intrinsic and extrinsic parameters, and object mass.
+| Variation samples are recorded per episode so evaluation results stay tied to the conditions that produced them.
 
 .. container:: image-gallery
 
@@ -226,7 +230,8 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Multi-node Evaluation**
-| Scale-out evaluation across multiple compute nodes.
+| Submit Arena experiment YAML files to OSMO so independent runs, policy servers, and result collection can execute across a cluster.
+| The same experiment definitions used locally can scale to many tasks, policies, and episodes, with outputs collected for reports and analysis.
 
 .. figure:: images/teaser_page/multinode_evaluation/multinode_evaluation.png
    :width: 80%
@@ -234,7 +239,7 @@ with composable tools for creating robotics simulation environments and running 
 
 
 | **Sensitivity Analysis**
-| Analyze the impact of variations on policy performance.
+| Convert variation sweeps into reports that show which environment factors are associated with policy success or failure.
 
 .. figure:: images/sensitivity_report_200_trails.png
    :width: 100%

--- a/docs/pages/motivation/motivation.rst
+++ b/docs/pages/motivation/motivation.rst
@@ -1,21 +1,15 @@
-Why is Isaac Lab Arena needed?
+Isaac Lab Arena Overview
 ===============================
 
-Do we need a framework for building and running task libraries?
-
-
-The Problem
-===========
-
-With the advent of *generalist* robot policies, such as `GR00T <https://github.com/NVIDIA/Isaac-GR00T>`_
-and `Pi_0 <https://github.com/Physical-Intelligence/openpi>`_,
-there is a growing need to evaluate these policies in a variety of tasks/environments.
-
-Traditional approaches to building task libraries suffer from significant limitations.
-Each new environment variation—whether testing a different robot embodiment or swapping objects—requires tedious manual creation of a new task configuration.
-This leads to redundant, unscalable tasks where most of the environment setup, scene configuration, and task logic is duplicated across variations.
-As the number of robot types and objects grows, maintaining and extending such task libraries becomes increasingly impractical.
-
+Generalist robot policies such as `GR00T <https://github.com/NVIDIA/Isaac-GR00T>`_
+and `Pi_0 <https://github.com/Physical-Intelligence/openpi>`_ aim to solve many tasks across many scenes,
+objects, embodiments, and deployment conditions.
+Evaluating that claim requires more than a fixed benchmark suite. Lighting changes, clutter, object
+substitutions, and robot morphology can all change policy behavior, and limited coverage can reward policies
+tuned to benchmark-specific conditions rather than policies that generalize.
+To address this, the evaluation set needed to test generalization grows combinatorially with tasks, scenes,
+embodiments, objects, and environment variations, making manual environment authoring a central bottleneck.
+Isaac Lab Arena provides a composable robotics simulation evaluation approach.
 
 .. figure:: ../../images/task_duplications.png
    :width: 100%
@@ -25,10 +19,8 @@ As the number of robot types and objects grows, maintaining and extending such t
    Task duplications in a task library.
    When evaluating policies across different robot embodiments and objects, most of the environment setup and task logic remains the same, leading to significant code duplication.
 
-
-
-Can we simplify environment creation?
-=====================================
+Variational Approach to Robot Policy Evaluation
+===============================================
 
 .. figure:: ../../images/variation_axis.png
    :width: 100%
@@ -36,45 +28,41 @@ Can we simplify environment creation?
    :align: center
 
    Axis of variation of a pick and place task.
-   Each environment differs along two axis, the robot embodiment and the object to be manipulated.
+   Each environment differs along two axes: the robot embodiment and the object to be manipulated.
    All other aspects of the environment and the task remain the same.
 
 
-Tasks in a task library are typically highly redundant.
-For example, you may want to test how well a policy performs on a pick and place task,
-on many different objects.
-In this example, each environment differs in the object-to-be-manipulated,
-but all other aspects remain the same.
-For example, the scene layout, the robot, the observations, actions, rewards, etc are all
-conserved across the environments.
-Isaac Lab's manager-based environment API is convenient for expressing one such task,
-but does not naturally support expressing this type of variation.
+Task libraries often encode the same scenario repeatedly. A pick-and-place
+benchmark, for example, may need to evaluate the same task across many target
+objects, robot embodiments, object placements, or scene conditions. In these
+cases, the core task definition does not change: the scene layout, observation
+space, action space, rewards, and success criteria are mostly shared. Only one
+or two dimensions vary.
 
-Isaac Lab Arena extends the manager-based interface to provide
-a convenient way of expressing task variation, while benefiting from
-the modularity, performance, and accuracy of Isaac Lab.
+Isaac Lab's manager-based environment API is convenient for expressing each
+individual task, but representing a full family of related variations can lead
+to many near-duplicate configurations. Isaac Lab Arena makes those differences
+explicit as variation axes. It extends the manager-based interface so related
+environments can be composed from reusable parts, while retaining the
+modularity, performance, and accuracy of Isaac Lab.
 
-
-Isaac Lab Arena
-===============
-
-Isaac Lab Arena is a framework that simplifies the creation and maintenance of such task/environment libraries.
-To simplify the expression of task/environment variation in Isaac Lab Arena,
-we *compose* the environment on-the-fly from independent sub-pieces.
-Because the sub-pieces are independent, they can be reused and independently varied.
-Furthermore, because the environment is built on the fly, we never need to write and maintain
-duplicate code.
+Concretely, Isaac Lab Arena treats an environment as a composition of reusable
+pieces instead of a standalone configuration for every variation. The shared
+parts stay in one place, while the axes that should vary, such as the scene,
+robot embodiment, or task, can be swapped independently. The environment is
+assembled on the fly, which avoids maintaining duplicate task code for each new
+combination.
 
 .. figure:: ../../images/isaac_lab_arena_arch_overview.png
    :width: 100%
    :alt: Isaac Lab Arena Architecture Overview
    :align: center
 
-Isaac Lab Arena decomposes the environment into three independent sub-pieces:
+Isaac Lab Arena decomposes each environment into three independent pieces:
 
-* **Scene**: The physical environment layout. The scene is a collection of objects.
-* **Embodiment**: The robot embodiment, its observations, actions, sensors etc.
-* **Task**: A definition of what is to be accomplished in the environment.
+* **Scene**: The physical layout and objects in the environment.
+* **Embodiment**: The robot, its observations, actions, and sensors.
+* **Task**: The objective, rewards, success criteria, and task-specific logic.
 
-The ``ArenaEnvBuilder`` composes the environment from these sub-pieces,
-into a ``ManagerBasedRLEnvCfg`` which can be run in Isaac Lab.
+The ``ArenaEnvBuilder`` composes these pieces into a ``ManagerBasedRLEnvCfg``
+that can be run in Isaac Lab.


### PR DESCRIPTION
## Summary
Refresh docs overview navigation and copy

## Detailed description
- Adds Home as the first sidebar item.
- Moves the overview page ahead of setup in the docs TOC.
- Rewrites the docs overview feature blurbs for clarity.
- Copy-edits product naming and wording in the overview page.