### PR TITLE
Open sensitivity plots inside Docker

### DIFF
--- a/docker/Dockerfile.isaaclab_arena
+++ b/docker/Dockerfile.isaaclab_arena
@@ -22,7 +22,9 @@ RUN apt-get update && apt-get install -y \
   sudo \
   jq \
   ffmpeg \
-  python3-pip
+  python3-pip && \
+  apt-get install -y --no-install-recommends \
+  pqiv
 
 ################################
 # Install Isaac Lab

--- a/docs/pages/example_workflows/sensitivity_analysis/sensitivity_analysis.rst
+++ b/docs/pages/example_workflows/sensitivity_analysis/sensitivity_analysis.rst
@@ -86,12 +86,11 @@ For the downloaded sample, the terminal output includes:
 Read the posterior marginals
 ----------------------------
 
-From another terminal on the host, set the corresponding host path and open the generated image:
+Still in the Base Docker container, open the generated image:
 
 .. code-block:: bash
 
-   POSTERIOR_FIGURE_PATH="$HOME/eval/camera_sensitivity_workflow/droid_pnp_camera_sensitivity_openpi/camera_sensitivity_posterior.png"
-   xdg-open "${POSTERIOR_FIGURE_PATH}"
+   pqiv "${POSTERIOR_FIGURE_PATH}"
 
 .. figure:: ../../../images/droid_camera_sensitivity_posterior.png
    :width: 100%


### PR DESCRIPTION
## Summary
Open sensitivity plots inside Docker

## Detailed description
- Avoid the host `xdg-open` dependency and unclear host/container handoff.
- Add lightweight `pqiv` without recommended packages and use it in the Base Docker container.
- Verify the rebuilt image, real PNG launch through X11, Sphinx warnings-as-errors, and pre-commit.