### PR TITLE
Add local OpenPI server skill

### DIFF
--- a/.agents/skills/serve-openpi-policy
+++ b/.agents/skills/serve-openpi-policy
@@ -1,0 +1,1 @@
+../../skills/user/serve-openpi-policy

--- a/skills/user/run-experiment/SKILL.md
+++ b/skills/user/run-experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-experiment
-description: Runs existing Isaac Lab-Arena Experiment Definitions locally with experiment_runner.py in a ready native or Docker runtime, applies local CLI overrides, and verifies generated result and report artifacts. Use for local named-Run or batch policy evaluations, variation listing, visualization or video, and result inspection. Do not use for installation or runtime preparation (setup-arena), pytest or regression checks (run-tests), interactive no-policy inspection (environment_runner.py), direct Policy Runner workflows, or OSMO preview, submission, or management.
+description: Runs existing Isaac Lab-Arena Experiment Definitions locally with experiment_runner.py in a ready native or Docker runtime, coordinates a required local OpenPI server, applies local CLI overrides, and verifies generated result and report artifacts. Use for local named-Run or batch policy evaluations, variation listing, visualization or video, and result inspection. Do not use for installation or runtime preparation (setup-arena), pytest or regression checks (run-tests), interactive no-policy inspection (environment_runner.py), direct Policy Runner workflows, or OSMO preview, submission, or management.
 allowed-tools: Read Grep Glob Skill Bash(git rev-parse --show-toplevel) Bash(id -un) Bash(test -d *) Bash(test -f *) Bash(test -x .venv/bin/python) Bash(env OMNI_KIT_ACCEPT_EULA=YES ACCEPT_EULA=Y .venv/bin/python isaaclab_arena/evaluation/experiment_runner.py *) Bash(docker ps *) Bash(docker exec *)
 ---
 
@@ -35,8 +35,16 @@ path; do not create new legacy configurations or apply Hydra overrides to them.
    and state the choice. If neither route is ready, use `setup-arena`; do not install dependencies,
    build an image, create mounts, or recreate a container here.
 5. Confirm that referenced configs, datasets, checkpoints, and output locations are available from
-   the selected runtime. For a remote policy, require an already-running and reachable server; do
-   not start or submit one as part of this workflow.
+   the selected runtime. Identify a policy from each Run's resolved `policy.type`, not the
+   Experiment filename.
+6. For an OpenPI `Pi0RemotePolicy` or registered `pi0_remote` policy whose `remote_host` is local,
+   use `serve-openpi-policy` for each distinct variant and port. It must reuse a compatible ready
+   server or start one before this workflow launches the Experiment; the user does not need to
+   invoke that skill separately. If Runs request different variants on the same port, stop and ask
+   the user to resolve the conflict.
+7. For an OpenPI policy pointing to another host, or another remote policy without a matching local
+   server skill, require an already-running and reachable endpoint. Do not replace a deliberately
+   remote endpoint with a local server or submit it to managed compute.
 
 For a built-in smoke evaluation, use
 `isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml`. It uses the local
@@ -126,8 +134,9 @@ console; the runner does not currently promise a separate `metrics.json`.
 For `--list_variations`, report the catalogue and explicitly state that no rollout or output
 artifacts were expected.
 
-Finish with the selected runtime, Experiment path, effective overrides, output path, per-Run
-statuses, episode counts, and any preserved partial artifacts or failures.
+Finish with the selected runtime, any policy-server endpoint and whether it was reused or started,
+the Experiment path, effective overrides, output path, per-Run statuses, episode counts, and any
+preserved partial artifacts or failures.
 
 ## Hand off other workflows
 
@@ -138,10 +147,13 @@ statuses, episode counts, and any preserved partial artifacts or failures.
   rollout outside an Experiment Definition.
 - Use a separate OSMO submission skill for previews, cluster resources, submission, monitoring, or
   remote result download. An unqualified request to "run" an Experiment means local execution.
+- Use `serve-openpi-policy` automatically when a local OpenPI Experiment needs a compatible server.
+  Leave that server running after the Experiment unless the user asks to stop it.
 
 ## References
 
 - [Evaluations](evaluations.md)
+- [OpenPI server skill](../serve-openpi-policy/SKILL.md)
 - [Arena Experiments](../../../docs/pages/concepts/concept_arena_experiments.rst)
 - [First Arena Experiment](../../../docs/pages/quickstart/arena_experiment.rst)
 - [Environment variations](../../../docs/pages/quickstart/environment_variations.rst)

