### PR TITLE
Add deformable pick-and-place support.

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import gymnasium as gym
 from typing import Any
@@ -19,6 +20,7 @@ from isaaclab_tasks.utils import parse_env_cfg
 from isaaclab_teleop import IsaacTeleopCfg
 
 import isaaclab_arena_curobo  # noqa: F401
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.registries import DeviceRegistry
 from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
@@ -410,7 +412,24 @@ class ArenaEnvBuilder:
             if presets == "newton":
                 env_cfg.scene.replicate_physics = True
 
-        env_kwargs: dict[str, Any] = {"variation_recorder": variation_recorder}
+        object_types = {
+            asset.name: asset.object_type
+            for asset in self.arena_env.scene.assets.values()
+            if isinstance(getattr(asset, "object_type", None), ObjectType)
+        }
+        object_bounds = {}
+        for name in object_types:
+            asset = self.arena_env.scene.assets[name]
+            if not hasattr(asset, "get_bounding_box") or getattr(asset, "usd_path", True) is None:
+                continue
+            with contextlib.suppress(AssertionError):
+                object_bounds[name] = asset.get_bounding_box()
+
+        env_kwargs: dict[str, Any] = {
+            "variation_recorder": variation_recorder,
+            "arena_object_types": object_types,
+            "arena_object_bounds": object_bounds,
+        }
         return env_cfg, env_kwargs
 
     def get_entry_point(self) -> str | type[ManagerBasedRLMimicEnv]:
@@ -448,14 +467,17 @@ class ArenaEnvBuilder:
             env_kwargs = {}
         entry_point = self.get_entry_point()
         # Register the environment with the Gym registry.
-        # NOTE(alexmillane, 2026-08-05): Do not spread env_kwargs into the registry kwargs. env_kwargs carries the
-        # VariationRecorder, whose bind_env() holds a reference to the constructed env
-        # (and thus its SimulationContext/PhysX GPU buffers). The Gym registry is process-global
-        # and never cleared, so pinning it there retains every registered env's GPU memory until
-        # process exit — an unbounded leak across a persistent SimulationApp.
+        # NOTE(alexmillane, 2026-08-05): Do not spread all env_kwargs into the registry kwargs. env_kwargs carries
+        # the VariationRecorder, whose bind_env() holds a reference to the constructed env (and thus its
+        # SimulationContext/PhysX GPU buffers). The Gym registry is process-global and never cleared, so pinning
+        # the recorder there retains every registered env's GPU memory until process exit. Object metadata is
+        # non-owning and must be registered so Isaac Lab external scripts can construct the env without access
+        # to the env_kwargs returned here.
         # TODO(alexmillane, 2026-08-05): Fix this issue and remove this note.
         kwargs = {
             "env_cfg_entry_point": env_cfg,
+            "arena_object_types": env_kwargs.get("arena_object_types", {}),
+            "arena_object_bounds": env_kwargs.get("arena_object_bounds", {}),
         }
         if env_cfg.demo_recorder_config is not None:
             kwargs["demo_recorder_cfg_entry_point"] = env_cfg.demo_recorder_config

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -9,11 +9,13 @@ from collections.abc import Sequence
 
 from isaaclab.envs import ManagerBasedRLEnv
 
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import IsaacLabArenaManagerBasedRLEnvCfg
 from isaaclab_arena.metrics.metric_data import MetricsDataCollection
 from isaaclab_arena.metrics.metrics_manager import MetricsManager
 from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderManager
 from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.variations.variation_recorder import VariationRecorder
 
 
@@ -27,12 +29,16 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         cfg: IsaacLabArenaManagerBasedRLEnvCfg,
         render_mode: str | None = None,
         variation_recorder: VariationRecorder | None = None,
+        arena_object_types: dict[str, ObjectType] | None = None,
+        arena_object_bounds: dict[str, AxisAlignedBoundingBox] | None = None,
         **kwargs,
     ):
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )
         self._variation_recorder = variation_recorder
+        self._arena_object_types = dict(arena_object_types or {})
+        self._arena_object_bounds = dict(arena_object_bounds or {})
         if variation_recorder is not None:
             # Bind so run-time variation draws can be attributed to the current episode index.
             variation_recorder.bind_env(self)
@@ -56,6 +62,16 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
     def object_initial_rest_pose_recorder(self) -> ObjectInitialRestPoseRecorder:
         """The recorder of initial object rest poses. Used when object_settled predicate is enabled by task progress tracking."""
         return self._object_initial_rest_pose_recorder
+
+    @property
+    def arena_object_types(self) -> dict[str, ObjectType]:
+        """Arena object types keyed by runtime scene name."""
+        return self._arena_object_types
+
+    @property
+    def arena_object_bounds(self) -> dict[str, AxisAlignedBoundingBox]:
+        """Local object bounds available to runtime geometry predicates."""
+        return self._arena_object_bounds
 
     @property
     def episode_recorder(self) -> EpisodeRecorderManager:

--- a/isaaclab_arena/scene/object_geometry.py
+++ b/isaaclab_arena/scene/object_geometry.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal runtime geometry helpers for object predicates."""
+
+from __future__ import annotations
+
+from isaaclab_arena.scene.object_state import get_env, object_state
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+
+def object_bounds_w(env, name: str) -> AxisAlignedBoundingBox:
+    """Return an object's authored local bounds transformed to its runtime pose."""
+    env = get_env(env)
+    assert name in env.arena_object_bounds, f"Arena local bounds metadata is missing for {name!r}"
+    state = object_state(env, name).aggregate
+    assert state.position_w is not None, f"Object {name!r} has no aggregate position"
+    assert state.orientation_w is not None, f"Object {name!r} has no aggregate orientation"
+    local_bounds = env.arena_object_bounds[name].to(state.position_w.device)
+    return local_bounds.rotated_by_quat(state.orientation_w).translated(state.position_w)

