### PR TITLE
Expand agent-generated PnP envs using LW kitchens

### DIFF
--- a/docs/images/kitchen_bench/kitchen_bananas_bowl_pi.gif
+++ b/docs/images/kitchen_bench/kitchen_bananas_bowl_pi.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72988565bc81bb81018d4d50a8211fe9e9d85fb779ac60e58981ac903a00f0c7
+size 7945878

--- a/docs/images/kitchen_bench/kitchen_ladle_to_plate_pi.gif
+++ b/docs/images/kitchen_bench/kitchen_ladle_to_plate_pi.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af3d410e2eadfdebaa4ad0e9fb1eb96465b51f1d4b66617d666d6b724974ad80
+size 5120217

--- a/docs/images/kitchen_bench/kitchen_lime_to_bowl_pi.gif
+++ b/docs/images/kitchen_bench/kitchen_lime_to_bowl_pi.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96a3d5c4183f9fd5b8687a27fbdea9cd1a7443f474e7e6bcd95ed73a019e9d24
+size 5308109

--- a/docs/images/kitchen_bench/kitchen_pepsi_basket_pi.gif
+++ b/docs/images/kitchen_bench/kitchen_pepsi_basket_pi.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:780bcbf82757e19b34136d9233592f2746f875d9671d025aa207aa73a31a0cf2
+size 3172121

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -42,7 +42,7 @@ Kitchen benchmark environment graph YAMLs live under
 ``isaaclab_arena_environments/kitchen_bench/``. They define DROID manipulation
 tasks across Lightwheel RoboCasa and Replicator kitchen layouts.
 
-See :doc:`kitchen_bench_catalog` for all 17 environment specs and their Pi
+See :doc:`kitchen_bench_catalog` for all 21environment specs and their Pi
 policy executions.
 
 

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -42,7 +42,7 @@ Kitchen benchmark environment graph YAMLs live under
 ``isaaclab_arena_environments/kitchen_bench/``. They define DROID manipulation
 tasks across Lightwheel RoboCasa and Replicator kitchen layouts.
 
-See :doc:`kitchen_bench_catalog` for all 21environment specs and their Pi
+See :doc:`kitchen_bench_catalog` for all 21 environment specs and their Pi
 policy executions.
 
 

--- a/docs/pages/example_workflows/kitchen_bench_catalog.rst
+++ b/docs/pages/example_workflows/kitchen_bench_catalog.rst
@@ -38,7 +38,7 @@ the maintained DROID external camera.
      - .. image:: ../../images/kitchen_bench/kitchen_lime_to_bowl_pi.gif
           :alt: Pi policy placing a lime in a wooden bowl in the L-shaped Scandinavian kitchen
           :width: 100%
-   * - `droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml>`_
+   * - `droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml>`_
      - .. image:: ../../images/kitchen_bench/kitchen_pepsi_basket_pi.gif
           :alt: Pi policy placing a Pepsi can in a basket in the U-shaped farmhouse kitchen
           :width: 100%

--- a/docs/pages/example_workflows/kitchen_bench_catalog.rst
+++ b/docs/pages/example_workflows/kitchen_bench_catalog.rst
@@ -1,7 +1,7 @@
 Kitchen Benchmark Catalog
 =========================
 
-The kitchen benchmark contains 17 DROID tasks defined as environment graph
+The kitchen benchmark contains 21 DROID tasks defined as environment graph
 YAML specs under ``isaaclab_arena_environments/kitchen_bench/``. Pass a spec
 to ``policy_runner.py`` with ``--env_spec`` to run that environment.
 Each row links to the source YAML and shows a Pi policy execution recorded from
@@ -25,6 +25,22 @@ the maintained DROID external camera.
    * - `droid_pick_and_place_lightwheel_kitchen.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_pick_and_place_lightwheel_kitchen.yaml>`_
      - .. image:: ../../images/kitchen_bench/droid_pick_and_place_lightwheel_kitchen_pi.gif
           :alt: Pi policy placing mustard in a bowl in the Lightwheel kitchen
