### PR TITLE
Split object provenance from rooted transforms

### DIFF
--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -7,22 +7,297 @@ from __future__ import annotations
 import torch
 from typing import Any
 
+import warp as wp
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.sim.spawners.spawner_cfg import SpawnerCfg
+from isaaclab.sim.views import FrameView
+from isaaclab_tasks.contrib.stack.mdp.franka_stack_events import randomize_object_pose
 
 from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
 from isaaclab_arena.assets.object_utils import detect_object_type
 from isaaclab_arena.relations.relations import RelationBase
+from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.usd.rigid_bodies import find_shallowest_rigid_body
 from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd, has_light, open_stage
+from isaaclab_arena.utils.velocity import Velocity
+from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
 
-class Object(ObjectBase):
-    """Pick-up object config for a pick-and-place environment."""
+class SpawnPrim:
+    """USD or spawner-backed prim provenance for an Arena object."""
+
+    def _init_spawn_prim(
+        self,
+        *,
+        usd_path: str | None,
+        spawner_cfg: SpawnerCfg | None,
+        scale: tuple[float, float, float] | None,
+        spawn_cfg_addon: dict[str, Any] | None = None,
+        asset_cfg_addon: dict[str, Any] | None = None,
+    ) -> None:
+        """Store one exclusive source for a prim spawned by this object."""
+        assert (usd_path is None) != (spawner_cfg is None), "Pass exactly one of usd_path or spawner_cfg"
+        self.usd_path = usd_path
+        self.spawner_cfg = spawner_cfg
+        self.scale = scale
+        self.spawn_cfg_addon = spawn_cfg_addon or {}
+        self.asset_cfg_addon = asset_cfg_addon or {}
+        self.bounding_box = None
+
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Get local bounding box (relative to object origin)."""
+        assert self.usd_path is not None
+        if self.bounding_box is None:
+            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
+        return self.bounding_box
+
+    def get_corners(self, pos: torch.Tensor) -> torch.Tensor:
+        return self.get_bounding_box().get_corners_at(pos)
+
+    def _get_contact_sensor_prim_path(self, usd_path: str | None = None) -> str:
+        """Return the shallowest rigid-body prim for contact sensing."""
+        usd_path = usd_path or self.usd_path
+        if usd_path is None:
+            return self.prim_path
+        rigid_body_relative_path = find_shallowest_rigid_body(
+            usd_path,
+            relative_to_root=True,
+            variants=(self.spawn_cfg_addon or {}).get("variants"),
+        )
+        assert (
+            rigid_body_relative_path is not None
+        ), f"No rigid body found in {self.name} USD file: {usd_path}. Can't add contact sensor."
+        return self.prim_path + rigid_body_relative_path
+
+    def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
+        """Return the custom spawner or a USD-file spawner."""
+        if self.spawner_cfg is not None:
+            return self.spawner_cfg
+        return UsdFileCfg(
+            usd_path=self.usd_path,
+            scale=self.scale,
+            activate_contact_sensors=activate_contact_sensors,
+            **self.spawn_cfg_addon,
+        )
+
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, Any]:
+        """Return spawn-specific arguments for an Isaac Lab asset config."""
+        return {
+            "spawn": self._get_spawn_cfg(activate_contact_sensors),
+            **self.asset_cfg_addon,
+        }
+
+    def _prepare_base_cfg_source(self) -> None:
+        """Warn when a spawned static USD contains lights."""
+        if self.spawner_cfg is None:
+            with open_stage(self.usd_path) as stage:
+                if has_light(stage):
+                    print(
+                        "WARNING: Base object has lights, this may cause issues when using with multiple environments."
+                    )
+
+
+class RootedTransform:
+    """Root-transform state and reset behavior for rigid, articulated, and static objects."""
+
+    def _init_rooted_transform(self) -> None:
+        """Initialize state shared by root-transform physics representations."""
+        self.reset_pose = True
+        self._base_frame_view: FrameView | None = None
+        self._base_frame_view_stage = None
+        if self.object_type == ObjectType.RIGID:
+            self.add_variation(ObjectMassVariation(self.name))
+
+    def _close_base_frame_view(self) -> None:
+        """Release the cached frame view. Safe to call more than once."""
+        frame_view = getattr(self, "_base_frame_view", None)
+        if frame_view is not None:
+            frame_view.close()
+            self._base_frame_view = None
+            self._base_frame_view_stage = None
+
+    def __del__(self):
+        """Release the cached frame view when this transform is dropped."""
+        self._close_base_frame_view()
+
+    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
+        """Store the pose and write its construction values into the object config."""
+        super()._set_initial_pose(pose)
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None and self.object_cfg is not None:
+            self.object_cfg.init_state.pos = initial_pose.position_xyz
+            self.object_cfg.init_state.rot = initial_pose.rotation_xyzw
+
+    def set_initial_velocity(self, velocity: Velocity) -> None:
+        """Set the initial velocity on the object config and its reset event."""
+        self.initial_velocity = velocity
+        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "lin_vel"):
+            self.object_cfg.init_state.lin_vel = velocity.linear_xyz
+        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "ang_vel"):
+            self.object_cfg.init_state.ang_vel = velocity.angular_xyz
+        self._pose_event_cfg = self._build_reset_event()
+
+    def get_contact_sensor_cfg(
+        self,
+        contact_against_object: ObjectBase | None = None,
+        usd_path: str | None = None,
+    ) -> ContactSensorCfg:
+        """Build a contact sensor config using provenance-specific prim-path hooks."""
+        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        return ContactSensorCfg(
+            prim_path=self._get_contact_sensor_prim_path(usd_path),
+            filter_prim_paths_expr=(
+                [] if contact_against_object is None else [contact_against_object._get_contact_sensor_prim_path()]
+            ),
+        )
+
+    def _requires_reset_pose_event(self) -> bool:
+        """Return whether this object needs a root-pose reset event."""
+        return self.get_initial_pose() is not None and self.object_type in (
+            ObjectType.RIGID,
+            ObjectType.ARTICULATION,
+        )
+
+    def _build_reset_event(self) -> EventTermCfg | None:
+        """Build the event that restores this object's pose and velocity."""
+        if not self._requires_reset_pose_event():
+            return None
+
+        initial_pose = self.get_initial_pose()
+        if isinstance(initial_pose, PosePerEnv):
+            return EventTermCfg(
+                func=set_object_pose_per_env,
+                mode="reset",
+                params={
+                    "asset_cfg": SceneEntityCfg(self.name),
+                    "pose_list": initial_pose.poses,
+                },
+            )
+        if isinstance(initial_pose, PoseRange):
+            return EventTermCfg(
+                func=randomize_object_pose,
+                mode="reset",
+                params={
+                    "pose_range": initial_pose.to_dict(),
+                    "asset_cfgs": [SceneEntityCfg(self.name)],
+                },
+            )
+        return EventTermCfg(
+            func=set_object_pose,
+            mode="reset",
+            params={
+                "pose": initial_pose,
+                "asset_cfg": SceneEntityCfg(self.name),
+                "velocity": self.initial_velocity,
+            },
+        )
+
+    def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
+        if self.object_type == ObjectType.RIGID:
+            return self._generate_rigid_cfg()
+        if self.object_type == ObjectType.ARTICULATION:
+            return self._generate_articulation_cfg()
+        if self.object_type == ObjectType.BASE:
+            return self._generate_base_cfg()
+        raise ValueError(f"Invalid object type: {self.object_type}")
+
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, Any]:
+        """Return provenance-specific arguments for an Isaac Lab asset config."""
+        raise NotImplementedError
+
+    def _prepare_base_cfg_source(self) -> None:
+        """Perform provenance-specific checks before creating a base asset config."""
+
+    def _add_initial_pose_to_cfg(
+        self, object_cfg: RigidObjectCfg | ArticulationCfg | AssetBaseCfg
+    ) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
+        """Apply the resolved initial root pose to an Isaac Lab asset config."""
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None:
+            object_cfg.init_state.pos = initial_pose.position_xyz
+            object_cfg.init_state.rot = initial_pose.rotation_xyzw
+        return object_cfg
+
+    def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
+        """Return the object's root pose in world or environment-relative coordinates."""
+        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
+        if self.object_type in (ObjectType.RIGID, ObjectType.ARTICULATION):
+            object_pose = wp.to_torch(env.unwrapped.scene[self.name].data.root_pose_w).clone()
+        elif self.object_type == ObjectType.BASE:
+            scene = env.unwrapped.scene
+            stage = scene.stage
+            if self._base_frame_view is None or self._base_frame_view_stage is not stage:
+                self._close_base_frame_view()
+                asset_cfg = scene[self.name]
+                frame_view = FrameView(asset_cfg.prim_path, device=env.unwrapped.device, stage=stage)
+                try:
+                    prim_paths = frame_view.prim_paths
+                    assert len(prim_paths) == env.unwrapped.num_envs, (
+                        f"AssetBaseCfg scene entry '{self.name}' resolved to {len(prim_paths)} prims; "
+                        f"expected {env.unwrapped.num_envs}."
+                    )
+                    for environment_id, prim_path in enumerate(prim_paths):
+                        environment_prim_path = scene.env_prim_paths[environment_id]
+                        assert str(prim_path).startswith(f"{environment_prim_path}/"), (
+                            f"AssetBaseCfg scene entry '{self.name}' pose row {environment_id} belongs to"
+                            f" '{prim_path}', not environment '{environment_prim_path}'."
+                        )
+                except Exception:
+                    frame_view.close()
+                    raise
+                self._base_frame_view = frame_view
+                self._base_frame_view_stage = stage
+            position_w, orientation_w = self._base_frame_view.get_world_poses()
+            object_pose = torch.cat((position_w.torch, orientation_w.torch), dim=-1)
+        else:
+            raise ValueError(f"Function not implemented for object type: {self.object_type}")
+        if is_relative:
+            object_pose[:, :3] -= env.unwrapped.scene.env_origins
+        return object_pose
+
+    def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
+        """Set the object's root pose and zero velocity in selected environments."""
+        env = env.unwrapped
+        assert self.name in env.scene.keys(), f"Asset {self.name} not found in scene"
+        if env_ids is None:
+            env_ids = torch.arange(env.num_envs, device=env.device)
+        set_object_pose(env, env_ids, SceneEntityCfg(self.name), pose)
+
+    def _generate_rigid_cfg(self) -> RigidObjectCfg:
+        assert self.object_type == ObjectType.RIGID
+        object_cfg = RigidObjectCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(activate_contact_sensors=True),
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+    def _generate_articulation_cfg(self) -> ArticulationCfg:
+        assert self.object_type == ObjectType.ARTICULATION
+        object_cfg = ArticulationCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(activate_contact_sensors=True),
+            actuators={},
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+    def _generate_base_cfg(self) -> AssetBaseCfg:
+        assert self.object_type == ObjectType.BASE
+        self._prepare_base_cfg_source()
+        object_cfg = AssetBaseCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(),
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+
+class Object(SpawnPrim, RootedTransform, ObjectBase):
+    """Spawned rigid, articulated, or static Arena object."""
 
     def __init__(
         self,
@@ -51,30 +326,18 @@ class Object(ObjectBase):
             )
             object_type = detect_object_type(usd_path=usd_path, variants=spawn_cfg_addon.get("variants"))
         super().__init__(name=name, prim_path=prim_path, object_type=object_type, **kwargs)