--- a/isaaclab_arena/scene/object_state.py
+++ b/isaaclab_arena/scene/object_state.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only, backend-neutral runtime state for Arena objects."""
+
+from __future__ import annotations
+
+import torch
+from dataclasses import dataclass
+
+import warp as wp
+
+from isaaclab_arena.assets.object_type import ObjectType
+
+
+@dataclass(frozen=True)
+class KinematicState:
+    """Kinematic channels for one aggregate object or its points."""
+
+    position_w: torch.Tensor | None = None
+    orientation_w: torch.Tensor | None = None
+    linear_velocity_w: torch.Tensor | None = None
+    angular_velocity_w: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class ObjectState:
+    """Aggregate state and optional deformable point state."""
+
+    aggregate: KinematicState
+    points: KinematicState | None = None
+
+
+def get_env(env):
+    """Resolve to the unwrapped manager-based environment."""
+    seen = set()
+    while hasattr(env, "unwrapped") and env.unwrapped is not env and id(env) not in seen:
+        seen.add(id(env))
+        env = env.unwrapped
+    return env
+
+
+def object_state(env, name: str) -> ObjectState:
+    """Return an object's state using its composed Arena object type."""
+    env = get_env(env)
+    assert name in env.scene.keys(), f"Asset {name!r} not found in scene"
+    assert name in env.arena_object_types, f"Arena object type metadata is missing for {name!r}"
+
+    entity = env.scene[name]
+    object_type = env.arena_object_types[name]
+    if object_type in (ObjectType.RIGID, ObjectType.ARTICULATION):
+        return ObjectState(
+            aggregate=KinematicState(
+                position_w=_to_torch(entity.data.root_pos_w),
+                orientation_w=_to_torch(entity.data.root_quat_w),
+                linear_velocity_w=_to_torch(entity.data.root_lin_vel_w),
+                angular_velocity_w=_to_torch(entity.data.root_ang_vel_w),
+            )
+        )
+    if object_type == ObjectType.DEFORMABLE:
+        return ObjectState(
+            aggregate=KinematicState(
+                position_w=_to_torch(entity.data.root_pos_w),
+                linear_velocity_w=_to_torch(entity.data.root_vel_w),
+            ),
+            points=KinematicState(
+                position_w=_to_torch(entity.data.nodal_pos_w),
+                linear_velocity_w=_to_torch(entity.data.nodal_vel_w),
+            ),
+        )
+    if object_type == ObjectType.BASE:
+        position_w, orientation_w = entity.get_world_poses()
+        return ObjectState(
+            aggregate=KinematicState(
+                position_w=_to_torch(position_w),
+                orientation_w=_to_torch(orientation_w),
+            )
+        )
+    raise ValueError(f"Unsupported Arena object type for {name!r}: {object_type!r}")
+
+
+def _to_torch(value) -> torch.Tensor:
+    """Convert an Isaac Lab state buffer to a torch tensor."""
+    if isinstance(value, torch.Tensor):
+        return value
+    tensor = getattr(value, "torch", None)
+    if isinstance(tensor, torch.Tensor):
+        return tensor
+    return wp.to_torch(value)

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -15,6 +15,7 @@ from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
 from isaaclab_arena.assets.register import agent_ready, register_task
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
@@ -24,7 +25,13 @@ from isaaclab_arena.metrics.success_rate import SuccessRateMetric
 from isaaclab_arena.progress_tracking.progress_objective import ProgressObjective
 from isaaclab_arena.tasks.common.mimic_default_params import MIMIC_DATAGEN_CONFIG_DEFAULTS
 from isaaclab_arena.tasks.predicates.object_settling import objects_settled
-from isaaclab_arena.tasks.predicates.spatial import object_is_above_height, object_on_destination, objects_in_proximity
+from isaaclab_arena.tasks.predicates.spatial import (
+    object_is_above_height,
+    object_is_below_height,
+    object_on_destination,
+    object_supported_by,
+    objects_in_proximity,
+)
 from isaaclab_arena.tasks.task_base import TaskBase
 from isaaclab_arena.tasks.task_transition import Relocate, TaskTransition
 from isaaclab_arena.tasks.terminations import SuccessMode, check_success
@@ -35,10 +42,11 @@ from isaaclab_arena.utils.configclass import make_configclass
 @agent_ready
 @register_task
 class PickAndPlaceTask(TaskBase):
-    """Pick-and-place task. Success fires when the pick-up object contacts the destination
-    with low velocity and, when ``max_separation`` is set, is within axis-aligned proximity
-    of the destination. Failure (object_dropped) fires when the object falls below the
-    background's ``object_min_z``.
+    """Pick-and-place task for rigid or deformable objects.
+
+    Rigid success uses destination contact and low velocity; deformable success uses geometric
+    support. When ``max_separation`` is set, success additionally requires axis-aligned proximity.
+    Failure fires when the object falls below the background's ``object_min_z``.
 
     The default Mimic cfg is ``PickPlaceMimicEnvCfg``. When a task needs a different cfg
     shape (different arm subtask sequences, different per-subtask numerical knobs,
@@ -54,7 +62,7 @@ class PickAndPlaceTask(TaskBase):
 
     def __init__(
         self,
-        pick_up_object: Asset,
+        pick_up_object: ObjectBase,
         destination_location: Asset,
         background_scene: Asset,
         destination_object: Asset | None = None,
@@ -70,7 +78,17 @@ class PickAndPlaceTask(TaskBase):
         self.destination_object = destination_object
         self.background_scene = background_scene
         self.destination_location = destination_location
-        self.contact_sensor_name = f"contact_sensor_{pick_up_object.name}"
+        if pick_up_object.object_type == ObjectType.RIGID:
+            self.placement_predicate = object_on_destination
+            self.contact_sensor_name = f"contact_sensor_{pick_up_object.name}"
+        elif pick_up_object.object_type == ObjectType.DEFORMABLE:
+            self.placement_predicate = object_supported_by
+            self.contact_sensor_name = None
+        else:
+            raise ValueError(
+                f"PickAndPlaceTask does not support pick-up object type {pick_up_object.object_type!r}; "
+                f"expected {ObjectType.RIGID.value!r} or {ObjectType.DEFORMABLE.value!r}."
+            )
         self.scene_config = self.make_scene_cfg()
         self.force_threshold = force_threshold
         self.velocity_threshold = velocity_threshold
@@ -91,6 +109,9 @@ class PickAndPlaceTask(TaskBase):
         self._apply_reachability_constraints([self.pick_up_object, self.destination_location])
 
     def make_scene_cfg(self):
+        if self.pick_up_object.object_type == ObjectType.DEFORMABLE:
+            return None
+        assert self.contact_sensor_name is not None
         contact_sensor_cfg = self.pick_up_object.get_contact_sensor_cfg(
             contact_against_object=self.destination_location,
         )
@@ -108,15 +129,7 @@ class PickAndPlaceTask(TaskBase):
 
     def make_termination_cfg(self):
         predicates = [
-            TerminationTermCfg(
-                func=object_on_destination,
-                params={
-                    "object_cfg": SceneEntityCfg(self.pick_up_object.name),
-                    "contact_sensor_cfg": SceneEntityCfg(self.contact_sensor_name),
-                    "force_threshold": self.force_threshold,
-                    "velocity_threshold": self.velocity_threshold,
-                },
-            ),
+            self._make_placement_predicate_cfg(),
         ]
         if self.max_separation is not None:
             # TODO(qianl): replace objects_in_proximity with object_centroid_in_proximity
@@ -143,15 +156,36 @@ class PickAndPlaceTask(TaskBase):
             },
         )
         object_dropped = TerminationTermCfg(
-            func=mdp_isaac_lab.root_height_below_minimum,
+            func=object_is_below_height,
             params={
+                "object_name": self.pick_up_object.name,
                 "minimum_height": self.background_scene.object_min_z,
-                "asset_cfg": SceneEntityCfg(self.pick_up_object.name),
             },
         )
         return TerminationsCfg(
             success=success,
             object_dropped=object_dropped,
+        )
+
+    def _make_placement_predicate_cfg(self) -> TerminationTermCfg:
+        """Build the object-type-specific placement predicate."""
+        if self.pick_up_object.object_type == ObjectType.RIGID:
+            assert self.contact_sensor_name is not None
+            return TerminationTermCfg(
+                func=self.placement_predicate,
+                params={
+                    "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                    "contact_sensor_cfg": SceneEntityCfg(self.contact_sensor_name),
+                    "force_threshold": self.force_threshold,
+                    "velocity_threshold": self.velocity_threshold,
+                },
+            )
+        return TerminationTermCfg(
+            func=self.placement_predicate,
+            params={
+                "object_cfg": SceneEntityCfg(self.pick_up_object.name),
+                "destination_cfg": SceneEntityCfg(self.destination_location.name),
+            },
         )
 
     def get_events_cfg(self):
