### PR TITLE
Ship the packages' runtime configuration in the built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,25 @@ include = [
 ]
 namespaces = false
 
+# Configuration the packages read at runtime. setuptools installs only .py files
+# unless the data files are declared, so in a non-editable install (anything built
+# from the wheel) the paths these modules resolve relative to __file__ do not
+# exist -- the G1 joint order and whole-body controller YAML among them. Every
+# install flavor here is editable, which is why the source tree does not show it.
+#
+# The globs must be recursive: the directories holding the environment specs
+# (isaaclab_arena_environments/robolab/scenes, .../tasks, kitchen_bench,
+# experiment_configs) carry no __init__.py, so they are not packages of their own.
+[tool.setuptools.package-data]
+"*" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.jsonl", "**/*.html"]
+
+# Test fixtures are not runtime data. Their large artifacts (hdf5, parquet, mp4,
+# pt) are not matched above; these keep the accompanying configs out as well. Both
+# forms are listed because test_data sits under a package in isaaclab_arena and
+# under a plain directory in isaaclab_arena_gr00t.
+[tool.setuptools.exclude-package-data]
+"*" = ["tests/test_data/**", "test_data/**"]
+
 # ----------------------------------------------------------------------------
 # Existing tool configuration (migrated unchanged from the previous pyproject)
 # ----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
-# 62.3 is the first release that expands the recursive `**` globs used in
-# [tool.setuptools.package-data]; below it a build would silently ship only the
-# top-level configs. 66.1 is the first that runs on Python 3.12 at all, the only
-# interpreter this project supports: 66.0 and earlier raise AttributeError on
-# `pkgutil.ImpImporter`, removed in 3.12, while importing pkg_resources.
+# >=66.1 for Python 3.12 compatibility, >=62.3 for the recursive `**` globs in
+# [tool.setuptools.package-data].
 requires = ["setuptools>=66.1"]
 build-backend = "setuptools.build_meta"
 
@@ -266,22 +263,12 @@ include = [
 ]
 namespaces = false
 
-# Configuration the packages read at runtime. setuptools installs only .py files
-# unless the data files are declared, so in a non-editable install (anything built
-# from the wheel) the paths these modules resolve relative to __file__ do not
-# exist -- the G1 joint order and whole-body controller YAML among them. Every
-# install flavor here is editable, which is why the source tree does not show it.
-#
-# The globs must be recursive: the directories holding the environment specs
-# (isaaclab_arena_environments/robolab/scenes, .../tasks, kitchen_bench,
-# experiment_configs) carry no __init__.py, so they are not packages of their own.
+# setuptools installs only .py files. Declare the configuration data files, and
+# exclude the test fixtures, for a non-editable install. The globs are recursive
+# because the environment spec directories are not packages of their own.
 [tool.setuptools.package-data]
 "*" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.jsonl", "**/*.html"]
 
-# Test fixtures are not runtime data. Their large artifacts (hdf5, parquet, mp4,
-# pt) are not matched above; these keep the accompanying configs out as well. Both
-# forms are listed because test_data sits under a package in isaaclab_arena and
-# under a plain directory in isaaclab_arena_gr00t.
 [tool.setuptools.exclude-package-data]
 "*" = ["tests/test_data/**", "test_data/**"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools>=61"]
+# 62.3 is the first release that expands the recursive `**` globs used in
+# [tool.setuptools.package-data]; below it a build would silently ship only the
+# top-level configs. 66.1 is the first that runs on Python 3.12 at all, the only
+# interpreter this project supports: 66.0 and earlier raise AttributeError on
+# `pkgutil.ImpImporter`, removed in 3.12, while importing pkg_resources.
+requires = ["setuptools>=66.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary
Ship package data files in the wheel

## Detailed description

- **What was the reason for the change?**

  `setuptools` installs only `.py` files unless a package's data files are declared, and this project declares none: there is no `[tool.setuptools.package-data]` table and no `MANIFEST.in`. A wheel built from `main` carries 593 entries, **not one of which is a data file**.

  Every module that resolves a config path relative to `__file__` therefore points at a file that does not exist in a non-editable install.


- **What has been changed?**

  The globs are recursive on purpose. Several config directories are not packages of their own — `isaaclab_arena_environments/robolab/scenes`, `.../tasks`, `kitchen_bench`, and `experiment_configs` carry no `__init__.py` — so a non-recursive `*.yaml` picks up 26 files and silently skips the other 97.

  Test fixtures are excluded. Their large artifacts (`hdf5`, `parquet`, `mp4`, `pt`, 226 MB in total) do not match the patterns in any case, and the small configs beside them are not runtime data. Both path forms are listed because `test_data` sits under a package in `isaaclab_arena` and under a plain directory in `isaaclab_arena_gr00t`.

- **What is the impact of this change?**

  No behavior change for any current install path: all of them are editable, where package data is a no-op. The wheel gains 123 data files and is 1.3 MB.

  Verified by building the wheel and installing it non-editable, where the two paths that used to fail now resolve:

  ```
  wheel entries: 716 | data files: 123
  per package: {'isaaclab_arena': 1, 'isaaclab_arena_dreamzero': 1, 'isaaclab_arena_environments': 95,
                'isaaclab_arena_examples': 1, 'isaaclab_arena_g1': 4, 'isaaclab_arena_gr00t': 21}
  test fixtures leaked: []
  robot_model.py joints_order_path exists: True
  G1AgilePolicy config_path exists: True
  ```