### PR TITLE
Add volume deformable objects

### DIFF
--- a/isaaclab_arena/assets/deformable_object.py
+++ b/isaaclab_arena/assets/deformable_object.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena volume-deformable object."""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab.assets import DeformableObjectCfg
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
+from isaaclab.sim.spawners.materials.visual_materials_cfg import VisualMaterialCfg
+from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg
+from isaaclab.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+
+from isaaclab_arena.assets.deformable_spawn import (
+    VolumeDeformableMaterial,
+    build_newton_volume_spawn,
+    build_physx_volume_spawn,
+)
+from isaaclab_arena.assets.object import SpawnPrim
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.terms.events import set_deformable_object_pose, set_deformable_object_pose_per_env
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+
+
+class DeformableTransform:
+    """Nodal state, reset, and backend resolution behavior for volume deformables."""
+
+    def _init_deformable_transform(
+        self,
+        *,
+        material: VolumeDeformableMaterial,
+        initial_pose: Pose | PosePerEnv | None = None,
+        visual_material: VisualMaterialCfg | None = None,
+        local_bounding_box: AxisAlignedBoundingBox | None = None,
+    ) -> None:
+        """Initialize deformable state after the concrete object initializes its prim source."""
+        self.material = material
+        self.visual_material = visual_material
+        self._local_bounding_box = local_bounding_box or self._bounding_box_from_spawner(self.spawner_cfg)
+        self.initial_pose = initial_pose
+        self.reset_pose = True
+        self._pose_event_cfg = self._build_reset_event()
+
+    @staticmethod
+    def _bounding_box_from_spawner(
+        spawner_cfg: DeformableObjectSpawnerCfg | None,
+    ) -> AxisAlignedBoundingBox | None:
+        if not isinstance(spawner_cfg, MeshCuboidCfg):
+            return None
+        half_size = tuple(size * 0.5 for size in spawner_cfg.size)
+        return AxisAlignedBoundingBox(
+            min_point=tuple(-value for value in half_size),
+            max_point=half_size,
+        )
+
+    def resolve_object_cfg(self, physics_preset: object | None = None) -> DeformableObjectCfg:
+        """Resolve this object for PhysX by default or an explicit Newton preset."""
+        selected_preset = physics_preset or "physx"
+        spawn_builder = {
+            "default": build_physx_volume_spawn,
+            "physx": build_physx_volume_spawn,
+            "newton_mjwarp_vbd": build_newton_volume_spawn,
+        }.get(selected_preset)
+        if spawn_builder is None:
+            raise ValueError(f"Physics preset {selected_preset!r} does not support volume deformables")
+        source = self.usd_path if self.usd_path is not None else self.spawner_cfg
+        spawn_cfg = spawn_builder(source, self.material, visual_material=self.visual_material, scale=self.scale)
+        object_cfg = DeformableObjectCfg(prim_path=self.prim_path, spawn=spawn_cfg, **self.asset_cfg_addon)
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None:
+            object_cfg.init_state.pos = initial_pose.position_xyz
+            object_cfg.init_state.rot = initial_pose.rotation_xyzw
+        self.object_cfg = object_cfg
+        return object_cfg
+
+    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
+        assert isinstance(pose, (Pose, PosePerEnv)), "Deformables support fixed Pose or PosePerEnv only"
+        super()._set_initial_pose(pose)
+        self.object_cfg = None
+
+    def set_initial_velocity(self, velocity) -> None:
+        """Set the linear velocity restored by the deformable reset event."""
+        self.initial_velocity = velocity
+        self._pose_event_cfg = self._build_reset_event()
+
+    def _build_reset_event(self) -> EventTermCfg | None:
+        if not self.reset_pose or self.initial_pose is None:
+            return None
+        if isinstance(self.initial_pose, PosePerEnv):
+            return EventTermCfg(
+                func=set_deformable_object_pose_per_env,
+                mode="reset",
+                params={"asset_cfg": SceneEntityCfg(self.name), "pose_list": self.initial_pose.poses},
+            )
+        return EventTermCfg(
+            func=set_deformable_object_pose,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(self.name),
+                "pose": self.initial_pose,
+                "velocity": self.initial_velocity,
+            },
+        )
+
+    def disable_reset_pose(self) -> None:
+        self.reset_pose = False
+        self._pose_event_cfg = self._build_reset_event()
+
+    def enable_reset_pose(self) -> None:
+        self.reset_pose = True
+        self._pose_event_cfg = self._build_reset_event()
+
+    def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
+        """Return centroid position with identity orientation."""
+        env = getattr(env, "unwrapped", env)
+        asset = env.scene[self.name]
+        object_pos = asset.data.root_pos_w.torch.clone()
+        object_quat = torch.zeros((env.num_envs, 4), device=env.device)
+        object_quat[:, 3] = 1.0
+        object_pose = torch.cat((object_pos, object_quat), dim=-1)
+        if is_relative:
+            object_pose[:, :3] -= env.scene.env_origins
+        return object_pose
+
+    def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
+        """Transform the default nodal state to the requested centroid pose."""
+        env = getattr(env, "unwrapped", env)
+        if env_ids is None:
+            env_ids = torch.arange(env.num_envs, device=env.device)
+        set_deformable_object_pose(env, env_ids, SceneEntityCfg(self.name), pose)
+
+    def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None):
+        raise NotImplementedError("Deformable objects do not support contact sensors")
+
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        assert self._local_bounding_box is not None, "A local bounding box is required for non-cuboid deformables"
+        return self._local_bounding_box
+
+
+class DeformableObject(DeformableTransform, SpawnPrim, ObjectBase):
+    """Spawned volume deformable resolved to one concrete Lab config at build time."""
+
+    def __init__(
+        self,
+        name: str,
+        material: VolumeDeformableMaterial,
+        usd_path: str | None = None,
+        spawner_cfg: DeformableObjectSpawnerCfg | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | PosePerEnv | None = None,
+        visual_material: VisualMaterialCfg | None = None,
+        scale: tuple[float, float, float] | None = None,
+        local_bounding_box: AxisAlignedBoundingBox | None = None,
+        asset_cfg_addon: dict | None = None,
+        **kwargs,
+    ):
+        super().__init__(name=name, prim_path=prim_path, object_type=ObjectType.DEFORMABLE, **kwargs)
+        self._init_spawn_prim(
+            usd_path=usd_path,
+            spawner_cfg=spawner_cfg,
+            scale=scale,
+            asset_cfg_addon=asset_cfg_addon,
+        )
+        self._init_deformable_transform(
+            material=material,
+            initial_pose=initial_pose,
+            visual_material=visual_material,
+            local_bounding_box=local_bounding_box,
+        )

--- a/isaaclab_arena/assets/deformable_spawn.py
+++ b/isaaclab_arena/assets/deformable_spawn.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral volume-deformable material and spawn mappings."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+
+from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+from isaaclab.sim.spawners.materials.visual_materials_cfg import VisualMaterialCfg
+from isaaclab.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
+from isaaclab_physx.sim.schemas import PhysxDeformableBodyPropertiesCfg
+from isaaclab_physx.sim.spawners.materials import PhysxDeformableBodyMaterialCfg
+
+
+@dataclass(frozen=True)
+class VolumeDeformableMaterial:
+    """Backend-neutral physical properties for a volume deformable."""
+
+    youngs_modulus: float
+    poissons_ratio: float
+    density: float
+    damping: float = 0.0
+    particle_radius: float = 0.008
+
+    def __post_init__(self) -> None:
+        assert self.youngs_modulus > 0.0, "youngs_modulus must be positive"
+        assert -1.0 < self.poissons_ratio < 0.5, "poissons_ratio must be in (-1, 0.5)"
+        assert self.density > 0.0, "density must be positive"
+        assert self.damping >= 0.0, "damping must be non-negative"
+        assert self.particle_radius > 0.0, "particle_radius must be positive"
+
+
+def lame_parameters(youngs_modulus: float, poissons_ratio: float) -> tuple[float, float]:
+    """Convert Young's modulus and Poisson's ratio to Lamé parameters."""
+    k_mu = youngs_modulus / (2.0 * (1.0 + poissons_ratio))
+    k_lambda = youngs_modulus * poissons_ratio / ((1.0 + poissons_ratio) * (1.0 - 2.0 * poissons_ratio))
+    return k_mu, k_lambda
+
+
+def _copy_source(
+    source: str | DeformableObjectSpawnerCfg,
+    scale: tuple[float, float, float] | None,
+) -> DeformableObjectSpawnerCfg:
+    """Copy a deformable source into a mutable spawn configuration."""
+    if isinstance(source, str):
+        return UsdFileCfg(usd_path=source, scale=scale)
+    assert scale is None, "scale is only supported for USD deformable sources"
+    return copy.deepcopy(source)
+
+
+def build_physx_volume_spawn(
+    source: str | DeformableObjectSpawnerCfg,
+    material: VolumeDeformableMaterial,
+    *,
+    visual_material: VisualMaterialCfg | None = None,
+    scale: tuple[float, float, float] | None = None,
+) -> DeformableObjectSpawnerCfg:
+    """Map a volume source and neutral material to a PhysX deformable spawner."""
+    spawn_cfg = _copy_source(source, scale)
+    spawn_cfg.deformable_props = PhysxDeformableBodyPropertiesCfg(
+        rest_offset=0.0,
+        contact_offset=material.particle_radius * 0.25,
+        linear_damping=material.damping,
+    )
+    spawn_cfg.physics_material = PhysxDeformableBodyMaterialCfg(
+        youngs_modulus=material.youngs_modulus,
+        poissons_ratio=material.poissons_ratio,
+        density=material.density,
+    )
+    if visual_material is not None:
+        spawn_cfg.visual_material = visual_material
+    return spawn_cfg
+
+
+def build_newton_volume_spawn(
+    source: str | DeformableObjectSpawnerCfg,
+    material: VolumeDeformableMaterial,
+    *,
+    visual_material: VisualMaterialCfg | None = None,
+    scale: tuple[float, float, float] | None = None,
+) -> DeformableObjectSpawnerCfg:
+    """Map a volume source and neutral material to a Newton deformable spawner."""
+    spawn_cfg = _copy_source(source, scale)
+
+    k_mu, k_lambda = lame_parameters(material.youngs_modulus, material.poissons_ratio)
+    spawn_cfg.deformable_props = NewtonDeformableBodyPropertiesCfg()
+    spawn_cfg.physics_material = NewtonDeformableBodyMaterialCfg(
+        density=material.density,
+        particle_radius=material.particle_radius,
+        k_mu=k_mu,
+        k_lambda=k_lambda,
+        k_damp=material.damping,
+    )
+    if visual_material is not None:
+        spawn_cfg.visual_material = visual_material
+    return spawn_cfg

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -7,22 +7,258 @@ from __future__ import annotations
 import torch
 from typing import Any
 
+import warp as wp
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.sim.spawners.spawner_cfg import SpawnerCfg
+from isaaclab_tasks.manager_based.manipulation.stack.mdp.franka_stack_events import randomize_object_pose
 
 from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
 from isaaclab_arena.assets.object_utils import detect_object_type
 from isaaclab_arena.relations.relations import RelationBase
+from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
-from isaaclab_arena.utils.pose import Pose
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.usd.rigid_bodies import find_shallowest_rigid_body
 from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd, has_light, open_stage
+from isaaclab_arena.utils.velocity import Velocity
+from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
 
-class Object(ObjectBase):
-    """Pick-up object config for a pick-and-place environment."""
+class SpawnPrim:
+    """USD or spawner-backed prim provenance for an Arena object."""
+
+    def _init_spawn_prim(
+        self,
+        *,
+        usd_path: str | None,
+        spawner_cfg: SpawnerCfg | None,
+        scale: tuple[float, float, float] | None,
+        spawn_cfg_addon: dict[str, Any] | None = None,
+        asset_cfg_addon: dict[str, Any] | None = None,
+    ) -> None:
+        """Store one exclusive source for a prim spawned by this object."""
+        assert (usd_path is None) != (spawner_cfg is None), "Pass exactly one of usd_path or spawner_cfg"
+        self.usd_path = usd_path
+        self.spawner_cfg = spawner_cfg
+        self.scale = scale
+        self.spawn_cfg_addon = spawn_cfg_addon or {}
+        self.asset_cfg_addon = asset_cfg_addon or {}
+        self.bounding_box = None
+
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Get local bounding box (relative to object origin)."""
+        assert self.usd_path is not None
+        if self.bounding_box is None:
+            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
+        return self.bounding_box
+
+    def get_corners(self, pos: torch.Tensor) -> torch.Tensor:
+        return self.get_bounding_box().get_corners_at(pos)
+
+    def _get_contact_sensor_prim_path(self, usd_path: str | None = None) -> str:
+        """Return the shallowest rigid-body prim for contact sensing."""
+        usd_path = usd_path or self.usd_path
+        if usd_path is None:
+            return self.prim_path
+        rigid_body_relative_path = find_shallowest_rigid_body(
+            usd_path,
+            relative_to_root=True,
+            variants=(self.spawn_cfg_addon or {}).get("variants"),
+        )
+        assert (
+            rigid_body_relative_path is not None
+        ), f"No rigid body found in {self.name} USD file: {usd_path}. Can't add contact sensor."
+        return self.prim_path + rigid_body_relative_path
+
+    def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
+        """Return the custom spawner or a USD-file spawner."""
+        if self.spawner_cfg is not None:
+            return self.spawner_cfg
+        return UsdFileCfg(
+            usd_path=self.usd_path,
+            scale=self.scale,
+            activate_contact_sensors=activate_contact_sensors,
+            **self.spawn_cfg_addon,
+        )
+
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, Any]:
+        """Return spawn-specific arguments for an Isaac Lab asset config."""
+        return {
+            "spawn": self._get_spawn_cfg(activate_contact_sensors),
+            **self.asset_cfg_addon,
+        }
+
+    def _prepare_base_cfg_source(self) -> None:
+        """Warn when a spawned static USD contains lights."""
+        if self.spawner_cfg is None:
+            with open_stage(self.usd_path) as stage:
+                if has_light(stage):
+                    print(
+                        "WARNING: Base object has lights, this may cause issues when using with multiple environments."
+                    )
+
+
+class RootedTransform:
+    """Root-transform state and reset behavior for rigid, articulated, and static objects."""
+
+    def _init_rooted_transform(self) -> None:
+        """Initialize state shared by root-transform physics representations."""
+        self.reset_pose = True
+        if self.object_type == ObjectType.RIGID:
+            self.add_variation(ObjectMassVariation(self.name))
+
+    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
+        """Store the pose and write its construction values into the object config."""
+        super()._set_initial_pose(pose)
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None and self.object_cfg is not None:
+            self.object_cfg.init_state.pos = initial_pose.position_xyz
+            self.object_cfg.init_state.rot = initial_pose.rotation_xyzw
+
+    def set_initial_velocity(self, velocity: Velocity) -> None:
+        """Set the initial velocity on the object config and its reset event."""
+        self.initial_velocity = velocity
+        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "lin_vel"):
+            self.object_cfg.init_state.lin_vel = velocity.linear_xyz
+        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "ang_vel"):
+            self.object_cfg.init_state.ang_vel = velocity.angular_xyz
+        self._pose_event_cfg = self._build_reset_event()
+
+    def get_contact_sensor_cfg(
+        self,
+        contact_against_object: ObjectBase | None = None,
+        usd_path: str | None = None,
+    ) -> ContactSensorCfg:
+        """Build a contact sensor config using provenance-specific prim-path hooks."""
+        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        return ContactSensorCfg(
+            prim_path=self._get_contact_sensor_prim_path(usd_path),
+            filter_prim_paths_expr=(
+                [] if contact_against_object is None else [contact_against_object._get_contact_sensor_prim_path()]
+            ),
+        )
+
+    def _requires_reset_pose_event(self) -> bool:
+        """Return whether this object needs a root-pose reset event."""
+        return self.get_initial_pose() is not None and self.object_type in (
+            ObjectType.RIGID,
+            ObjectType.ARTICULATION,
+        )
+
+    def _build_reset_event(self) -> EventTermCfg | None:
+        """Build the event that restores this object's pose and velocity."""
+        if not self._requires_reset_pose_event():
+            return None
+
+        initial_pose = self.get_initial_pose()
+        if isinstance(initial_pose, PosePerEnv):
+            return EventTermCfg(
+                func=set_object_pose_per_env,
+                mode="reset",
+                params={
+                    "asset_cfg": SceneEntityCfg(self.name),
+                    "pose_list": initial_pose.poses,
+                },
+            )
+        if isinstance(initial_pose, PoseRange):
+            return EventTermCfg(
+                func=randomize_object_pose,
+                mode="reset",
+                params={
+                    "pose_range": initial_pose.to_dict(),
+                    "asset_cfgs": [SceneEntityCfg(self.name)],
+                },
+            )
+        return EventTermCfg(
+            func=set_object_pose,
+            mode="reset",
+            params={
+                "pose": initial_pose,
+                "asset_cfg": SceneEntityCfg(self.name),
+                "velocity": self.initial_velocity,
+            },
+        )
+
+    def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
+        if self.object_type == ObjectType.RIGID:
+            return self._generate_rigid_cfg()
+        if self.object_type == ObjectType.ARTICULATION:
+            return self._generate_articulation_cfg()
+        if self.object_type == ObjectType.BASE:
+            return self._generate_base_cfg()
+        raise ValueError(f"Invalid object type: {self.object_type}")
+
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, Any]:
+        """Return provenance-specific arguments for an Isaac Lab asset config."""
+        raise NotImplementedError
+
+    def _prepare_base_cfg_source(self) -> None:
+        """Perform provenance-specific checks before creating a base asset config."""
+
+    def _add_initial_pose_to_cfg(
+        self, object_cfg: RigidObjectCfg | ArticulationCfg | AssetBaseCfg
+    ) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
+        """Apply the resolved initial root pose to an Isaac Lab asset config."""
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None:
+            object_cfg.init_state.pos = initial_pose.position_xyz
+            object_cfg.init_state.rot = initial_pose.rotation_xyzw
+        return object_cfg
+
+    def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
+        """Return the object's root pose in world or environment-relative coordinates."""
+        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
+        if self.object_type in (ObjectType.RIGID, ObjectType.ARTICULATION):
+            object_pose = wp.to_torch(env.unwrapped.scene[self.name].data.root_pose_w).clone()
+        elif self.object_type == ObjectType.BASE:
+            object_pose = torch.cat(env.unwrapped.scene[self.name].get_world_poses(), dim=-1)
+        else:
+            raise ValueError(f"Function not implemented for object type: {self.object_type}")
+        if is_relative:
+            object_pose[:, :3] -= env.unwrapped.scene.env_origins
+        return object_pose
+
+    def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
+        """Set the object's root pose and zero velocity in selected environments."""
+        env = env.unwrapped
+        assert self.name in env.scene.keys(), f"Asset {self.name} not found in scene"
+        if env_ids is None:
+            env_ids = torch.arange(env.num_envs, device=env.device)
+        set_object_pose(env, env_ids, SceneEntityCfg(self.name), pose)
+
+    def _generate_rigid_cfg(self) -> RigidObjectCfg:
+        assert self.object_type == ObjectType.RIGID
+        object_cfg = RigidObjectCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(activate_contact_sensors=True),
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+    def _generate_articulation_cfg(self) -> ArticulationCfg:
+        assert self.object_type == ObjectType.ARTICULATION
+        object_cfg = ArticulationCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(activate_contact_sensors=True),
+            actuators={},
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+    def _generate_base_cfg(self) -> AssetBaseCfg:
+        assert self.object_type == ObjectType.BASE
+        self._prepare_base_cfg_source()
+        object_cfg = AssetBaseCfg(
+            prim_path=self.prim_path,
+            **self._get_cfg_source_kwargs(),
+        )
+        return self._add_initial_pose_to_cfg(object_cfg)
+
+
+class Object(SpawnPrim, RootedTransform, ObjectBase):
+    """Spawned rigid, articulated, or static Arena object."""
 
     def __init__(
         self,
@@ -51,30 +287,18 @@ class Object(ObjectBase):
             )
             object_type = detect_object_type(usd_path=usd_path, variants=spawn_cfg_addon.get("variants"))
         super().__init__(name=name, prim_path=prim_path, object_type=object_type, **kwargs)
