### PR TITLE
Add local GR00T server skill

### DIFF
--- a/.agents/skills/serve-gr00t-policy
+++ b/.agents/skills/serve-gr00t-policy
@@ -1,0 +1,1 @@
+../../skills/user/serve-gr00t-policy

--- a/skills/user/run-experiment/SKILL.md
+++ b/skills/user/run-experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-experiment
-description: Runs existing Isaac Lab-Arena Experiment Definitions locally with experiment_runner.py in a ready native or Docker runtime, coordinates a required local OpenPI server, applies local CLI overrides, and verifies generated result and report artifacts. Use for local named-Run or batch policy evaluations, variation listing, visualization or video, and result inspection. Do not use for installation or runtime preparation (setup-arena), pytest or regression checks (run-tests), interactive no-policy inspection (environment_runner.py), direct Policy Runner workflows, or OSMO preview, submission, or management.
+description: Runs existing Isaac Lab-Arena Experiment Definitions locally with experiment_runner.py in a ready native or Docker runtime, coordinates required local OpenPI or GR00T servers, applies local CLI overrides, and verifies generated result and report artifacts. Use for local named-Run or batch policy evaluations, variation listing, visualization or video, and result inspection. Do not use for installation or runtime preparation (setup-arena), pytest or regression checks (run-tests), interactive no-policy inspection (environment_runner.py), direct Policy Runner workflows, or OSMO preview, submission, or management.
 allowed-tools: Read Grep Glob Skill Bash(git rev-parse --show-toplevel) Bash(id -un) Bash(test -d *) Bash(test -f *) Bash(test -x .venv/bin/python) Bash(env OMNI_KIT_ACCEPT_EULA=YES ACCEPT_EULA=Y .venv/bin/python isaaclab_arena/evaluation/experiment_runner.py *) Bash(docker ps *) Bash(docker exec *)
 ---
 
@@ -42,9 +42,14 @@ path; do not create new legacy configurations or apply Hydra overrides to them.
    server or start one before this workflow launches the Experiment; the user does not need to
    invoke that skill separately. If Runs request different variants on the same port, stop and ask
    the user to resolve the conflict.
-7. For an OpenPI policy pointing to another host, or another remote policy without a matching local
-   server skill, require an already-running and reachable endpoint. Do not replace a deliberately
-   remote endpoint with a local server or submit it to managed compute.
+7. For a GR00T `Gr00tRemoteClosedloopPolicy` or registered `gr00t_remote_closedloop` policy whose
+   `remote_host` is local, use `serve-gr00t-policy`. It may automatically start the maintained
+   N1.6-DROID server or require an explicit model and embodiment for another client configuration;
+   the Experiment does not declare the server checkpoint. If multiple Runs require incompatible
+   server contracts on one port, resolve the conflict before launching.
+8. For a supported policy pointing to another host, or another remote policy without a matching
+   local server skill, require an already-running and reachable endpoint. Do not replace a
+   deliberately remote endpoint with a local server or submit it to managed compute.
 
 For a built-in smoke evaluation, use
 `isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml`. It uses the local
@@ -149,11 +154,14 @@ preserved partial artifacts or failures.
   remote result download. An unqualified request to "run" an Experiment means local execution.
 - Use `serve-openpi-policy` automatically when a local OpenPI Experiment needs a compatible server.
   Leave that server running after the Experiment unless the user asks to stop it.
+- Use `serve-gr00t-policy` automatically when a local GR00T Experiment needs a compatible server.
+  Leave that server running after the Experiment unless the user asks to stop it.
 
 ## References
 
 - [Evaluations](evaluations.md)
 - [OpenPI server skill](../serve-openpi-policy/SKILL.md)
+- [GR00T server skill](../serve-gr00t-policy/SKILL.md)
 - [Arena Experiments](../../../docs/pages/concepts/concept_arena_experiments.rst)
 - [First Arena Experiment](../../../docs/pages/quickstart/arena_experiment.rst)
 - [Environment variations](../../../docs/pages/quickstart/environment_variations.rst)

--- a/skills/user/run-experiment/evaluations.md
+++ b/skills/user/run-experiment/evaluations.md
@@ -106,7 +106,29 @@ Known failure modes:
 - Treats a listening TCP port as sufficient readiness, submits to OSMO, or stops the server without
   being asked.
 
