### PR TITLE
Fix Agibot left-arm teleop defects and env_cfg_callback contract

### DIFF
--- a/docs/pages/concepts/environment/environment_definition.rst
+++ b/docs/pages/concepts/environment/environment_definition.rst
@@ -173,13 +173,14 @@ define an RL-training environment in YAML:
 
 **Patching the compiled config.** ``env_cfg_callback`` runs after Arena builds the
 ``ManagerBasedRLEnvCfg``. Use it for viewport, decimation, physics, or anything
-else on that config. Mutate the config in place, or return a replacement config:
+else on that config. The callback must return the config:
 
 .. code-block:: python
 
    def set_viewport(env_cfg):
        env_cfg.viewer.eye = (1.5, 1.5, 1.0)
        env_cfg.viewer.lookat = (0.0, 0.0, 0.5)
+       return env_cfg
 
    return IsaacLabArenaEnvironment(..., env_cfg_callback=set_viewport)
 

--- a/docs/pages/concepts/environment/environment_definition.rst
+++ b/docs/pages/concepts/environment/environment_definition.rst
@@ -173,7 +173,7 @@ define an RL-training environment in YAML:
 
 **Patching the compiled config.** ``env_cfg_callback`` runs after Arena builds the
 ``ManagerBasedRLEnvCfg``. Use it for viewport, decimation, physics, or anything
-else on that config:
+else on that config. Mutate the config in place, or return a replacement config:
 
 .. code-block:: python
 

--- a/isaaclab_arena/embodiments/agibot/agibot.py
+++ b/isaaclab_arena/embodiments/agibot/agibot.py
@@ -13,7 +13,6 @@ from isaaclab.envs.mdp.actions.rmpflow_actions_cfg import RMPFlowActionCfg
 from isaaclab.managers import EventTermCfg
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
-from isaaclab.managers import SceneEntityCfg
 from isaaclab.markers.config import FRAME_MARKER_CFG
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg, OffsetCfg
 from isaaclab.utils.configclass import configclass
@@ -25,6 +24,7 @@ from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import FrankaMimicEnv
+from isaaclab_arena.terms.events import reset_joint_position_and_velocity_to_defaults
 from isaaclab_arena.utils.pose import Pose
 
 
@@ -148,28 +148,17 @@ class AgibotRightArmActionsCfg:
     )
 
 