-        self.usd_path = usd_path
-        self.spawner_cfg = spawner_cfg
-        self.scale = scale
+        self._init_spawn_prim(
+            usd_path=usd_path,
+            spawner_cfg=spawner_cfg,
+            scale=scale,
+            spawn_cfg_addon=spawn_cfg_addon,
+            asset_cfg_addon=asset_cfg_addon,
+        )
         self.initial_pose = initial_pose
         self.relations = list(relations)
-        self.reset_pose = True
-        self.spawn_cfg_addon = spawn_cfg_addon
-        self.asset_cfg_addon = asset_cfg_addon
-        self.bounding_box = None
+        self._init_rooted_transform()
         self.object_cfg = self._init_object_cfg()
         self._pose_event_cfg = self._build_reset_event()
-
-    def get_bounding_box(self) -> AxisAlignedBoundingBox:
-        """Get local bounding box (relative to object origin)."""
-        assert self.usd_path is not None
-        if self.bounding_box is None:
-            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
-        return self.bounding_box
-
-    def get_corners(self, pos: torch.Tensor) -> torch.Tensor:
-        assert self.usd_path is not None
-        if self.bounding_box is None:
-            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
-        return self.bounding_box.get_corners_at(pos)
 
     def is_initial_pose_set(self) -> bool:
         return self.initial_pose is not None