-## Scenario 7: Respect Workflow Boundaries
+## Scenario 7: Start A Required Local GR00T Server
+
+Query: "Run `droid_pnp_gr00t_experiment.yaml` locally; I haven't started a GR00T server."
+
+Expected behavior:
+
+- Detects GR00T from the Run's resolved policy type and reads its host, port, and referenced client
+  policy configuration.
+- Uses `serve-gr00t-policy` to reuse a matching ready server or start the maintained N1.6-DROID
+  server before launching the Experiment.
+- Discloses and confirms a potentially large first dependency resolution or checkpoint download.
+- Waits for protocol-level GR00T readiness from a retained asynchronous terminal session, runs the
+  Experiment while that session remains active, verifies its artifacts, and leaves the server
+  running while reporting its endpoint and identity.
+
+Known failure modes:
+
+- Requires the user to discover and invoke the server skill separately.
+- Infers GR00T only from the filename, guesses a custom checkpoint, or starts a mismatched model.
+- Waits for the server process to exit, treats TCP listening as sufficient readiness, submits to
+  OSMO, or stops the server without being asked.
+
+## Scenario 8: Respect Workflow Boundaries
 
 Query: "Submit this Experiment to OSMO pool `example-pool` and download the results."
 
@@ -120,7 +142,7 @@ Known failure modes:
 - Treats local and managed execution as interchangeable.
 - Submits remote compute using the local skill's permissions.
 
-## Scenario 8: Route Runtime Setup And Regression Testing
+## Scenario 9: Route Runtime Setup And Regression Testing
 
 Query: "I just cloned Arena. Install it, then run the no-camera pytest phase."
 