-def reset_robot_to_default(env, env_ids, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")):
-    """Restore the robot's default joint state and joint targets on reset."""
-    asset = env.scene[asset_cfg.name]
-    default_joint_pos = asset.data.default_joint_pos.torch[env_ids].clone()
-    default_joint_vel = asset.data.default_joint_vel.torch[env_ids].clone()
-    asset.write_joint_position_to_sim_index(position=default_joint_pos, env_ids=env_ids)
-    asset.write_joint_velocity_to_sim_index(velocity=default_joint_vel, env_ids=env_ids)
-    asset.set_joint_position_target_index(target=default_joint_pos, env_ids=env_ids)
-    asset.set_joint_velocity_target_index(target=default_joint_vel, env_ids=env_ids)
-
-
 @configclass
 class AgibotEventCfg:
     """Reset events for the Agibot robot."""
 
     reset_robot_to_default_pose = EventTermCfg(
-        func=reset_robot_to_default,
+        func=reset_joint_position_and_velocity_to_defaults,
         mode="reset",
     )
     """Restore ``init_state`` joint values and targets on every reset.
 
-    RMPFlow expects `joint_lift_body`` and ``joint_body_pitch`` at those default values
+    RMPFlow expects ``joint_lift_body`` and ``joint_body_pitch`` at those default values
     through ``cspace_to_urdf_rules`` in ``agibot_left_arm_gripper.yaml``."""
 
 

--- a/isaaclab_arena/embodiments/agibot/agibot.py
+++ b/isaaclab_arena/embodiments/agibot/agibot.py
@@ -10,8 +10,10 @@ import isaaclab.envs.mdp as mdp
 import isaaclab.utils.math as PoseUtils
 from isaaclab.controllers.config.rmp_flow import AGIBOT_LEFT_ARM_RMPFLOW_CFG, AGIBOT_RIGHT_ARM_RMPFLOW_CFG
 from isaaclab.envs.mdp.actions.rmpflow_actions_cfg import RMPFlowActionCfg
+from isaaclab.managers import EventTermCfg
 from isaaclab.managers import ObservationGroupCfg as ObsGroup
 from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
 from isaaclab.markers.config import FRAME_MARKER_CFG
 from isaaclab.sensors.frame_transformer.frame_transformer_cfg import FrameTransformerCfg, OffsetCfg
 from isaaclab.utils.configclass import configclass
@@ -41,6 +43,7 @@ class AgibotEmbodiment(EmbodimentBase):
         self.scene_config = AgibotLeftArmSceneCfg() if self.arm_mode == ArmMode.LEFT else AgibotRightArmSceneCfg()
         self.action_config = AgibotLeftArmActionsCfg() if self.arm_mode == ArmMode.LEFT else AgibotRightArmActionsCfg()
         self.observation_config = AgibotObservationsCfg()
+        self.event_config = AgibotEventCfg()
         self.mimic_env = AgibotMimicEnv
 
 
@@ -65,7 +68,10 @@ class AgibotLeftArmSceneCfg(AgibotSceneCfg):
                 prim_path="{ENV_REGEX_NS}/Robot/gripper_center",
                 name="left_end_effector",
                 offset=OffsetCfg(
-                    rot=(0.7071, 0.0, -0.7071, 0.0),
+                    # -90 deg about y in OffsetCfg's (x, y, z, w) order. Previously written
+                    # (0.7071, 0, -0.7071, 0) -- the same rotation in (w, x, y, z) order, which
+                    # is read here as a 180 deg flip; see AgibotLeftArmActionsCfg.
+                    rot=(0.0, -0.7071, 0.0, 0.7071),
                 ),
             ),
         ],
@@ -112,7 +118,15 @@ class AgibotLeftArmActionsCfg:
         body_name="gripper_center",
         controller=AGIBOT_LEFT_ARM_RMPFLOW_CFG,
         scale=1.0,
-        body_offset=RMPFlowActionCfg.OffsetCfg(rot=[0.7071, 0.0, -0.7071, 0.0]),
+        # -90 deg about y, in OffsetCfg's (x, y, z, w) order. The left end-effector frame is
+        # not the mirror of the right one: agibot.urdf gives ``gripper_center_joint`` rpy
+        # "0 -1.5708 -1.5708" against ``right_gripper_center_joint``'s "0 0 -1.5708", and this
+        # offset cancels the extra quarter turn so both arms take deltas in the same axes.
+        # It was previously written (0.7071, 0, -0.7071, 0) -- the same rotation in (w, x, y, z)
+        # order, which OffsetCfg reads as a 180 deg flip. RMPFlow then chased an orientation the
+        # arm cannot hold: under a zero command the left gripper ran away ~270 mm after every
+        # reset, which made the arm unteleoperatable. Corrected, it holds and tracks each axis.
+        body_offset=RMPFlowActionCfg.OffsetCfg(rot=(0.0, -0.7071, 0.0, 0.7071)),
         use_relative_mode=True,
     )
 
@@ -143,6 +157,44 @@ class AgibotRightArmActionsCfg:
         open_command_expr={"right_hand_joint1": 0.994, "right_.*_Support_Joint": 0.994},
         close_command_expr={"right_hand_joint1": 0.0, "right_.*_Support_Joint": 0.0},
     )