@@ -86,109 +310,6 @@ class Object(ObjectBase):
     def enable_reset_pose(self) -> None:
         self.reset_pose = True
         self._pose_event_cfg = self._build_reset_event()
-
-    def get_contact_sensor_cfg(
-        self, contact_against_object: ObjectBase | None = None, usd_path: str | None = None
-    ) -> ContactSensorCfg:
-        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
-        # We override this function from the parent class because in some assets, the rigid body
-        # is not at the root of the USD file. To be robust to this, we find the shallowest rigid body
-        # and add the contact sensor to it.
-        # TODO(alexmillane, 2026.01.29): This capability to search for the correct place
-        # to add the contact sensor is not yet supported for ObjectReferences and RigidObjectSet.
-        # For these objects we just (try to) add the contact sensor to the root prim.
-        usd_path = usd_path or self.usd_path
-        rigid_body_relative_path = find_shallowest_rigid_body(
-            usd_path,
-            relative_to_root=True,
-            variants=(self.spawn_cfg_addon or {}).get("variants"),
-        )
-        assert (
-            rigid_body_relative_path is not None
-        ), f"No rigid body found in {self.name} USD file: {usd_path}. Can't add contact sensor."
-        contact_sensor_prim_path = self.prim_path + rigid_body_relative_path
-        # There are also cases where the contact against object does not have its rigid body at the root.
-        # In that case, we also need to find the shallowest rigid body.
-        # NOTE(alexmillane, 2026.04.10): For now we only support this for Object, but in the future we
-        # could support this for ObjectReference and RigidObjectSet. For now, those object types
-        # are assumed to have their rigid body at the their prim path.
-        if isinstance(contact_against_object, Object):
-            assert (
-                contact_against_object.object_type == ObjectType.RIGID
-            ), "Contact sensor is only supported for rigid objects"
-            contact_against_relative_path = find_shallowest_rigid_body(
-                contact_against_object.usd_path,
-                relative_to_root=True,
-                variants=(contact_against_object.spawn_cfg_addon or {}).get("variants"),
-            )
-            assert contact_against_relative_path is not None, (
-                f"No rigid body found in {contact_against_object.name} USD file: {contact_against_object.usd_path}."
-                " Can't add contact sensor."
-            )
-            filter_prim_paths = [contact_against_object.get_prim_path() + contact_against_relative_path]
-        elif isinstance(contact_against_object, ObjectBase):
-            filter_prim_paths = [contact_against_object.get_prim_path()]
-        elif contact_against_object is None:
-            filter_prim_paths = []
-        return ContactSensorCfg(
-            prim_path=contact_sensor_prim_path,
-            filter_prim_paths_expr=filter_prim_paths,
-        )
-
-    def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
-        """Return the spawn config to use: custom spawner_cfg if set, else a UsdFileCfg."""
-        if self.spawner_cfg is not None:
-            return self.spawner_cfg
-        return UsdFileCfg(
-            usd_path=self.usd_path,
-            scale=self.scale,
-            activate_contact_sensors=activate_contact_sensors,
-            **self.spawn_cfg_addon,
-        )
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        assert self.object_type == ObjectType.RIGID
-        object_cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(activate_contact_sensors=True),
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        assert self.object_type == ObjectType.ARTICULATION
-        object_cfg = ArticulationCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(activate_contact_sensors=True),
-            **self.asset_cfg_addon,
-            actuators={},
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        assert self.object_type == ObjectType.BASE
-        if self.spawner_cfg is None:
-            with open_stage(self.usd_path) as stage:
-                if has_light(stage):
-                    print(
-                        "WARNING: Base object has lights, this may cause issues when using with multiple environments."
-                    )
-        object_cfg = AssetBaseCfg(
-            prim_path=self.prim_path,
-            spawn=self._get_spawn_cfg(),
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(object_cfg)
-
-    def _add_initial_pose_to_cfg(
-        self, object_cfg: RigidObjectCfg | ArticulationCfg | AssetBaseCfg
-    ) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
-        # Optionally specify initial pose
-        initial_pose = self._get_initial_pose_as_pose()
-        if initial_pose is not None:
-            object_cfg.init_state.pos = initial_pose.position_xyz
-            object_cfg.init_state.rot = initial_pose.rotation_xyzw
-        return object_cfg
 
     def _requires_reset_pose_event(self) -> bool:
         return super()._requires_reset_pose_event() and self.reset_pose

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -8,12 +8,9 @@ from __future__ import annotations
 import torch
 from abc import ABC, abstractmethod
 
-import warp as wp
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
-from isaaclab.managers import EventTermCfg, SceneEntityCfg
+from isaaclab.managers import EventTermCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
-from isaaclab_tasks.manager_based.manipulation.stack.mdp.franka_stack_events import randomize_object_pose
 
 # Re-export ObjectType from the lightweight module so existing
 # `from isaaclab_arena.assets.object_base import ObjectType` consumers keep working,
@@ -21,10 +18,8 @@ from isaaclab_tasks.manager_based.manipulation.stack.mdp.franka_stack_events imp
 # pulling in isaaclab/omni/pxr at module-load time.
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.relations.placement_asset import PlaceableAsset
-from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
-from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.velocity import Velocity
-from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
 __all__ = [
     "ObjectBase",
@@ -33,7 +28,7 @@ __all__ = [
 
 
 class ObjectBase(PlaceableAsset, ABC):
-    """Parent class for (spawnable) Object and ObjectReference."""
+    """Base class for Arena scene objects with a construction-time immutable prim path."""
 
     def __init__(
         self,
@@ -47,169 +42,34 @@ class ObjectBase(PlaceableAsset, ABC):
             prim_path = "{ENV_REGEX_NS}/" + self.name
         self.prim_path = prim_path
         self.object_type = object_type
-        if self.object_type == ObjectType.RIGID:
-            self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None
         self.object_cfg = None
 
-    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
-        """Store the pose and write its construction values into the object config."""
-        self.initial_pose = pose
-        initial_pose = self._get_initial_pose_as_pose()
-        if initial_pose is not None and self.object_cfg is not None:
-            self.object_cfg.init_state.pos = initial_pose.position_xyz
-            self.object_cfg.init_state.rot = initial_pose.rotation_xyzw
-
-    def set_initial_velocity(self, velocity: Velocity) -> None:
-        """Set / override the initial velocity and rebuild derived configs.
-
-        The velocity is applied as ``init_state.lin_vel`` and
-        ``init_state.ang_vel`` on the underlying config
-        (``RigidObjectCfg`` or ``ArticulationCfg``) and is also restored
-        on every environment reset via the reset event.
-
-        Args:
-            velocity: A ``Velocity`` specifying linear and angular components.
-        """
-        self.initial_velocity = velocity
-        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "lin_vel"):
-            self.object_cfg.init_state.lin_vel = velocity.linear_xyz
-        if self.object_cfg is not None and hasattr(self.object_cfg.init_state, "ang_vel"):
-            self.object_cfg.init_state.ang_vel = velocity.angular_xyz
-        self._pose_event_cfg = self._build_reset_event()
-
-    def _requires_reset_pose_event(self) -> bool:
-        """Whether a reset-event for the initial pose should be generated.
-
-        Subclasses may override to add extra conditions (e.g. a ``reset_pose`` flag).
-        """
-        return self.get_initial_pose() is not None and self.object_type in (
-            ObjectType.RIGID,
-            ObjectType.ARTICULATION,
-        )
-
-    def _build_reset_event(self) -> EventTermCfg | None:
-        """Build the ``EventTermCfg`` for resetting this object's pose and velocity."""
-        if not self._requires_reset_pose_event():
-            return None
-
-        initial_pose = self.get_initial_pose()
-        if isinstance(initial_pose, PosePerEnv):
-            return EventTermCfg(
-                func=set_object_pose_per_env,
-                mode="reset",
-                params={
-                    "asset_cfg": SceneEntityCfg(self.name),
-                    "pose_list": initial_pose.poses,
-                },
-            )
-        elif isinstance(initial_pose, PoseRange):
-            return EventTermCfg(
-                func=randomize_object_pose,
-                mode="reset",
-                params={
-                    "pose_range": initial_pose.to_dict(),
-                    "asset_cfgs": [SceneEntityCfg(self.name)],
-                },
-            )
-        else:  # Pose
-            return EventTermCfg(
-                func=set_object_pose,
-                mode="reset",
-                params={
-                    "pose": initial_pose,
-                    "asset_cfg": SceneEntityCfg(self.name),
-                    "velocity": self.initial_velocity,
-                },
-            )
-
-    def set_prim_path(self, prim_path: str) -> None:
-        self.prim_path = prim_path
+    def resolve_object_cfg(self, physics_preset: object | None = None):
+        """Return the concrete Isaac Lab config for a selected physics preset."""
+        return self.object_cfg
 
     def get_prim_path(self) -> str:
         return self.prim_path
 
-    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
+    def _get_contact_sensor_prim_path(self, usd_path: str | None = None) -> str:
+        """Return the root prim used for contact sensing by default."""
+        return self.prim_path
+
+    def get_object_cfg(self) -> tuple[str, object]:
         return self.name, self.object_cfg
 
     def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
         return self.name, self._pose_event_cfg
 
-    def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
-        if self.object_type == ObjectType.RIGID:
-            object_cfg = self._generate_rigid_cfg()
-        elif self.object_type == ObjectType.ARTICULATION:
-            object_cfg = self._generate_articulation_cfg()
-        elif self.object_type == ObjectType.BASE:
-            object_cfg = self._generate_base_cfg()
-        else:
-            raise ValueError(f"Invalid object type: {self.object_type}")
-        return object_cfg
-
+    @abstractmethod
     def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
-        """Get the pose of the object in the environment.
+        """Return the object's per-environment pose as ``(x, y, z, qx, qy, qz, qw)``."""
 
-        Args:
-            env: The environment.
-            is_relative: Whether to return the pose in the relative frame of the environment.
-
-        Returns:
-            The pose of the object in each environment. The shape is (num_envs, 7).
-            The order is (x, y, z, qx, qy, qz, qw).
-        """
-        # We require that the asset has been added to the scene under its name.
-        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if (self.object_type == ObjectType.RIGID) or (self.object_type == ObjectType.ARTICULATION):
-            object_pose = wp.to_torch(env.unwrapped.scene[self.name].data.root_pose_w).clone()
-        elif self.object_type == ObjectType.BASE:
-            object_pose = torch.cat(env.unwrapped.scene[self.name].get_world_poses(), dim=-1)
-        else:
-            raise ValueError(f"Function not implemented for object type: {self.object_type}")
-        if is_relative:
-            object_pose[:, :3] -= env.unwrapped.scene.env_origins
-        return object_pose
-
+    @abstractmethod
     def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
-        """Set the pose of the object in the environment.
-
-        Args:
-            env: The environment.
-            pose: The pose to set.
-        """
-        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if env_ids is None:
-            env_ids = torch.arange(env.unwrapped.num_envs, device=env.unwrapped.device)
-        # Grab the object
-        asset = env.unwrapped.scene[self.name]
-        num_envs = len(env_ids)
-        # Convert the pose to the env frame
-        pose_t_xyz_q_xyzw = pose.to_tensor(device=env.unwrapped.device).repeat(num_envs, 1)
-        pose_t_xyz_q_xyzw[:, :3] += env.unwrapped.scene.env_origins[env_ids]
-        # Set the pose and velocity
-        asset.write_root_pose_to_sim(pose_t_xyz_q_xyzw, env_ids=env_ids)
-        asset.write_root_velocity_to_sim(
-            torch.zeros(env.unwrapped.num_envs, 6, device=env.unwrapped.device), env_ids=env_ids
-        )
+        """Write the object's pose for the selected environments."""
 
     def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
-        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
-        filter_prim_paths = [contact_against_object.get_prim_path()] if contact_against_object else []
-        return ContactSensorCfg(
-            prim_path=self.prim_path,
-            filter_prim_paths_expr=filter_prim_paths,
-        )
-
-    @abstractmethod
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        # Subclasses must implement this method
-        pass
-
-    @abstractmethod
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        # Subclasses must implement this method
-        pass
-
-    @abstractmethod
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        # Subclasses must implement this method
-        pass
+        """Return a contact sensor config when this object representation supports one."""
+        raise NotImplementedError(f"{type(self).__name__} does not support contact sensors")

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -5,12 +5,10 @@
 
 import trimesh
 
-from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
-from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from pxr import Usd
 
 from isaaclab_arena.affordances.openable import Openable
-from isaaclab_arena.assets.object import Object
+from isaaclab_arena.assets.object import Object, RootedTransform
 from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
 from isaaclab_arena.relations.relations import IsAnchor, RelationBase
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, quaternion_to_90_deg_z_quarters
@@ -24,11 +22,11 @@ from isaaclab_arena.utils.usd_helpers import (
 from isaaclab_arena.utils.usd_pose_helpers import get_prim_pose_in_default_prim_frame
 
 
-class ObjectReference(ObjectBase):
-    """An object which *refers* to an existing element in the scene"""
+class ReferencedPrim:
+    """Provenance and geometry behavior for a prim nested in a parent asset."""
 
-    def __init__(self, parent_asset: Object, **kwargs):
-        super().__init__(**kwargs)
+    def _init_referenced_prim(self, parent_asset: Object) -> None:
+        """Resolve and cache this object's parent-relative prim state."""
         self.parent_asset = parent_asset
         self._parent_scale = parent_asset.scale
         # Resolve the path and pose together to avoid opening the parent USD stage multiple times.
@@ -56,6 +54,12 @@ class ObjectReference(ObjectBase):
         """Return the referenced prim's absolute path in its parent USD stage."""
         return self._prim_path_in_parent_usd
 
+    def _resolve_prim_path_in_parent_usd(self, parent_stage: Usd.Stage) -> str:
+        """Return the cached referenced path, resolving it for partially initialized test objects."""
+        return getattr(self, "_prim_path_in_parent_usd", None) or self.isaaclab_prim_path_to_original_prim_path(
+            self.prim_path, self.parent_asset, parent_stage
+        )
+
     def add_relation(self, relation: RelationBase) -> None:
         """Add a relation to this object reference.
 
@@ -81,9 +85,7 @@ class ObjectReference(ObjectBase):
         """
         if self._bounding_box is None:
             with open_stage(self.parent_asset.usd_path) as parent_stage:
-                prim_path_in_usd = self.isaaclab_prim_path_to_original_prim_path(
-                    self.prim_path, self.parent_asset, parent_stage
-                )
+                prim_path_in_usd = self._resolve_prim_path_in_parent_usd(parent_stage)
                 raw_bbox = compute_local_bounding_box_from_prim(parent_stage, prim_path_in_usd)
                 # Apply parent's scale (no centering - solver is origin-agnostic)
                 self._bounding_box = raw_bbox.scaled(self._parent_scale)
@@ -121,61 +123,14 @@ class ObjectReference(ObjectBase):
     def _extract_collision_mesh(self) -> trimesh.Trimesh:
         """Extract the referenced prim mesh from the parent asset USD."""
         with open_stage(self.parent_asset.usd_path) as parent_stage:
-            prim_path_in_usd = self.isaaclab_prim_path_to_original_prim_path(
-                self.prim_path, self.parent_asset, parent_stage
-            )
+            prim_path_in_usd = self._resolve_prim_path_in_parent_usd(parent_stage)
             if not parent_stage.GetPrimAtPath(prim_path_in_usd):
                 raise ValueError(f"No prim found with path {prim_path_in_usd} in {self.parent_asset.usd_path}")
             return extract_trimesh_from_prim(parent_stage, prim_path_in_usd, self._parent_scale)
 
-    def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
-        # NOTE(alexmillane): Right now this requires that the object
-        # has the contact sensor enabled prior to using this reference.
-        # At the moment, for the tests, I enabled the relevant APIs in the GUI.
-        # TODO(alexmillane, 2025.09.08): Make the code automatically enable the
-        # contact reporter API.
-        # NOTE(alexmillane, 2025.11.27): I've added a function for adding
-        # the contact reporter API to a prim in a USD, perhaps that can be repurposed
-        # and used here.
-        # Just call out to the parent class method.
-        return super().get_contact_sensor_cfg(contact_against_object)
-
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        assert self.object_type == ObjectType.RIGID
-        initial_pose = self.get_initial_pose()
-        object_cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            init_state=RigidObjectCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
-
-    def _generate_articulation_cfg(self) -> ArticulationCfg:
-        assert self.object_type == ObjectType.ARTICULATION
-        initial_pose = self.get_initial_pose()
-        object_cfg = ArticulationCfg(
-            prim_path=self.prim_path,
-            actuators={},
-            init_state=ArticulationCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
-
-    def _generate_base_cfg(self) -> AssetBaseCfg:
-        assert self.object_type == ObjectType.BASE
-        initial_pose = self.get_initial_pose()
-        object_cfg = AssetBaseCfg(
-            prim_path=self.prim_path,
-            init_state=AssetBaseCfg.InitialStateCfg(
-                pos=initial_pose.position_xyz,
-                rot=initial_pose.rotation_xyzw,
-            ),
-        )
-        return object_cfg
+    def _get_cfg_source_kwargs(self, activate_contact_sensors: bool = False) -> dict[str, object]:
+        """Return no spawn arguments because the referenced prim already exists."""
+        return {}
 
     def _get_referenced_prim_path_and_pose_relative_to_parent(self, parent_asset: Object) -> tuple[str, Pose]:
         """Get the prim path and transform pose relative to the parent's default prim.
@@ -230,6 +185,15 @@ class ObjectReference(ObjectBase):
         # Append the default prim path.
         original_prim_path = str(default_prim_path) + original_prim_path
         return original_prim_path
+
+
+class ObjectReference(ReferencedPrim, RootedTransform, ObjectBase):
+    """Rigid, articulated, or static object represented by an existing parent prim."""
+
+    def __init__(self, parent_asset: Object, **kwargs):
+        super().__init__(**kwargs)
+        self._init_rooted_transform()
+        self._init_referenced_prim(parent_asset)
 
 
 class OpenableObjectReference(ObjectReference, Openable):

--- a/isaaclab_arena/assets/object_type.py
+++ b/isaaclab_arena/assets/object_type.py
@@ -22,3 +22,4 @@ class ObjectType(str, Enum):
     BASE = "base"
     RIGID = "rigid"
     ARTICULATION = "articulation"
+    DEFORMABLE = "deformable"

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -6,7 +6,7 @@
 import pathlib
 from typing import Any, Union
 
-from isaaclab.assets import AssetBaseCfg, RigidObjectCfg
+from isaaclab.assets import AssetBaseCfg, DeformableObjectCfg, RigidObjectCfg
 from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from pxr import Gf, Usd, UsdGeom
@@ -20,7 +20,7 @@ from isaaclab_arena.utils.configclass import make_configclass
 from isaaclab_arena.utils.phyx_utils import add_contact_report
 from isaaclab_arena.variations.variation_base import VariationBase
 
-AssetCfg = Union[AssetBaseCfg, RigidObjectCfg, ArticulationCfg, ContactSensorCfg]
+AssetCfg = Union[AssetBaseCfg, RigidObjectCfg, ArticulationCfg, DeformableObjectCfg, ContactSensorCfg]
 
 
 class Scene:
@@ -65,12 +65,16 @@ class Scene:
         for asset in sorted_assets:
             self.add_asset(asset)
 
-    def get_scene_cfg(self) -> Any:
+    def get_scene_cfg(self, physics_preset: str | None = None) -> Any:
         """Returns a configclass containing all the scene elements."""
         # Combine the configs into a configclass.
         fields: list[tuple[str, type, AssetCfg]] = []
         for asset in self.assets.values():
-            asset_cfg_name, asset_cfg = asset.get_object_cfg()
+            if hasattr(asset, "resolve_object_cfg"):
+                asset_cfg_name = asset.name
+                asset_cfg = asset.resolve_object_cfg(physics_preset)
+            else:
+                asset_cfg_name, asset_cfg = asset.get_object_cfg()
             fields.append((asset_cfg_name, type(asset_cfg), asset_cfg))
         SceneCfg = make_configclass("SceneCfg", fields)
         scene_cfg = SceneCfg()

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -13,6 +13,96 @@ from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.velocity import Velocity
 
 
+def _quat_inverse_xyzw(quat: torch.Tensor) -> torch.Tensor:
+    quat = quat / quat.norm(dim=-1, keepdim=True).clamp_min(1.0e-8)
+    return torch.cat((-quat[:, :3], quat[:, 3:]), dim=-1)
+
+
+def _quat_multiply_xyzw(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    lx, ly, lz, lw = lhs.unbind(dim=-1)
+    rx, ry, rz, rw = rhs.unbind(dim=-1)
+    return torch.stack(
+        (
+            lw * rx + lx * rw + ly * rz - lz * ry,
+            lw * ry - lx * rz + ly * rw + lz * rx,
+            lw * rz + lx * ry - ly * rx + lz * rw,
+            lw * rw - lx * rx - ly * ry - lz * rz,
+        ),
+        dim=-1,
+    )
+
+
+def _quat_rotate_xyzw(quat: torch.Tensor, points: torch.Tensor) -> torch.Tensor:
+    quat = quat / quat.norm(dim=-1, keepdim=True).clamp_min(1.0e-8)
+    q_vec = quat[:, :3].unsqueeze(1).expand_as(points)
+    q_w = quat[:, 3:].unsqueeze(1)
+    t = 2.0 * torch.cross(q_vec, points, dim=-1)
+    return points + q_w * t + torch.cross(q_vec, t, dim=-1)
+
+
+def _deformable_nodal_state_for_pose(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose: Pose,
+    velocity: Velocity | None = None,
+) -> torch.Tensor:
+    """Transform an asset's default nodal state to an env-local pose."""
+    asset = env.scene[asset_cfg.name]
+    nodal_state = asset.data.default_nodal_state_w.torch[env_ids].clone()
+    default_pos_w = nodal_state[..., :3]
+    default_centroid_w = default_pos_w.mean(dim=1)
+
+    target_pos_w = torch.tensor(pose.position_xyz, device=env.device).repeat(len(env_ids), 1)
+    target_pos_w += env.scene.env_origins[env_ids]
+    target_quat = torch.tensor(pose.rotation_xyzw, device=env.device).repeat(len(env_ids), 1)
+    default_quat = torch.tensor(asset.cfg.init_state.rot, device=env.device).repeat(len(env_ids), 1)
+    delta_quat = _quat_multiply_xyzw(target_quat, _quat_inverse_xyzw(default_quat))
+    nodal_state[..., :3] = target_pos_w.unsqueeze(1) + _quat_rotate_xyzw(
+        delta_quat, default_pos_w - default_centroid_w.unsqueeze(1)
+    )
+    if velocity is None:
+        nodal_state[..., 3:] = 0.0
+    else:
+        nodal_state[..., 3:] = torch.tensor(velocity.linear_xyz, device=env.device)
+    return nodal_state
+
+
+def set_deformable_object_pose(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose: Pose,
+    velocity: Velocity | None = None,
+) -> None:
+    """Restore a deformable by transforming its default nodal state."""
+    if env_ids is None:
+        return
+    asset = env.scene[asset_cfg.name]
+    nodal_state = _deformable_nodal_state_for_pose(env, env_ids, asset_cfg, pose, velocity)
+    asset.write_nodal_state_to_sim_index(nodal_state, env_ids=env_ids)
+    asset.reset(env_ids=env_ids)
+
+
+def set_deformable_object_pose_per_env(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_list: list[Pose],
+) -> None:
+    """Restore selected deformable instances from absolute env-indexed poses."""
+    if env_ids is None:
+        return
+    assert env_ids.ndim == 1, "env_ids must be one-dimensional"
+    assert len(pose_list) == env.scene.env_origins.shape[0], "pose_list must contain one pose per environment"
+    asset = env.scene[asset_cfg.name]
+    for cur_env in env_ids.tolist():
+        cur_env_ids = torch.tensor([cur_env], device=env.device)
+        nodal_state = _deformable_nodal_state_for_pose(env, cur_env_ids, asset_cfg, pose_list[cur_env])
+        asset.write_nodal_state_to_sim_index(nodal_state, env_ids=cur_env_ids)
+    asset.reset(env_ids=env_ids)
+
+
 def set_object_pose(
     env: ManagerBasedEnv,
     env_ids: torch.Tensor,

--- a/isaaclab_arena/tests/test_affordance_base.py
+++ b/isaaclab_arena/tests/test_affordance_base.py
@@ -10,6 +10,78 @@ from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_wi
 HEADLESS = True
 
 
+def _test_runtime_object_hierarchy(simulation_app):
+    """Runtime object classes expose the transform and provenance mixins they support."""
+    from isaaclab_arena.assets.deformable_object import DeformableObject, DeformableTransform
+    from isaaclab_arena.assets.object import Object, RootedTransform, SpawnPrim
+    from isaaclab_arena.assets.object_base import ObjectBase
+    from isaaclab_arena.assets.object_reference import ObjectReference, ReferencedPrim
+
+    assert issubclass(Object, ObjectBase)
+    assert SpawnPrim in Object.__mro__
+    assert RootedTransform in Object.__mro__
+
+    assert issubclass(ObjectReference, ObjectBase)
+    assert ReferencedPrim in ObjectReference.__mro__
+    assert RootedTransform in ObjectReference.__mro__
+
+    assert issubclass(DeformableObject, ObjectBase)
+    assert SpawnPrim in DeformableObject.__mro__
+    assert DeformableTransform in DeformableObject.__mro__
+    assert RootedTransform not in DeformableObject.__mro__
+    return True
+
+
+def test_runtime_object_hierarchy():
+    assert run_function_with_persistent_simulation_app(_test_runtime_object_hierarchy, headless=HEADLESS)
+
+
+def _test_runtime_object_affordance_mro_initialization(simulation_app):
+    """Rooted runtime classes cooperatively initialize affordances through their MRO."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from isaaclab_arena.affordances.openable import Openable
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_reference import OpenableObjectReference, ReferencedPrim
+
+    class OpenableObject(Object, Openable):
+        def _generate_base_cfg(self):
+            return SimpleNamespace(init_state=SimpleNamespace())
+
+    rooted_object = OpenableObject(
+        name="cabinet",
+        usd_path="/tmp/cabinet.usd",
+        object_type=ObjectType.BASE,
+        openable_joint_name="door_joint",
+        openable_threshold=0.25,
+    )
+    assert rooted_object.name == "cabinet"
+    assert rooted_object.openable_joint_name == "door_joint"
+    assert rooted_object.openable_threshold == 0.25
+
+    with patch.object(ReferencedPrim, "_init_referenced_prim", lambda self, parent_asset: None):
+        rooted_reference = OpenableObjectReference(
+            name="door",
+            prim_path="{ENV_REGEX_NS}/cabinet/door",
+            parent_asset=rooted_object,
+            openable_joint_name="door_joint",
+            openable_threshold=0.75,
+        )
+    assert rooted_reference.name == "door"
+    assert rooted_reference.openable_joint_name == "door_joint"
+    assert rooted_reference.openable_threshold == 0.75
+    return True
+
+
+def test_runtime_object_affordance_mro_initialization():
+    assert run_function_with_persistent_simulation_app(
+        _test_runtime_object_affordance_mro_initialization,
+        headless=HEADLESS,
+    )
+
+
 def _test_affordance_base(simulation_app):
 
     from isaaclab_arena.affordances.openable import Openable

--- a/isaaclab_arena/tests/test_deformable_object.py
+++ b/isaaclab_arena/tests/test_deformable_object.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused configuration and PhysX smoke tests for volume deformables."""
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+HEADLESS = True
+
+
+def _make_soft_cube(initial_pose=None):
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+    from isaaclab_arena.assets.deformable_spawn import VolumeDeformableMaterial
+
+    return DeformableObject(
+        name="soft_cube",
+        spawner_cfg=sim_utils.MeshCuboidCfg(size=(0.1, 0.1, 0.1)),
+        material=VolumeDeformableMaterial(
+            youngs_modulus=8.0e4,
+            poissons_ratio=0.4,
+            density=300.0,
+            particle_radius=0.01,
+        ),
+        initial_pose=initial_pose,
+    )
+
+
+def _test_volume_deformable_config(simulation_app) -> bool:
+    from isaaclab.assets import DeformableObjectCfg
+    from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+    from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
+    from isaaclab_physx.sim.schemas import PhysxDeformableBodyPropertiesCfg
+    from isaaclab_physx.sim.spawners.materials import PhysxDeformableBodyMaterialCfg
+
+    from isaaclab_arena.assets.deformable_spawn import lame_parameters
+    from isaaclab_arena.utils.pose import Pose
+
+    pose = Pose(position_xyz=(0.1, -0.2, 0.3), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+    soft_cube = _make_soft_cube(initial_pose=pose)
+    cfg = soft_cube.resolve_object_cfg()
+
+    assert isinstance(cfg, DeformableObjectCfg)
+    assert isinstance(cfg.spawn.deformable_props, PhysxDeformableBodyPropertiesCfg)
+    assert isinstance(cfg.spawn.physics_material, PhysxDeformableBodyMaterialCfg)
+    assert cfg.spawn.physics_material.youngs_modulus == pytest.approx(8.0e4)
+    assert cfg.spawn.physics_material.poissons_ratio == pytest.approx(0.4)
+    assert cfg.spawn.physics_material.density == pytest.approx(300.0)
+    assert cfg.init_state.pos == pose.position_xyz
+    assert cfg.init_state.rot == pose.rotation_xyzw
+    assert soft_cube.object_type.value == "deformable"
+
+    cfg = soft_cube.resolve_object_cfg("newton_mjwarp_vbd")
+    assert isinstance(cfg.spawn.deformable_props, NewtonDeformableBodyPropertiesCfg)
+    assert isinstance(cfg.spawn.physics_material, NewtonDeformableBodyMaterialCfg)
+    expected_mu, expected_lambda = lame_parameters(8.0e4, 0.4)
+    assert cfg.spawn.physics_material.k_mu == pytest.approx(expected_mu)
+    assert cfg.spawn.physics_material.k_lambda == pytest.approx(expected_lambda)
+    assert cfg.spawn.physics_material.density == pytest.approx(300.0)
+    with pytest.raises(ValueError, match="does not support volume deformables"):
+        soft_cube.resolve_object_cfg("newton")
+    return True
+
+
+def _test_physx_deformable_smoke(simulation_app) -> bool:
+    import torch
+
+    from isaaclab.assets import DeformableObjectCfg
+
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+    poses = PosePerEnv(
+        poses=[
+            Pose(position_xyz=(0.0, 0.0, 0.5), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+            Pose(position_xyz=(0.2, 0.0, 0.6), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+        ]
+    )
+    soft_cube = _make_soft_cube(initial_pose=poses)
+    arena_env = IsaacLabArenaEnvironment(
+        name="physx_deformable_smoke",
+        scene=Scene(assets=[soft_cube]),
+    )
+    args = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "2"])
+    builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args))
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    assert isinstance(env_cfg.scene.soft_cube, DeformableObjectCfg)
+    env = builder.make_registered(env_cfg, env_kwargs)
+    env.reset()
+
+    try:
+        asset = env.unwrapped.scene[soft_cube.name]
+        nodal_state = asset.data.nodal_state_w.torch.clone()
+        assert torch.isfinite(nodal_state).all()
+        expected = torch.tensor([pose.position_xyz for pose in poses.poses], device=env.unwrapped.device)
+        centroids = nodal_state[..., :3].mean(dim=1) - env.unwrapped.scene.env_origins
+        torch.testing.assert_close(centroids, expected, atol=2.0e-3, rtol=0.0)
+
+        displaced = nodal_state.clone()
+        displaced[..., 0] += 0.25
+        asset.write_nodal_state_to_sim_index(displaced)
+        env.reset()
+        restored = asset.data.nodal_state_w.torch
+        restored_centroids = restored[..., :3].mean(dim=1) - env.unwrapped.scene.env_origins
+        torch.testing.assert_close(restored_centroids, expected, atol=2.0e-3, rtol=0.0)
+    finally:
+        env.close()
+    return True
+
+
+def test_volume_deformable_config():
+    assert run_function_with_persistent_simulation_app(_test_volume_deformable_config, headless=HEADLESS)
+
+
+def test_physx_deformable_smoke():
+    assert run_function_with_persistent_simulation_app(_test_physx_deformable_smoke, headless=HEADLESS)

--- a/isaaclab_arena/tests/test_object_configuration.py
+++ b/isaaclab_arena/tests/test_object_configuration.py
@@ -10,6 +10,10 @@ HEADLESS = True
 
 def _test_object_initial_pose_update(simulation_app):
 
+    from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg
+
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.utils.pose import Pose
 
@@ -26,6 +30,16 @@ def _test_object_initial_pose_update(simulation_app):
     # Now lets check that the initial pose has been updated and that the debug visualization is still disabled.
     assert rigid_object.get_initial_pose() == new_initial_pose
     assert rigid_object.object_cfg.debug_vis is False
+
+    source = Object(name="source", object_type=ObjectType.RIGID, spawner_cfg=MeshCuboidCfg(size=(0.1, 0.1, 0.1)))
+    destination = Object(
+        name="destination",
+        object_type=ObjectType.RIGID,
+        spawner_cfg=MeshCuboidCfg(size=(0.1, 0.1, 0.1)),
+    )
+    contact_sensor_cfg = source.get_contact_sensor_cfg(contact_against_object=destination)
+    assert contact_sensor_cfg.prim_path == source.prim_path
+    assert contact_sensor_cfg.filter_prim_paths_expr == [destination.prim_path]
 
     return True
 


### PR DESCRIPTION
## Summary
Add volume deformable object support.

## Detailed description
- Build on `qianl/refactor/split-object-behavior-axes` using `DeformableTransform`, `SpawnPrim`, and `ObjectBase`.
- Resolve neutral volume materials and spawn sources into PhysX or Newton VBD configurations.
- Add nodal pose/reset behavior, deformable bounds, and explicit rejection of rigid contact sensors.
- Add hierarchy, configuration, reset, and PhysX smoke coverage.