--- a/skills/user/serve-gr00t-policy/SKILL.md
+++ b/skills/user/serve-gr00t-policy/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: serve-gr00t-policy
+description: Starts, reuses, verifies, and explicitly stops the local GR00T inference server used by Isaac Lab-Arena Gr00tRemoteClosedloopPolicy experiments. Use when serving the maintained N1.6-DROID policy locally, selecting a GR00T port or model, checking server readiness, handling a GR00T endpoint conflict, or when run-experiment discovers a local GR00T policy dependency. Do not use for running Experiment Definitions, OSMO submission, training, replay-policy serving, other policy providers, or general Arena setup.
+allowed-tools: Read Grep Glob Skill Bash(git rev-parse --show-toplevel) Bash(git submodule status *) Bash(git submodule update --init submodules/Isaac-GR00T) Bash(test -d *) Bash(test -f *) Bash(uv --version) Bash(nvidia-smi *) Bash(ps -eo pid=,args=) Bash(ss -ltnp *) Bash(uv run python gr00t/eval/run_gr00t_server.py *) Bash(uv run python */isaaclab_arena_gr00t/utils/wait_for_gr00t_server.py *)
+---
+
+# Serve GR00T Policy
+
+Start one local, model-backed GR00T inference server and finish with a verified endpoint for an
+Arena `Gr00tRemoteClosedloopPolicy` client. Keep Experiment execution, artifacts, training, OSMO,
+and other policy providers outside this skill.
+
+## Read the checked-out workflow
+
+Before acting, read:
+
+- `docs/pages/quickstart/running_a_real_policy/gr00t.rst` for the maintained local workflow,
+  hardware notes, checkpoint, embodiment, and endpoint.
+- The server script referenced by that document for its current arguments and readiness message.
+- `isaaclab_arena_gr00t/utils/wait_for_gr00t_server.py` for the protocol-level readiness probe.
+
+Treat the current checkout as the source of truth. The maintained documentation currently launches
+from `submodules/Isaac-GR00T`, but explicitly marks that location as transitional. If the docs name
+a separate GR00T checkout after the refactor, follow them rather than recreating the removed
+submodule. Report any mismatch between this skill, the docs, and the server script.
+
+## Resolve the server contract
+
+1. Confirm the Arena repository root and locate the GR00T checkout named by the current docs.
+2. Resolve the host and port from the request or the Experiment policy. Start a server only for a
+   loopback client host such as `127.0.0.1` or `localhost`. Treat another host as an external
+   dependency and return control to `run-experiment`.
+3. Identify GR00T from the resolved policy type
+   `isaaclab_arena_gr00t.policy.gr00t_remote_closedloop_policy.Gr00tRemoteClosedloopPolicy` or its
+   registered name `gr00t_remote_closedloop`, not from the Experiment filename.
+4. Read the referenced client policy configuration for its embodiment tag. Use the model and
+   embodiment pairing declared by the maintained GR00T quickstart only when they match that
+   documented workflow. It currently maps `OXE_DROID` to `nvidia/GR00T-N1.6-DROID` on port `5555`.
+5. For any other embodiment, require an explicit model or checkpoint path and embodiment tag. The
+   Experiment client configuration does not declare the server checkpoint, so never infer one from
+   a Run name, environment, task, or embodiment alone.
+6. If multiple Runs require incompatible embodiments or explicitly selected models on one port,
+   stop and ask the user to assign separate endpoints or choose one server contract.
+
+Support model-backed inference only. Do not use this skill for fine-tuning, dataset replay, or
+adding `--use-sim-policy-wrapper`; Arena performs its own observation and action translation. Do
+not derive the server device from the client-side `policy_device` field.
+
+## Inspect before launching
+
+Confirm that the documented GR00T checkout is populated, `uv` and a compatible NVIDIA GPU are
+available, and the selected port is not owned by an incompatible process. When the current docs
+still require the GR00T submodule and it is missing, disclose the documented submodule update and
+obtain confirmation before changing submodule state.
+
+Inspect local server candidates without assuming a process ID:
+
+```bash
+ps -eo pid=,args=
+ss -ltnp
+```
+
+For a candidate on the selected port, require both:
+
+- A live process command matching the documented server script, model or checkpoint, embodiment,
+  host, and port.
+- A successful GR00T ping from the maintained Arena readiness helper, with finite request and total
+  timeouts. A TCP listener or startup banner alone is insufficient.
+
+The GR00T protocol does not expose model identity. If the process command cannot prove the model
+and embodiment, report that compatibility is unknown rather than reusing it. If an incompatible or
+unidentified process owns the selected port, do not stop it or silently choose another port; ask
+the user whether to select a different port or explicitly stop the known owner.
+
+## Confirm potentially large first-run work
+
+The current GR00T checkout creates a separate Python 3.10 uv environment and the first model-backed
+launch downloads the selected checkpoint. The maintained Arena docs do not promise time or storage
+estimates. If the dependency environment or checkpoint cache cannot be proven ready, disclose both
+operations and obtain confirmation before starting them. Also warn when the GR00T server and Isaac
+Sim will contend for the same GPU.
+
+Do not install or change system Python, CUDA, GPU drivers, or `uv`; clear caches; upgrade the GR00T
+checkout; or substitute a different model through this skill. Follow the current hardware guidance,
+including its separate Blackwell requirements.
+
+## Launch and verify
+
+Start the documented command from the GR00T checkout in a retained terminal session that runs
+asynchronously from this workflow. Keep the server in the foreground of that session, record the
+returned session or task handle, and pass every resolved value explicitly. The current maintained
+DROID command is:
+
+```bash
+uv run python gr00t/eval/run_gr00t_server.py \
+  --model-path nvidia/GR00T-N1.6-DROID \
+  --embodiment-tag OXE_DROID \
+  --device cuda --host 127.0.0.1 --port 5555
+```
+
+Resolve a relative local checkpoint path before changing into the GR00T checkout, then pass its
+absolute path to the server. After the readiness line appears, verify the endpoint with the helper
+from the GR00T uv environment, substituting the absolute Arena root and selected endpoint:
+
+```bash
+uv run python <arena-root>/isaaclab_arena_gr00t/utils/wait_for_gr00t_server.py \
+  --host 127.0.0.1 --port 5555 \
+  --timeout-sec 60 --poll-interval-sec 5 --request-timeout-ms 5000
+```
+
+Do not append `&`, use `nohup`, or detach the process inside the shell. Poll the retained session
+without waiting for the server command to finish. Require the process to remain live and emit the
+current readiness line, then run the Arena readiness helper against the selected endpoint and
+require its successful GR00T ping. Keep the retained session active while returning control to
+`run-experiment`.
+
+On failure, preserve and report the server output. Do not silently rebuild the environment, change
+models or ports, weaken strictness, add the sim wrapper, or retry with different settings.
+
+## Hand off the endpoint
+
+Return the model or checkpoint, embodiment tag, loopback host, port, readiness evidence, exact
+process identity, and retained session handle when this workflow started the server. If
+`run-experiment` requested it, return control without invoking the Experiment Runner here.
+
+When the user approves a different port, provide the corresponding per-Run Hydra override:
+
+```text
+runs.<run-name>.policy.remote_port=5556
+```
+
+Do not edit the Experiment Definition merely to change a local endpoint.
+
+## Stop only on request
+
+Leave the server running after an Experiment unless the user asks to stop it. For a server started
+here, send an interrupt through its retained terminal session, wait for the command to exit, and
+confirm that the recorded process and listener stopped. Never call the unauthenticated GR00T kill
+endpoint or signal a reused process based only on its port. If ownership or the retained session
+cannot be identified safely, report that limitation instead of guessing.
+
+## References
+
+- [Evaluation scenarios](evaluations.md)
+- [GR00T workflow](../../../docs/pages/quickstart/running_a_real_policy/gr00t.rst)
+- [GR00T readiness helper](../../../isaaclab_arena_gr00t/utils/wait_for_gr00t_server.py)