@@ -164,39 +198,54 @@ class PickAndPlaceTask(TaskBase):
         ``arm_mode`` and return its result. Otherwise build the default
         ``PickPlaceMimicEnvCfg``.
         """
+        if self.pick_up_object.object_type == ObjectType.DEFORMABLE:
+            raise NotImplementedError("Mimic data generation is not supported for deformable pick-and-place objects.")
         if self.mimic_env_cfg_factory is not None:
             return self.mimic_env_cfg_factory(arm_mode)
+        destination_location_name = (
+            self.destination_object.name if self.destination_object is not None else self.destination_location.name
+        )
         return PickPlaceMimicEnvCfg(
             arm_mode=arm_mode,
             pick_up_object_name=self.pick_up_object.name,
-            destination_location_name=self.destination_object.name,
+            destination_location_name=destination_location_name,
         )
 
     def get_metrics(self) -> list[MetricBase]:
+        if self.pick_up_object.object_type == ObjectType.DEFORMABLE:
+            return [SuccessRateMetric()]
         return [SuccessRateMetric(), ObjectMovedRateMetric(self.pick_up_object)]
 
     def get_progress_objectives(self) -> list[ProgressObjective]:
+        placement_cfg = self._make_placement_predicate_cfg()
+        predicates = [
+            partial(
+                objects_settled,
+                object_names=[self.pick_up_object.name],
+            ),
+            partial(
+                object_is_above_height,
+                object_name=self.pick_up_object.name,
+                use_settled_state=True,
+            ),
+            partial(placement_cfg.func, **placement_cfg.params),
+        ]
+        if self.max_separation is not None:
+            max_x_separation, max_y_separation, max_z_separation = self.max_separation
+            predicates.append(
+                partial(
+                    objects_in_proximity,
+                    object_cfg=SceneEntityCfg(self.pick_up_object.name),
+                    target_object_cfg=SceneEntityCfg(self.destination_location.name),
+                    max_x_separation=max_x_separation,
+                    max_y_separation=max_y_separation,
+                    max_z_separation=max_z_separation,
+                )
+            )
         return [
             ProgressObjective(
                 name="pick_and_place",
-                predicate_groups=[
-                    partial(
-                        objects_settled,
-                        object_names=[self.pick_up_object.name],
-                    ),
-                    partial(
-                        object_is_above_height,
-                        object_name=self.pick_up_object.name,
-                        use_settled_state=True,
-                    ),
-                    partial(
-                        object_on_destination,
-                        object_cfg=SceneEntityCfg(self.pick_up_object.name),
-                        contact_sensor_cfg=SceneEntityCfg(self.contact_sensor_name),
-                        force_threshold=self.force_threshold,
-                        velocity_threshold=self.velocity_threshold,
-                    ),
-                ],
+                predicate_groups=predicates,
             ),
         ]
 

--- a/isaaclab_arena/tasks/predicates/object_settling.py
+++ b/isaaclab_arena/tasks/predicates/object_settling.py
@@ -17,8 +17,8 @@ import torch
 
 from isaaclab_arena.tasks.predicates.predicate_utils import (
     get_env,
+    get_max_point_speed_w,
     get_root_ang_vel_w,
-    get_root_lin_vel_w,
     get_root_pos_w,
     select,
 )
@@ -102,15 +102,14 @@ def objects_settled(
 ) -> torch.Tensor:
     """True per env when every object in the env is at rest, records each object's rest pose on first settle.
 
-    An object is at rest when both its linear speed (m/s) and its angular speed (rad/s) are below the
-    respective thresholds. The recorded rest poses are readable via ``get_object_initial_rest_state``.
+    Rigid objects use root linear and angular speed. Deformable objects use maximum nodal speed and
+    have no angular-speed condition. Recorded rest poses are readable via ``get_object_initial_rest_state``.
     """
 
-    lin_speeds = torch.stack(
-        [torch.linalg.vector_norm(get_root_lin_vel_w(env, name), dim=-1) for name in object_names], dim=0
-    )
+    lin_speeds = torch.stack([get_max_point_speed_w(env, name) for name in object_names], dim=0)
     ang_speeds = torch.stack(
-        [torch.linalg.vector_norm(get_root_ang_vel_w(env, name), dim=-1) for name in object_names], dim=0
+        [torch.linalg.vector_norm(get_root_ang_vel_w(env, name, required=False), dim=-1) for name in object_names],
+        dim=0,
     )
     settled = torch.all((lin_speeds < lin_vel_threshold) & (ang_speeds < ang_vel_threshold), dim=0)
 

--- a/isaaclab_arena/tasks/predicates/predicate_utils.py
+++ b/isaaclab_arena/tasks/predicates/predicate_utils.py
@@ -7,17 +7,9 @@ from __future__ import annotations
 
 import torch
 
-import warp as wp
 from isaaclab.assets import RigidObject
 
-
-def get_env(env):
-    """Resolve to the unwrapped manager-based env regardless of wrapper depth."""
-    seen = set()
-    while hasattr(env, "unwrapped") and env.unwrapped is not env and id(env) not in seen:
-        seen.add(id(env))
-        env = env.unwrapped
-    return env
+from isaaclab_arena.scene.object_state import get_env, object_state
 
 
 def get_rigid_object(env, name: str) -> RigidObject:
@@ -26,18 +18,36 @@ def get_rigid_object(env, name: str) -> RigidObject:
 
 
 def get_root_pos_w(env, name: str) -> torch.Tensor:
-    """Get the root position of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_pos_w)
+    """Get the aggregate object position in the world frame."""
+    position_w = object_state(env, name).aggregate.position_w
+    assert position_w is not None, f"Object {name!r} has no aggregate position"
+    return position_w
 
 
 def get_root_lin_vel_w(env, name: str) -> torch.Tensor:
-    """Get the root linear velocity of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_lin_vel_w)
+    """Get the aggregate object linear velocity in the world frame."""
+    linear_velocity_w = object_state(env, name).aggregate.linear_velocity_w
+    assert linear_velocity_w is not None, f"Object {name!r} has no aggregate linear velocity"
+    return linear_velocity_w
 
 
-def get_root_ang_vel_w(env, name: str) -> torch.Tensor:
-    """Get the root angular velocity of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_ang_vel_w)
+def get_root_ang_vel_w(env, name: str, required: bool = True) -> torch.Tensor:
+    """Get aggregate angular velocity, optionally returning zero when unavailable."""
+    state = object_state(env, name).aggregate
+    if state.angular_velocity_w is not None:
+        return state.angular_velocity_w
+    assert not required, f"Object {name!r} has no aggregate angular velocity"
+    assert state.position_w is not None, f"Object {name!r} has no aggregate position"
+    return torch.zeros_like(state.position_w)
+
+
+def get_max_point_speed_w(env, name: str) -> torch.Tensor:
+    """Get maximum point speed, using root speed for non-deformable objects."""
+    state = object_state(env, name)
+    kinematics = state.points if state.points is not None else state.aggregate
+    assert kinematics.linear_velocity_w is not None, f"Object {name!r} has no linear velocity"
+    speed = torch.linalg.vector_norm(kinematics.linear_velocity_w, dim=-1)
+    return speed.amax(dim=1) if state.points is not None else speed
 
 
 def select(result: torch.Tensor, env_id: int | None) -> torch.Tensor:

--- a/isaaclab_arena/tasks/predicates/spatial.py
+++ b/isaaclab_arena/tasks/predicates/spatial.py
@@ -6,15 +6,19 @@
 from __future__ import annotations
 
 import torch
+from typing import Literal
 
 import warp as wp
-from isaaclab.assets import RigidObject
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sensors.contact_sensor.contact_sensor import ContactSensor
 
+from isaaclab_arena.scene.object_geometry import object_bounds_w
+from isaaclab_arena.scene.object_state import object_state
 from isaaclab_arena.tasks.predicates.object_settling import get_object_initial_rest_state
 from isaaclab_arena.tasks.predicates.predicate_utils import get_env, get_root_lin_vel_w, get_root_pos_w, select