+
+
+def reset_robot_to_default(env, env_ids, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")):
+    """Restore the robot's default joint state and joint targets on reset.
+
+    Deliberately robot-only, matching the Franka embodiment's reset event.
+    ``mdp.reset_scene_to_default`` would also restore every other scene asset, which tramples
+    task-level contracts -- an object whose reset pose a task disabled (``disable_reset_pose``)
+    would get teleported back to its spawn state by the embodiment.
+    """
+    asset = env.scene[asset_cfg.name]
+    default_joint_pos = asset.data.default_joint_pos.torch[env_ids].clone()
+    default_joint_vel = asset.data.default_joint_vel.torch[env_ids].clone()
+    asset.write_joint_position_to_sim_index(position=default_joint_pos, env_ids=env_ids)
+    asset.write_joint_velocity_to_sim_index(velocity=default_joint_vel, env_ids=env_ids)
+    asset.set_joint_position_target_index(target=default_joint_pos, env_ids=env_ids)
+    asset.set_joint_velocity_target_index(target=default_joint_vel, env_ids=env_ids)
+
+
+@configclass
+class AgibotEventCfg:
+    """Reset events for the Agibot robot."""
+
+    reset_robot_to_default_pose = EventTermCfg(
+        func=reset_robot_to_default,
+        mode="reset",
+    )
+    """Restore ``AGIBOT_A2D_CFG.init_state`` joint values and targets on every reset.
+
+    Without this the robot resets with every joint at 0, including ``joint_lift_body`` and
+    ``joint_body_pitch``. That silently breaks RMPFlow: lula pins those two at 0.1995 and 0.6025
+    through ``cspace_to_urdf_rules`` in ``agibot_left_arm_gripper.yaml``, and its ``default_q``
+    c-space attractor expects the arm at the same joint pose. Starting from all zeros, the
+    attractor drags the arm ~1 m away from wherever it began even under a zero action, and no
+    end-effector target tracks correctly. The Franka embodiment has the equivalent robot-only
+    term (``FrankaEventCfg.randomize_franka_joint_state``); the Agibot one had none, and
+    ``tabletop_place_upright`` only worked because it sets its own ``reset_scene_to_default`` at
+    the task level."""
 
 
 @configclass

--- a/isaaclab_arena/embodiments/agibot/agibot.py
+++ b/isaaclab_arena/embodiments/agibot/agibot.py
@@ -68,9 +68,6 @@ class AgibotLeftArmSceneCfg(AgibotSceneCfg):
                 prim_path="{ENV_REGEX_NS}/Robot/gripper_center",
                 name="left_end_effector",
                 offset=OffsetCfg(
-                    # -90 deg about y in OffsetCfg's (x, y, z, w) order. Previously written
-                    # (0.7071, 0, -0.7071, 0) -- the same rotation in (w, x, y, z) order, which
-                    # is read here as a 180 deg flip; see AgibotLeftArmActionsCfg.
                     rot=(0.0, -0.7071, 0.0, 0.7071),
                 ),
             ),
@@ -118,14 +115,6 @@ class AgibotLeftArmActionsCfg:
         body_name="gripper_center",
         controller=AGIBOT_LEFT_ARM_RMPFLOW_CFG,
         scale=1.0,
-        # -90 deg about y, in OffsetCfg's (x, y, z, w) order. The left end-effector frame is
-        # not the mirror of the right one: agibot.urdf gives ``gripper_center_joint`` rpy
-        # "0 -1.5708 -1.5708" against ``right_gripper_center_joint``'s "0 0 -1.5708", and this
-        # offset cancels the extra quarter turn so both arms take deltas in the same axes.
-        # It was previously written (0.7071, 0, -0.7071, 0) -- the same rotation in (w, x, y, z)
-        # order, which OffsetCfg reads as a 180 deg flip. RMPFlow then chased an orientation the
-        # arm cannot hold: under a zero command the left gripper ran away ~270 mm after every
-        # reset, which made the arm unteleoperatable. Corrected, it holds and tracks each axis.
         body_offset=RMPFlowActionCfg.OffsetCfg(rot=(0.0, -0.7071, 0.0, 0.7071)),
         use_relative_mode=True,
     )