--- a/skills/user/serve-gr00t-policy/evaluations.md
+++ b/skills/user/serve-gr00t-policy/evaluations.md
@@ -1,0 +1,91 @@
+# Serve GR00T Policy Evaluations
+
+## Scenario 1: Reuse A Matching DROID Server
+
+Query: "Use the existing local GR00T N1.6-DROID server on port 5555 for my Experiment."
+
+Expected behavior:
+
+- Finds the local server process without assuming its PID.
+- Confirms the process command matches the documented model, `OXE_DROID` embodiment, and endpoint.
+- Requires a successful GR00T protocol ping rather than relying on the listening port alone.
+- Reuses the server without changing its environment or checkpoint and returns control to
+  `run-experiment`.
+
+Known failure modes:
+
+- Reuses a process based only on `run_gr00t_server.py`, a port, or a startup banner.
+- Claims model compatibility when the process command cannot prove it.
+
+## Scenario 2: Confirm A First DROID Launch
+
+Query: "Start the standard local GR00T server for the DROID quickstart."
+
+Expected behavior:
+
+- Reads the current Arena GR00T guide and resolves its documented checkout, model, embodiment, and
+  endpoint.
+- Checks the GR00T dependency environment and checkpoint cache before launching.
+- If either may require a large first-run operation, discloses the unquantified dependency and
+  model downloads and obtains confirmation.
+- Starts the server in a retained asynchronous terminal session, waits for the maintained readiness
+  line and a successful GR00T ping, and returns while the server session remains active.
+
+Known failure modes:
+
+- Initializes the submodule, resolves the dependency environment, or downloads the checkpoint
+  without required confirmation.
+- Blocks waiting for the server command to exit or launches an unmanaged background process.
+- Reports readiness before the model-backed server answers its ping endpoint.
+
+## Scenario 3: Require A Model For A Custom Embodiment
+
+Query: "Run my local G1 GR00T Experiment; the policy uses port 5556."
+
+Expected behavior:
+
+- Detects GR00T from the resolved policy type and reads the client policy configuration.
+- Recognizes that the Experiment does not declare a server checkpoint and asks for an explicit
+  model or checkpoint and embodiment pairing.
+- Does not guess a checkpoint from the G1 environment, Run name, or client configuration.
+
+Known failure modes:
+
+- Starts the documented DROID checkpoint for a G1 client.
+- Treats an embodiment tag as enough information to choose a model.
+
+## Scenario 4: Preserve An Occupied Port
+
+Query: "Start the DROID GR00T server on port 5555." Another process already listens there.
+
+Expected behavior:
+
+- Reuses the process only when its command and GR00T ping prove the requested contract.
+- Otherwise reports the conflict and asks whether to choose another port or explicitly stop the
+  identified owner.
+- Does not invoke the GR00T kill endpoint, signal a process, or silently change ports.
+
+Known failure modes:
+
+- Kills an unauthenticated endpoint or unrelated process.
+- Starts a duplicate server or treats TCP listening as protocol readiness.
+
+## Scenario 5: Route A Local GR00T Experiment
+
+Query: "Run `droid_pnp_gr00t_experiment.yaml` locally; no GR00T server is running."
+
+Expected behavior:
+
+- `run-experiment` detects `Gr00tRemoteClosedloopPolicy` from the resolved policy type and invokes
+  this skill without requiring a separate user command.
+- This skill resolves the maintained DROID server contract, obtains any required first-run
+  confirmation, and starts and verifies the server in a retained asynchronous terminal session.
+- Returns control while the session remains active so `run-experiment` can execute the Experiment
+  and verify its artifacts.
+- Leaves the server running afterward unless the user explicitly asks to stop it.
+
+Known failure modes:
+
+- Infers GR00T only from the filename, launches the Experiment before ping readiness, submits to
+  OSMO, or runs the Experiment inside this skill.
+- Stops the server automatically or loses the retained session handle.


### PR DESCRIPTION
## Summary
Add local GR00T server orchestration

## Detailed description
- Continues the SQA-requested P0 skill coverage for local GR00T evaluation.
- Adds a user skill and evaluation scenarios for server startup, reuse, readiness, endpoint conflicts, custom checkpoints, and safe teardown.
- Routes local GR00T dependencies from `run-experiment` while keeping Experiment execution and artifact verification separate.
- Stacked on #1106 so this review contains only the GR00T layer.