--- a/skills/user/run-experiment/evaluations.md
+++ b/skills/user/run-experiment/evaluations.md
@@ -84,7 +84,27 @@ Known failure modes:
 - Starts the full evaluation or edits the Experiment Definition.
 - Reports missing output artifacts as a failure.
 
-## Scenario 6: Respect Workflow Boundaries
+## Scenario 6: Start A Required Local OpenPI Server
+
+Query: "Run `droid_pnp_openpi_experiment.yaml` locally; I haven't started a policy server."
+
+Expected behavior:
+
+- Detects OpenPI from the Run's resolved policy type and reads its variant, host, and port.
+- Uses `serve-openpi-policy` to reuse a matching ready server or start one on the configured local
+  endpoint before launching the Experiment.
+- Discloses and confirms a potentially large first image build or checkpoint download.
+- Waits for OpenPI readiness, runs the Experiment, verifies its artifacts, and leaves the server
+  running while reporting its endpoint and identity.
+
+Known failure modes:
+
+- Requires the user to discover and invoke the server skill separately.
+- Infers OpenPI only from the filename, starts a duplicate server, or serves a mismatched variant.
+- Treats a listening TCP port as sufficient readiness, submits to OSMO, or stops the server without
+  being asked.
+
+## Scenario 7: Respect Workflow Boundaries
 
 Query: "Submit this Experiment to OSMO pool `example-pool` and download the results."
 
@@ -98,7 +118,7 @@ Known failure modes:
 - Treats local and managed execution as interchangeable.
 - Submits remote compute using the local skill's permissions.
 
-## Scenario 7: Route Runtime Setup And Regression Testing
+## Scenario 8: Route Runtime Setup And Regression Testing
 
 Query: "I just cloned Arena. Install it, then run the no-camera pytest phase."
 

--- a/skills/user/run-experiment/evaluations.md
+++ b/skills/user/run-experiment/evaluations.md
@@ -94,13 +94,15 @@ Expected behavior:
 - Uses `serve-openpi-policy` to reuse a matching ready server or start one on the configured local
   endpoint before launching the Experiment.
 - Discloses and confirms a potentially large first image build or checkpoint download.
-- Waits for OpenPI readiness, runs the Experiment, verifies its artifacts, and leaves the server
-  running while reporting its endpoint and identity.
+- Waits for OpenPI readiness from a retained asynchronous terminal session, runs the Experiment
+  while that session remains active, verifies its artifacts, and leaves the server running while
+  reporting its endpoint and identity.
 
 Known failure modes:
 
 - Requires the user to discover and invoke the server skill separately.
 - Infers OpenPI only from the filename, starts a duplicate server, or serves a mismatched variant.
+- Waits for the server command to exit before running the Experiment or loses its session handle.
 - Treats a listening TCP port as sufficient readiness, submits to OSMO, or stops the server without
   being asked.
 

--- a/skills/user/serve-openpi-policy/SKILL.md
+++ b/skills/user/serve-openpi-policy/SKILL.md
@@ -68,10 +68,10 @@ owner.
 
 ## Disclose first-run work
 
-Before a missing-image launch, explain that the documented first build takes about three minutes
-and creates an image of roughly 19 GB. Also disclose that a first launch of a variant can download
-roughly 11 GB of checkpoint data into the OpenPI cache. Obtain confirmation before starting that
-large build or download.
+Read the current build-time, image-size, and checkpoint-download estimates from the checked-out
+OpenPI workflow and disclose them before a missing-image or uncached-variant launch. Obtain
+confirmation before starting that large build or download. Do not rely on copied estimates when the
+checked-out documentation has newer values.
 
 Use `-r` only when the user explicitly requests a forced rebuild and confirms it. Do not push an
 image, run a no-cache build, clear caches, or install or change Docker, GPU drivers, or the NVIDIA
@@ -79,25 +79,33 @@ Container Toolkit through this skill.
 
 ## Launch and verify
 
-Run the wrapper from the repository root in a foreground terminal session. Pass the resolved values
-explicitly so the effective server matches the Experiment:
+Start the wrapper from the repository root in a retained terminal session that runs asynchronously
+from this workflow. Keep the wrapper in the foreground of that session, record the returned session
+or task handle, and pass the resolved values explicitly so the effective server matches the
+Experiment:
 
 ```bash
 ./isaaclab_arena_openpi/docker/run_openpi_server.sh -v <pi05-or-pi0> -p <port>
 ```
 
