### PR TITLE
Move DreamZero into internal docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -354,3 +354,9 @@ TABLE OF CONTENTS
 
    pages/references/release_notes
    pages/references/citing_us
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Development Team Internal
+
+   pages/development_team_internal/index

--- a/docs/pages/development_team_internal/dreamzero.rst
+++ b/docs/pages/development_team_internal/dreamzero.rst
@@ -49,7 +49,7 @@ the language instruction, and a three-episode rollout:
 .. dropdown:: Configuration file (``droid_pnp_dreamzero_experiment.yaml``)
    :animate: fade-in
 
-   .. literalinclude:: ../../../../isaaclab_arena_environments/experiment_configs/droid_pnp_dreamzero_experiment.yaml
+   .. literalinclude:: ../../../isaaclab_arena_environments/experiment_configs/droid_pnp_dreamzero_experiment.yaml
       :language: yaml
 
 The policy configuration uses ``localhost:5000`` by default, matching the port forward

--- a/docs/pages/development_team_internal/index.rst
+++ b/docs/pages/development_team_internal/index.rst
@@ -1,0 +1,11 @@
+Development Team Internal
+=========================
+
+Guides intended for the Isaac Lab Arena development team. These workflows rely on
+internal resources (such as specific compute pools or prebuilt server images) and are
+not part of the supported user-facing documentation.
+
+.. toctree::
+   :maxdepth: 1
+
+   dreamzero

--- a/docs/pages/quickstart/running_a_real_policy/index.rst
+++ b/docs/pages/quickstart/running_a_real_policy/index.rst
@@ -5,11 +5,10 @@ The earlier zero-action example keeps the robot still, so its success rate stays
 section, you replace that policy with a pre-trained model. Each guide shows how to start the model
 server and run a saved YAML configuration.
 
-Start with OpenPI for an interactive first rollout, then try GR00T or DreamZero.
+Start with OpenPI for an interactive first rollout, then try GR00T.
 
 .. toctree::
    :maxdepth: 1
 
    openpi
    gr00t
-   dreamzero


### PR DESCRIPTION
## Summary
Move DreamZero documentation into internal docs.

## Detailed description
- Addresses [6610909](https://nvbugspro.nvidia.com/bug/6610909)
- DreamZero docs are not suitable for internal users (they require push access to internal NGC)
- Move these docs into (new) internal section.
- Note: These docs are still visible if a user navigates there, however, there should be no expectation that they work.
