### PR TITLE
Reset background physics

### DIFF
--- a/docs/pages/concepts/scene/concept_assets_design.rst
+++ b/docs/pages/concepts/scene/concept_assets_design.rst
@@ -86,8 +86,10 @@ Resetting nested background physics
 Backgrounds are registered as ``BASE`` assets, but their composed USDs may contain
 dynamic rigid bodies and articulations. Set ``reset_nested_physics=True`` on a
 ``Background`` to register those nested physics roots as private Isaac Lab scene
-entities. Arena snapshots their initialized poses, velocities, and joint states and
-restores them on each episode reset without making the bodies kinematic.
+reset views. Arena creates the views after simulation and RTX initialization, then
+snapshots their poses, velocities, and joint states and restores them on each episode
+reset without making the bodies kinematic. These private roots are not exposed through
+the Isaac Lab scene entity registries.
 
 Explicit ``ObjectReference`` entries take ownership of their paths and are not
 duplicated. Articulation links are reset through their articulation root, while
@@ -97,7 +99,10 @@ Discovery follows the composed USD physics APIs rather than asset naming convent
 For Replicator content, physics contributed by a resolved ``_OnlineVisual`` reference
 is included. A ``_PlacementEnvelope`` is excluded when it is guide geometry without
 physics APIs. Instanceable subtrees that contribute dynamic physics are materialized
-at spawn time because physics views cannot control dynamic instance proxies.
+at spawn time because physics views cannot control dynamic instance proxies. Authored
+roots that do not correspond to a live physics backend object after composition are
+skipped. All live roots, including ``_OnlineVisual`` objects, remain dynamic and
+interactive during physics stepping.
 
 Rigid object sets
 -----------------

--- a/docs/pages/concepts/scene/concept_assets_design.rst
+++ b/docs/pages/concepts/scene/concept_assets_design.rst
@@ -80,6 +80,25 @@ you use an ``ObjectReference``.
 The ``parent_asset`` tells the environment which spawned USD the prim path belongs to.
 The prim path uses ``{ENV_REGEX_NS}`` so it resolves correctly across parallel environments.
 
+Resetting nested background physics
+-----------------------------------
+
+Backgrounds are registered as ``BASE`` assets, but their composed USDs may contain
+dynamic rigid bodies and articulations. Set ``reset_nested_physics=True`` on a
+``Background`` to register those nested physics roots as private Isaac Lab scene
+entities. Arena snapshots their initialized poses, velocities, and joint states and
+restores them on each episode reset without making the bodies kinematic.
+
+Explicit ``ObjectReference`` entries take ownership of their paths and are not
+duplicated. Articulation links are reset through their articulation root, while
+joint-connected rigid bodies without an articulation root are reset individually.
+
+Discovery follows the composed USD physics APIs rather than asset naming conventions.
+For Replicator content, physics contributed by a resolved ``_OnlineVisual`` reference
+is included. A ``_PlacementEnvelope`` is excluded when it is guide geometry without
+physics APIs. Instanceable subtrees that contribute dynamic physics are materialized
+at spawn time because physics views cannot control dynamic instance proxies.
+
 Rigid object sets
 -----------------
 

--- a/isaaclab_arena/assets/background.py
+++ b/isaaclab_arena/assets/background.py
@@ -3,11 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+
+from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs.common import ViewerCfg
 
 from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.usd_prim_tree import UsdPhysicsRootRecord, load_usd_physics_roots
 
 
 class Background(Object):
@@ -22,8 +26,10 @@ class Background(Object):
         object_min_z: float,
         prim_path: str | None = None,
         initial_pose: Pose | None = None,
+        reset_nested_physics: bool = False,
         **kwargs,
     ):