-        self.usd_path = usd_path
-        self.spawner_cfg = spawner_cfg
-        self.scale = scale
+        self._init_spawn_prim(
+            usd_path=usd_path,
+            spawner_cfg=spawner_cfg,
+            scale=scale,
+            spawn_cfg_addon=spawn_cfg_addon,
+            asset_cfg_addon=asset_cfg_addon,
+        )
         self.initial_pose = initial_pose
         self.relations = list(relations)
-        self.reset_pose = True
-        self.spawn_cfg_addon = spawn_cfg_addon
-        self.asset_cfg_addon = asset_cfg_addon
-        self.bounding_box = None
+        self._init_rooted_transform()
         self.object_cfg = self._init_object_cfg()
         self._pose_event_cfg = self._build_reset_event()
-
-    def get_bounding_box(self) -> AxisAlignedBoundingBox:
-        """Get local bounding box (relative to object origin)."""
-        assert self.usd_path is not None
-        if self.bounding_box is None:
-            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
-        return self.bounding_box
-
-    def get_corners(self, pos: torch.Tensor) -> torch.Tensor:
-        assert self.usd_path is not None
-        if self.bounding_box is None:
-            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
-        return self.bounding_box.get_corners_at(pos)
 
     def is_initial_pose_set(self) -> bool:
         return self.initial_pose is not None