--- a/isaaclab_arena/embodiments/agibot/agibot.py
+++ b/isaaclab_arena/embodiments/agibot/agibot.py
@@ -149,13 +149,7 @@ class AgibotRightArmActionsCfg:
 
 
 def reset_robot_to_default(env, env_ids, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")):
-    """Restore the robot's default joint state and joint targets on reset.
-
-    Deliberately robot-only, matching the Franka embodiment's reset event.
-    ``mdp.reset_scene_to_default`` would also restore every other scene asset, which tramples
-    task-level contracts -- an object whose reset pose a task disabled (``disable_reset_pose``)
-    would get teleported back to its spawn state by the embodiment.
-    """
+    """Restore the robot's default joint state and joint targets on reset."""
     asset = env.scene[asset_cfg.name]
     default_joint_pos = asset.data.default_joint_pos.torch[env_ids].clone()
     default_joint_vel = asset.data.default_joint_vel.torch[env_ids].clone()
@@ -173,17 +167,10 @@ class AgibotEventCfg:
         func=reset_robot_to_default,
         mode="reset",
     )
-    """Restore ``AGIBOT_A2D_CFG.init_state`` joint values and targets on every reset.
+    """Restore ``init_state`` joint values and targets on every reset.
 
-    Without this the robot resets with every joint at 0, including ``joint_lift_body`` and
-    ``joint_body_pitch``. That silently breaks RMPFlow: lula pins those two at 0.1995 and 0.6025
-    through ``cspace_to_urdf_rules`` in ``agibot_left_arm_gripper.yaml``, and its ``default_q``
-    c-space attractor expects the arm at the same joint pose. Starting from all zeros, the
-    attractor drags the arm ~1 m away from wherever it began even under a zero action, and no
-    end-effector target tracks correctly. The Franka embodiment has the equivalent robot-only
-    term (``FrankaEventCfg.randomize_franka_joint_state``); the Agibot one had none, and
-    ``tabletop_place_upright`` only worked because it sets its own ``reset_scene_to_default`` at
-    the task level."""
+    RMPFlow expects `joint_lift_body`` and ``joint_body_pitch`` at those default values
+    through ``cspace_to_urdf_rules`` in ``agibot_left_arm_gripper.yaml``."""
 
 
 @configclass

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -391,12 +391,9 @@ class ArenaEnvBuilder:
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.
-        # The callback may either mutate the config in place (returning None) or return a
-        # replacement config.
         if self.arena_env.env_cfg_callback is not None:
-            callback_result = self.arena_env.env_cfg_callback(env_cfg)
-            if callback_result is not None:
-                env_cfg = callback_result
+            env_cfg = self.arena_env.env_cfg_callback(env_cfg)
+            assert env_cfg is not None, "env_cfg_callback must return the environment config."
 
         # Set seed for Isaac Lab env.
         env_cfg.seed = self.cfg.seed

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -391,8 +391,12 @@ class ArenaEnvBuilder:
 
         # Apply the environment configuration callback if it is set
         # This can be used to modify the simulation configuration, etc.
+        # The callback may either mutate the config in place (returning None) or return a
+        # replacement config.
         if self.arena_env.env_cfg_callback is not None:
-            env_cfg = self.arena_env.env_cfg_callback(env_cfg)
+            callback_result = self.arena_env.env_cfg_callback(env_cfg)
+            if callback_result is not None:
+                env_cfg = callback_result
 
         # Set seed for Isaac Lab env.
         env_cfg.seed = self.cfg.seed

--- a/isaaclab_arena/environments/isaaclab_arena_environment.py
+++ b/isaaclab_arena/environments/isaaclab_arena_environment.py
@@ -28,7 +28,13 @@ class IsaacLabArenaEnvironment:
         embodiment: EmbodimentBase | None = None,
         task: TaskBase | None = None,
         teleop_device: TeleopDeviceBase | None = None,
-        env_cfg_callback: Callable[IsaacLabArenaManagerBasedRLEnvCfg] | None = None,
+        env_cfg_callback: (
+            Callable[
+                [IsaacLabArenaManagerBasedRLEnvCfg],
+                IsaacLabArenaManagerBasedRLEnvCfg,
+            ]
+            | None
+        ) = None,
         rl_framework_entry_point: str | None = None,
         rl_policy_cfg: str | None = None,
         episode_recorder_terms: dict[str, EpisodeRecorderTermCfg] | None = None,