-Keep the session alive. Do not report readiness until the wrapper remains running and emits the
-readiness line for the selected port. The wrapper owns the image build, host-network Docker launch,
-GPU access, checkpoint cache, and cache-ownership cleanup; do not duplicate those operations.
+Retain the terminal session handle and poll its output without waiting for the command to finish;
+the command is expected to remain active for the server's lifetime. Do not append `&`, use `nohup`,
+or replace the wrapper with a detached Docker command. Do not report readiness until the wrapper
+remains running and emits the readiness line for the selected port. After readiness, leave that
+session active while returning control to `run-experiment`.
+
+The wrapper owns the image build, host-network Docker launch, GPU access, checkpoint cache, and
+cache-ownership cleanup; do not duplicate those operations.
 
 On failure, preserve and report the wrapper output. Do not silently rebuild, change variants or
 ports, stop another process, or retry with different settings.
 
 ## Hand off the endpoint
 
-Return the variant, loopback host, port, readiness evidence, exact container identity, and the
-foreground session identity when known. If `run-experiment` requested the server, return control to
-it so it can execute the Experiment and verify artifacts. Do not invoke the Experiment Runner here.
+Return the variant, loopback host, port, readiness evidence, exact container identity, and retained
+terminal session handle when this workflow started the server. If `run-experiment` requested the
+server, return control to it while the retained session remains active so it can execute the
+Experiment and verify artifacts. Do not invoke the Experiment Runner here.
 
 When the user approves a different port, provide the corresponding per-Run Hydra override, for
 example:
@@ -111,10 +119,10 @@ Do not edit the Experiment Definition merely to change the local endpoint.
 ## Stop only on request
 
 Leave the server running after an Experiment unless the user asks to stop it. For a server started
-in this workflow, interrupt its retained foreground session so the wrapper can remove its temporary
-container and repair cache ownership. Never stop an arbitrary port owner or a reused server based
-only on an image name. If the original session cannot be identified safely, report that limitation
-instead of guessing.
+in this workflow, send an interrupt through its retained terminal session, wait for the wrapper to
+exit, and confirm that its temporary container stopped. This lets the wrapper repair cache
+ownership. Never stop an arbitrary port owner or a reused server based only on an image name. If the
+original session cannot be identified safely, report that limitation instead of guessing.
 
 ## References
 