+          :width: 100%
+   * - `droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bananas_bowl_pi.gif
+          :alt: Pi policy placing bananas in a wooden bowl in the U-shaped farmhouse kitchen
+          :width: 100%
+   * - `droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_ladle_to_plate_pi.gif
+          :alt: Pi policy placing a ladle in a plate in the G-shaped Scandinavian kitchen
+          :width: 100%
+   * - `droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_lime_to_bowl_pi.gif
+          :alt: Pi policy placing a lime in a wooden bowl in the L-shaped Scandinavian kitchen
+          :width: 100%
+   * - `droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_pepsi_basket_pi.gif
+          :alt: Pi policy placing a Pepsi can in a basket in the U-shaped farmhouse kitchen
           :width: 100%
    * - `replicator_kitchen_g_shape_banana_bowl.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/replicator_kitchen_g_shape_banana_bowl.yaml>`_
      - .. image:: ../../images/kitchen_bench/replicator_kitchen_g_shape_banana_bowl_pi.gif

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml
@@ -14,7 +14,9 @@ embodiment:
 background:
   id: kitchen
   registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
-  params: {}
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
 objects:
 - id: banana_1
   registry_name: banana_ycb_robolab

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_place_bananas_in_wooden_bowl
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
+  params: {}
+objects:
+- id: banana_1
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: banana_2
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: plate
+  registry_name: plate_large_vomp_robolab
+  params: {}
+- id: wooden_bowl
+  registry_name: wooden_bowl_hot3d_robolab
+  params: {}
+- id: apple
+  registry_name: apple_01_objaverse_robolab
+  params: {}
+- id: orange
+  registry_name: orange_01_fruits_veggies_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: island
+  parent_id: kitchen
+  prim_path: island_island_group/top_geometry_right
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: island
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: island
+  params:
+    side: negative_x
+- kind: 'on'
+  subject: plate
+  reference: island
+  params: {}
+- kind: 'on'
+  subject: banana_1
+  reference: plate
+  params: {}
+- kind: 'on'
+  subject: banana_2
+  reference: plate
+  params: {}
+- kind: 'on'
+  subject: wooden_bowl
+  reference: island
+  params: {}
+- kind: next_to
+  subject: wooden_bowl
+  reference: plate
+  params:
+    side: negative_x
+- kind: 'on'
+  subject: apple
+  reference: island
+  params: {}
+- kind: 'on'
+  subject: orange
+  reference: island
+  params: {}
+task:
+  composition: parallel
+  description: Pick up both bananas from the plate and place them into the wooden
+    bowl in either order.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana_1
+      destination_location: wooden_bowl
+      destination_object: wooden_bowl
+      background_scene: kitchen
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana_2
+      destination_location: wooden_bowl
+      destination_object: wooden_bowl
+      background_scene: kitchen

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_place_ladle_in_plate
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_g_shaped_large_scandinavian
+  params: {}
+objects:
+- id: green_ladle
+  registry_name: ladle_handal_robolab
+  params: {}
+- id: plate
+  registry_name: plate_large_vomp_robolab
+  params: {}
+- id: spoon_1
+  registry_name: spoon_1_handal_robolab
+  params: {}
+- id: spoon_2
+  registry_name: spoon_2_handal_robolab
+  params: {}
+- id: spoon_3
+  registry_name: spoon_big_vomp_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry
+  object_type: base
+  params: {}
+- id: toaster
+  parent_id: kitchen
+  prim_path: toaster_main_group
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: is_anchor
+  subject: toaster
+  params: {}
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: 'on'
+  subject: green_ladle
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: plate
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: spoon_1
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: spoon_2
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: spoon_3
+  reference: counter_top
+  params: {}
+- kind: next_to
+  subject: green_ladle
+  reference: toaster
+  params:
+    side: negative_y
+- kind: next_to
+  subject: plate
+  reference: toaster
+  params:
+    side: negative_x
+task:
+  composition: atomic
+  description: Pick up the ladle from the counter top and place it into the plate.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: green_ladle
+      destination_location: plate
+      background_scene: kitchen
+      destination_object: plate

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_ladle_in_plate_lightwheel_kitchen_g_shaped_large_scandinavian.yaml
@@ -14,7 +14,9 @@ embodiment:
 background:
   id: kitchen
   registry_name: lightwheel_kitchen_g_shaped_large_scandinavian