+        self.reset_nested_physics = reset_nested_physics
         super().__init__(
             name=name,
             usd_path=usd_path,
@@ -39,6 +45,57 @@ class Background(Object):
         # TODO(alexmillane, 2025.09.19): Make this value relative to the background
         # prim origin.
         self.object_min_z = object_min_z
+        self._nested_physics_records: list[UsdPhysicsRootRecord] | None = None
+
+    def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
+        """Return a USD spawner that materializes nested instance-proxy physics."""
+        cfg = super()._get_spawn_cfg(activate_contact_sensors)
+        if self.reset_nested_physics:
+            from isaaclab_arena.assets.background_spawner import spawn_from_usd_with_resettable_nested_physics
+
+            cfg.func = spawn_from_usd_with_resettable_nested_physics
+        return cfg
+
+    def get_nested_physics_cfgs(
+        self,
+        claimed_prim_paths: dict[str, ObjectType] | None = None,
+    ) -> dict[str, ArticulationCfg | RigidObjectCfg]:
+        """Return non-spawning configs for unclaimed nested physics roots.
+
+        Args:
+            claimed_prim_paths: Runtime paths already represented by explicit object references.
+
+        Returns:
+            Hidden scene configs keyed by deterministic private names.
+        """
+        if not self.reset_nested_physics:
+            return {}
+        if self._nested_physics_records is None:
+            self._nested_physics_records = load_usd_physics_roots(self.usd_path)
+
+        claimed_prim_paths = claimed_prim_paths or {}
+        configs: dict[str, ArticulationCfg | RigidObjectCfg] = {}
+        background_slug = re.sub(r"\W+", "_", self.name).strip("_")
+        for index, record in enumerate(self._nested_physics_records):
+            prim_path = f"{self.prim_path}/{record.relative_path}"
+            is_claimed = prim_path in claimed_prim_paths or any(
+                claimed_type == ObjectType.ARTICULATION and prim_path.startswith(f"{claimed_path}/")
+                for claimed_path, claimed_type in claimed_prim_paths.items()
+            )
+            if is_claimed:
+                continue
+            path_slug = re.sub(r"\W+", "_", record.relative_path).strip("_")
+            entity_name = f"_background_physics_{background_slug}_{index}_{path_slug}"
+            assert entity_name not in configs, f"Duplicate hidden background entity name: {entity_name}"
+            if record.object_type == ObjectType.ARTICULATION:
+                configs[entity_name] = ArticulationCfg(
+                    prim_path=prim_path,
+                    actuators={},
+                    init_state=ArticulationCfg.InitialStateCfg(joint_pos={}, joint_vel={}),
+                )
+            else:
+                configs[entity_name] = RigidObjectCfg(prim_path=prim_path)
+        return configs
 
     def get_viewer_cfg(self) -> ViewerCfg | None:
         """Return a custom viewer camera framing for this background, or None to auto-frame."""

--- a/isaaclab_arena/assets/background.py
+++ b/isaaclab_arena/assets/background.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import re
-
-from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs.common import ViewerCfg
 
 from isaaclab_arena.assets.object import Object
@@ -56,17 +53,17 @@ class Background(Object):
             cfg.func = spawn_from_usd_with_resettable_nested_physics
         return cfg
 
-    def get_nested_physics_cfgs(
+    def get_nested_physics_prim_paths(
         self,
         claimed_prim_paths: dict[str, ObjectType] | None = None,
-    ) -> dict[str, ArticulationCfg | RigidObjectCfg]:
-        """Return non-spawning configs for unclaimed nested physics roots.
+    ) -> dict[str, ObjectType]:
+        """Return unclaimed nested physics root paths.
 
         Args:
             claimed_prim_paths: Runtime paths already represented by explicit object references.
 
         Returns:
-            Hidden scene configs keyed by deterministic private names.
+            Runtime path templates mapped to their physics object types.
         """
         if not self.reset_nested_physics:
             return {}
@@ -74,9 +71,8 @@ class Background(Object):
             self._nested_physics_records = load_usd_physics_roots(self.usd_path)
 
         claimed_prim_paths = claimed_prim_paths or {}
-        configs: dict[str, ArticulationCfg | RigidObjectCfg] = {}
-        background_slug = re.sub(r"\W+", "_", self.name).strip("_")
-        for index, record in enumerate(self._nested_physics_records):
+        paths: dict[str, ObjectType] = {}
+        for record in self._nested_physics_records:
             prim_path = f"{self.prim_path}/{record.relative_path}"
             is_claimed = prim_path in claimed_prim_paths or any(
                 claimed_type == ObjectType.ARTICULATION and prim_path.startswith(f"{claimed_path}/")
@@ -84,18 +80,8 @@ class Background(Object):
             )
             if is_claimed:
                 continue
-            path_slug = re.sub(r"\W+", "_", record.relative_path).strip("_")
-            entity_name = f"_background_physics_{background_slug}_{index}_{path_slug}"
-            assert entity_name not in configs, f"Duplicate hidden background entity name: {entity_name}"
-            if record.object_type == ObjectType.ARTICULATION:
-                configs[entity_name] = ArticulationCfg(
-                    prim_path=prim_path,
-                    actuators={},
-                    init_state=ArticulationCfg.InitialStateCfg(joint_pos={}, joint_vel={}),
-                )
-            else:
-                configs[entity_name] = RigidObjectCfg(prim_path=prim_path)
-        return configs
+            paths[prim_path] = record.object_type
+        return paths
 
     def get_viewer_cfg(self) -> ViewerCfg | None:
         """Return a custom viewer camera framing for this background, or None to auto-frame."""

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -30,10 +30,12 @@ class LibraryBackground(Background):
     object_min_z: float
     spawn_cfg_addon: dict[str, Any] = {}
     asset_cfg_addon: dict[str, Any] = {}
+    reset_nested_physics = False
 
     def __init__(self, **kwargs):
         # Check lazy USD paths are set by here
         assert self.usd_path is not None
+        kwargs.setdefault("reset_nested_physics", self.reset_nested_physics)
         super().__init__(
             name=self.name,
             tags=self.tags,
@@ -175,6 +177,7 @@ class LightwheelKitchenBackground(LibraryBackground):
     object_min_z = -0.2
     layout_id = 1
     style_id = 1
+    reset_nested_physics = True
 
     def __init__(
         self,
@@ -247,6 +250,7 @@ class ReplicatorKitchenBackground(LibraryBackground):
     tags = ["background", "replicator"]
     initial_pose = Pose.identity()
     object_min_z = -0.2
+    reset_nested_physics = True
 
     def get_viewer_cfg(self) -> ViewerCfg:
         return ViewerCfg(eye=(0.0, -1.0, 1.65), lookat=(0.0, 0.0, 1.35))

--- a/isaaclab_arena/assets/background_spawner.py
+++ b/isaaclab_arena/assets/background_spawner.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""USD spawning helpers for interactive nested background physics."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from isaaclab.sim.spawners.from_files import spawn_from_usd
+from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+from isaaclab.sim.utils import clone
+
+if TYPE_CHECKING:
+    from pxr import Usd
+
+
+def deinstance_nested_physics(prim: Usd.Prim) -> tuple[str, ...]:
+    """De-instance subtrees that contribute dynamic physics prims."""
+    from pxr import Usd, UsdPhysics
+
+    instance_roots: dict[str, Usd.Prim] = {}
+    for candidate in Usd.PrimRange(prim, Usd.TraverseInstanceProxies()):
+        if not (candidate.HasAPI(UsdPhysics.RigidBodyAPI) or candidate.HasAPI(UsdPhysics.ArticulationRootAPI)):
+            continue
+        ancestor = candidate
+        while ancestor.IsValid() and ancestor.GetPath().HasPrefix(prim.GetPath()):
+            if ancestor.IsInstance():
+                instance_roots[str(ancestor.GetPath())] = ancestor
+                break
+            if ancestor == prim:
+                break
+            ancestor = ancestor.GetParent()
+
+    deinstanced_paths = []
+    for path, instance_root in sorted(instance_roots.items()):
+        assert instance_root.SetInstanceable(False), f"Failed to de-instance nested physics subtree '{path}'"
+        deinstanced_paths.append(path)
+    return tuple(deinstanced_paths)
+
+
+@clone
+def spawn_from_usd_with_resettable_nested_physics(
+    prim_path: str,
+    cfg: UsdFileCfg,
+    translation: tuple[float, float, float] | None = None,
+    orientation: tuple[float, float, float, float] | None = None,
+    **kwargs,
+) -> Usd.Prim:
+    """Spawn a USD background and materialize instance-proxy physics subtrees."""
+    prim = spawn_from_usd(prim_path, cfg, translation, orientation, **kwargs)
+    deinstance_nested_physics(prim)
+    return prim

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -42,6 +42,7 @@ from isaaclab_arena.relations.object_placer_params import ObjectPlacerParams
 from isaaclab_arena.relations.placement_events import PLACEMENT_RESET_EVENT_NAME
 from isaaclab_arena.relations.relation_solver_params import RelationSolverParams
 from isaaclab_arena.tasks.no_task import NoTask
+from isaaclab_arena.terms.events import ResetNestedBackgroundPhysics
 from isaaclab_arena.utils.configclass import combine_configclass_instances, make_configclass
 from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
 from isaaclab_arena.utils.isaaclab_utils.resolve_clone_plan_source_patch import patch_resolve_clone_plan_source
@@ -258,8 +259,26 @@ class ArenaEnvBuilder:
         progress_tracking_events_cfg: Any = (
             make_progress_tracking_events_cfg(progress_objectives) if progress_objectives else None
         )
+        background_physics_events_cfg = None
+        background_entities = self.arena_env.scene.get_background_physics_entities()
+        if background_entities:
+            reset_nested_background_physics = EventTermCfg(
+                func=ResetNestedBackgroundPhysics,
+                mode="reset",
+                params={
+                    "background_prim_paths": self.arena_env.scene.get_background_physics_prim_paths(),
+                    "background_entities": background_entities,
+                    "claimed_paths": self.arena_env.scene.get_background_physics_claimed_paths(),
+                },
+            )
+            BackgroundPhysicsEventsCfg = make_configclass(
+                "BackgroundPhysicsEventsCfg",
+                [("reset_nested_background_physics", EventTermCfg, reset_nested_background_physics)],
+            )
+            background_physics_events_cfg = BackgroundPhysicsEventsCfg()
         events_cfg = combine_configclass_instances(
             "EventsCfg",
+            background_physics_events_cfg,
             embodiment.get_events_cfg(),
             self.arena_env.scene.get_events_cfg(),
             task.get_events_cfg(),

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -260,14 +260,14 @@ class ArenaEnvBuilder:
             make_progress_tracking_events_cfg(progress_objectives) if progress_objectives else None
         )
         background_physics_events_cfg = None
-        background_entities = self.arena_env.scene.get_background_physics_entities()
-        if background_entities:
+        background_physics_paths = self.arena_env.scene.get_background_physics_paths()
+        if background_physics_paths:
             reset_nested_background_physics = EventTermCfg(
                 func=ResetNestedBackgroundPhysics,
                 mode="reset",
                 params={
                     "background_prim_paths": self.arena_env.scene.get_background_physics_prim_paths(),
-                    "background_entities": background_entities,
+                    "physics_paths": background_physics_paths,
                     "claimed_paths": self.arena_env.scene.get_background_physics_claimed_paths(),
                 },
             )

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -35,7 +35,7 @@ class Scene:
         self.rewards_cfg = None
         self.curriculum_cfg = None
         self.commands_cfg = None
-        self._background_physics_entities: dict[str, dict[str, str]] = {}
+        self._background_physics_paths: dict[str, dict[str, ObjectType]] = {}
         self._background_physics_claimed_paths: dict[str, dict[str, ObjectType]] = {}
         self._background_physics_prim_paths: dict[str, str] = {}
         if assets is not None:
@@ -73,14 +73,13 @@ class Scene:
         """Returns a configclass containing all the scene elements."""
         # Combine the configs into a configclass.
         fields: list[tuple[str, type, AssetCfg]] = []
-        self._background_physics_entities = {}
+        self._background_physics_paths = {}
         self._background_physics_claimed_paths = {}
         self._background_physics_prim_paths = {}
         for asset in self.assets.values():
             asset_cfg_name, asset_cfg = asset.get_object_cfg()
             fields.append((asset_cfg_name, type(asset_cfg), asset_cfg))
 
-        existing_names = {name for name, _, _ in fields}
         for background in (asset for asset in self.assets.values() if isinstance(asset, Background)):
             if not background.reset_nested_physics:
                 continue
@@ -89,22 +88,16 @@ class Scene:
                 for asset in self.assets.values()
                 if isinstance(asset, ObjectReference) and asset.parent_asset is background
             }
-            hidden_cfgs = background.get_nested_physics_cfgs(claimed_paths)
-            self._background_physics_entities[background.name] = {}
+            self._background_physics_paths[background.name] = background.get_nested_physics_prim_paths(claimed_paths)
             self._background_physics_claimed_paths[background.name] = claimed_paths
             self._background_physics_prim_paths[background.name] = background.prim_path
-            for entity_name, entity_cfg in hidden_cfgs.items():
-                assert entity_name not in existing_names, f"Background physics entity name collision: {entity_name}"
-                existing_names.add(entity_name)
-                fields.append((entity_name, type(entity_cfg), entity_cfg))
-                self._background_physics_entities[background.name][entity_name] = entity_cfg.prim_path
         SceneCfg = make_configclass("SceneCfg", fields)
         scene_cfg = SceneCfg()
         return scene_cfg
 
-    def get_background_physics_entities(self) -> dict[str, dict[str, str]]:
-        """Return opted-in backgrounds mapped to hidden entity names and paths."""
-        return {background: dict(entities) for background, entities in self._background_physics_entities.items()}
+    def get_background_physics_paths(self) -> dict[str, dict[str, ObjectType]]:
+        """Return opted-in backgrounds mapped to deferred-reset physics roots."""
+        return {background: dict(paths) for background, paths in self._background_physics_paths.items()}
 
     def get_background_physics_claimed_paths(self) -> dict[str, dict[str, ObjectType]]:
         """Return opted-in backgrounds mapped to explicitly claimed runtime paths."""

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -12,6 +12,7 @@ from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from pxr import Gf, Usd, UsdGeom
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.background import Background
 from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_reference import ObjectReference
@@ -34,6 +35,9 @@ class Scene:
         self.rewards_cfg = None
         self.curriculum_cfg = None
         self.commands_cfg = None
+        self._background_physics_entities: dict[str, dict[str, str]] = {}
+        self._background_physics_claimed_paths: dict[str, dict[str, ObjectType]] = {}
+        self._background_physics_prim_paths: dict[str, str] = {}
         if assets is not None:
             self.add_assets(assets)
 
@@ -69,12 +73,46 @@ class Scene:
         """Returns a configclass containing all the scene elements."""
         # Combine the configs into a configclass.
         fields: list[tuple[str, type, AssetCfg]] = []
+        self._background_physics_entities = {}
+        self._background_physics_claimed_paths = {}
+        self._background_physics_prim_paths = {}
         for asset in self.assets.values():
             asset_cfg_name, asset_cfg = asset.get_object_cfg()
             fields.append((asset_cfg_name, type(asset_cfg), asset_cfg))
+
+        existing_names = {name for name, _, _ in fields}
+        for background in (asset for asset in self.assets.values() if isinstance(asset, Background)):
+            if not background.reset_nested_physics:
+                continue
+            claimed_paths = {
+                asset.prim_path: asset.object_type
+                for asset in self.assets.values()
+                if isinstance(asset, ObjectReference) and asset.parent_asset is background
+            }
+            hidden_cfgs = background.get_nested_physics_cfgs(claimed_paths)
+            self._background_physics_entities[background.name] = {}
+            self._background_physics_claimed_paths[background.name] = claimed_paths
+            self._background_physics_prim_paths[background.name] = background.prim_path
+            for entity_name, entity_cfg in hidden_cfgs.items():
+                assert entity_name not in existing_names, f"Background physics entity name collision: {entity_name}"
+                existing_names.add(entity_name)
+                fields.append((entity_name, type(entity_cfg), entity_cfg))
+                self._background_physics_entities[background.name][entity_name] = entity_cfg.prim_path
         SceneCfg = make_configclass("SceneCfg", fields)
         scene_cfg = SceneCfg()
         return scene_cfg
+
+    def get_background_physics_entities(self) -> dict[str, dict[str, str]]:
+        """Return opted-in backgrounds mapped to hidden entity names and paths."""
+        return {background: dict(entities) for background, entities in self._background_physics_entities.items()}
+
+    def get_background_physics_claimed_paths(self) -> dict[str, dict[str, ObjectType]]:
+        """Return opted-in backgrounds mapped to explicitly claimed runtime paths."""
+        return {background: dict(paths) for background, paths in self._background_physics_claimed_paths.items()}
+
+    def get_background_physics_prim_paths(self) -> dict[str, str]:
+        """Return opted-in backgrounds mapped to their runtime root paths."""
+        return dict(self._background_physics_prim_paths)
 
     def get_observation_cfg(self) -> Any:
         return self.observation_cfg

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -4,8 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+from dataclasses import dataclass
+from typing import Any
 
+import carb
 import warp as wp
+from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 
@@ -15,18 +19,47 @@ from isaaclab_arena.utils.usd_prim_tree import find_nested_physics_roots
 from isaaclab_arena.utils.velocity import Velocity
 
 
+@dataclass(frozen=True)
+class _RigidReset:
+    """A private rigid asset and its initialized state."""
+
+    asset: Any
+    root_pose: torch.Tensor
+    root_velocity: torch.Tensor
+
+    def restore(self, env_ids: torch.Tensor) -> None:
+        self.asset.write_root_pose_to_sim_index(root_pose=self.root_pose[env_ids], env_ids=env_ids)
+        self.asset.write_root_velocity_to_sim_index(root_velocity=self.root_velocity[env_ids], env_ids=env_ids)
+
+
+@dataclass(frozen=True)
+class _ArticulationReset:
+    """A private articulation asset and its initialized state."""
+
+    asset: Any
+    root_pose: torch.Tensor
+    root_velocity: torch.Tensor
+    joint_position: torch.Tensor
+    joint_velocity: torch.Tensor
+
+    def restore(self, env_ids: torch.Tensor) -> None:
+        self.asset.write_root_pose_to_sim_index(root_pose=self.root_pose[env_ids], env_ids=env_ids)
+        self.asset.write_root_velocity_to_sim_index(root_velocity=self.root_velocity[env_ids], env_ids=env_ids)
+        self.asset.write_joint_position_to_sim_index(position=self.joint_position[env_ids], env_ids=env_ids)
+        self.asset.write_joint_velocity_to_sim_index(velocity=self.joint_velocity[env_ids], env_ids=env_ids)
+
+
 class ResetNestedBackgroundPhysics(ManagerTermBase):
-    """Restore hidden background physics entities to their initialized state."""
+    """Restore unclaimed background physics roots through deferred runtime views."""
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedEnv):
         super().__init__(cfg, env)
         self._background_prim_paths: dict[str, str] = cfg.params["background_prim_paths"]
-        self._background_entities: dict[str, dict[str, str]] = cfg.params["background_entities"]
+        self._physics_paths: dict[str, dict[str, ObjectType]] = cfg.params["physics_paths"]
         self._claimed_paths: dict[str, dict[str, ObjectType]] = cfg.params["claimed_paths"]
-        self._entity_names = {
-            entity_name for entities in self._background_entities.values() for entity_name in entities
-        }
-        self._initial_state: dict[str, dict[str, dict[str, torch.Tensor]]] | None = None
+        self._is_initialized = False
+        self._rigid_resets: list[_RigidReset] = []
+        self._articulation_resets: list[_ArticulationReset] = []
 
     @staticmethod
     def _runtime_path(path_template: str, env_prim_path: str) -> str:
@@ -53,9 +86,7 @@ class ResetNestedBackgroundPhysics(ManagerTermBase):
                     for claimed_path, claimed_type in claimed_paths.items()
                 )
             }
-            expected_paths = {
-                self._runtime_path(path, env_prim_path) for path in self._background_entities[background_name].values()
-            }
+            expected_paths = {self._runtime_path(path, env_prim_path) for path in self._physics_paths[background_name]}
             missing = sorted(unclaimed_runtime_paths - expected_paths)
             stale = sorted(expected_paths - unclaimed_runtime_paths)
             assert not missing and not stale, (
@@ -64,47 +95,69 @@ class ResetNestedBackgroundPhysics(ManagerTermBase):
             )
 
     def _capture_initial_state(self, env: ManagerBasedEnv) -> None:
+        """Create private assets after simulation initialization and snapshot their state."""
         self._validate_runtime_composition(env)
-        scene_state = env.scene.get_state(is_relative=False)
-        self._initial_state = {"articulation": {}, "rigid_object": {}}
-        for asset_type in self._initial_state:
-            for entity_name, asset_state in scene_state[asset_type].items():
-                if entity_name in self._entity_names:
-                    self._initial_state[asset_type][entity_name] = {
-                        state_name: value.clone() for state_name, value in asset_state.items()
-                    }
-        captured_names = {entity_name for assets in self._initial_state.values() for entity_name in assets}
-        assert captured_names == self._entity_names, (
-            "Hidden background entities were not initialized as rigid objects or articulations: "
-            f"{sorted(self._entity_names - captured_names)}"
-        )
+        for physics_paths in self._physics_paths.values():
+            for path_template, object_type in physics_paths.items():
+                prim_path = path_template.replace("{ENV_REGEX_NS}", env.scene.env_regex_ns)
+                if object_type == ObjectType.ARTICULATION:
+                    asset_cfg = ArticulationCfg(
+                        prim_path=prim_path,
+                        actuators={},
+                        init_state=ArticulationCfg.InitialStateCfg(joint_pos={}, joint_vel={}),
+                    )
+                    asset = asset_cfg.class_type(asset_cfg)
+                    try:
+                        asset._initialize_callback(None)
+                    except (AttributeError, RuntimeError) as exc:
+                        asset._clear_callbacks()
+                        carb.log_warn(f"Skipping unavailable background articulation '{prim_path}': {exc}")
+                        continue
+                    self._articulation_resets.append(
+                        _ArticulationReset(
+                            asset=asset,
+                            root_pose=asset.data.root_pose_w.torch.clone(),
+                            root_velocity=asset.data.root_vel_w.torch.clone(),
+                            joint_position=asset.data.joint_pos.torch.clone(),
+                            joint_velocity=asset.data.joint_vel.torch.clone(),
+                        )
+                    )
+                else:
+                    asset_cfg = RigidObjectCfg(prim_path=prim_path)
+                    asset = asset_cfg.class_type(asset_cfg)
+                    try:
+                        asset._initialize_callback(None)
+                    except (AttributeError, RuntimeError) as exc:
+                        asset._clear_callbacks()
+                        carb.log_warn(f"Skipping unavailable background rigid body '{prim_path}': {exc}")
+                        continue
+                    self._rigid_resets.append(
+                        _RigidReset(
+                            asset=asset,
+                            root_pose=asset.data.root_pose_w.torch.clone(),
+                            root_velocity=asset.data.root_vel_w.torch.clone(),
+                        )
+                    )
+        self._is_initialized = True
 
     def __call__(
         self,
         env: ManagerBasedEnv,
         env_ids: torch.Tensor | None,
         background_prim_paths: dict[str, str],  # noqa: ARG002
-        background_entities: dict[str, dict[str, str]],  # noqa: ARG002
+        physics_paths: dict[str, dict[str, ObjectType]],  # noqa: ARG002
         claimed_paths: dict[str, dict[str, ObjectType]],  # noqa: ARG002
     ) -> None:
-        if self._initial_state is None:
+        if not self._is_initialized:
             self._capture_initial_state(env)
-        assert self._initial_state is not None
         if env_ids is None:
             env_ids = torch.arange(env.scene.num_envs, device=env.device)
         else:
             env_ids = torch.as_tensor(env_ids, device=env.device).reshape(-1)
-
-        for entity_name, state in self._initial_state["rigid_object"].items():
-            asset = env.scene.rigid_objects[entity_name]
-            asset.write_root_pose_to_sim_index(root_pose=state["root_pose"][env_ids], env_ids=env_ids)
-            asset.write_root_velocity_to_sim_index(root_velocity=state["root_velocity"][env_ids], env_ids=env_ids)
-        for entity_name, state in self._initial_state["articulation"].items():
-            asset = env.scene.articulations[entity_name]
-            asset.write_root_pose_to_sim_index(root_pose=state["root_pose"][env_ids], env_ids=env_ids)
-            asset.write_root_velocity_to_sim_index(root_velocity=state["root_velocity"][env_ids], env_ids=env_ids)
-            asset.write_joint_position_to_sim_index(position=state["joint_position"][env_ids], env_ids=env_ids)
-            asset.write_joint_velocity_to_sim_index(velocity=state["joint_velocity"][env_ids], env_ids=env_ids)
+        for reset in self._rigid_resets:
+            reset.restore(env_ids)
+        for reset in self._articulation_resets:
+            reset.restore(env_ids)
 
 
 def set_object_pose(

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -7,10 +7,104 @@ import torch
 
 import warp as wp
 from isaaclab.envs import ManagerBasedEnv
-from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.usd_prim_tree import find_nested_physics_roots
 from isaaclab_arena.utils.velocity import Velocity
+
+
+class ResetNestedBackgroundPhysics(ManagerTermBase):
+    """Restore hidden background physics entities to their initialized state."""
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+        self._background_prim_paths: dict[str, str] = cfg.params["background_prim_paths"]
+        self._background_entities: dict[str, dict[str, str]] = cfg.params["background_entities"]
+        self._claimed_paths: dict[str, dict[str, ObjectType]] = cfg.params["claimed_paths"]
+        self._entity_names = {
+            entity_name for entities in self._background_entities.values() for entity_name in entities
+        }
+        self._initial_state: dict[str, dict[str, dict[str, torch.Tensor]]] | None = None
+
+    @staticmethod
+    def _runtime_path(path_template: str, env_prim_path: str) -> str:
+        return path_template.replace("{ENV_REGEX_NS}", env_prim_path)
+
+    def _validate_runtime_composition(self, env: ManagerBasedEnv) -> None:
+        """Verify source-stage discovery covers every live unclaimed physics root."""
+        env_prim_path = env.scene.env_prim_paths[0]
+        for background_name, background_path_template in self._background_prim_paths.items():
+            background_path = self._runtime_path(background_path_template, env_prim_path)
+            background_prim = env.scene.stage.GetPrimAtPath(background_path)
+            assert background_prim.IsValid(), f"Missing opted-in background prim at '{background_path}'"
+            runtime_roots = find_nested_physics_roots(background_prim)
+            claimed_paths = {
+                self._runtime_path(path, env_prim_path): object_type
+                for path, object_type in self._claimed_paths[background_name].items()
+            }
+            unclaimed_runtime_paths = {
+                path
+                for path in runtime_roots
+                if path not in claimed_paths
+                and not any(
+                    claimed_type == ObjectType.ARTICULATION and path.startswith(f"{claimed_path}/")
+                    for claimed_path, claimed_type in claimed_paths.items()
+                )
+            }
+            expected_paths = {
+                self._runtime_path(path, env_prim_path) for path in self._background_entities[background_name].values()
+            }
+            missing = sorted(unclaimed_runtime_paths - expected_paths)
+            stale = sorted(expected_paths - unclaimed_runtime_paths)
+            assert not missing and not stale, (
+                f"Nested physics discovery for background '{background_name}' differs from the live composed stage. "
+                f"Unregistered runtime roots: {missing}. Missing runtime roots for generated entities: {stale}."
+            )
+
+    def _capture_initial_state(self, env: ManagerBasedEnv) -> None:
+        self._validate_runtime_composition(env)
+        scene_state = env.scene.get_state(is_relative=False)
+        self._initial_state = {"articulation": {}, "rigid_object": {}}
+        for asset_type in self._initial_state:
+            for entity_name, asset_state in scene_state[asset_type].items():
+                if entity_name in self._entity_names:
+                    self._initial_state[asset_type][entity_name] = {
+                        state_name: value.clone() for state_name, value in asset_state.items()
+                    }
+        captured_names = {entity_name for assets in self._initial_state.values() for entity_name in assets}
+        assert captured_names == self._entity_names, (
+            "Hidden background entities were not initialized as rigid objects or articulations: "
+            f"{sorted(self._entity_names - captured_names)}"
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedEnv,
+        env_ids: torch.Tensor | None,
+        background_prim_paths: dict[str, str],  # noqa: ARG002
+        background_entities: dict[str, dict[str, str]],  # noqa: ARG002
+        claimed_paths: dict[str, dict[str, ObjectType]],  # noqa: ARG002
+    ) -> None:
+        if self._initial_state is None:
+            self._capture_initial_state(env)
+        assert self._initial_state is not None
+        if env_ids is None:
+            env_ids = torch.arange(env.scene.num_envs, device=env.device)
+        else:
+            env_ids = torch.as_tensor(env_ids, device=env.device).reshape(-1)
+
+        for entity_name, state in self._initial_state["rigid_object"].items():
+            asset = env.scene.rigid_objects[entity_name]
+            asset.write_root_pose_to_sim_index(root_pose=state["root_pose"][env_ids], env_ids=env_ids)
+            asset.write_root_velocity_to_sim_index(root_velocity=state["root_velocity"][env_ids], env_ids=env_ids)
+        for entity_name, state in self._initial_state["articulation"].items():
+            asset = env.scene.articulations[entity_name]
+            asset.write_root_pose_to_sim_index(root_pose=state["root_pose"][env_ids], env_ids=env_ids)
+            asset.write_root_velocity_to_sim_index(root_velocity=state["root_velocity"][env_ids], env_ids=env_ids)
+            asset.write_joint_position_to_sim_index(position=state["joint_position"][env_ids], env_ids=env_ids)
+            asset.write_joint_velocity_to_sim_index(velocity=state["joint_velocity"][env_ids], env_ids=env_ids)
 
 
 def set_object_pose(

--- a/isaaclab_arena/tests/test_background_physics_reset.py
+++ b/isaaclab_arena/tests/test_background_physics_reset.py
@@ -75,7 +75,6 @@ def _test_background_physics_discovery_and_reset(
     import tempfile
     import torch
 
-    from isaaclab.assets import ArticulationCfg, RigidObjectCfg
     from pxr import UsdPhysics
 
     from isaaclab_arena.assets.background import Background
@@ -112,11 +111,14 @@ def _test_background_physics_discovery_and_reset(
             object_min_z=0.0,
             reset_nested_physics=True,
         )
-        configs = background.get_nested_physics_cfgs({"{ENV_REGEX_NS}/background/free_body": ObjectType.RIGID})
-        assert len(configs) == (4 if include_joint_network else 2)
-        assert sum(isinstance(cfg, ArticulationCfg) for cfg in configs.values()) == 1
-        assert sum(isinstance(cfg, RigidObjectCfg) for cfg in configs.values()) == (3 if include_joint_network else 1)
-        assert all(cfg.spawn is None for cfg in configs.values())
+        physics_paths = background.get_nested_physics_prim_paths(
+            {"{ENV_REGEX_NS}/background/free_body": ObjectType.RIGID}
+        )
+        assert len(physics_paths) == (4 if include_joint_network else 2)
+        assert sum(object_type == ObjectType.ARTICULATION for object_type in physics_paths.values()) == 1
+        assert sum(object_type == ObjectType.RIGID for object_type in physics_paths.values()) == (
+            3 if include_joint_network else 1
+        )
 
         scene = Scene(
             assets=[
@@ -132,71 +134,60 @@ def _test_background_physics_discovery_and_reset(
         args = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "2", *cli_options])
         builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args))
         env_cfg, _ = builder.compose_manager_cfg()
-        hidden_entities = scene.get_background_physics_entities()["background"]
-        assert len(hidden_entities) == (5 if include_joint_network else 3)
+        reset_paths = scene.get_background_physics_paths()["background"]
+        assert len(reset_paths) == (5 if include_joint_network else 3)
         assert list(vars(env_cfg.events))[0] == "reset_nested_background_physics"
 
         env = builder.make_registered(env_cfg)
         try:
             env.reset()
             base_env = env.unwrapped
-            initial_state = base_env.scene.get_state()
-            rigid_name = next(name for name, path in hidden_entities.items() if path.endswith("/free_body"))
-            articulation_name = next(name for name in hidden_entities if name in base_env.scene.articulations)
-
-            rigid = base_env.scene.rigid_objects[rigid_name]
-            initial_pose = initial_state["rigid_object"][rigid_name]["root_pose"].clone()
-            initial_joint_position = initial_state["articulation"][articulation_name]["joint_position"].clone()
+            reset_term = base_env.event_manager.get_term_cfg("reset_nested_background_physics").func
+            rigid_reset = next(
+                reset for reset in reset_term._rigid_resets if reset.asset.cfg.prim_path.endswith("/free_body")
+            )
+            articulation_reset = reset_term._articulation_resets[0]
+            rigid = rigid_reset.asset
+            articulation = articulation_reset.asset
+            initial_pose = rigid_reset.root_pose
+            initial_velocity = rigid_reset.root_velocity
+            initial_joint_position = articulation_reset.joint_position
+            env_ids = torch.arange(2, device=base_env.device)
             if check_interactivity:
-                probe_velocity = torch.zeros((1, 6), device=base_env.device)
-                probe_velocity[:, 0] = 2.0
-                rigid.write_root_velocity_to_sim_index(
-                    root_velocity=probe_velocity,
-                    env_ids=torch.tensor([0], device=base_env.device),
-                )
+                probe_velocity = initial_velocity.clone()
+                probe_velocity[0, 0] = 2.0
+                rigid.write_root_velocity_to_sim_index(root_velocity=probe_velocity, env_ids=env_ids)
                 base_env.sim.step()
                 base_env.scene.update(base_env.step_dt)
+                rigid.update(base_env.step_dt)
                 assert rigid.data.root_pose_w.torch[0, 0] > initial_pose[0, 0]
                 base_env.reset(env_ids=torch.arange(2, device=base_env.device))
 
             moved_pose = initial_pose.clone()
             moved_pose[:, 0] += 0.4
-            env_ids = torch.arange(2, device=base_env.device)
             rigid.write_root_pose_to_sim_index(root_pose=moved_pose, env_ids=env_ids)
             rigid.write_root_velocity_to_sim_index(
                 root_velocity=torch.ones((2, 6), device=base_env.device),
                 env_ids=env_ids,
             )
-
-            articulation_asset = base_env.scene.articulations[articulation_name]
             moved_joint_position = initial_joint_position.clone()
             moved_joint_position[:, 0] += 0.2
-            articulation_asset.write_joint_position_to_sim_index(position=moved_joint_position, env_ids=env_ids)
+            articulation.write_joint_position_to_sim_index(position=moved_joint_position, env_ids=env_ids)
 
             runtime_rigid_prim = base_env.scene.stage.GetPrimAtPath(
-                hidden_entities[rigid_name].replace("{ENV_REGEX_NS}", base_env.scene.env_prim_paths[0])
+                rigid.cfg.prim_path.replace(base_env.scene.env_regex_ns, base_env.scene.env_prim_paths[0])
             )
             kinematic_attr = UsdPhysics.RigidBodyAPI(runtime_rigid_prim).GetKinematicEnabledAttr()
             assert not kinematic_attr or not kinematic_attr.Get()
 
             base_env.reset(env_ids=torch.tensor([0], device=base_env.device))
-            reset_state = base_env.scene.get_state()
-            assert torch.allclose(
-                reset_state["rigid_object"][rigid_name]["root_pose"][0],
-                initial_pose[0],
-                atol=1.0e-5,
-            )
-            assert torch.allclose(
-                reset_state["rigid_object"][rigid_name]["root_velocity"][0],
-                initial_state["rigid_object"][rigid_name]["root_velocity"][0],
-                atol=1.0e-5,
-            )
-            assert torch.allclose(
-                reset_state["articulation"][articulation_name]["joint_position"][0],
-                initial_joint_position[0],
-                atol=1.0e-5,
-            )
-            assert torch.allclose(reset_state["rigid_object"][rigid_name]["root_pose"][1], moved_pose[1])
+            reset_pose = rigid.data.root_pose_w.torch
+            reset_velocity = rigid.data.root_vel_w.torch
+            reset_joint_position = articulation.data.joint_pos.torch
+            assert torch.allclose(reset_pose[0], initial_pose[0], atol=1.0e-5)
+            assert torch.allclose(reset_velocity[0], initial_velocity[0], atol=1.0e-5)
+            assert torch.allclose(reset_joint_position[0], initial_joint_position[0], atol=1.0e-5)
+            assert torch.allclose(reset_pose[1], moved_pose[1])
         finally:
             env.close()
     return True

--- a/isaaclab_arena/tests/test_background_physics_reset.py
+++ b/isaaclab_arena/tests/test_background_physics_reset.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test discovery and reset of dynamic entities nested in background USDs."""
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+
+def _create_background_usds(
+    background_path: str,
+    online_asset_path: str,
+    include_joint_network: bool = True,
+) -> None:
+    """Create composed loose, jointed, articulated, and guide content."""
+    from pxr import Gf, Usd, UsdGeom, UsdPhysics
+
+    online_stage = Usd.Stage.CreateNew(online_asset_path)
+    online_root = UsdGeom.Xform.Define(online_stage, "/OnlineAsset")
+    online_stage.SetDefaultPrim(online_root.GetPrim())
+    online_body = UsdGeom.Cube.Define(online_stage, "/OnlineAsset/body")
+    online_body.CreateSizeAttr(0.1)
+    UsdPhysics.CollisionAPI.Apply(online_body.GetPrim())
+    UsdPhysics.RigidBodyAPI.Apply(online_body.GetPrim())
+    online_stage.GetRootLayer().Save()
+
+    stage = Usd.Stage.CreateNew(background_path)
+    root = UsdGeom.Xform.Define(stage, "/Background")
+    stage.SetDefaultPrim(root.GetPrim())
+
+    def add_cube(prim_path: str, position: tuple[float, float, float]) -> Usd.Prim:
+        cube = UsdGeom.Cube.Define(stage, prim_path)
+        cube.CreateSizeAttr(0.2)
+        cube.AddTranslateOp().Set(Gf.Vec3d(*position))
+        UsdPhysics.CollisionAPI.Apply(cube.GetPrim())
+        UsdPhysics.RigidBodyAPI.Apply(cube.GetPrim())
+        UsdPhysics.MassAPI.Apply(cube.GetPrim()).CreateMassAttr(1.0)
+        return cube.GetPrim()
+
+    add_cube("/Background/free_body", (-0.6, 0.0, 1.0))
+    if include_joint_network:
+        add_cube("/Background/hinged/base", (-0.2, 0.0, 1.0))
+        add_cube("/Background/hinged/door", (0.0, 0.0, 1.0))
+        hinge = UsdPhysics.RevoluteJoint.Define(stage, "/Background/hinged/joint")
+        hinge.CreateBody0Rel().SetTargets(["/Background/hinged/base"])
+        hinge.CreateBody1Rel().SetTargets(["/Background/hinged/door"])
+        hinge.CreateAxisAttr("Z")
+
+    articulation = UsdGeom.Xform.Define(stage, "/Background/articulation")
+    UsdPhysics.ArticulationRootAPI.Apply(articulation.GetPrim())
+    add_cube("/Background/articulation/base", (0.3, 0.0, 1.0))
+    add_cube("/Background/articulation/link", (0.5, 0.0, 1.0))
+    fixed_joint = UsdPhysics.FixedJoint.Define(stage, "/Background/articulation/world_joint")
+    fixed_joint.CreateBody1Rel().SetTargets(["/Background/articulation/base"])
+    articulation_joint = UsdPhysics.RevoluteJoint.Define(stage, "/Background/articulation/joint")
+    articulation_joint.CreateBody0Rel().SetTargets(["/Background/articulation/base"])
+    articulation_joint.CreateBody1Rel().SetTargets(["/Background/articulation/link"])
+    articulation_joint.CreateAxisAttr("Z")
+
+    online_visual = stage.DefinePrim("/Background/Prop_OnlineVisual", "Xform")
+    online_visual.GetReferences().AddReference(online_asset_path)
+    online_visual.SetInstanceable(True)
+    placement_envelope = UsdGeom.Cube.Define(stage, "/Background/Prop_PlacementEnvelope")
+    placement_envelope.CreatePurposeAttr("guide")
+    stage.GetRootLayer().Save()
+
+
+def _test_background_physics_discovery_and_reset(
+    _,
+    cli_options: tuple[str, ...] = (),
+    check_interactivity: bool = True,
+    include_joint_network: bool = True,
+) -> bool:
+    import tempfile
+    import torch
+
+    from isaaclab.assets import ArticulationCfg, RigidObjectCfg
+    from pxr import UsdPhysics
+
+    from isaaclab_arena.assets.background import Background
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.usd_prim_tree import load_usd_physics_roots
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        background_path = f"{temp_dir}/background.usd"
+        online_asset_path = f"{temp_dir}/online_asset.usd"
+        _create_background_usds(background_path, online_asset_path, include_joint_network)
+
+        records = {record.relative_path: record.object_type for record in load_usd_physics_roots(background_path)}
+        expected_records = {
+            "Prop_OnlineVisual/body": ObjectType.RIGID,
+            "articulation": ObjectType.ARTICULATION,
+            "free_body": ObjectType.RIGID,
+        }
+        if include_joint_network:
+            expected_records.update({
+                "hinged/base": ObjectType.RIGID,
+                "hinged/door": ObjectType.RIGID,
+            })
+        assert records == expected_records
+        assert "Prop_PlacementEnvelope" not in records
+        assert not any(path.startswith("articulation/") for path in records)
+
+        background = Background(
+            "background",
+            background_path,
+            object_min_z=0.0,
+            reset_nested_physics=True,
+        )
+        configs = background.get_nested_physics_cfgs({"{ENV_REGEX_NS}/background/free_body": ObjectType.RIGID})
+        assert len(configs) == (4 if include_joint_network else 2)
+        assert sum(isinstance(cfg, ArticulationCfg) for cfg in configs.values()) == 1
+        assert sum(isinstance(cfg, RigidObjectCfg) for cfg in configs.values()) == (3 if include_joint_network else 1)
+        assert all(cfg.spawn is None for cfg in configs.values())
+
+        scene = Scene(
+            assets=[
+                Background(
+                    "background",
+                    background_path,
+                    object_min_z=0.0,
+                    reset_nested_physics=True,
+                )
+            ]
+        )
+        arena_env = IsaacLabArenaEnvironment(name="background_physics_reset", scene=scene)
+        args = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "2", *cli_options])
+        builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args))
+        env_cfg, _ = builder.compose_manager_cfg()
+        hidden_entities = scene.get_background_physics_entities()["background"]
+        assert len(hidden_entities) == (5 if include_joint_network else 3)
+        assert list(vars(env_cfg.events))[0] == "reset_nested_background_physics"
+
+        env = builder.make_registered(env_cfg)
+        try:
+            env.reset()
+            base_env = env.unwrapped
+            initial_state = base_env.scene.get_state()
+            rigid_name = next(name for name, path in hidden_entities.items() if path.endswith("/free_body"))
+            articulation_name = next(name for name in hidden_entities if name in base_env.scene.articulations)
+
+            rigid = base_env.scene.rigid_objects[rigid_name]
+            initial_pose = initial_state["rigid_object"][rigid_name]["root_pose"].clone()
+            initial_joint_position = initial_state["articulation"][articulation_name]["joint_position"].clone()
+            if check_interactivity:
+                probe_velocity = torch.zeros((1, 6), device=base_env.device)
+                probe_velocity[:, 0] = 2.0
+                rigid.write_root_velocity_to_sim_index(
+                    root_velocity=probe_velocity,
+                    env_ids=torch.tensor([0], device=base_env.device),
+                )
+                base_env.sim.step()
+                base_env.scene.update(base_env.step_dt)
+                assert rigid.data.root_pose_w.torch[0, 0] > initial_pose[0, 0]
+                base_env.reset(env_ids=torch.arange(2, device=base_env.device))
+
+            moved_pose = initial_pose.clone()
+            moved_pose[:, 0] += 0.4
+            env_ids = torch.arange(2, device=base_env.device)
+            rigid.write_root_pose_to_sim_index(root_pose=moved_pose, env_ids=env_ids)
+            rigid.write_root_velocity_to_sim_index(
+                root_velocity=torch.ones((2, 6), device=base_env.device),
+                env_ids=env_ids,
+            )
+
+            articulation_asset = base_env.scene.articulations[articulation_name]
+            moved_joint_position = initial_joint_position.clone()
+            moved_joint_position[:, 0] += 0.2
+            articulation_asset.write_joint_position_to_sim_index(position=moved_joint_position, env_ids=env_ids)
+
+            runtime_rigid_prim = base_env.scene.stage.GetPrimAtPath(
+                hidden_entities[rigid_name].replace("{ENV_REGEX_NS}", base_env.scene.env_prim_paths[0])
+            )
+            kinematic_attr = UsdPhysics.RigidBodyAPI(runtime_rigid_prim).GetKinematicEnabledAttr()
+            assert not kinematic_attr or not kinematic_attr.Get()
+
+            base_env.reset(env_ids=torch.tensor([0], device=base_env.device))
+            reset_state = base_env.scene.get_state()
+            assert torch.allclose(
+                reset_state["rigid_object"][rigid_name]["root_pose"][0],
+                initial_pose[0],
+                atol=1.0e-5,
+            )
+            assert torch.allclose(
+                reset_state["rigid_object"][rigid_name]["root_velocity"][0],
+                initial_state["rigid_object"][rigid_name]["root_velocity"][0],
+                atol=1.0e-5,
+            )
+            assert torch.allclose(
+                reset_state["articulation"][articulation_name]["joint_position"][0],
+                initial_joint_position[0],
+                atol=1.0e-5,
+            )
+            assert torch.allclose(reset_state["rigid_object"][rigid_name]["root_pose"][1], moved_pose[1])
+        finally:
+            env.close()
+    return True
+
+
+def test_background_physics_discovery_and_reset():
+    assert run_function_with_persistent_simulation_app(_test_background_physics_discovery_and_reset)
+
+
+def test_background_physics_reset_without_fabric():
+    assert run_function_with_persistent_simulation_app(
+        _test_background_physics_discovery_and_reset,
+        cli_options=("--disable_fabric",),
+    )
+
+
+def test_background_physics_reset_with_newton():
+    assert run_function_with_persistent_simulation_app(
+        _test_background_physics_discovery_and_reset,
+        cli_options=("--presets", "newton"),
+        check_interactivity=False,
+        include_joint_network=False,
+    )