--- a/skills/user/serve-openpi-policy/SKILL.md
+++ b/skills/user/serve-openpi-policy/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: serve-openpi-policy
+description: Starts, reuses, verifies, and explicitly stops the local Dockerized OpenPI inference server used by Isaac Lab-Arena Pi0RemotePolicy experiments. Use when serving pi05 or pi0 locally, selecting an OpenPI port or variant, checking whether the OpenPI server is ready, handling an OpenPI server conflict, or when run-experiment discovers a local OpenPI policy dependency. Do not use for running Experiment Definitions, OSMO submission, other policy providers, training, or general Arena container setup.
+allowed-tools: Read Grep Glob Skill Bash(git rev-parse --show-toplevel) Bash(test -x isaaclab_arena_openpi/docker/run_openpi_server.sh) Bash(docker images -q isaaclab_arena:openpi_server) Bash(docker logs *) Bash(docker ps *) Bash(ss -ltn *) Bash(./isaaclab_arena_openpi/docker/run_openpi_server.sh *)
+---
+
+# Serve OpenPI Policy
+
+Start one local OpenPI inference server and finish with a verified endpoint for an Arena
+`Pi0RemotePolicy` client. Keep Experiment execution, artifacts, OSMO, and other policy providers
+outside this skill.
+
+## Read the checked-out workflow
+
+Before acting, read:
+
+- `docs/pages/quickstart/running_a_real_policy/openpi.rst` for the maintained two-terminal workflow,
+  first-run costs, and readiness message.
+- `isaaclab_arena_openpi/docker/run_openpi_server.sh` for the supported flags and current variant
+  mapping.
+
+Treat the current checkout as the source of truth. Use the wrapper rather than reconstructing its
+Docker command or calling `build_server_image.sh` directly. Report any mismatch between this skill,
+the documentation, and the wrapper.
+
+## Resolve the requested endpoint
+
+1. Confirm the repository root and executable wrapper.
+2. Resolve the variant and port from the request or the Experiment's policy configuration. Use
+   `pi05` and port `8000` only when neither source specifies them.
+3. Accept only variants supported by the wrapper: `pi05` or `pi0`. Require an integer port from 1
+   through 65535.
+4. Serve only a loopback client endpoint such as `127.0.0.1` or `localhost`. If an Experiment names
+   another host, treat it as an external server dependency and return control to `run-experiment`;
+   do not start an unrelated local server.
+
+When called by `run-experiment`, identify OpenPI from the resolved policy type
+`isaaclab_arena_openpi.policy.pi0_remote_policy.Pi0RemotePolicy` or its registered name
+`pi0_remote`, not from the Experiment filename. Match the server's variant and port to the policy
+configuration. If Runs request different variants on the same port, stop and ask the user to choose
+separate ports or one variant.
+
+## Reuse a compatible server
+
+Inspect before launching:
+
+```bash
+docker images -q isaaclab_arena:openpi_server
+docker ps --no-trunc --filter ancestor=isaaclab_arena:openpi_server \
+  --format '{{.ID}}\t{{.Names}}\t{{.Command}}'
+ss -ltn
+```
+
+The wrapper assigns a random container name, so never identify a server by a hardcoded name. For
+each candidate, use its full command to match the selected port and the variant-specific policy
+configuration, then use `docker logs <exact-container>` to require this maintained readiness line
+for the selected port:
+
+```text
+INFO:websockets.server:server listening on 0.0.0.0:<port>
+```
+
+Reuse the server only when the container is still running, its variant and port match, and its logs
+show readiness. A listening TCP port alone is insufficient evidence that it speaks the OpenPI
+protocol. If the selected port is occupied by an incompatible server or another process, do not
+stop it. Report the conflict and ask whether to select a different port or explicitly stop its
+owner.
+
+## Disclose first-run work
+
+Before a missing-image launch, explain that the documented first build takes about three minutes
+and creates an image of roughly 19 GB. Also disclose that a first launch of a variant can download
+roughly 11 GB of checkpoint data into the OpenPI cache. Obtain confirmation before starting that
+large build or download.
+
+Use `-r` only when the user explicitly requests a forced rebuild and confirms it. Do not push an
+image, run a no-cache build, clear caches, or install or change Docker, GPU drivers, or the NVIDIA
+Container Toolkit through this skill.
+
+## Launch and verify
+
+Run the wrapper from the repository root in a foreground terminal session. Pass the resolved values
+explicitly so the effective server matches the Experiment:
+
+```bash
+./isaaclab_arena_openpi/docker/run_openpi_server.sh -v <pi05-or-pi0> -p <port>
+```
+
+Keep the session alive. Do not report readiness until the wrapper remains running and emits the
+readiness line for the selected port. The wrapper owns the image build, host-network Docker launch,
+GPU access, checkpoint cache, and cache-ownership cleanup; do not duplicate those operations.
+
+On failure, preserve and report the wrapper output. Do not silently rebuild, change variants or
+ports, stop another process, or retry with different settings.
+
+## Hand off the endpoint
+
+Return the variant, loopback host, port, readiness evidence, exact container identity, and the
+foreground session identity when known. If `run-experiment` requested the server, return control to
+it so it can execute the Experiment and verify artifacts. Do not invoke the Experiment Runner here.
+
+When the user approves a different port, provide the corresponding per-Run Hydra override, for
+example:
+
+```text
+runs.<run-name>.policy.remote_port=8001
+```
+
+Do not edit the Experiment Definition merely to change the local endpoint.
+
+## Stop only on request
+
+Leave the server running after an Experiment unless the user asks to stop it. For a server started
+in this workflow, interrupt its retained foreground session so the wrapper can remove its temporary
+container and repair cache ownership. Never stop an arbitrary port owner or a reused server based
+only on an image name. If the original session cannot be identified safely, report that limitation
+instead of guessing.
+
+## References
+
+- [Evaluation scenarios](evaluations.md)
+- [OpenPI workflow](../../../docs/pages/quickstart/running_a_real_policy/openpi.rst)
+- [OpenPI server wrapper](../../../isaaclab_arena_openpi/docker/run_openpi_server.sh)

--- a/skills/user/serve-openpi-policy/evaluations.md
+++ b/skills/user/serve-openpi-policy/evaluations.md
@@ -23,14 +23,16 @@ Query: "Start the default OpenPI server for a local rollout."
 Expected behavior:
 
 - Checks for a compatible running server and the server image before launching.
-- If the image is missing, discloses the roughly 19 GB image build and possible 11 GB checkpoint
-  download and obtains confirmation.
-- Starts pi05 on port 8000 only after confirmation and waits for the readiness log.
+- If the image or selected variant is uncached, reads and discloses the current build and download
+  estimates from the checked-out OpenPI workflow and obtains confirmation.
+- Starts pi05 on port 8000 only after confirmation in a retained asynchronous terminal session and
+  waits for the readiness log without waiting for the server process to exit.
 
 Known failure modes:
 
 - Starts a large build or download without confirmation.
 - Reports readiness while the build, download, or server startup is still running.
+- Blocks forever waiting for the server command to exit or launches an unmanaged background process.
 
 ## Scenario 3: Select Pi0 On A Non-Default Port
 
