### PR TITLE
Enable Kit visualizer for livestream

### DIFF
--- a/isaaclab_arena/tests/test_simulation_app.py
+++ b/isaaclab_arena/tests/test_simulation_app.py
@@ -7,6 +7,7 @@ import argparse
 
 import pytest
 
+from isaaclab_arena.utils.isaaclab_utils import simulation_app
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import _ensure_livestream_visualizer
 
 
@@ -17,6 +18,20 @@ def test_livestream_enables_kit_visualizer(livestream):
     _ensure_livestream_visualizer(args)
 
     assert args.visualizer == ["kit"]
+
+
+def test_get_app_launcher_enables_kit_visualizer_for_livestream(monkeypatch):
+    args = argparse.Namespace(livestream=1, visualizer=None)
+    launched_args = None
+
+    def fake_app_launcher(app_args):
+        nonlocal launched_args
+        launched_args = app_args
+
+    monkeypatch.setattr(simulation_app, "AppLauncher", fake_app_launcher)
+    simulation_app.get_app_launcher(args)
+
+    assert launched_args.visualizer == ["kit"]
 
 
 def test_livestream_environment_enables_kit_visualizer(monkeypatch):

--- a/isaaclab_arena/tests/test_simulation_app.py
+++ b/isaaclab_arena/tests/test_simulation_app.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+import pytest
+
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import _ensure_livestream_visualizer
+
+
+@pytest.mark.parametrize("livestream", [1, 2])
+def test_livestream_enables_kit_visualizer(livestream):
+    args = argparse.Namespace(livestream=livestream, visualizer=None)
+
+    _ensure_livestream_visualizer(args)
+
+    assert args.visualizer == ["kit"]
+
+
+def test_livestream_environment_enables_kit_visualizer(monkeypatch):
+    monkeypatch.setenv("LIVESTREAM", "1")
+    args = argparse.Namespace(livestream=-1, visualizer=None)
+
+    _ensure_livestream_visualizer(args)
+
+    assert args.visualizer == ["kit"]
+
+
+def test_livestream_preserves_explicit_visualizer():
+    args = argparse.Namespace(livestream=1, visualizer=["viser"])
+
+    _ensure_livestream_visualizer(args)
+
+    assert args.visualizer == ["viser"]
+
+
+def test_disabled_livestream_preserves_default_visualizer():
+    args = argparse.Namespace(livestream=0, visualizer=None)
+
+    _ensure_livestream_visualizer(args)
+
+    assert args.visualizer is None

--- a/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
+++ b/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
@@ -24,6 +24,14 @@ def get_isaac_sim_version() -> str:
 STARTUP_COMPLETE_MARKER = "[isaaclab-arena] AppLauncher initialization complete"
 
 
+def _ensure_livestream_visualizer(args: argparse.Namespace) -> None:
+    """Enable Kit visualization when livestreaming without an explicit visualizer."""
+    livestream = getattr(args, "livestream", -1)
+    livestream_enabled = livestream in {1, 2} or (livestream == -1 and os.environ.get("LIVESTREAM") in {"1", "2"})
+    if livestream_enabled and getattr(args, "visualizer", None) is None:
+        args.visualizer = ["kit"]
+
+
 def get_app_launcher(args: argparse.Namespace) -> AppLauncher:
     """Get an app launcher."""
     import time
@@ -144,6 +152,7 @@ class SimulationAppContext:
         return self.app_launcher.app.is_exiting()
 
     def __enter__(self):
+        _ensure_livestream_visualizer(self.args)
         self.app_launcher = get_app_launcher(self.args)
         return self
 

--- a/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
+++ b/isaaclab_arena/utils/isaaclab_utils/simulation_app.py
@@ -36,6 +36,7 @@ def get_app_launcher(args: argparse.Namespace) -> AppLauncher:
     """Get an app launcher."""
     import time
 
+    _ensure_livestream_visualizer(args)
     t0 = time.monotonic()
     app_launcher = AppLauncher(args)
     elapsed = time.monotonic() - t0
@@ -152,7 +153,6 @@ class SimulationAppContext:
         return self.app_launcher.app.is_exiting()
 
     def __enter__(self):
-        _ensure_livestream_visualizer(self.args)
         self.app_launcher = get_app_launcher(self.args)
         return self
 


### PR DESCRIPTION
## Summary
Enable Kit visualizer for livestream

## Detailed description
- Fixes #331: livestream runs could start without a Kit visualizer and show a black stream.
- Select `kit` for livestream modes 1 and 2 when no visualizer is configured.
- Preserve explicit visualizer choices and cover CLI, environment, and disabled modes.