@@ -86,109 +349,6 @@ class Object(ObjectBase):
     def enable_reset_pose(self) -> None:
         self.reset_pose = True
         self._pose_event_cfg = self._build_reset_event()
-
-    def get_contact_sensor_cfg(
-        self, contact_against_object: ObjectBase | None = None, usd_path: str | None = None
-    ) -> ContactSensorCfg:
-        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
-        # We override this function from the parent class because in some assets, the rigid body
-        # is not at the root of the USD file. To be robust to this, we find the shallowest rigid body
-        # and add the contact sensor to it.
-        # TODO(alexmillane, 2026.01.29): This capability to search for the correct place
-        # to add the contact sensor is not yet supported for ObjectReferences and RigidObjectSet.
-        # For these objects we just (try to) add the contact sensor to the root prim.
-        usd_path = usd_path or self.usd_path
-        rigid_body_relative_path = find_shallowest_rigid_body(
-            usd_path,
-            relative_to_root=True,
-            variants=(self.spawn_cfg_addon or {}).get("variants"),
-        )
-        assert (
-            rigid_body_relative_path is not None
-        ), f"No rigid body found in {self.name} USD file: {usd_path}. Can't add contact sensor."
-        contact_sensor_prim_path = self.prim_path + rigid_body_relative_path
-        # There are also cases where the contact against object does not have its rigid body at the root.
-        # In that case, we also need to find the shallowest rigid body.
-        # NOTE(alexmillane, 2026.04.10): For now we only support this for Object, but in the future we
-        # could support this for ObjectReference and RigidObjectSet. For now, those object types
-        # are assumed to have their rigid body at the their prim path.
-        if isinstance(contact_against_object, Object):
-            assert (
-                contact_against_object.object_type == ObjectType.RIGID
-            ), "Contact sensor is only supported for rigid objects"
-            contact_against_relative_path = find_shallowest_rigid_body(
-                contact_against_object.usd_path,
-                relative_to_root=True,
-                variants=(contact_against_object.spawn_cfg_addon or {}).get("variants"),
-            )
-            assert contact_against_relative_path is not None, (
-                f"No rigid body found in {contact_against_object.name} USD file: {contact_against_object.usd_path}."
-                " Can't add contact sensor."
-            )
-            filter_prim_paths = [contact_against_object.get_prim_path() + contact_against_relative_path]
-        elif isinstance(contact_against_object, ObjectBase):
-            filter_prim_paths = [contact_against_object.get_prim_path()]
-        elif contact_against_object is None:
-            filter_prim_paths = []
-        return ContactSensorCfg(
-            prim_path=contact_sensor_prim_path,
-            filter_prim_paths_expr=filter_prim_paths,
-        )
-
-    def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
-        """Return the spawn config to use: custom spawner_cfg if set, else a UsdFileCfg."""
-        if self.spawner_cfg is not None:
-            return self.spawner_cfg
-        return UsdFileCfg(
-            usd_path=self.usd_path,
-            scale=self.scale,
-            activate_contact_sensors=activate_contact_sensors,
-            **self.spawn_cfg_addon,
-        )
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        assert self.object_type == ObjectType.RIGID
-        object_cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(activate_contact_sensors=True),
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        assert self.object_type == ObjectType.ARTICULATION
-        object_cfg = ArticulationCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(activate_contact_sensors=True),
-            **self.asset_cfg_addon,
-            actuators={},
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        assert self.object_type == ObjectType.BASE
-        if self.spawner_cfg is None:
-            with open_stage(self.usd_path) as stage:
-                if has_light(stage):
-                    print(
-                        "WARNING: Base object has lights, this may cause issues when using with multiple environments."
-                    )
-        object_cfg = AssetBaseCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(),
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _add_initial_pose_to_cfg(
-        self, object_cfg: RigidObjectCfg | ArticulationCfg | AssetBaseCfg
-    ) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
-        # Optionally specify initial pose
-        initial_pose = self._get_initial_pose_as_pose()
-        if initial_pose is not None:
-            object_cfg.init_state.pos = initial_pose.position_xyz
-            object_cfg.init_state.rot = initial_pose.rotation_xyzw
-        return object_cfg
 
     def _requires_reset_pose_event(self) -> bool:
         return super()._requires_reset_pose_event() and self.reset_pose

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -8,13 +8,9 @@ from __future__ import annotations
 import torch
 from abc import ABC, abstractmethod
 
