### PR TITLE
Remove warning when no variation recorder is used

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -45,11 +45,6 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
     @property
     def variation_recorder(self) -> VariationRecorder | None:
         """The recorder of variation samples, or ``None`` if the env was not built with one."""
-        if self._variation_recorder is None:
-            print(
-                "[WARNING] variation_recorder is None; no variation samples were recorded. "
-                "Build the env through ArenaEnvBuilder to record variations."
-            )
         return self._variation_recorder
 
     @property


### PR DESCRIPTION
## Summary

The variation recorder is currently throwing a warning whenever the recorder is set to None to tell users that no variations are being recorded. A value of None for the recorder is a valid configuration and used for cases such as Isaac Lab recorder script interop. 

The current setup throws this warning message every env reset when no recorder is provided even when it's intended. This PR removes the warning to prevent confusion.