@@ -70,11 +72,13 @@ Expected behavior:
 
 - `run-experiment` detects `Pi0RemotePolicy` from the policy type and uses this skill without a
   separate user invocation.
-- This skill resolves the configured variant and local endpoint, starts and verifies the server,
-  then returns control for Experiment execution.
+- This skill resolves the configured variant and local endpoint, starts and verifies the server in
+  a retained asynchronous terminal session, then returns control while that session remains active
+  for Experiment execution.
 - The server remains running afterward unless the user explicitly asks to stop it.
 
 Known failure modes:
 
 - Infers the provider only from the filename, asks the user to invoke this skill manually, runs the
-  Experiment before readiness, submits to OSMO, or stops the server automatically.
+  Experiment before readiness, waits for the server process to exit, loses the retained session
+  handle, submits to OSMO, or stops the server automatically.

--- a/skills/user/serve-openpi-policy/evaluations.md
+++ b/skills/user/serve-openpi-policy/evaluations.md
@@ -1,0 +1,80 @@
+# Serve OpenPI Policy Evaluations
+
+## Scenario 1: Reuse A Matching Server
+
+Query: "Use the existing pi05 server on port 8000 for my local Arena Experiment."
+
+Expected behavior:
+
+- Finds the running OpenPI container without assuming its Docker-generated name.
+- Confirms the command serves pi05 on port 8000 and requires the documented readiness log.
+- Reuses the server without rebuilding, downloading, or starting a duplicate.
+- Returns the verified endpoint to `run-experiment` without executing the Experiment here.
+
+Known failure modes:
+
+- Reuses a server based only on its image or open port.
+- Starts a second server or claims TCP listening proves OpenPI readiness.
+
+## Scenario 2: Confirm A Large First Launch
+
+Query: "Start the default OpenPI server for a local rollout."
+
+Expected behavior:
+
+- Checks for a compatible running server and the server image before launching.
+- If the image is missing, discloses the roughly 19 GB image build and possible 11 GB checkpoint
+  download and obtains confirmation.
+- Starts pi05 on port 8000 only after confirmation and waits for the readiness log.
+
+Known failure modes:
+
+- Starts a large build or download without confirmation.
+- Reports readiness while the build, download, or server startup is still running.
+
+## Scenario 3: Select Pi0 On A Non-Default Port
+
+Query: "Serve pi0 on port 8001 and use it for the `openpi_rollout` Run."
+
+Expected behavior:
+
+- Validates the pi0 variant and port, checks the port for conflicts, and starts or reuses the exact
+  matching server.
+- Returns `runs.openpi_rollout.policy.remote_port=8001` to `run-experiment` without editing YAML.
+- Keeps server lifecycle separate from Experiment execution and artifact verification.
+
+Known failure modes:
+
+- Serves the default pi05 variant, applies a shared or OSMO override, or edits the Experiment.
+
+## Scenario 4: Preserve An Occupied Port
+
+Query: "Start pi05 on port 8000." Another process already listens there.
+
+Expected behavior:
+
+- Determines whether a ready matching OpenPI container owns the endpoint and reuses it if so.
+- Otherwise reports the conflict and asks whether to choose another port or explicitly stop the
+  owner.
+- Does not kill a process, stop a container, or silently choose another port.
+
+Known failure modes:
+
+- Stops an unrelated process or server, guesses ownership, or changes the requested endpoint.
+
+## Scenario 5: Route A Local OpenPI Experiment
+
+Query: "Run `droid_pnp_openpi_experiment.yaml` locally; no server is running."
+
+Expected behavior:
+
+- `run-experiment` detects `Pi0RemotePolicy` from the policy type and uses this skill without a
+  separate user invocation.
+- This skill resolves the configured variant and local endpoint, starts and verifies the server,
+  then returns control for Experiment execution.
+- The server remains running afterward unless the user explicitly asks to stop it.
+
+Known failure modes:
+
+- Infers the provider only from the filename, asks the user to invoke this skill manually, runs the
+  Experiment before readiness, submits to OSMO, or stops the server automatically.


### PR DESCRIPTION
## Summary
Add local OpenPI server skill

## Detailed description
- Implements the SQA-requested local policy journey on top of #1105.
- Adds a flat-discovered serve-openpi-policy workflow for safe pi05/pi0 reuse, launch, readiness, and shutdown.
- Makes run-experiment detect local Pi0RemotePolicy Runs and arrange the matching server automatically.
- Adds scenarios for first-launch confirmation, reuse, variant and port conflicts, and the combined handoff.