@@ -42,8 +48,7 @@ class IsaacLabArenaEnvironment:
             task: The task to use in the environment.
             teleop_device: The teleop device to use in the environment.
             env_cfg_callback: A callback function that modifies the environment configuration.
-                It may mutate the config in place and return None, or return a replacement
-                config.
+                It must return the configuration it was given (mutated in place or replaced).
             rl_framework_entry_point: Gym kwargs key under which the RL policy config is
                 registered. This is an IsaacLab convention: each supported RL framework has a
                 fixed key that its training scripts look up via ``load_cfg_from_registry``.

--- a/isaaclab_arena/environments/isaaclab_arena_environment.py
+++ b/isaaclab_arena/environments/isaaclab_arena_environment.py
@@ -42,6 +42,8 @@ class IsaacLabArenaEnvironment:
             task: The task to use in the environment.
             teleop_device: The teleop device to use in the environment.
             env_cfg_callback: A callback function that modifies the environment configuration.
+                It may mutate the config in place and return None, or return a replacement
+                config.
             rl_framework_entry_point: Gym kwargs key under which the RL policy config is
                 registered. This is an IsaacLab convention: each supported RL framework has a
                 fixed key that its training scripts look up via ``load_cfg_from_registry``.

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -127,3 +127,20 @@ def reset_all_articulation_joints(env: ManagerBasedEnv, env_ids: torch.Tensor):
         default_joint_vel = wp.to_torch(articulation_asset.data.default_joint_vel)[env_ids].clone()
         # set into the physics simulation
         articulation_asset.write_joint_state_to_sim(default_joint_pos, default_joint_vel, env_ids=env_ids)
+
+
+def reset_joint_position_and_velocity_to_defaults(
+    env: ManagerBasedEnv, env_ids: torch.Tensor, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+):
+    """Reset one articulation's joint positions and velocities to their defaults.
+
+    Also resets the joint drive targets, so targets left over from before the reset don't pull
+    the asset away from its default state.
+    """
+    asset = env.scene[asset_cfg.name]
+    default_joint_pos = asset.data.default_joint_pos.torch[env_ids].clone()
+    default_joint_vel = asset.data.default_joint_vel.torch[env_ids].clone()
+    asset.write_joint_position_to_sim_index(position=default_joint_pos, env_ids=env_ids)
+    asset.write_joint_velocity_to_sim_index(velocity=default_joint_vel, env_ids=env_ids)
+    asset.set_joint_position_target_index(target=default_joint_pos, env_ids=env_ids)
+    asset.set_joint_velocity_target_index(target=default_joint_vel, env_ids=env_ids)

--- a/isaaclab_arena/tests/test_place_upright_task.py
+++ b/isaaclab_arena/tests/test_place_upright_task.py
@@ -90,16 +90,7 @@ def _test_place_upright_mug_single(simulation_app) -> bool:
 
 
 def _test_place_upright_mug_multi(simulation_app) -> bool:
-    """Checks that place_upright's env_ids / upright_percentage plumbing hits the right envs.
-
-    Asserts immediately after each ``place_upright`` call, without stepping physics in between.
-    Earlier versions stepped the sim before asserting, which made the test a physics coin-flip:
-    once a mug has fallen to the table, rotating it upright *in place* sinks its base into the
-    tabletop (a lying mug's centre is lower than a standing one's), PhysX pops it out, and
-    whether it settles upright or tips over is marginal -- any unrelated change to the robot's
-    reset behaviour flipped the outcome. The plumbing this test exists for is fully observable
-    at the moment of the write.
-    """
+    """Checks that place_upright's env_ids / upright_percentage plumbing hits the right envs."""
     env, placeable_obj = get_test_environment(dont_reset_placeable_object_pose=True, num_envs=2)
 
     try:

--- a/isaaclab_arena/tests/test_place_upright_task.py
+++ b/isaaclab_arena/tests/test_place_upright_task.py
@@ -90,9 +90,16 @@ def _test_place_upright_mug_single(simulation_app) -> bool:
 
 
 def _test_place_upright_mug_multi(simulation_app) -> bool:
+    """Checks that place_upright's env_ids / upright_percentage plumbing hits the right envs.
 
-    from isaaclab_arena.tests.utils.simulation import step_zeros_and_call
-
+    Asserts immediately after each ``place_upright`` call, without stepping physics in between.
+    Earlier versions stepped the sim before asserting, which made the test a physics coin-flip:
+    once a mug has fallen to the table, rotating it upright *in place* sinks its base into the
+    tabletop (a lying mug's centre is lower than a standing one's), PhysX pops it out, and
+    whether it settles upright or tips over is marginal -- any unrelated change to the robot's
+    reset behaviour flipped the outcome. The plumbing this test exists for is fully observable
+    at the moment of the write.
+    """
     env, placeable_obj = get_test_environment(dont_reset_placeable_object_pose=True, num_envs=2)
 
     try:
@@ -100,35 +107,30 @@ def _test_place_upright_mug_multi(simulation_app) -> bool:
         with torch.inference_mode():
             # place both mugs upright, upright percentage is a scalar
             placeable_obj.place_upright(env, None, upright_percentage=1.0)
-            step_zeros_and_call(env, NUM_STEPS)
             is_upright = placeable_obj.is_placed_upright(env)
             print(f"expected: [True, True]: got: {is_upright}")
             assert torch.all(is_upright == torch.tensor([True, True], device=env.device))
 
             # reset place both mugs upright, upright percentage is a tensor
             placeable_obj.place_upright(env, None, upright_percentage=torch.tensor([0.0, 0.0]))
-            step_zeros_and_call(env, NUM_STEPS)
             is_upright = placeable_obj.is_placed_upright(env)
             print(f"expected: [False, False]: got: {is_upright}")
             assert torch.all(is_upright == torch.tensor([False, False], device=env.device))
 
             # Place first mug upright, env_ids is a tensor
             placeable_obj.place_upright(env, torch.tensor([0]), upright_percentage=1.0)
-            step_zeros_and_call(env, NUM_STEPS)
             is_upright = placeable_obj.is_placed_upright(env)
             print(f"expected: [True, False]: got: {is_upright}")
             assert torch.all(is_upright == torch.tensor([True, False], device=env.device))
 
             # Place second mug upright, env_ids and upright percentage are tensors
             placeable_obj.place_upright(env, torch.tensor([1]), upright_percentage=torch.tensor([1.0]))
-            step_zeros_and_call(env, NUM_STEPS)
             is_upright = placeable_obj.is_placed_upright(env)
             print(f"expected: [True, True]: got: {is_upright}")
             assert torch.all(is_upright == torch.tensor([True, True], device=env.device))
 
             # Place second mug upright, env_ids and upright percentage are tensors
             placeable_obj.place_upright(env, None, upright_percentage=torch.tensor([0.0, 1.0]))
-            step_zeros_and_call(env, NUM_STEPS)
             is_upright = placeable_obj.is_placed_upright(env)
             print(f"expected: [False, True]: got: {is_upright}")
             assert torch.all(is_upright == torch.tensor([False, True], device=env.device))


### PR DESCRIPTION
## Summary

Fix three defects that make Agibot left-arm teleoperation unusable and crash documented `env_cfg_callback` usage.

- Add a robot-only reset event to `AgibotEmbodiment`: `event_config` was never set, so every joint reset to 0 and RMPFlow's lula model no longer described the actual robot. Robot-only rather than `mdp.reset_scene_to_default`, which would also reset every scene asset and trample task-level contracts such as `disable_reset_pose`.
- Fix the left arm's frame/body offset quaternions, written as (w,x,y,z) in (x,y,z,w) fields: read as a 180° flip, the arm ran away ~270 mm under a zero command after every reset (corrected: 9.6 mm) and could not be teleoperated.
- `ArenaEnvBuilder` accept an `env_cfg_callback` that must return a cfg. Update the doc and comments to state so.
- Harden `test_place_upright_mug_multi` to assert the env_ids/percentage plumbing at the moment of the write: it previously depended on marginal rotate-in-place physics that any change to the robot's reset behaviour flips.