--- a/isaaclab_arena/tests/test_background_physics_reset_cameras.py
+++ b/isaaclab_arena/tests/test_background_physics_reset_cameras.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""RTX regression coverage for composed Replicator background physics."""
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+
+def _test_replicator_online_visual_physics_with_rtx(_) -> bool:
+    import sys
+    import torch
+
+    import warp as wp
+
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
+
+    env_spec = "isaaclab_arena_environments/kitchen_bench/replicator_kitchen_peninsula_mustard_bowl.yaml"
+    previous_argv = sys.argv
+    sys.argv = [
+        "test_background_physics_reset_cameras.py",
+        "--env_spec",
+        env_spec,
+        "--headless",
+        "--num_envs",
+        "1",
+        "--enable_cameras",
+    ]
+    try:
+        args = get_isaaclab_arena_environments_cli_parser().parse_args()
+    finally:
+        sys.argv = previous_argv
+
+    builder = get_arena_builder_from_cli(args)
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    env = builder.make_registered(env_cfg, env_kwargs, render_mode="rgb_array")
+    try:
+        env.reset()
+        physics_paths = builder.arena_env.scene.get_background_physics_paths()["replicator_kitchen_peninsula"]
+        assert len(physics_paths) == 56
+        banana_path = next(
+            path for path, object_type in physics_paths.items() if "Banana" in path and object_type == ObjectType.RIGID
+        )
+        runtime_path = banana_path.replace("{ENV_REGEX_NS}", env.unwrapped.scene.env_prim_paths[0])
+        banana_view = env.unwrapped.sim.physics_manager.get_physics_sim_view().create_rigid_body_view(runtime_path)
+        assert banana_view.count == 1
+        initial_transform = wp.to_torch(banana_view.get_transforms()).clone()
+        initial_velocity = wp.to_torch(banana_view.get_velocities()).clone()
+        moved_transform = initial_transform.clone()
+        moved_transform[:, 0] += 1.0
+        indices = wp.from_torch(torch.tensor([0], device=env.unwrapped.device, dtype=torch.int32))
+        banana_view.set_transforms(wp.from_torch(moved_transform), indices=indices)
+        banana_view.set_velocities(
+            wp.from_torch(torch.ones((1, 6), device=env.unwrapped.device)),
+            indices=indices,
+        )
+
+        env.reset()
+        assert torch.allclose(wp.to_torch(banana_view.get_transforms()), initial_transform, atol=1.0e-5)
+        assert torch.allclose(
+            wp.to_torch(banana_view.get_velocities()),
+            initial_velocity,
+            atol=1.0e-5,
+        )
+    finally:
+        env.close()
+    return True
+
+
+@pytest.mark.with_cameras
+def test_replicator_online_visual_physics_with_rtx():
+    assert run_function_with_persistent_simulation_app(
+        _test_replicator_online_visual_physics_with_rtx,
+        enable_cameras=True,
+    )

--- a/isaaclab_arena/tests/test_usd_prim_tree.py
+++ b/isaaclab_arena/tests/test_usd_prim_tree.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environment_spec.arena_env_graph_types import AssetSpec
-from isaaclab_arena.utils.usd_prim_tree import load_usd_prim_tree
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+from isaaclab_arena.utils.usd_prim_tree import load_usd_physics_roots, load_usd_prim_tree
 
 
-def test_kitchen_prim_tree_counter_and_fridge():
+def _test_kitchen_physics_prim_trees(_) -> bool:
     """Requires Lightwheel Robocasa kitchen USD on disk (Docker dev image)."""
     usd_path = AssetSpec(
         id="lightwheel_robocasa_kitchen",
@@ -30,3 +31,24 @@ def test_kitchen_prim_tree_counter_and_fridge():
     assert fridge is not None, "fridge_main_group missing from kitchen USD"
     assert fridge.object_type == ObjectType.ARTICULATION
     assert "fridge_door_joint" in fridge.joint_names
+
+    physics_roots = load_usd_physics_roots(usd_path)
+    assert len(physics_roots) == 21
+    assert all(record.object_type == ObjectType.ARTICULATION for record in physics_roots)
+
+    usd_path = AssetSpec(
+        id="replicator_kitchen_peninsula",
+        registry_name="replicator_kitchen_peninsula",
+    ).resolve_usd_path()
+    physics_roots = load_usd_physics_roots(usd_path)
+
+    assert len(physics_roots) == 56
+    online_visual_roots = [record for record in physics_roots if "_OnlineVisual" in record.relative_path]
+    assert len(online_visual_roots) == 24
+    assert any(record.object_type == ObjectType.ARTICULATION for record in online_visual_roots)
+    assert any(record.object_type == ObjectType.RIGID for record in online_visual_roots)
+    return True
+
+
+def test_kitchen_physics_prim_trees():
+    assert run_function_with_persistent_simulation_app(_test_kitchen_physics_prim_trees)

--- a/isaaclab_arena/utils/usd_prim_tree.py
+++ b/isaaclab_arena/utils/usd_prim_tree.py
@@ -21,6 +21,91 @@ class UsdPrimRecord:
     joint_names: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class UsdPhysicsRootRecord:
+    """One independently resettable physics root inside a composed USD asset."""
+
+    relative_path: str
+    object_type: ObjectType
+
+
+def _traverse_composed_stage(stage):
+    """Traverse loaded prims, including prims beneath instance proxies."""
+    from pxr import Usd
+
+    stage.Load()
+    return Usd.PrimRange.Stage(stage, Usd.TraverseInstanceProxies())
+
+
+def find_nested_physics_roots(root_prim) -> dict[str, ObjectType]:
+    """Return absolute paths of independently resettable physics roots below a prim."""
+    from pxr import Usd
+
+    from isaaclab_arena.utils.usd_helpers import is_articulation_root, is_rigid_body
+
+    prims = list(Usd.PrimRange(root_prim, Usd.TraverseInstanceProxies()))
+    articulation_paths = tuple(prim.GetPath() for prim in prims if is_articulation_root(prim))
+    roots: dict[str, ObjectType] = {}
+    for prim in prims:
+        prim_path = prim.GetPath()
+        if prim == root_prim:
+            continue
+        if is_articulation_root(prim):
+            roots[str(prim_path)] = ObjectType.ARTICULATION
+        elif is_rigid_body(prim) and not any(
+            prim_path != articulation_path and prim_path.HasPrefix(articulation_path)
+            for articulation_path in articulation_paths
+        ):
+            roots[str(prim_path)] = ObjectType.RIGID
+    return roots
+
+
+def load_usd_physics_roots(usd_path: str) -> list[UsdPhysicsRootRecord]:
+    """Return independently resettable physics roots in a composed USD asset.
+
+    Articulation links are owned by their articulation root and are omitted.
+    Rigid bodies outside articulation subtrees remain separate records, including
+    bodies connected by ordinary USD joints.
+
+    Args:
+        usd_path: Local filesystem path or Nucleus/HTTPS URL for the USD.
+
+    Returns:
+        Sorted records keyed by default-prim-relative path.
+    """
+    from isaaclab.utils.assets import retrieve_file_path
+    from pxr import Tf, Usd
+
+    from isaaclab_arena.utils.usd_helpers import relative_path_from_default_prim
+
+    records: list[UsdPhysicsRootRecord] = []
+    try:
+        stage = Usd.Stage.Open(usd_path)
+    except Tf.ErrorException:
+        stage = None
+    if stage is None:
+        stage = Usd.Stage.Open(retrieve_file_path(usd_path))
+    assert stage is not None, f"Failed to open composed USD stage: {usd_path}"
+    try:
+        stage.Load()
+        for prim_path, object_type in find_nested_physics_roots(stage.GetDefaultPrim()).items():
+            relative_path = relative_path_from_default_prim(stage, prim_path)
+            if not relative_path:
+                continue
+            records.append(UsdPhysicsRootRecord(relative_path=relative_path, object_type=object_type))
+    finally:
+        del stage
+
+    records.sort(key=lambda record: (record.relative_path, record.object_type.value))
+    duplicate_paths = [
+        path
+        for path in {record.relative_path for record in records}
+        if sum(record.relative_path == path for record in records) > 1
+    ]
+    assert not duplicate_paths, f"Physics roots have duplicate composed paths: {sorted(duplicate_paths)}"
+    return records
+
+
 def load_usd_prim_tree(usd_path: str) -> list[UsdPrimRecord]:
     """Return prim records for the physics/collision subtree of a USD asset.
 