-  params: {}
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
 objects:
 - id: green_ladle
   registry_name: ladle_handal_robolab

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_place_lime_in_wooden_bowl
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_l_shaped_scandinavian
+  params: {}
+objects:
+- id: lime
+  registry_name: lime01_fruits_veggies_robolab
+  params: {}
+- id: wooden_bowl
+  registry_name: wooden_bowl_hot3d_robolab
+  params: {}
+- id: broccoli
+  registry_name: broccoli
+  params: {}
+- id: sweet_potato
+  registry_name: sweet_potato
+  params: {}
+- id: red_bell_pepper
+  registry_name: red_bell_pepper_objaverse_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry_right
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: lime
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: wooden_bowl
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: broccoli
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: sweet_potato
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: red_bell_pepper
+  reference: counter_top
+  params: {}
+task:
+  composition: atomic
+  description: Pick up the lime from the counter top and place it into the wooden
+    bowl.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lime
+      destination_location: wooden_bowl
+      background_scene: kitchen
+      destination_object: wooden_bowl

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_lime_in_wooden_bowl_l_shaped_scandinavian.yaml
@@ -14,7 +14,9 @@ embodiment:
 background:
   id: kitchen
   registry_name: lightwheel_kitchen_l_shaped_scandinavian
-  params: {}
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
 objects:
 - id: lime
   registry_name: lime01_fruits_veggies_robolab

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml
@@ -14,7 +14,9 @@ embodiment:
 background:
   id: kitchen
   registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
-  params: {}
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
 objects:
 - id: tuna_can
   registry_name: tuna_can_ycb_robolab

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_basket_u_shaped_with_island_farmhouse2.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: droid_place_pepsi_in_plate
+env_name: droid_place_pepsi_in_basket
 embodiment:
   id: droid
   registry_name: droid_abs_joint_pos

--- a/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/droid_place_pepsi_in_plate_u_shaped_with_island_farmhouse2.yaml
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_place_pepsi_in_plate
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
+  params: {}
+objects:
+- id: tuna_can
+  registry_name: tuna_can_ycb_robolab
+  params: {}
+- id: mug
+  registry_name: mug
+  params: {}
+- id: pepsi_can
+  registry_name: simready_usd_object
+  params:
+    usd_path: https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/SimReady/Residential/Kitchen/Food/Canned_Goods/Can_M01/sm_food_beverage_can_m01_01.usd
+- id: corn_can
+  registry_name: corn_can_hope_robolab
+  params: {}
+- id: mini_plastic_basket
+  registry_name: simready_usd_object
+  params:
+    usd_path: https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/SimReady/Residential/Kitchen/Baskets/Plastic_Basket_A01/sm_misc_basket_plastic_a01_01.usd
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: island_island_group/top_geometry_left
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: positive_y
+- kind: 'on'
+  subject: tuna_can
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: mini_plastic_basket
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: mug
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: pepsi_can
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: corn_can
+  reference: counter_top
+  params: {}
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: -1.57
+task:
+  composition: atomic
+  description: Pick up the Pepsi can from the counter top and place it into the mini
+    plastic basket.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pepsi_can
+      destination_location: mini_plastic_basket
+      background_scene: kitchen
+      destination_object: mini_plastic_basket


### PR DESCRIPTION
## Summary
Add 4 more agent-generated envs yaml in LW kitchens (diff layouts & styles than existing). Validated using Pi with Curobo reachability checker.