+
+HeightMode = Literal["centroid", "min", "max", "min_point", "max_point"]
 
 
 def object_is_above_height(
@@ -24,6 +28,7 @@ def object_is_above_height(
     use_settled_state: bool = False,
     distance: float = 1e-2,
     env_id: int | None = None,
+    height_mode: HeightMode = "centroid",
 ) -> torch.Tensor:
     """Checks if an object is above a certain height.
 
@@ -38,7 +43,7 @@ def object_is_above_height(
         surface_height is not None
     ) != use_settled_state, "object_is_above_height requires exactly one of surface_height or use_settled_state"
 
-    object_z = get_root_pos_w(env, object_name)[:, 2]
+    object_z = _object_height(env, object_name, height_mode)
     if use_settled_state:
         settled_pos, has_settled = get_object_initial_rest_state(env, object_name)
         result = has_settled & (object_z > (settled_pos[:, 2] + distance))
@@ -76,13 +81,9 @@ def objects_in_proximity(
     Returns True when the object is within a certain proximity of the target object.
     """
 
-    # Get object entities from the scene
-    object: RigidObject = env.scene[object_cfg.name]
-    target_object: RigidObject = env.scene[target_object_cfg.name]
-
     # Get positions relative to environment origin
-    object_pos = wp.to_torch(object.data.root_pos_w) - env.scene.env_origins
-    target_object_pos = wp.to_torch(target_object.data.root_pos_w) - env.scene.env_origins
+    object_pos = get_root_pos_w(env, object_cfg.name) - env.scene.env_origins
+    target_object_pos = get_root_pos_w(env, target_object_cfg.name) - env.scene.env_origins
 
     # object to target object
     x_separation = torch.abs(object_pos[:, 0] - target_object_pos[:, 0])
@@ -94,6 +95,45 @@ def objects_in_proximity(
     done = torch.logical_and(done, z_separation < max_z_separation)
 
     return done
+
+
+def object_is_below_height(
+    env: ManagerBasedRLEnv,
+    object_name: str,
+    minimum_height: float,
+    height_mode: HeightMode = "centroid",
+) -> torch.Tensor:
+    """Return whether the selected object height is below ``minimum_height``."""
+    return _object_height(env, object_name, height_mode) < minimum_height
+
+
+def object_supported_by(
+    env: ManagerBasedRLEnv,
+    object_cfg: SceneEntityCfg,
+    destination_cfg: SceneEntityCfg,
+    support_tolerance: float = 0.03,
+    low_point_tolerance: float = 0.01,
+    minimum_support_fraction: float = 0.5,
+) -> torch.Tensor:
+    """Check deformable support using low nodal points and destination bounds."""
+    points = object_state(env, object_cfg.name).points
+    assert points is not None, f"Object {object_cfg.name!r} has no deformable point state"
+    assert points.position_w is not None, f"Object {object_cfg.name!r} has no nodal positions"
+
+    position_w = points.position_w
+    low_z = position_w[..., 2].amin(dim=1, keepdim=True)
+    low_mask = position_w[..., 2] <= low_z + low_point_tolerance
+    destination_bounds = object_bounds_w(env, destination_cfg.name)
+
+    inside_xy = torch.all(
+        (position_w[..., :2] >= destination_bounds.min_point[:, None, :2])
+        & (position_w[..., :2] <= destination_bounds.max_point[:, None, :2]),
+        dim=-1,
+    )
+    near_top = torch.abs(position_w[..., 2] - destination_bounds.top_surface_z[:, None]) <= support_tolerance
+    supported_points = low_mask & inside_xy & near_top
+    support_fraction = supported_points.sum(dim=1) / low_mask.sum(dim=1).clamp_min(1)
+    return support_fraction >= minimum_support_fraction
 
 
 def object_on_destination(
@@ -110,7 +150,6 @@ def object_on_destination(
     """
 
     unwrapped_env = get_env(env)
-    object: RigidObject = unwrapped_env.scene[object_cfg.name]
     sensor: ContactSensor = unwrapped_env.scene[contact_sensor_cfg.name]
 
     # force_matrix_w shape is (N, B, M, 3), where N is the number of sensors, B is number of bodies in each sensor
@@ -123,13 +162,32 @@ def object_on_destination(
     force_matrix_norm = torch.norm(wp.to_torch(sensor.data.force_matrix_w), dim=-1).reshape(-1)
     force_above_threshold = force_matrix_norm > force_threshold
 
-    velocity_w = wp.to_torch(object.data.root_lin_vel_w)
+    velocity_w = get_root_lin_vel_w(env, object_cfg.name)
     velocity_w_norm = torch.norm(velocity_w, dim=-1)
     velocity_below_threshold = velocity_w_norm < velocity_threshold
 
     condition_met = torch.logical_and(force_above_threshold, velocity_below_threshold)
 
     return condition_met
+
+
+def _object_height(env, object_name: str, height_mode: HeightMode) -> torch.Tensor:
+    """Reduce aggregate or nodal world height with the requested semantics."""
+    state = object_state(env, object_name)
+    assert state.aggregate.position_w is not None, f"Object {object_name!r} has no aggregate position"
+    if height_mode == "centroid":
+        return state.aggregate.position_w[:, 2]
+
+    kinematics = state.points if state.points is not None else state.aggregate
+    assert kinematics.position_w is not None, f"Object {object_name!r} has no positions"
+    point_z = kinematics.position_w[..., 2]
+    if state.points is None:
+        return point_z
+    if height_mode in ("min", "min_point"):
+        return point_z.amin(dim=1)
+    if height_mode in ("max", "max_point"):
+        return point_z.amax(dim=1)
+    raise ValueError(f"Unsupported height mode: {height_mode!r}")
 
 
 def objects_on_destinations(

--- a/isaaclab_arena/tests/test_droid_deformable_cube_pick_and_place_environment.py
+++ b/isaaclab_arena/tests/test_droid_deformable_cube_pick_and_place_environment.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registration, configuration, and PhysX smoke tests for the deformable-cube environment."""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+ENVIRONMENT_NAME = "droid_deformable_cube_pick_and_place"
+
+
+def _test_droid_deformable_cube_environment_registration_and_config(simulation_app) -> bool:
+    """The registered factory builds the intended fixed-pose Arena description."""
+    from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.registries import EnvironmentRegistry
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+    from isaaclab_arena.utils.pose import Pose
+    from isaaclab_arena_environments.cli import (
+        ensure_environments_registered,
+        get_arena_builder_from_cli,
+        get_isaaclab_arena_environments_cli_parser,
+    )
+    from isaaclab_arena_environments.droid_deformable_cube_pick_and_place_environment import (
+        DroidDeformableCubePickAndPlaceEnvironment,
+        DroidDeformableCubePickAndPlaceEnvironmentCfg,
+    )
+
+    ensure_environments_registered()
+    registry = EnvironmentRegistry()
+    factory_type = registry.get_component_by_name(ENVIRONMENT_NAME)
+    assert factory_type is DroidDeformableCubePickAndPlaceEnvironment
+    assert registry.get_environment_cfg_type(factory_type) is DroidDeformableCubePickAndPlaceEnvironmentCfg
+
+    arena_env = factory_type().build(DroidDeformableCubePickAndPlaceEnvironmentCfg())
+    assert arena_env.embodiment.name == "droid_abs_joint_pos"
+    assert isinstance(arena_env.task, PickAndPlaceTask)
+
+    cube = arena_env.scene.assets["deformable_cube"]
+    destination = arena_env.scene.assets["plate"]
+    table = arena_env.scene.assets["maple_table_robolab"]
+    assert isinstance(cube, DeformableObject)
+    assert isinstance(cube._source, MeshCuboidCfg)
+    assert cube.object_type is ObjectType.DEFORMABLE
+    assert destination.object_type is ObjectType.RIGID
+    assert isinstance(cube.get_initial_pose(), Pose)
+    assert isinstance(destination.get_initial_pose(), Pose)
+    assert arena_env.task.pick_up_object is cube
+    assert arena_env.task.destination_location is destination
+    assert arena_env.task.background_scene is table
+
+    args_cli = get_isaaclab_arena_environments_cli_parser().parse_args(
+        [ENVIRONMENT_NAME, "--embodiment", "droid_differential_ik"]
+    )
+    switched_env = get_arena_builder_from_cli(args_cli).arena_env
+    assert switched_env.embodiment.name == "droid_differential_ik"
+    return True
+
+
+def test_droid_deformable_cube_environment_registration_and_config() -> None:
+    """The registered factory builds the intended fixed-pose Arena description."""
+    assert run_function_with_persistent_simulation_app(
+        _test_droid_deformable_cube_environment_registration_and_config,
+        headless=True,
+    )
+
+
+def _test_droid_deformable_cube_physx_smoke(simulation_app) -> bool:
+    """Spawn, reset, step, evaluate support, and close through the runner construction path."""
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+    from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
+
+    env = None
+    try:
+        parser = get_isaaclab_arena_environments_cli_parser(get_isaaclab_arena_cli_parser())
+        args_cli = parser.parse_args(["--num_envs", "1", ENVIRONMENT_NAME])
+        builder = get_arena_builder_from_cli(args_cli)
+        env_cfg, env_kwargs = builder.compose_manager_cfg()
+
+        env = builder.make_registered(env_cfg, env_kwargs)
+        assert "isaaclab_physx" in str(env.unwrapped.sim.physics_manager)
+        observation, _ = env.reset()
+        assert observation is not None
+        assert {
+            "robot",
+            "deformable_cube",
+            "plate",
+            "maple_table_robolab",
+        } <= set(env.unwrapped.scene.keys())
+
+        actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+        with torch.inference_mode():
+            env.step(actions)
+            env.step(actions)
+
+            placement_cfg = builder.arena_env.task.get_termination_cfg().success.params["predicates"][0]
+            placement_result = placement_cfg.func(env, **placement_cfg.params)
+        assert placement_result.shape == (1,)
+        assert placement_result.dtype == torch.bool
+        return True
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_droid_deformable_cube_physx_smoke() -> None:
+    """The registered environment completes its PhysX lifecycle without errors."""
+    assert run_function_with_persistent_simulation_app(
+        _test_droid_deformable_cube_physx_smoke,
+        headless=True,
+    )

--- a/isaaclab_arena/tests/test_external_environment.py
+++ b/isaaclab_arena/tests/test_external_environment.py
@@ -25,6 +25,7 @@ def _test_external_environment_registration_callback(_) -> bool:
     """Verify the Isaac Lab callback registers an externally defined Arena environment."""
     import gymnasium as gym
 
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.environments.isaaclab_interop import environment_registration_callback
 
     callback_args = [
@@ -40,7 +41,11 @@ def _test_external_environment_registration_callback(_) -> bool:
         remaining_args = environment_registration_callback()
 
     assert remaining_args == []
-    assert gym.spec("franka_table").id == "franka_table"
+    spec = gym.spec("franka_table")
+    assert spec.id == "franka_table"
+    assert spec.kwargs["arena_object_types"]["cracker_box"] is ObjectType.RIGID
+    assert "cracker_box" in spec.kwargs["arena_object_bounds"]
+    assert "variation_recorder" not in spec.kwargs
     return True
 
 

--- a/isaaclab_arena/tests/test_object_state.py
+++ b/isaaclab_arena/tests/test_object_state.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Controlled tests for Arena rigid and deformable runtime state."""
+
+import torch
+import types
+
+
+class _Scene:
+    def __init__(self, entities: dict[str, object], num_envs: int):
+        self._entities = entities
+        self.env_origins = torch.zeros(num_envs, 3)
+
+    def __getitem__(self, name: str):
+        return self._entities[name]
+
+    def keys(self):
+        return self._entities.keys()
+
+
+class _Env:
+    def __init__(self, entities, object_types, object_bounds=None):
+        from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
+
+        first = next(iter(entities.values()))
+        root_pos_w = getattr(first.data, "root_pos_w")
+        self.num_envs = root_pos_w.shape[0]
+        self.device = root_pos_w.device
+        self.scene = _Scene(entities, self.num_envs)
+        self.arena_object_types = object_types
+        self.arena_object_bounds = object_bounds or {}
+        self.object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(self.num_envs, self.device)
+        self.unwrapped = self
+
+
+def test_simulated_deformable_cube_supported_and_settled():
+    from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+    assert run_function_with_persistent_simulation_app(
+        _test_simulated_deformable_cube_supported_and_settled,
+        headless=True,
+    )
+
+
+def test_object_state_dispatches_from_arena_object_type():
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena.scene.object_state import object_state
+
+    rigid_pos = torch.tensor([[0.0, 0.0, 0.2], [1.0, 0.0, 0.3]])
+    rigid = types.SimpleNamespace(
+        data=types.SimpleNamespace(
+            root_pos_w=rigid_pos,
+            root_quat_w=torch.tensor([[0.0, 0.0, 0.0, 1.0]]).expand(2, 4),
+            root_lin_vel_w=torch.ones(2, 3),
+            root_ang_vel_w=torch.full((2, 3), 2.0),
+        )
+    )
+    nodal_pos = torch.tensor([
+        [[0.0, 0.0, 0.1], [0.2, 0.0, 0.3]],
+        [[1.0, 0.0, 0.2], [1.2, 0.0, 0.4]],
+    ])
+    nodal_vel = torch.tensor([
+        [[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0]],
+        [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]],
+    ])
+    soft = types.SimpleNamespace(
+        data=types.SimpleNamespace(
+            root_pos_w=nodal_pos.mean(dim=1),
+            root_vel_w=nodal_vel.mean(dim=1),
+            nodal_pos_w=nodal_pos,
+            nodal_vel_w=nodal_vel,
+        )
+    )
+    env = _Env({"rigid": rigid, "soft": soft}, {"rigid": ObjectType.RIGID, "soft": ObjectType.DEFORMABLE})
+
+    rigid_state = object_state(env, "rigid")
+    soft_state = object_state(env, "soft")
+    assert rigid_state.points is None
+    assert torch.equal(rigid_state.aggregate.angular_velocity_w, rigid.data.root_ang_vel_w)
+    assert soft_state.aggregate.orientation_w is None
+    assert soft_state.points is not None
+    assert torch.equal(soft_state.points.position_w, nodal_pos)
+    assert torch.equal(soft_state.points.linear_velocity_w, nodal_vel)
+
+
+def test_deformable_supported_and_settled_use_nodal_state():
+    from isaaclab.managers import SceneEntityCfg
+
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena.tasks.predicates.object_settling import objects_settled
+    from isaaclab_arena.tasks.predicates.spatial import object_supported_by
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+    soft_pos = torch.tensor([
+        [[-0.02, 0.00, 0.10], [0.02, 0.00, 0.10], [0.00, 0.00, 0.20]],
+        [[0.48, 0.00, 0.10], [0.52, 0.00, 0.10], [0.50, 0.00, 0.20]],
+    ])
+    # Both centroids are stationary; env 1 still has fast internal nodal motion.
+    soft_vel = torch.tensor([
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.2, 0.0, 0.0], [-0.2, 0.0, 0.0], [0.0, 0.0, 0.0]],
+    ])
+    soft = types.SimpleNamespace(
+        data=types.SimpleNamespace(
+            root_pos_w=soft_pos.mean(dim=1),
+            root_vel_w=soft_vel.mean(dim=1),
+            nodal_pos_w=soft_pos,
+            nodal_vel_w=soft_vel,
+        )
+    )
+    destination_pos = torch.tensor([[0.0, 0.0, 0.05], [0.0, 0.0, 0.05]])
+    destination = types.SimpleNamespace(
+        data=types.SimpleNamespace(
+            root_pos_w=destination_pos,
+            root_quat_w=torch.tensor([[0.0, 0.0, 0.0, 1.0]]).expand(2, 4),
+            root_lin_vel_w=torch.zeros(2, 3),
+            root_ang_vel_w=torch.zeros(2, 3),
+        )
+    )
+    env = _Env(
+        {"soft": soft, "destination": destination},
+        {"soft": ObjectType.DEFORMABLE, "destination": ObjectType.RIGID},
+        {
+            "destination": AxisAlignedBoundingBox(
+                min_point=(-0.1, -0.1, -0.05),
+                max_point=(0.1, 0.1, 0.05),
+            )
+        },
+    )
+
+    supported = object_supported_by(
+        env,
+        SceneEntityCfg("soft"),
+        SceneEntityCfg("destination"),
+        support_tolerance=1.0e-4,
+    )
+    settled = objects_settled(env, ["soft"], lin_vel_threshold=0.1)
+    assert supported.tolist() == [True, False]
+    assert settled.tolist() == [True, False]
+
+
+def test_objects_settled_preserves_rigid_angular_speed_check():
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena.tasks.predicates.object_settling import objects_settled
+
+    position = torch.zeros(2, 3)
+    rigid = types.SimpleNamespace(
+        data=types.SimpleNamespace(
+            root_pos_w=position,
+            root_quat_w=torch.tensor([[0.0, 0.0, 0.0, 1.0]]).expand(2, 4),
+            root_lin_vel_w=torch.zeros(2, 3),
+            root_ang_vel_w=torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.1]]),
+        )
+    )
+    env = _Env({"cube": rigid}, {"cube": ObjectType.RIGID})
+    assert objects_settled(env, ["cube"]).tolist() == [True, False]
+
+
+def _test_simulated_deformable_cube_supported_and_settled(simulation_app):
+    import isaaclab.sim as sim_utils
+    from isaaclab.managers import SceneEntityCfg
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+    from isaaclab_arena.assets.deformable_spawn import VolumeDeformableMaterial
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.predicates.object_settling import objects_settled
+    from isaaclab_arena.tasks.predicates.spatial import object_supported_by
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+    from isaaclab_arena.utils.pose import Pose
+
+    destination = Object(
+        name="destination",
+        object_type=ObjectType.BASE,
+        spawner_cfg=sim_utils.CuboidCfg(size=(0.4, 0.4, 0.1)),
+        initial_pose=Pose(position_xyz=(0.0, 0.0, 0.05)),
+    )
+    soft_cube = DeformableObject(
+        name="soft_cube",
+        spawner_cfg=sim_utils.MeshCuboidCfg(size=(0.1, 0.1, 0.1)),
+        material=VolumeDeformableMaterial(
+            youngs_modulus=8.0e4,
+            poissons_ratio=0.4,
+            density=300.0,
+            particle_radius=0.01,
+        ),
+        initial_pose=Pose(position_xyz=(0.0, 0.0, 0.15)),
+    )
+    arena_env = IsaacLabArenaEnvironment(
+        name="object_state_deformable_cube",
+        scene=Scene(assets=[destination, soft_cube]),
+    )
+    args = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args))
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    env_kwargs["arena_object_bounds"]["destination"] = AxisAlignedBoundingBox(
+        min_point=(-0.2, -0.2, -0.05),
+        max_point=(0.2, 0.2, 0.05),
+    )
+    env = builder.make_registered(env_cfg, env_kwargs)
+    env.reset()
+
+    try:
+        nodal_state = env.unwrapped.scene["soft_cube"].data.nodal_state_w.torch.clone()
+        nodal_state[..., 3:] = 0.0
+        env.unwrapped.scene["soft_cube"].write_nodal_state_to_sim_index(nodal_state)
+        assert object_supported_by(
+            env,
+            SceneEntityCfg("soft_cube"),
+            SceneEntityCfg("destination"),
+        ).item()
+        assert objects_settled(env, ["soft_cube"]).item()
+    finally:
+        env.close()
+    return True

--- a/isaaclab_arena/tests/test_pick_and_place_task_config.py
+++ b/isaaclab_arena/tests/test_pick_and_place_task_config.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration-level tests for rigid and deformable pick-and-place tasks."""
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+
+def _test_pick_and_place_task_config(simulation_app, case: str, object_type_name: str | None = None) -> bool:
+    """Run one config assertion after SimulationApp initialization."""
+    from isaaclab_arena.assets.asset import Asset
+    from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+    from isaaclab_arena.embodiments.common.arm_mode import ArmMode
+    from isaaclab_arena.metrics.object_moved import ObjectMovedRateMetric
+    from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+    from isaaclab_arena.tasks.predicates.object_settling import objects_settled
+    from isaaclab_arena.tasks.predicates.spatial import (
+        object_is_above_height,
+        object_is_below_height,
+        object_on_destination,
+        object_supported_by,
+        objects_in_proximity,
+    )
+    from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+
+    class TestObject(ObjectBase):
+        """Minimal object used to inspect task configs without loading USD assets."""
+
+        def __init__(self, name: str, object_type: ObjectType):
+            super().__init__(name=name, object_type=object_type)
+
+        def get_object_pose(self, env, is_relative: bool = True):
+            raise NotImplementedError
+
+        def set_object_pose(self, env, pose, env_ids=None) -> None:
+            raise NotImplementedError
+
+        def get_bounding_box(self) -> AxisAlignedBoundingBox:
+            return AxisAlignedBoundingBox(min_point=(-0.1, -0.1, -0.1), max_point=(0.1, 0.1, 0.1))
+
+    def make_task(
+        object_type: ObjectType,
+        *,
+        destination_object: Asset | None = None,
+        max_separation: tuple[float, float, float] | None = None,
+    ) -> PickAndPlaceTask:
+        pick_up_object = TestObject("pick_up", object_type)
+        destination = TestObject("destination", ObjectType.BASE)
+        background = Asset("background")
+        background.object_min_z = -0.2
+        return PickAndPlaceTask(
+            pick_up_object=pick_up_object,
+            destination_location=destination,
+            destination_object=destination_object,
+            background_scene=background,
+            max_separation=max_separation,
+        )
+
+    def progress_predicates(task: PickAndPlaceTask):
+        objective = task.get_progress_objectives()[0]
+        assert len(objective.group_names) == 1
+        return [predicate for predicate, _ in objective.get_chain(objective.group_names[0])]
+
+    object_type = ObjectType[object_type_name] if object_type_name is not None else None
+
+    if case == "rigid":
+        task = make_task(ObjectType.RIGID)
+        assert task.contact_sensor_name == "contact_sensor_pick_up"
+        assert getattr(task.get_scene_cfg(), task.contact_sensor_name) is not None
+        success_predicates = task.get_termination_cfg().success.params["predicates"]
+        assert len(success_predicates) == 1
+        assert success_predicates[0].func is object_on_destination
+        assert success_predicates[0].params["force_threshold"] == task.force_threshold
+        assert success_predicates[0].params["velocity_threshold"] == task.velocity_threshold
+        assert task.get_termination_cfg().object_dropped.func is object_is_below_height
+        assert [type(metric) for metric in task.get_metrics()] == [SuccessRateMetric, ObjectMovedRateMetric]
+    elif case == "deformable":
+        task = make_task(ObjectType.DEFORMABLE)
+        assert task.contact_sensor_name is None
+        assert task.get_scene_cfg() is None
+        success_predicates = task.get_termination_cfg().success.params["predicates"]
+        assert len(success_predicates) == 1
+        assert success_predicates[0].func is object_supported_by
+        assert success_predicates[0].params["object_cfg"].name == "pick_up"
+        assert success_predicates[0].params["destination_cfg"].name == "destination"
+        assert task.get_termination_cfg().object_dropped.func is object_is_below_height
+        assert [type(metric) for metric in task.get_metrics()] == [SuccessRateMetric]
+    elif case == "unsupported":
+        assert object_type is not None
+        with pytest.raises(ValueError, match=f"does not support pick-up object type.*{object_type.value}"):
+            make_task(object_type)
+    elif case == "progress":
+        assert object_type is not None
+        placement_predicate = object_on_destination if object_type is ObjectType.RIGID else object_supported_by
+        predicates = progress_predicates(make_task(object_type))
+        assert [predicate.func for predicate in predicates] == [
+            objects_settled,
+            object_is_above_height,
+            placement_predicate,
+        ]
+    elif case == "max_separation":
+        assert object_type is not None
+        task = make_task(object_type, max_separation=(0.1, 0.2, 0.3))
+        success_predicates = task.get_termination_cfg().success.params["predicates"]
+        assert success_predicates[-1].func is objects_in_proximity
+        assert success_predicates[-1].params["max_x_separation"] == 0.1
+        assert success_predicates[-1].params["max_y_separation"] == 0.2
+        assert success_predicates[-1].params["max_z_separation"] == 0.3
+        assert progress_predicates(task)[-1].func is objects_in_proximity
+    elif case == "deformable_mimic":
+        task = make_task(ObjectType.DEFORMABLE)
+        task.mimic_env_cfg_factory = lambda _: pytest.fail("deformable Mimic factory must not run")
+        with pytest.raises(NotImplementedError, match="not supported for deformable"):
+            task.get_mimic_env_cfg(ArmMode.SINGLE_ARM)
+    elif case == "mimic_destination":
+        mimic_cfg = make_task(ObjectType.RIGID).get_mimic_env_cfg(ArmMode.SINGLE_ARM)
+        assert mimic_cfg.pick_up_object_name == "pick_up"
+        assert mimic_cfg.destination_location_name == "destination"
+    elif case == "mimic_alias":
+        destination_object = Asset("destination_alias")
+        task = make_task(ObjectType.RIGID, destination_object=destination_object)
+        assert task.get_mimic_env_cfg(ArmMode.SINGLE_ARM).destination_location_name == "destination_alias"
+    else:
+        raise ValueError(f"Unknown test case {case!r}")
+    return True
+
+
+def _run_case(case: str, object_type_name: str | None = None) -> None:
+    result = run_function_with_persistent_simulation_app(
+        _test_pick_and_place_task_config,
+        case=case,
+        object_type_name=object_type_name,
+    )
+    assert result, f"PickAndPlaceTask config case {case!r} failed"
+
+
+def test_rigid_task_uses_contact_sensor_and_preserves_configs() -> None:
+    _run_case("rigid")
+
+
+def test_deformable_task_uses_support_without_contact_sensor() -> None:
+    _run_case("deformable")
+
+
+@pytest.mark.parametrize("object_type_name", ["BASE", "ARTICULATION"])
+def test_unsupported_pick_up_object_type_fails_clearly(object_type_name: str) -> None:
+    _run_case("unsupported", object_type_name)
+
+
+@pytest.mark.parametrize("object_type_name", ["RIGID", "DEFORMABLE"])
+def test_progress_uses_selected_placement_predicate(object_type_name: str) -> None:
+    _run_case("progress", object_type_name)
+
+
+@pytest.mark.parametrize("object_type_name", ["RIGID", "DEFORMABLE"])
+def test_max_separation_remains_an_additional_success_and_progress_predicate(
+    object_type_name: str,
+) -> None:
+    _run_case("max_separation", object_type_name)
+
+
+def test_deformable_mimic_fails_before_custom_factory_runs() -> None:
+    _run_case("deformable_mimic")
+
+
+def test_rigid_mimic_uses_destination_location_when_alias_is_absent() -> None:
+    _run_case("mimic_destination")
+
+
+def test_rigid_mimic_preserves_destination_object_alias() -> None:
+    _run_case("mimic_alias")

--- a/isaaclab_arena_environments/droid_deformable_cube_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/droid_deformable_cube_pick_and_place_environment.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""DROID PhysX deformable-cube pick-and-place environment.
+
+Launch a short headless rollout from the development container:
+
+    /isaac-sim/python.sh -m isaaclab_arena.evaluation.policy_runner \
+        --headless --policy_type zero_action --num_steps 10 \
+        droid_deformable_cube_pick_and_place
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+
+@dataclass
+class DroidDeformableCubePickAndPlaceEnvironmentCfg(ArenaEnvironmentCfg):
+    """Configure the DROID deformable-cube pick-and-place environment."""
+
+    embodiment: str = "droid_abs_joint_pos"
+    """DROID embodiment registry name, exposed as ``--embodiment`` on the legacy CLI."""
+
+
+@register_environment
+class DroidDeformableCubePickAndPlaceEnvironment(
+    ArenaEnvironmentFactory[DroidDeformableCubePickAndPlaceEnvironmentCfg]
+):
+    """Build the fixed-pose PhysX deformable-cube example."""
+
+    name = "droid_deformable_cube_pick_and_place"
+    _legacy_argparse_cfg_type = DroidDeformableCubePickAndPlaceEnvironmentCfg
+
+    def build(self, cfg: DroidDeformableCubePickAndPlaceEnvironmentCfg) -> IsaacLabArenaEnvironment:
+        """Build the environment from its typed configuration."""
+        from isaaclab.sim.spawners.materials.visual_materials_cfg import PreviewSurfaceCfg
+        from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg
+
+        from isaaclab_arena.assets.deformable_object import DeformableObject
+        from isaaclab_arena.assets.deformable_spawn import VolumeDeformableMaterial
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+        from isaaclab_arena.utils.pose import Pose
+
+        table = self.asset_registry.get_asset_by_name("maple_table_robolab")()
+        light = self.asset_registry.get_asset_by_name("light")()
+        directional_light = self.asset_registry.get_asset_by_name("directional_light")()
+        destination = self.asset_registry.get_asset_by_name("plate_large_vomp_robolab")(
+            instance_name="plate",
+            initial_pose=Pose(position_xyz=(0.55, -0.25, 0.02), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+        )
+
+        cube = DeformableObject(
+            name="deformable_cube",
+            spawner_cfg=MeshCuboidCfg(size=(0.15, 0.04, 0.04)),
+            material=VolumeDeformableMaterial(
+                youngs_modulus=8.0e4,
+                poissons_ratio=0.25,
+                density=300.0,
+                particle_radius=0.01,
+            ),
+            visual_material=PreviewSurfaceCfg(diffuse_color=(0.95, 0.85, 0.1)),
+            initial_pose=Pose(position_xyz=(0.48, 0.18, 0.05), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+        )
+
+        assert cfg.embodiment in {"droid_abs_joint_pos", "droid_differential_ik"}, (
+            "The deformable-cube example supports droid_abs_joint_pos and droid_differential_ik, "
+            f"got {cfg.embodiment!r}."
+        )
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(
+            enable_cameras=cfg.enable_cameras,
+        )
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        task = PickAndPlaceTask(
+            pick_up_object=cube,
+            destination_location=destination,
+            background_scene=table,
+            episode_length_s=30.0,
+            task_description="Pick up the deformable cube and place it on the plate.",
+        )
+        return IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=Scene(assets=[table, light, directional_light, destination, cube]),
+            task=task,
+        )


### PR DESCRIPTION
## Summary
Add deformable pick-and-place support.

## Detailed description
- Add backend-neutral object state, geometry, settling, and support predicates for deformables.
- Select rigid contact or deformable geometric success conditions based on the pick-up object type.
- Add a Franka deformable-cube pick-and-place environment with configuration and smoke coverage.
- Forward Arena object-type metadata through external environment registration.
