### PR TITLE
Point GR00T workflow docs at the host checkpoint path and add the Blackwell CUDA reqs

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_4_policy_training.rst
@@ -109,6 +109,13 @@ We post-train the GR00T N1.6 policy on the task.
 The GR00T N1.6 policy has 3 billion parameters so post-training is an expensive operation.
 We provide one post-training option, 8 GPUs with 48GB memory, to achieve the best quality.
 
+.. note::
+
+   Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The
+   `official GR00T documentation <https://github.com/NVIDIA/Isaac-GR00T/blob/e29d8fc50b0e4745120ae3fb72447986fe638aa6/README.md?plain=1#L102>`_
+   specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
+   documentation for the latest requirements.
+
 Training takes approximately 4-8 hours on 8x L40s GPUs.
 
 Compute Requirements:

--- a/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
@@ -63,12 +63,17 @@ leave it running:
    specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
    documentation for the latest requirements.
 
+.. note::
+
+   ``$MODELS_DIR`` exists inside the container. On the host, the checkpoint is
+   under the models directory passed to ``./docker/run_docker.sh -m`` (default ``$HOME/models``).
+
 .. code-block:: bash
 
    cd submodules/Isaac-GR00T
    uv run python gr00t/eval/run_gr00t_server.py \
      --modality-config-path ../../isaaclab_arena_gr00t/embodiments/g1/g1_sim_wbc_data_config.py \
-     --model-path /models/isaaclab_arena/locomanipulation_tutorial/checkpoint-20000 \
+     --model-path $HOME/models/isaaclab_arena/locomanipulation_tutorial/checkpoint-20000 \
      --embodiment-tag NEW_EMBODIMENT \
      --device cuda --host 127.0.0.1 --port 5555
 

--- a/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_5_evaluation.rst
@@ -50,12 +50,6 @@ submodule pinned at commit ``e29d8fc``; populate it with
 checked out. Then, from the repository root in that terminal, launch the server and
 leave it running:
 
-.. todo::
-
-   The ``submodules/Isaac-GR00T`` submodule will be removed after the policy
-   config refactor. After that, users will be expected to set up a separate
-   GR00T repository checkout themselves and launch the server from there.
-
 .. note::
 
    Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_4_policy_training.rst
@@ -120,6 +120,13 @@ We provide two post-training options:
 * Best Quality: 8 GPUs with 48GB memory
 * Low Hardware Requirements: 1 GPU with 24GB memory
 
+.. note::
+
+   Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The
+   `official GR00T documentation <https://github.com/NVIDIA/Isaac-GR00T/blob/e29d8fc50b0e4745120ae3fb72447986fe638aa6/README.md?plain=1#L102>`_
+   specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
+   documentation for the latest requirements.
+
 
 .. tab-set::
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
@@ -50,12 +50,6 @@ submodule pinned at commit ``e29d8fc``; populate it with
 checked out. Then, from the repository root in that terminal, launch the server and
 leave it running:
 
-.. todo::
-
-   The ``submodules/Isaac-GR00T`` submodule will be removed after the policy
-   config refactor. After that, users will be expected to set up a separate
-   GR00T repository checkout themselves and launch the server from there.
-
 .. note::
 
    Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_5_evaluation.rst
@@ -63,12 +63,17 @@ leave it running:
    specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
    documentation for the latest requirements.
 
+.. note::
+
+   ``$MODELS_DIR`` exists inside the container. On the host, the checkpoint is
+   under the models directory passed to ``./docker/run_docker.sh -m`` (default ``$HOME/models``).
+
 .. code-block:: bash
 
    cd submodules/Isaac-GR00T
    uv run python gr00t/eval/run_gr00t_server.py \
      --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-     --model-path /models/isaaclab_arena/sequential_static_manipulation_tutorial/checkpoint-20000 \
+     --model-path $HOME/models/isaaclab_arena/sequential_static_manipulation_tutorial/checkpoint-20000 \
      --embodiment-tag GR1 \
      --device cuda --host 127.0.0.1 --port 5555
 

--- a/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_4_policy_training.rst
@@ -113,6 +113,13 @@ We provide two post-training options:
 * Best Quality: 8 GPUs with 48GB memory
 * Low Hardware Requirements: 1 GPU with 24GB memory
 
+.. note::
+
+   Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The
+   `official GR00T documentation <https://github.com/NVIDIA/Isaac-GR00T/blob/e29d8fc50b0e4745120ae3fb72447986fe638aa6/README.md?plain=1#L102>`_
+   specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
+   documentation for the latest requirements.
+
 
 .. tab-set::
 

--- a/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
@@ -58,12 +58,17 @@ leave it running:
    specifies CUDA 12.8 and ``pytorch-cu128`` for RTX 5090 systems. Please refer to the
    documentation for the latest requirements.
 
+.. note::
+
+   ``$MODELS_DIR`` exists inside the container. On the host, the checkpoint is
+   under the models directory passed to ``./docker/run_docker.sh -m`` (default ``$HOME/models``).
+
 .. code-block:: bash
 
    cd submodules/Isaac-GR00T
    uv run python gr00t/eval/run_gr00t_server.py \
      --modality-config-path ../../isaaclab_arena_gr00t/embodiments/gr1/gr1_arms_only_data_config.py \
-     --model-path /models/isaaclab_arena/static_manipulation_tutorial/checkpoint-20000 \
+     --model-path $HOME/models/isaaclab_arena/static_manipulation_tutorial/checkpoint-20000 \
      --embodiment-tag GR1 \
      --device cuda --host 127.0.0.1 --port 5555
 

--- a/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_5_evaluation.rst
@@ -45,12 +45,6 @@ submodule pinned at commit ``e29d8fc``; populate it with
 checked out. Then, from the repository root in that terminal, launch the server and
 leave it running:
 
-.. todo::
-
-   The ``submodules/Isaac-GR00T`` submodule will be removed after the policy
-   config refactor. After that, users will be expected to set up a separate
-   GR00T repository checkout themselves and launch the server from there.
-
 .. note::
 
    Blackwell GPUs with compute capability ``sm_120`` require CUDA 12.8 or newer. The

--- a/docs/pages/quickstart/running_a_real_policy/gr00t.rst
+++ b/docs/pages/quickstart/running_a_real_policy/gr00t.rst
@@ -27,12 +27,6 @@ submodule pinned at commit ``e29d8fc``. Populate it if needed:
 
 Then start the server from the repository root in a separate shell:
 
-.. todo::
-
-   The ``submodules/Isaac-GR00T`` submodule will be removed after the policy
-   config refactor. After that, users will set up a separate GR00T repository
-   checkout and launch the server from there.
-
 .. code-block:: bash
 
    cd submodules/Isaac-GR00T


### PR DESCRIPTION
## Summary
Doc only. Point GR00T workflow docs at the host checkpoint path and add the Blackwell CUDA reqs.
Fix  https://nvbugspro.nvidia.com/bug/6652391, https://nvbugspro.nvidia.com/bug/6658396
