### PR TITLE
[Doc] Suppress pqiv accessibility warning

### DIFF
--- a/docs/pages/example_workflows/sensitivity_analysis/sensitivity_analysis.rst
+++ b/docs/pages/example_workflows/sensitivity_analysis/sensitivity_analysis.rst
@@ -90,7 +90,7 @@ Still in the Base Docker container, open the generated image:
 
 .. code-block:: bash
 
-   pqiv "${POSTERIOR_FIGURE_PATH}"
+   NO_AT_BRIDGE=1 pqiv "${POSTERIOR_FIGURE_PATH}"
 
 .. figure:: ../../../images/droid_camera_sensitivity_posterior.png
    :width: 100%


### PR DESCRIPTION
## Summary
Suppress the pqiv warning when showing a png from within the docker. Adresses comment in [6597251](https://nvbugspro.nvidia.com/bug/6597251)

## Detailed description
- The container exposes the display without an AT-SPI accessibility bus, causing a harmless warning.
- Prefix the sensitivity-report viewer command with `NO_AT_BRIDGE=1`.
- Image viewing behavior is unchanged.