-import warp as wp
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
-from isaaclab.managers import EventTermCfg, SceneEntityCfg
+from isaaclab.managers import EventTermCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
-from isaaclab.sim.views import FrameView
-from isaaclab_tasks.contrib.stack.mdp.franka_stack_events import randomize_object_pose
 
 # Re-export ObjectType from the lightweight module so existing
 # `from isaaclab_arena.assets.object_base import ObjectType` consumers keep working,
@@ -22,10 +18,8 @@ from isaaclab_tasks.contrib.stack.mdp.franka_stack_events import randomize_objec
 # pulling in isaaclab/omni/pxr at module-load time.
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.relations.placement_asset import PlaceableAsset
-from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.velocity import Velocity
-from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
 __all__ = [
     "ObjectBase",
@@ -34,7 +28,7 @@ __all__ = [
 
 
 class ObjectBase(PlaceableAsset, ABC):
-    """Parent class for (spawnable) Object and ObjectReference."""
+    """Base class for Arena scene objects with a construction-time immutable prim path."""
 
     def __init__(
         self,
@@ -48,207 +42,34 @@ class ObjectBase(PlaceableAsset, ABC):
             prim_path = "{ENV_REGEX_NS}/" + self.name
         self.prim_path = prim_path
         self.object_type = object_type
-        if self.object_type == ObjectType.RIGID:
-            self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None
         self.object_cfg = None
-        self._base_frame_view: FrameView | None = None
-        self._base_frame_view_stage = None
 
-    def _close_base_frame_view(self) -> None:
-        """Release the cached frame view. Safe to call more than once."""
-        frame_view = getattr(self, "_base_frame_view", None)
-        if frame_view is not None:
-            frame_view.close()
-            self._base_frame_view = None
-            self._base_frame_view_stage = None
-
-    def __del__(self):
-        """Release the cached frame view when this object is dropped."""
-        self._close_base_frame_view()
-
-    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
-        """Store the pose and write its construction values into the object config."""
-        self.initial_pose = pose
-        initial_pose = self._get_initial_pose_as_pose()
-        if initial_pose is not None and self.object_cfg is not None:
-            self.object_cfg.init_state.pos = initial_pose.position_xyz
-            self.object_cfg.init_state.rot = initial_pose.rotation_xyzw
-
-    def set_initial_velocity(self, velocity: Velocity) -> None:
-        """Set / override the initial velocity and rebuild derived configs.
-
-        The velocity is applied as ``init_state.lin_vel`` and
-        ``init_state.ang_vel`` on the underlying config
-        (``RigidObjectCfg`` or ``ArticulationCfg``) and is also restored
-        on every environment reset via the reset event.
-
-        Args:
-            velocity: A ``Velocity`` specifying linear and angular components.
-        """
-        self.initial_velocity = velocity
-        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "lin_vel"):
-            self.object_cfg.init_state.lin_vel = velocity.linear_xyz
-        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "ang_vel"):
-            self.object_cfg.init_state.ang_vel = velocity.angular_xyz
-        self._pose_event_cfg = self._build_reset_event()
-
-    def _requires_reset_pose_event(self) -> bool:
-        """Whether a reset-event for the initial pose should be generated.
-
-        Subclasses may override to add extra conditions (e.g. a ``reset_pose`` flag).
-        """
-        return self.get_initial_pose() is not None and self.object_type in (
-            ObjectType.RIGID,
-            ObjectType.ARTICULATION,
-        )
-
-    def _build_reset_event(self) -> EventTermCfg | None:
-        """Build the ``EventTermCfg`` for resetting this object's pose and velocity."""
-        if not self._requires_reset_pose_event():
-            return None
-
-        initial_pose = self.get_initial_pose()
-        if isinstance(initial_pose, PosePerEnv):
-            return EventTermCfg(
-                func=set_object_pose_per_env,
-                mode="reset",
-                params={
-                    "asset_cfg": SceneEntityCfg(self.name),
-                    "pose_list": initial_pose.poses,
-                },
-            )
-        elif isinstance(initial_pose, PoseRange):
-            return EventTermCfg(
-                func=randomize_object_pose,
-                mode="reset",
-                params={
-                    "pose_range": initial_pose.to_dict(),
-                    "asset_cfgs": [SceneEntityCfg(self.name)],
-                },
-            )
-        else:  # Pose
-            return EventTermCfg(
-                func=set_object_pose,
-                mode="reset",
-                params={
-                    "pose": initial_pose,
-                    "asset_cfg": SceneEntityCfg(self.name),
-                    "velocity": self.initial_velocity,
-                },
-            )
-
-    def set_prim_path(self, prim_path: str) -> None:
-        self.prim_path = prim_path
+    def resolve_object_cfg(self, physics_preset: object | None = None):
+        """Return the concrete Isaac Lab config for a selected physics preset."""
+        return self.object_cfg
 
     def get_prim_path(self) -> str:
         return self.prim_path
 
-    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
+    def get_object_cfg(self) -> tuple[str, object]:
         return self.name, self.object_cfg
 
     def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
         return self.name, self._pose_event_cfg
 
-    def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
-        if self.object_type == ObjectType.RIGID:
-            object_cfg = self._generate_rigid_cfg()
-        elif self.object_type == ObjectType.ARTICULATION:
-            object_cfg = self._generate_articulation_cfg()
-        elif self.object_type == ObjectType.BASE:
-            object_cfg = self._generate_base_cfg()
-        else:
-            raise ValueError(f"Invalid object type: {self.object_type}")
-        return object_cfg
-
+    @abstractmethod
     def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
-        """Get the pose of the object in the environment.
+        """Return the object's per-environment pose as ``(x, y, z, qx, qy, qz, qw)``."""
 
-        Args:
-            env: The environment.
-            is_relative: Whether to return the pose in the relative frame of the environment.
-
-        Returns:
-            The pose of the object in each environment. The shape is (num_envs, 7).
-            The order is (x, y, z, qx, qy, qz, qw).
-        """
-        # We require that the asset has been added to the scene under its name.
-        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if (self.object_type == ObjectType.RIGID) or (self.object_type == ObjectType.ARTICULATION):
-            object_pose = wp.to_torch(env.unwrapped.scene[self.name].data.root_pose_w).clone()
-        elif self.object_type == ObjectType.BASE:
-            scene = env.unwrapped.scene
-            stage = scene.stage
-            if self._base_frame_view is None or self._base_frame_view_stage is not stage:
-                self._close_base_frame_view()
-                asset_cfg = scene[self.name]
-                frame_view = FrameView(asset_cfg.prim_path, device=env.unwrapped.device, stage=stage)
-                try:
-                    prim_paths = frame_view.prim_paths
-                    assert len(prim_paths) == env.unwrapped.num_envs, (
-                        f"AssetBaseCfg scene entry '{self.name}' resolved to {len(prim_paths)} prims; "
-                        f"expected {env.unwrapped.num_envs}."
-                    )
-                    for environment_id, prim_path in enumerate(prim_paths):
-                        environment_prim_path = scene.env_prim_paths[environment_id]
-                        assert str(prim_path).startswith(f"{environment_prim_path}/"), (
-                            f"AssetBaseCfg scene entry '{self.name}' pose row {environment_id} belongs to"
-                            f" '{prim_path}', not environment '{environment_prim_path}'."
-                        )
-                except Exception:
-                    frame_view.close()
-                    raise
-                self._base_frame_view = frame_view
-                self._base_frame_view_stage = stage
-            position_w, orientation_w = self._base_frame_view.get_world_poses()
-            object_pose = torch.cat((position_w.torch, orientation_w.torch), dim=-1)
-        else:
-            raise ValueError(f"Function not implemented for object type: {self.object_type}")
-        if is_relative:
-            object_pose[:, :3] -= env.unwrapped.scene.env_origins
-        return object_pose
-
+    @abstractmethod
     def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
-        """Set the pose of the object in the environment.
-
-        Args:
-            env: The environment.
-            pose: The pose to set.
-        """
-        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if env_ids is None:
-            env_ids = torch.arange(env.unwrapped.num_envs, device=env.unwrapped.device)
-        # Grab the object
-        asset = env.unwrapped.scene[self.name]
-        num_envs = len(env_ids)
-        # Convert the pose to the env frame
-        pose_t_xyz_q_xyzw = pose.to_tensor(device=env.unwrapped.device).repeat(num_envs, 1)
-        pose_t_xyz_q_xyzw[:, :3] += env.unwrapped.scene.env_origins[env_ids]
-        # Set the pose and velocity
-        asset.write_root_pose_to_sim(pose_t_xyz_q_xyzw, env_ids=env_ids)
-        asset.write_root_velocity_to_sim(
-            torch.zeros(env.unwrapped.num_envs, 6, device=env.unwrapped.device), env_ids=env_ids
-        )
+        """Write the object's pose for the selected environments."""
 
     def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
-        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
-        filter_prim_paths = [contact_against_object.get_prim_path()] if contact_against_object else []
-        return ContactSensorCfg(
-            prim_path=self.prim_path,
-            filter_prim_paths_expr=filter_prim_paths,
-        )
+        """Return a contact sensor config when this object representation supports one."""
+        raise NotImplementedError(f"{type(self).__name__} does not support contact sensors")
 
-    @abstractmethod
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        # Subclasses must implement this method
-        pass
-
-    @abstractmethod
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        # Subclasses must implement this method
-        pass
-
-    @abstractmethod
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        # Subclasses must implement this method
-        pass
+    def _get_contact_sensor_prim_path(self, usd_path: str | None = None) -> str:
+        """Return the root prim used for contact sensing by default."""
+        return self.prim_path

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -5,14 +5,12 @@
 
 import trimesh
 
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
-from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from pxr import Usd
 
 from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.affordances.pressable import Pressable
 from isaaclab_arena.affordances.turnable import Turnable
-from isaaclab_arena.assets.object import Object
+from isaaclab_arena.assets.object import Object, RootedTransform
 from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
 from isaaclab_arena.relations.relations import IsAnchor, RelationBase
 from isaaclab_arena.terms.events import reset_articulation_pose_and_joints
@@ -27,11 +25,11 @@ from isaaclab_arena.utils.usd_helpers import (
 from isaaclab_arena.utils.usd_pose_helpers import get_prim_pose_in_default_prim_frame
 
 
-class ObjectReference(ObjectBase):
-    """An object which *refers* to an existing element in the scene"""
+class ReferencedPrim:
+    """Provenance and geometry behavior for a prim nested in a parent asset."""
 
-    def __init__(self, parent_asset: Object, **kwargs):
-        super().__init__(**kwargs)
+    def _init_referenced_prim(self, parent_asset: Object) -> None:
+        """Resolve and cache this object's parent-relative prim state."""
         self.parent_asset = parent_asset
         self._parent_scale = parent_asset.scale
         # Resolve the path and pose together to avoid opening the parent USD stage multiple times.
@@ -67,6 +65,12 @@ class ObjectReference(ObjectBase):
         """Return the referenced prim's absolute path in its parent USD stage."""
         return self._prim_path_in_parent_usd
 
+    def _resolve_prim_path_in_parent_usd(self, parent_stage: Usd.Stage) -> str:
+        """Return the cached referenced path, resolving it for partially initialized test objects."""
+        return getattr(self, "_prim_path_in_parent_usd", None) or self.isaaclab_prim_path_to_original_prim_path(
+            self.prim_path, self.parent_asset, parent_stage
+        )
+
     def add_relation(self, relation: RelationBase) -> None:
         """Add a relation to this object reference.
 
@@ -92,9 +96,7 @@ class ObjectReference(ObjectBase):
         """
         if self._bounding_box is None:
             with open_stage(self.parent_asset.usd_path) as parent_stage:
-                prim_path_in_usd = self.isaaclab_prim_path_to_original_prim_path(
-                    self.prim_path, self.parent_asset, parent_stage
-                )
+                prim_path_in_usd = self._resolve_prim_path_in_parent_usd(parent_stage)
                 raw_bbox = compute_world_aligned_bounding_box_relative_to_prim_origin(parent_stage, prim_path_in_usd)
                 # Apply parent's scale (no centering - solver is origin-agnostic)
                 self._bounding_box = raw_bbox.scaled(self._parent_scale)
@@ -132,61 +134,14 @@ class ObjectReference(ObjectBase):
     def _extract_collision_mesh(self) -> trimesh.Trimesh:
         """Extract the referenced prim mesh from the parent asset USD."""
         with open_stage(self.parent_asset.usd_path) as parent_stage:
-            prim_path_in_usd = self.isaaclab_prim_path_to_original_prim_path(
-                self.prim_path, self.parent_asset, parent_stage
-            )
+            prim_path_in_usd = self._resolve_prim_path_in_parent_usd(parent_stage)
             if not parent_stage.GetPrimAtPath(prim_path_in_usd):
                 raise ValueError(f"No prim found with path {prim_path_in_usd} in {self.parent_asset.usd_path}")
             return extract_trimesh_from_prim(parent_stage, prim_path_in_usd, self._parent_scale)
 
-    def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
-        # NOTE(alexmillane): Right now this requires that the object
-        # has the contact sensor enabled prior to using this reference.
-        # At the moment, for the tests, I enabled the relevant APIs in the GUI.
-        # TODO(alexmillane, 2025.09.08): Make the code automatically enable the
-        # contact reporter API.
-        # NOTE(alexmillane, 2025.11.27): I've added a function for adding
-        # the contact reporter API to a prim in a USD, perhaps that can be repurposed
-        # and used here.
-        # Just call out to the parent class method.
-        return super().get_contact_sensor_cfg(contact_against_object)
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        assert self.object_type == ObjectType.RIGID
-        initial_pose = self.get_initial_pose()
-        object_cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            init_state=RigidObjectCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
-
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        assert self.object_type == ObjectType.ARTICULATION
-        initial_pose = self.get_initial_pose()
-        object_cfg = ArticulationCfg(
-            prim_path=self.prim_path,
-            actuators={},
-            init_state=ArticulationCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
-
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        assert self.object_type == ObjectType.BASE
-        initial_pose = self.get_initial_pose()
-        object_cfg = AssetBaseCfg(
-            prim_path=self.prim_path,
-            init_state=AssetBaseCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, object]:
+        """Return no spawn arguments because the referenced prim already exists."""
+        return {}
 
     def _get_referenced_prim_path_and_pose_relative_to_parent(self, parent_asset: Object) -> tuple[str, Pose]:
         """Get the prim path and transform pose relative to the parent's default prim.
@@ -241,6 +196,15 @@ class ObjectReference(ObjectBase):
         # Append the default prim path.
         original_prim_path = str(default_prim_path) + original_prim_path
         return original_prim_path
+
+
+class ObjectReference(ReferencedPrim, RootedTransform, ObjectBase):
+    """Rigid, articulated, or static object represented by an existing parent prim."""
+
+    def __init__(self, parent_asset: Object, **kwargs):
+        super().__init__(**kwargs)
+        self._init_rooted_transform()
+        self._init_referenced_prim(parent_asset)
 
 
 class OpenableObjectReference(ObjectReference, Openable):

--- a/isaaclab_arena/tests/test_object_configuration.py
+++ b/isaaclab_arena/tests/test_object_configuration.py
@@ -10,6 +10,10 @@ HEADLESS = True
 
 def _test_object_initial_pose_update(simulation_app):
 
+    from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg
+
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.utils.pose import Pose
 
@@ -26,6 +30,16 @@ def _test_object_initial_pose_update(simulation_app):
     # Now lets check that the initial pose has been updated and that the debug visualization is still disabled.
     assert rigid_object.get_initial_pose() == new_initial_pose
     assert rigid_object.object_cfg.debug_vis is False
+
+    source = Object(name="source", object_type=ObjectType.RIGID, spawner_cfg=MeshCuboidCfg(size=(0.1, 0.1, 0.1)))
+    destination = Object(
+        name="destination",
+        object_type=ObjectType.RIGID,
+        spawner_cfg=MeshCuboidCfg(size=(0.1, 0.1, 0.1)),
+    )
+    contact_sensor_cfg = source.get_contact_sensor_cfg(contact_against_object=destination)
+    assert contact_sensor_cfg.prim_path == source.prim_path
+    assert contact_sensor_cfg.filter_prim_paths_expr == [destination.prim_path]
 
     return True
 


### PR DESCRIPTION
## Summary
Separate object provenance and transform behavior.

## Detailed description
- Compose `Object` and `ObjectReference` from provenance-specific behavior and shared `RootedTransform`.
- Centralize rooted configuration, pose, reset, and contact-sensor handling.
- Support contact sensors for spawner-backed objects without source USDs.
- Breaking: remove `ObjectBase.set_prim_path()` and require direct subclasses to provide transform behavior.