@@ -55,7 +140,7 @@ def load_usd_prim_tree(usd_path: str) -> list[UsdPrimRecord]:
         # TODO(qianl): Ancestor-only prims are labeled base; non-leaf refs are valid today.
         # Revisit when relation solving adds descendant mesh exclusion; no issue observed yet.
         included_paths: set[str] = set()
-        for prim in stage.Traverse():
+        for prim in _traverse_composed_stage(stage):
             if prim.IsPseudoRoot():
                 continue
             if not has_physics_or_collision(prim):
@@ -68,7 +153,7 @@ def load_usd_prim_tree(usd_path: str) -> list[UsdPrimRecord]:
                 included_paths.add(path)
                 ancestor = ancestor.GetParent()
 
-        for prim in stage.Traverse():
+        for prim in _traverse_composed_stage(stage):
             if prim.IsPseudoRoot():
                 continue
             if str(prim.GetPath()) not in included_paths:


### PR DESCRIPTION
## Summary
Reset background physics

## Detailed description
- Reset unclaimed background rigid bodies and articulations while preserving dynamic interaction.
- Defer reset-view initialization until after RTX startup to avoid invalidating Replicator OnlineVisual tensor views.
- Add PhysX, Newton, Fabric, RTX, and kitchen evaluation coverage.
