### PR TITLE
Add average-progress metric to the task plotting script

### DIFF
--- a/isaaclab_arena/tests/test_plot_success_rates.py
+++ b/isaaclab_arena/tests/test_plot_success_rates.py
@@ -10,9 +10,12 @@ from pathlib import Path
 import pytest
 
 from isaaclab_arena.visualization.plot_success_rates import (
+    AverageProgressResult,
     SuccessRateResult,
+    collect_average_progress,
     collect_success_rates,
     main,
+    plot_average_progress,
     plot_success_rates,
 )
 
@@ -21,6 +24,20 @@ def _write_episode_results(results_path: Path, job_name: str, successes: list[bo
     """Write minimal episode records for one Run."""
     results_path.parent.mkdir(parents=True, exist_ok=True)
     records = [json.dumps({"job_name": job_name, "success": success}) for success in successes]
+    results_path.write_text("\n".join(records) + "\n", encoding="utf-8")
+
+
+def _write_progress_results(results_path: Path, job_name: str, overall_scores: list[float | None]) -> None:
+    """Write episode records carrying a ``progress`` block for one Run.
+
+    Each element is either None (progress not recorded) or the episode's ``overall_score`` (already
+    normalized to [0, 1] by the progress tracker).
+    """
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    records = []
+    for overall_score in overall_scores:
+        value = None if overall_score is None else {"overall_score": overall_score}
+        records.append(json.dumps({"job_name": job_name, "success": None, "progress": value}))
     results_path.write_text("\n".join(records) + "\n", encoding="utf-8")
 
 
@@ -131,8 +148,9 @@ def test_plot_success_rates_writes_png_with_missing_policy_pair(tmp_path):
     assert output_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
 
 
-def test_main_writes_default_plot_and_reports_unavailable_pair(tmp_path, capsys):
+def test_main_skips_metric_without_data_and_reports_unavailable_pair(tmp_path, capsys):
     results_directory = tmp_path / "results"
+    # Only success is recorded, so the average-progress metric is skipped (not an error).
     _write_episode_results(results_directory / "task_alpha_pi0/episode_results.jsonl", "task_alpha_pi0", [True])
 
     return_code = main([str(results_directory), "--policies", "pi0", "cosmos"])
@@ -140,5 +158,101 @@ def test_main_writes_default_plot_and_reports_unavailable_pair(tmp_path, capsys)
     captured_output = capsys.readouterr()
     assert return_code == 0
     assert (results_directory / "success_rates.png").is_file()
-    assert "Read 1 scored episodes across 1 tasks and 2 policies." in captured_output.out
+    assert not (results_directory / "average_progress.png").exists()
+    assert "[success_rate] Read 1 scored episodes across 1 tasks and 2 policies." in captured_output.out
+    assert "[average_progress] skipped" in captured_output.err
     assert "Unavailable results (bars marked N/A): task_alpha/cosmos" in captured_output.err
+
+
+def test_collect_average_progress_averages_recorded_overall_score(tmp_path):
+    results_directory = tmp_path / "results"
+    _write_progress_results(
+        results_directory / "task_alpha_pi0/episode_results_rebuild0.jsonl",
+        "task_alpha_pi0",
+        [1.0, 0.5],
+    )
+    _write_progress_results(
+        results_directory / "task_alpha_pi0/episode_results_rebuild1.jsonl",
+        "task_alpha_pi0",
+        [0.0, None],  # one scored-at-zero episode and one unrecorded episode
+    )
+    _write_progress_results(
+        results_directory / "task_alpha_cosmos/episode_results_rebuild0.jsonl",
+        "task_alpha_cosmos",
+        [0.25],
+    )
+
+    results = collect_average_progress(results_directory, ["pi0", "cosmos"])
+
+    assert results[("task_alpha", "pi0")] == AverageProgressResult(total_progress=1.5, scored_episodes=3)
+    assert results[("task_alpha", "pi0")].average_progress == pytest.approx(0.5)
+    assert results[("task_alpha", "cosmos")].average_progress == pytest.approx(0.25)
+
+
+def test_collect_average_progress_preserves_task_with_only_unscored_episodes(tmp_path):
+    results_directory = tmp_path / "results"
+    _write_progress_results(results_directory / "task_alpha_pi0/episode_results.jsonl", "task_alpha_pi0", [1.0])
+    _write_progress_results(results_directory / "task_beta_pi0/episode_results.jsonl", "task_beta_pi0", [None])
+
+    results = collect_average_progress(results_directory, ["pi0"])
+
+    assert results[("task_beta", "pi0")] == AverageProgressResult(total_progress=0.0, scored_episodes=0)
+    assert results[("task_beta", "pi0")].average_progress is None
+
+
+def test_collect_average_progress_rejects_out_of_range_score(tmp_path):
+    results_path = tmp_path / "episode_results.jsonl"
+    # overall_score is recorded already normalized to [0, 1]; an out-of-range value is an error.
+    _write_progress_results(results_path, "task_alpha_pi0", [1.5])
+
+    with pytest.raises(ValueError, match=r"outside \[0, 1\]"):
+        collect_average_progress(results_path, ["pi0"])
+
+
+def test_plot_average_progress_writes_png_with_missing_policy_pair(tmp_path):
+    results = {
+        ("task_alpha", "pi0"): AverageProgressResult(total_progress=1.0, scored_episodes=2),
+        ("task_alpha", "cosmos"): AverageProgressResult(total_progress=2.0, scored_episodes=2),
+        ("task_beta", "pi0"): AverageProgressResult(total_progress=0.0, scored_episodes=0),
+    }
+    output_path = tmp_path / "average_progress.png"
+
+    plot_average_progress(results, ["pi0", "cosmos"], output_path)
+
+    assert output_path.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_main_writes_both_plots_by_default(tmp_path, capsys):
+    results_directory = tmp_path / "results"
+    results_directory.mkdir()
+    (results_directory / "task_alpha_pi0").mkdir()
+    (results_directory / "task_alpha_pi0" / "episode_results.jsonl").write_text(
+        json.dumps({"job_name": "task_alpha_pi0", "success": True, "progress": {"overall_score": 0.5}}) + "\n",
+        encoding="utf-8",
+    )
+
+    return_code = main([str(results_directory), "--policies", "pi0"])
+
+    captured_output = capsys.readouterr()
+    assert return_code == 0
+    assert (results_directory / "success_rates.png").is_file()
+    assert (results_directory / "average_progress.png").is_file()
+    assert "[success_rate] Read 1 scored episodes across 1 tasks and 1 policies." in captured_output.out
+    assert "[average_progress] Read 1 scored episodes across 1 tasks and 1 policies." in captured_output.out
+
+
+def test_main_writes_both_plots_into_output_dir(tmp_path):
+    results_directory = tmp_path / "results"
+    results_directory.mkdir()
+    (results_directory / "task_alpha_pi0").mkdir()
+    (results_directory / "task_alpha_pi0" / "episode_results.jsonl").write_text(
+        json.dumps({"job_name": "task_alpha_pi0", "success": True, "progress": {"overall_score": 0.5}}) + "\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "plots"
+
+    return_code = main([str(results_directory), "--policies", "pi0", "--output-dir", str(output_dir)])
+
+    assert return_code == 0
+    assert (output_dir / "success_rates.png").is_file()
+    assert (output_dir / "average_progress.png").is_file()

--- a/isaaclab_arena/visualization/plot_success_rates.py
+++ b/isaaclab_arena/visualization/plot_success_rates.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Plot task success rates for policies encoded in Arena Run names.
+"""Plot per-task success rate and average progress for policies encoded in Arena Run names.
 
-Every Run name must end in one of the explicitly supplied ``_<policy>`` suffixes. The remaining
-prefix becomes the task name used to group policy bars.
+Every Run name must end in one of the explicitly supplied ``_<policy>`` suffixes; the remaining prefix
+is the task name used to group policy bars. Both metrics are written as grouped bar charts.
 """
 
 from __future__ import annotations
@@ -19,7 +19,7 @@ import re
 import sys
 import tarfile
 from collections import defaultdict
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -28,7 +28,6 @@ import matplotlib.pyplot as plt  # noqa: E402
 
 _RESULTS_FILENAME_PATTERN = re.compile(r"^episode_results(?:_rebuild\d+)?(?:_rank\d+)?\.jsonl$")
 _RUN_DIRECTORY_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$")
-_ARCHIVE_SUFFIXES = (".tar.gz", ".tar.bz2", ".tar.xz", ".tgz", ".tbz2", ".txz", ".tar")
 _POLICY_STYLES = (
     ("#0072B2", ""),
     ("#D55E00", "xxx"),
@@ -63,6 +62,41 @@ class SuccessRateResult:
         if self.total_episodes == 0:
             return None
         return self.successful_episodes / self.total_episodes
+
+    @property
+    def num_scored_episodes(self) -> int:
+        """Number of episodes that contributed to the metric."""
+        return self.total_episodes
+
+
+@dataclass(frozen=True)
+class AverageProgressResult:
+    """Summed progress score and scored episode count for one task-policy pair."""
+
+    total_progress: float
+    """Sum over episodes of the ``progress`` score in ``[0, 1]``."""
+
+    scored_episodes: int
+    """Number of episodes whose ``progress`` score is a number in ``[0, 1]``."""
+
+    def __post_init__(self) -> None:
+        assert self.scored_episodes >= 0, "The number of scored episodes must not be negative."
+        assert self.total_progress >= 0.0, "The summed progress must not be negative."
+        assert (
+            self.total_progress <= self.scored_episodes
+        ), "The summed progress must not exceed the scored episode count."
+
+    @property
+    def average_progress(self) -> float | None:
+        """Return the mean progress score, or None when no episode was scored."""
+        if self.scored_episodes == 0:
+            return None
+        return self.total_progress / self.scored_episodes
+
+    @property
+    def num_scored_episodes(self) -> int:
+        """Number of episodes that contributed to the metric."""
+        return self.scored_episodes
 
 
 def _validate_policies(policies: Sequence[str]) -> tuple[str, ...]:
@@ -161,8 +195,8 @@ def _resolve_results_path(results_path: Path) -> Path:
     return run_directories[-1]
 
 
-def _parse_record(line: str, source_name: str, line_number: int) -> tuple[str, bool | None]:
-    """Return a validated ``(job_name, success)`` pair from one JSONL record."""
+def _load_record(line: str, source_name: str, line_number: int) -> tuple[dict, str, str]:
+    """Return a validated ``(record, job_name, location)`` triple from one JSONL line."""
     location = f"{source_name}:{line_number}"
     try:
         record = json.loads(line)
@@ -170,16 +204,46 @@ def _parse_record(line: str, source_name: str, line_number: int) -> tuple[str, b
         raise ValueError(f"Invalid JSON at {location}: {error.msg}.") from error
     if not isinstance(record, dict):
         raise ValueError(f"Episode result at {location} must be a JSON object.")
-
     job_name = record.get("job_name")
     if not isinstance(job_name, str) or not job_name:
         raise ValueError(f"Episode result at {location} must contain a non-empty string 'job_name'.")
+    return record, job_name, location
+
+
+def _parse_success_record(line: str, source_name: str, line_number: int) -> tuple[str, bool | None]:
+    """Return a validated ``(job_name, success)`` pair from one JSONL record."""
+    record, job_name, location = _load_record(line, source_name, line_number)
     if "success" not in record:
         raise ValueError(f"Episode result at {location} does not contain 'success'.")
     success = record["success"]
     if success is not None and not isinstance(success, bool):
         raise ValueError(f"Episode result at {location} has 'success' that is not a boolean or null.")
     return job_name, success
+
+
+def _parse_progress_record(line: str, source_name: str, line_number: int) -> tuple[str, float | None]:
+    """Return a validated ``(job_name, progress_fraction)`` pair from one JSONL record."""
+    record, job_name, location = _load_record(line, source_name, line_number)
+    return job_name, _progress_fraction(record.get("progress"), location)
+
+
+def _progress_fraction(progress: object, location: str) -> float | None:
+    """Return the episode's recorded progress in ``[0, 1]``, or None when it was not recorded."""
+    if progress is None:
+        return None
+    if not isinstance(progress, dict):
+        raise ValueError(f"Episode result at {location} has 'progress' that is not an object or null.")
+    overall_score = progress.get("overall_score")
+    if overall_score is None:
+        return None
+    if isinstance(overall_score, bool) or not isinstance(overall_score, (int, float)):
+        raise ValueError(f"Episode result at {location} has 'progress.overall_score' that is not a number.")
+    # overall_score is recorded already normalized to [0, 1]; reject out-of-range values rather than
+    # silently clamp them.
+    fraction = float(overall_score)
+    if not 0.0 <= fraction <= 1.0:
+        raise ValueError(f"Episode result at {location} has 'progress.overall_score' {fraction} outside [0, 1].")
+    return fraction
 
 
 def _split_task_and_policy(job_name: str, policies: Sequence[str]) -> tuple[str, str]:
@@ -213,7 +277,7 @@ def collect_success_rates(
     episode_counts: dict[tuple[str, str], list[int]] = defaultdict(lambda: [0, 0])
 
     for source_name, line_number, line in _iter_result_lines(resolved_results_path):
-        job_name, success = _parse_record(line, source_name, line_number)
+        job_name, success = _parse_success_record(line, source_name, line_number)
         task_name, policy_name = _split_task_and_policy(job_name, policy_names)
         counts = episode_counts[(task_name, policy_name)]
         if success is None:
@@ -230,24 +294,62 @@ def collect_success_rates(
     }
 
 
-def plot_success_rates(
-    results: dict[tuple[str, str], SuccessRateResult],
-    policies: Sequence[str],
-    output_path: str | Path,
-    title: str = "Task success rate",
-) -> None:
-    """Render a grouped success-rate bar chart and save it to ``output_path``.
+def collect_average_progress(
+    results_path: str | Path, policies: Sequence[str]
+) -> dict[tuple[str, str], AverageProgressResult]:
+    """Collect episode-weighted average progress keyed by derived task name and policy.
 
     Args:
-        results: Success counts keyed by ``(task_name, policy_name)``.
+        results_path: Results directory, JSONL file, or tar archive to read.
+        policies: Policy names expected as underscore-delimited Run-name suffixes.
+
+    Returns:
+        Summed progress and scored counts keyed by ``(task_name, policy_name)``.
+    """
+    resolved_results_path = _resolve_results_path(Path(results_path).expanduser())
+    policy_names = _validate_policies(policies)
+    progress_totals: dict[tuple[str, str], list[float]] = defaultdict(lambda: [0.0, 0.0])
+
+    for source_name, line_number, line in _iter_result_lines(resolved_results_path):
+        job_name, score = _parse_progress_record(line, source_name, line_number)
+        task_name, policy_name = _split_task_and_policy(job_name, policy_names)
+        totals = progress_totals[(task_name, policy_name)]
+        if score is None:
+            continue
+        totals[0] += score
+        totals[1] += 1
+
+    if not progress_totals or not any(totals[1] for totals in progress_totals.values()):
+        raise ValueError(f"No scored progress episodes found under '{results_path}'.")
+
+    return {
+        key: AverageProgressResult(total_progress=totals[0], scored_episodes=int(totals[1]))
+        for key, totals in progress_totals.items()
+    }
+
+
+def _plot_grouped_percentages(
+    percentages: dict[tuple[str, str], float | None],
+    policies: Sequence[str],
+    output_path: str | Path,
+    *,
+    title: str,
+    y_label: str,
+) -> None:
+    """Render a grouped percentage bar chart of ``(task, policy) -> percent`` and save it.
+
+    Args:
+        percentages: Percentages in ``[0, 100]`` keyed by ``(task_name, policy_name)``; a None or
+            missing pair is drawn as an ``N/A`` marker.
         policies: Policy names in the desired left-to-right and legend order.
         output_path: Destination image path; its extension selects the output format.
         title: Plot title.
+        y_label: Label for the vertical axis.
     """
     policy_names = _validate_policies(policies)
-    if not results:
-        raise ValueError("At least one success-rate result is required.")
-    task_names = sorted({task_name for task_name, _ in results})
+    if not percentages:
+        raise ValueError("At least one result is required.")
+    task_names = sorted({task_name for task_name, _ in percentages})
     task_positions = list(range(len(task_names)))
     bar_width = 0.8 / len(policy_names)
     width_per_task = max(1.15, 0.36 * len(policy_names))
@@ -260,14 +362,10 @@ def plot_success_rates(
         offsets = [
             task_position + (policy_index - (len(policy_names) - 1) / 2) * bar_width for task_position in task_positions
         ]
-        percentages = []
-        for task_name in task_names:
-            result = results.get((task_name, policy_name))
-            success_rate = None if result is None else result.success_rate
-            percentages.append(None if success_rate is None else success_rate * 100.0)
+        percentage_values = [percentages.get((task_name, policy_name)) for task_name in task_names]
         bars = axes.bar(
             offsets,
-            [0.0 if percentage is None else percentage for percentage in percentages],
+            [0.0 if percentage is None else percentage for percentage in percentage_values],
             bar_width,
             label=policy_name,
             color=color,
@@ -275,7 +373,7 @@ def plot_success_rates(
             hatch=hatch,
             linewidth=0.8,
         )
-        for task_name, bar, percentage in zip(task_names, bars, percentages):
+        for task_name, bar, percentage in zip(task_names, bars, percentage_values):
             if percentage is None:
                 bar.set_visible(False)
                 axes.annotate(
@@ -301,7 +399,7 @@ def plot_success_rates(
             )
 
     axes.set_axisbelow(True)
-    axes.set_ylabel("Success rate (%)")
+    axes.set_ylabel(y_label)
     axes.set_ylim(0, 105)
     axes.set_yticks(range(0, 101, 20))
     axes.set_xticks(task_positions)
@@ -319,22 +417,74 @@ def plot_success_rates(
     plt.close(figure)
 
 
-def _default_output_path(results_path: Path) -> Path:
-    """Return a non-colliding default image path beside the input."""
-    if results_path.is_dir():
-        return results_path / "success_rates.png"
-    input_name = results_path.name
-    for archive_suffix in _ARCHIVE_SUFFIXES:
-        if input_name.endswith(archive_suffix):
-            input_name = input_name[: -len(archive_suffix)]
-            break
-    else:
-        input_name = results_path.stem
-    return results_path.with_name(f"{input_name}_success_rates.png")
+def plot_success_rates(
+    results: dict[tuple[str, str], SuccessRateResult],
+    policies: Sequence[str],
+    output_path: str | Path,
+    title: str = "Task success rate",
+) -> None:
+    """Render a grouped success-rate bar chart and save it to ``output_path``.
+
+    Args:
+        results: Success counts keyed by ``(task_name, policy_name)``.
+        policies: Policy names in the desired left-to-right and legend order.
+        output_path: Destination image path; its extension selects the output format.
+        title: Plot title.
+    """
+    if not results:
+        raise ValueError("At least one success-rate result is required.")
+    percentages = {
+        key: None if result.success_rate is None else result.success_rate * 100.0 for key, result in results.items()
+    }
+    _plot_grouped_percentages(percentages, policies, output_path, title=title, y_label="Success rate (%)")
+
+
+def plot_average_progress(
+    results: dict[tuple[str, str], AverageProgressResult],
+    policies: Sequence[str],
+    output_path: str | Path,
+    title: str = "Average task progress",
+) -> None:
+    """Render a grouped average-progress bar chart and save it to ``output_path``.
+
+    Args:
+        results: Summed progress and scored counts keyed by ``(task_name, policy_name)``.
+        policies: Policy names in the desired left-to-right and legend order.
+        output_path: Destination image path; its extension selects the output format.
+        title: Plot title.
+    """
+    if not results:
+        raise ValueError("At least one average-progress result is required.")
+    percentages = {
+        key: None if result.average_progress is None else result.average_progress * 100.0
+        for key, result in results.items()
+    }
+    _plot_grouped_percentages(percentages, policies, output_path, title=title, y_label="Average progress (%)")
+
+
+@dataclass(frozen=True)
+class _MetricSpec:
+    """Collection and rendering configuration for one plottable metric."""
+
+    collect: Callable[[str | Path, Sequence[str]], dict]
+    plot: Callable[[dict, Sequence[str], str | Path, str], None]
+    default_basename: str
+    default_title: str
+
+
+_METRICS = {
+    "success_rate": _MetricSpec(collect_success_rates, plot_success_rates, "success_rates", "Task success rate"),
+    "average_progress": _MetricSpec(
+        collect_average_progress, plot_average_progress, "average_progress", "Average task progress"
+    ),
+}
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Parse command-line arguments, aggregate results, and write the plot."""
+    """Write a success-rate and an average-progress bar chart into the output directory.
+
+    Both metrics are plotted; a metric with no scored episodes is skipped with a warning.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("results_path", type=Path, help="Results directory, JSONL file, or tar archive")
     parser.add_argument(
@@ -343,33 +493,54 @@ def main(argv: Sequence[str] | None = None) -> int:
         required=True,
         help="All policy suffixes present in the input, in bar and legend order (for example: pi0 cosmos)",
     )
-    parser.add_argument("--output", type=Path, help="Output image path (default: beside the input)")
-    parser.add_argument("--title", default="Task success rate", help="Plot title")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for the output images (default: the results directory)",
+    )
+    parser.add_argument("--title", help="Plot title applied to both charts (default: a per-metric title)")
     args = parser.parse_args(argv)
 
+    requested_results_path = args.results_path.expanduser()
     try:
-        requested_results_path = args.results_path.expanduser()
         resolved_results_path = _resolve_results_path(requested_results_path)
-        results = collect_success_rates(resolved_results_path, args.policies)
-        output_path = args.output or _default_output_path(resolved_results_path)
-        plot_success_rates(results, args.policies, output_path, args.title)
-    except (OSError, UnicodeError, ValueError) as error:
+    except OSError as error:
         parser.error(str(error))
-
-    task_names = {task_name for task_name, _ in results}
-    total_episodes = sum(result.total_episodes for result in results.values())
-    unavailable_pairs = [
-        f"{task_name}/{policy_name}"
-        for task_name in sorted(task_names)
-        for policy_name in args.policies
-        if (task_name, policy_name) not in results or results[(task_name, policy_name)].total_episodes == 0
-    ]
     if resolved_results_path != requested_results_path:
         print(f"Using most recent experiment directory: {resolved_results_path}")
-    if unavailable_pairs:
-        print(f"Unavailable results (bars marked N/A): {', '.join(unavailable_pairs)}", file=sys.stderr)
-    print(f"Read {total_episodes} scored episodes across {len(task_names)} tasks and {len(args.policies)} policies.")
-    print(f"Wrote {output_path}")
+    output_dir = args.output_dir or (
+        resolved_results_path if resolved_results_path.is_dir() else resolved_results_path.parent
+    )
+
+    any_plotted = False
+    for metric_name, metric in _METRICS.items():
+        try:
+            results = metric.collect(resolved_results_path, args.policies)
+        except (OSError, UnicodeError, ValueError) as error:
+            print(f"[{metric_name}] skipped: {error}", file=sys.stderr)
+            continue
+        output_path = output_dir / f"{metric.default_basename}.png"
+        metric.plot(results, args.policies, output_path, args.title or metric.default_title)
+        any_plotted = True
+
+        task_names = {task_name for task_name, _ in results}
+        total_episodes = sum(result.num_scored_episodes for result in results.values())
+        unavailable_pairs = [
+            f"{task_name}/{policy_name}"
+            for task_name in sorted(task_names)
+            for policy_name in args.policies
+            if (task_name, policy_name) not in results or results[(task_name, policy_name)].num_scored_episodes == 0
+        ]
+        if unavailable_pairs:
+            print(f"Unavailable results (bars marked N/A): {', '.join(unavailable_pairs)}", file=sys.stderr)
+        print(
+            f"[{metric_name}] Read {total_episodes} scored episodes across {len(task_names)} tasks and "
+            f"{len(args.policies)} policies."
+        )
+        print(f"Wrote {output_path}")
+
+    if not any_plotted:
+        parser.error(f"no metrics could be plotted from '{requested_results_path}'")
     return 0
 
 


### PR DESCRIPTION
## Summary
Add per-task average-progress bar charts alongside success rate.

## Detailed description
- **Why:**
  - `plot_success_rates.py` only plotted success rate.
  - For difficult tasks this is not sufficiently informative.
- **What:** 
  - Extends the plotting script to plot average success rates.
- **Impact:**
  - CLI change — `main` always produces `success_rates.png` and `average_progress.png` (previously `--metrics`/`--output` selected a single chart).
