### PR TITLE
Fix user skill evaluation coverage

### DIFF
--- a/skills/user/run-experiment/evaluations.md
+++ b/skills/user/run-experiment/evaluations.md
@@ -20,11 +20,13 @@ Known failure modes:
 
 ## Scenario 2: Local Shared Override
 
-Query: "Run `my_experiment.yaml` headless, set the shared episode count to 4, and don't edit the YAML."
+Query: "Run `isaaclab_arena_environments/experiment_configs/getting_started_experiment.yaml`
+headless, set the shared episode count to 4, and don't edit the YAML."
 
 Expected behavior:
 
-- Uses `--viz none` and the local override `shared.rollout_limit.num_episodes=4`.
+- Passes the maintained configuration explicitly with `--experiment_config`, uses `--viz none`,
+  and applies the local override `shared.rollout_limit.num_episodes=4`.
 - Leaves the Experiment Definition unchanged and reports the effective override.
 - Verifies canonical results and per-Run episode records after execution.
 

--- a/skills/user/serve-openpi-policy/SKILL.md
+++ b/skills/user/serve-openpi-policy/SKILL.md
@@ -107,10 +107,11 @@ terminal session handle when this workflow started the server. If `run-experimen
 server, return control to it while the retained session remains active so it can execute the
 Experiment and verify artifacts. Do not invoke the Experiment Runner here.
 
-When the user approves a different port, provide the corresponding per-Run Hydra override, for
-example:
+When the selected variant or port differs from the Experiment configuration, provide every
+corresponding per-Run Hydra override so the client and server remain compatible, for example:
 
 ```text
+runs.<run-name>.policy.policy_variant=pi0
 runs.<run-name>.policy.remote_port=8001
 ```
 

--- a/skills/user/serve-openpi-policy/evaluations.md
+++ b/skills/user/serve-openpi-policy/evaluations.md
@@ -36,18 +36,22 @@ Known failure modes:
 
 ## Scenario 3: Select Pi0 On A Non-Default Port
 
-Query: "Serve pi0 on port 8001 and use it for the `openpi_rollout` Run."
+Query: "Serve pi0 on port 8001 and use it for the `droid_pnp_openpi` Run in
+`isaaclab_arena_environments/experiment_configs/droid_pnp_openpi_experiment.yaml`."
 
 Expected behavior:
 
 - Validates the pi0 variant and port, checks the port for conflicts, and starts or reuses the exact
   matching server.
-- Returns `runs.openpi_rollout.policy.remote_port=8001` to `run-experiment` without editing YAML.
+- Detects that the Run selects pi05 and returns both
+  `runs.droid_pnp_openpi.policy.policy_variant=pi0` and
+  `runs.droid_pnp_openpi.policy.remote_port=8001` to `run-experiment` without editing YAML.
 - Keeps server lifecycle separate from Experiment execution and artifact verification.
 
 Known failure modes:
 
-- Serves the default pi05 variant, applies a shared or OSMO override, or edits the Experiment.
+- Serves the default pi05 variant, returns only the port override and leaves the client configured
+  for pi05, applies a shared or OSMO override, or edits the Experiment.
 
 ## Scenario 4: Preserve An Occupied Port
 

--- a/skills/user/setup-arena/SKILL.md
+++ b/skills/user/setup-arena/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-arena
 description: Sets up and verifies a runnable Isaac Lab-Arena checkout using the supported native uv source, native uv wheel, or Docker route. Use when installing Arena, preparing a fresh checkout to run examples or evaluations, choosing between uv and Docker, starting or attaching to the Arena container, mounting datasets/models/evaluation outputs, enabling cuRobo, or checking whether an installation is ready. Do not use for contributor hooks, forced image rebuilds, pytest regression testing, or experiment configuration.
-allowed-tools: Read Grep Glob Skill Bash(git rev-parse *) Bash(git submodule *) Bash(head *) Bash(id -un) Bash(test -d *) Bash(test -x *) Bash(uv --version) Bash(uv sync *) Bash(nvidia-smi *) Bash(.venv/bin/python *) Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker inspect *) Bash(docker ps *)
+allowed-tools: Read Grep Glob Skill Bash(git rev-parse *) Bash(git submodule *) Bash(head *) Bash(id -un) Bash(test -d *) Bash(test -x *) Bash(uv --version) Bash(uv sync *) Bash(nvidia-smi *) Bash(.venv/bin/python *) Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker inspect *) Bash(docker ps *) Bash(docker stop *)
 ---
 
 # Setup Arena
@@ -123,3 +123,8 @@ zero-action exit status when run. Treat setup readiness separately from policy s
 Use `dev-container` for contributor bootstrap or forced rebuilds and `run-tests` only when the user
 explicitly asks for regression testing. Treat any requested experiment as the next workflow after
 setup; do not absorb its policy, configuration, execution, or artifact checks into this skill.
+
+## References
+
+- [Evaluation scenarios](evaluations.md)
+- [Installation workflow](../../../docs/pages/quickstart/installation.rst)

--- a/skills/user/setup-arena/SKILL.md
+++ b/skills/user/setup-arena/SKILL.md
@@ -37,6 +37,10 @@ uv does not provide the optional cuRobo package; use Docker with `-c` for `ik_re
 4. Show the chosen route, exact documented commands, expected downloads/build, and any required
    EULA or host-directory changes. Ask once before starting a large sync or image build.
 
+Run the documentation read and safe read-only preflight immediately; do not ask for confirmation or
+defer them as a proposed plan. Confirmation is only for the state-changing sync, build, or stop that
+follows the preflight.
+
 If a prerequisite is missing, report the failed check and the documented recovery. Do not install or
 change GPU drivers, Docker, the NVIDIA Container Toolkit, or other system packages without explicit
 approval.
@@ -92,18 +96,32 @@ Use these options only when the request needs them:
 Confirm that each explicitly requested mount path exists before launching. Mount flags apply only
 when creating a container; they do not change an already-running container. If the requested
 configuration differs, explain that recreation is required and obtain approval before stopping the
-checkout-specific Arena container. When recreating it, preserve the current image flavor, container
-suffix, and mounts the user did not ask to change.
+checkout-specific Arena container. Before asking for approval, inspect its exact name, image, and
+mounts and show the complete reconstructed launcher command. Populate this shape from the inspected
+configuration instead of relying on launcher defaults:
+
+```bash
+./docker/run_docker.sh [-c] [-s <current-suffix>] -d <new-datasets> \
+  [-m <current-models>] [-e <current-evaluation>]
+```
+
+Include `-c` for an existing cuRobo image, `-s` for an existing suffix, and each current model or
+evaluation mount. Replace only the mount the user asked to change, and stop the container only after
+the user approves that exact command.
 
 The launcher builds a missing image, starts this checkout's container, and attaches interactively.
 Keep that process alive in a terminal session. Do not force a rebuild here; use `dev-container` for
 an explicit contributor rebuild or image-debugging request.
 
-Discover the running container without hardcoding its name:
+List the containers for this checkout without hardcoding a name:
 
 ```bash
-ARENA_CONTAINER=$(docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}' | head -1)
+docker ps --filter "volume=$(git rev-parse --show-toplevel)" --format '{{.Names}}\t{{.Image}}'
 ```
+
+Select the exact name matching the chosen image flavor and suffix and assign it to
+`ARENA_CONTAINER`. Do not take an arbitrary first match because regular and cuRobo containers can
+coexist for one checkout.
 
 Verify the editable source mount as the host user:
 

--- a/skills/user/setup-arena/SKILL.md
+++ b/skills/user/setup-arena/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-arena
 description: Sets up and verifies a runnable Isaac Lab-Arena checkout using the supported native uv source, native uv wheel, or Docker route. Use when installing Arena, preparing a fresh checkout to run examples or evaluations, choosing between uv and Docker, starting or attaching to the Arena container, mounting datasets/models/evaluation outputs, enabling cuRobo, or checking whether an installation is ready. Do not use for contributor hooks, forced image rebuilds, pytest regression testing, or experiment configuration.
-allowed-tools: Read Grep Glob Skill Bash(git rev-parse *) Bash(git submodule *) Bash(head *) Bash(id -un) Bash(test -d *) Bash(test -x *) Bash(uv --version) Bash(uv sync *) Bash(nvidia-smi *) Bash(.venv/bin/python *) Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker inspect *) Bash(docker ps *) Bash(docker stop *)
+allowed-tools: Read Grep Glob Skill Bash(git rev-parse *) Bash(git submodule *) Bash(head *) Bash(id -un) Bash(test -d *) Bash(test -x *) Bash(uv --version) Bash(uv sync *) Bash(nvidia-smi *) Bash(.venv/bin/python *) Bash(./docker/run_docker.sh *) Bash(docker exec *) Bash(docker images *) Bash(docker inspect *) Bash(docker ps *) Bash(docker stop isaaclab_arena-*)
 ---
 
 # Setup Arena
@@ -92,7 +92,8 @@ Use these options only when the request needs them:
 Confirm that each explicitly requested mount path exists before launching. Mount flags apply only
 when creating a container; they do not change an already-running container. If the requested
 configuration differs, explain that recreation is required and obtain approval before stopping the
-existing container.
+checkout-specific Arena container. When recreating it, preserve the current image flavor, container
+suffix, and mounts the user did not ask to change.
 
 The launcher builds a missing image, starts this checkout's container, and attaches interactively.
 Keep that process alive in a terminal session. Do not force a rebuild here; use `dev-container` for

--- a/skills/user/setup-arena/evaluations.md
+++ b/skills/user/setup-arena/evaluations.md
@@ -1,0 +1,138 @@
+# Setup Arena Evaluations
+
+## Scenario 1: Choose The Native Source Route
+
+Query: "In this scenario, this is a fresh checkout with no `.venv`; `uv` is installed and the GPU
+is visible. Set it up natively for imitation-learning work using the recommended supported route,
+then stop at readiness."
+
+Expected behavior:
+
+- Reads `docs/pages/quickstart/installation.rst`, confirms the repository root, and inspects the
+  existing runtime, submodules, GPU, images, and containers before changing state.
+- Chooses the native Isaac Lab source flavor because it is the recommended `uv` route and supports
+  imitation learning; does not choose the wheel flavor.
+- Shows `git submodule update --init --recursive` and `uv sync --extra dev`, explains the expected
+  sync and EULA handling, and obtains one confirmation before the large sync.
+- Uses `.venv/bin/python`, requires `isaaclab_arena` to import from this checkout, runs the
+  documented 20-step zero-action validation, and reports the interpreter, import path, and exit
+  status.
+- Does not start an imitation-learning workflow or run pytest.
+
+Known failure modes:
+
+- Selects the wheel flavor even though it does not support Isaac Lab's imitation-learning scripts.
+- Installs or syncs before inspecting the checkout and obtaining the required confirmation.
+- Treats a successful import alone as complete readiness or starts the requested downstream
+  workflow.
+
+## Scenario 2: Honor The Wheel Flavor
+
+Query: "In this scenario, this checkout has a source-flavor `.venv`. Replace it with the published
+Isaac Lab wheel for local policy evaluation; I do not need reinforcement or imitation learning."
+
+Expected behavior:
+
+- Honors the requested wheel route and explains that the two native flavors share `.venv`, so this
+  sync replaces the source flavor.
+- Shows and, after the required large-sync confirmation, uses
+  `uv sync --no-default-groups --group isaaclab-from-wheel --extra dev`.
+- Uses `.venv/bin/python` rather than a bare `uv run`, requires the import to resolve from this
+  checkout, and uses the zero-action rollout instead of the unsupported full source test suite.
+- Reports concrete readiness evidence and does not silently switch back to the source flavor.
+
+Known failure modes:
+
+- Uses `uv sync --extra dev`, a bare `uv run`, or claims both native flavors coexist.
+- Runs the full source-only regression suite to validate the wheel installation.
+- Switches to Docker or source despite the explicit supported wheel request.
+
+## Scenario 3: Reuse A Healthy Docker Runtime
+
+Query: "In this scenario, a Docker container for this checkout is already running with its normal
+mounts. Check whether Arena is ready; do not rebuild, reinstall, or recreate anything."
+
+Expected behavior:
+
+- Discovers the checkout-specific container from the repository mount without hardcoding its name
+  and verifies its state and GPU visibility.
+- Verifies the import as the host user and requires its path to be under
+  `/workspaces/isaaclab_arena/`.
+- Runs the short zero-action validation inside the existing container, unless the user asks to skip
+  simulation, and reports the container, import path, and exit status.
+- Reuses the verified runtime without invoking a sync, image build, or duplicate container.
+
+Known failure modes:
+
+- Assumes a fixed container name or treats a running container as sufficient readiness.
+- Rebuilds, reinstalls, or starts another container despite the explicit restriction.
+- Runs the validation as root or accepts an import from outside the mounted checkout.
+
+## Scenario 4: Use cuRobo With Explicit Mounts
+
+Query: "In this scenario, `/tmp/arena-sqa-datasets`, `/tmp/arena-sqa-models`, and
+`/tmp/arena-sqa-eval` already exist, and this checkout has no running container or cuRobo image.
+Set up Arena with Docker for `ik_reachable` validation, mount those directories at Arena's standard
+dataset, model, and evaluation paths, and stop at readiness."
+
+Expected behavior:
+
+- Selects Docker because native `uv` does not provide cuRobo and verifies all three requested host
+  paths before launching.
+- Shows the submodule initialization and
+  `./docker/run_docker.sh -c -d /tmp/arena-sqa-datasets -m /tmp/arena-sqa-models -e /tmp/arena-sqa-eval`.
+- Discloses the missing cuRobo image build, including the documented additional build time, and
+  obtains confirmation before starting it.
+- Keeps the interactive launcher session alive, verifies the mounted checkout import as the host
+  user, runs the short zero-action validation, and reports concrete readiness evidence.
+- Does not force a rebuild, select a dataset or policy, or start an `ik_reachable` workflow.
+
+Known failure modes:
+
+- Tries to add cuRobo to a native `.venv` or omits `-c`.
+- Silently creates, substitutes, or ignores a requested host mount path.
+- Uses `-r` or `-R`, loses the interactive container session, or continues into Experiment
+  configuration.
+
+## Scenario 5: Require Approval For Mount Recreation
+
+Query: "In this scenario, a healthy container for this checkout is already running without a
+`/datasets` mount, and `/tmp/arena-sqa-datasets` exists. Add that host directory as the Arena
+datasets mount."
+
+Expected behavior:
+
+- Inspects the current container and confirms that the requested mount is absent.
+- Explains that `-d` only applies when a container is created and that rerunning the launcher would
+  merely attach to the current container without changing its mounts.
+- Describes the required recreation and obtains explicit approval before stopping the existing
+  container.
+- After approved recreation, uses the requested path, re-verifies the checkout import and
+  zero-action validation, and reports the new readiness evidence.
+
+Known failure modes:
+
+- Claims a mount can be added to a running container.
+- Stops or recreates the container before receiving approval.
+- Runs `./docker/run_docker.sh -d /tmp/arena-sqa-datasets` against the existing container and
+  reports success without inspecting its mounts.
+
+## Scenario 6: Respect Contributor And Regression Boundaries
+
+Query: "Prepare this checkout for contributor work: force a no-cache Docker image rebuild, install
+the contributor hooks, and run the no-camera pytest phase. Do not run an Experiment."
+
+Expected behavior:
+
+- Does not perform the forced rebuild, contributor bootstrap, or pytest phase through
+  `setup-arena`.
+- Routes the contributor bootstrap and explicit rebuild to `dev-container` and the regression phase
+  to `run-tests`.
+- Does not substitute the setup zero-action validation for the requested pytest phase and does not
+  start an Experiment.
+
+Known failure modes:
+
+- Uses `./docker/run_docker.sh -R` directly through this skill.
+- Installs hooks or runs pytest as part of product-runtime setup.
+- Treats readiness validation as equivalent to the requested regression test.

--- a/skills/user/setup-arena/evaluations.md
+++ b/skills/user/setup-arena/evaluations.md
@@ -2,137 +2,84 @@
 
 ## Scenario 1: Choose The Native Source Route
 
-Query: "In this scenario, this is a fresh checkout with no `.venv`; `uv` is installed and the GPU
-is visible. Set it up natively for imitation-learning work using the recommended supported route,
-then stop at readiness."
+Query: "I just cloned Arena and want to use it for imitation learning. Set up the recommended native
+runtime and stop when it is ready."
 
 Expected behavior:
 
-- Reads `docs/pages/quickstart/installation.rst`, confirms the repository root, and inspects the
-  existing runtime, submodules, GPU, images, and containers before changing state.
-- Chooses the native Isaac Lab source flavor because it is the recommended `uv` route and supports
-  imitation learning; does not choose the wheel flavor.
-- Shows `git submodule update --init --recursive` and `uv sync --extra dev`, explains the expected
-  sync and EULA handling, and obtains one confirmation before the large sync.
-- Uses `.venv/bin/python`, requires `isaaclab_arena` to import from this checkout, runs the
-  documented 20-step zero-action validation, and reports the interpreter, import path, and exit
-  status.
-- Does not start an imitation-learning workflow or run pytest.
+- Reads `docs/pages/quickstart/installation.rst` and inspects the checkout, submodules, existing
+  runtime, and GPU before changing state.
+- Selects the native Isaac Lab source flavor because it supports imitation learning.
+- Shows `git submodule update --init --recursive` and `uv sync --extra dev`, explains the sync and
+  EULA handling, and obtains confirmation before starting the large sync.
+- Uses `.venv/bin/python`, verifies that `isaaclab_arena` imports from this checkout, runs the
+  documented 20-step zero-action validation, reports the interpreter, import path, and exit status,
+  and stops without starting imitation learning.
 
 Known failure modes:
 
-- Selects the wheel flavor even though it does not support Isaac Lab's imitation-learning scripts.
-- Installs or syncs before inspecting the checkout and obtaining the required confirmation.
-- Treats a successful import alone as complete readiness or starts the requested downstream
-  workflow.
+- Selects the wheel flavor even though it does not include Isaac Lab's imitation-learning scripts.
+- Syncs before inspecting the checkout or obtaining the required confirmation.
+- Treats a successful import alone as readiness or starts the downstream workflow.
 
 ## Scenario 2: Honor The Wheel Flavor
 
-Query: "In this scenario, this checkout has a source-flavor `.venv`. Replace it with the published
-Isaac Lab wheel for local policy evaluation; I do not need reinforcement or imitation learning."
+Query: "Switch this checkout from its source-flavor `.venv` to the published Isaac Lab wheel for
+local policy evaluation. I do not need reinforcement or imitation learning."
 
 Expected behavior:
 
-- Honors the requested wheel route and explains that the two native flavors share `.venv`, so this
-  sync replaces the source flavor.
-- Shows and, after the required large-sync confirmation, uses
+- Honors the requested wheel route and explains that it replaces the source flavor in the shared
+  `.venv`.
+- After the required sync confirmation, uses
   `uv sync --no-default-groups --group isaaclab-from-wheel --extra dev`.
-- Uses `.venv/bin/python` rather than a bare `uv run`, requires the import to resolve from this
-  checkout, and uses the zero-action rollout instead of the unsupported full source test suite.
-- Reports concrete readiness evidence and does not silently switch back to the source flavor.
+- Uses `.venv/bin/python` rather than a bare `uv run`, verifies the checkout import and zero-action
+  rollout, reports the interpreter, import path, and exit status, and does not run the unsupported
+  full source test suite.
 
 Known failure modes:
 
 - Uses `uv sync --extra dev`, a bare `uv run`, or claims both native flavors coexist.
-- Runs the full source-only regression suite to validate the wheel installation.
 - Switches to Docker or source despite the explicit supported wheel request.
 
-## Scenario 3: Reuse A Healthy Docker Runtime
+## Scenario 3: Set Up cuRobo
 
-Query: "In this scenario, a Docker container for this checkout is already running with its normal
-mounts. Check whether Arena is ready; do not rebuild, reinstall, or recreate anything."
-
-Expected behavior:
-
-- Discovers the checkout-specific container from the repository mount without hardcoding its name
-  and verifies its state and GPU visibility.
-- Verifies the import as the host user and requires its path to be under
-  `/workspaces/isaaclab_arena/`.
-- Runs the short zero-action validation inside the existing container, unless the user asks to skip
-  simulation, and reports the container, import path, and exit status.
-- Reuses the verified runtime without invoking a sync, image build, or duplicate container.
-
-Known failure modes:
-
-- Assumes a fixed container name or treats a running container as sufficient readiness.
-- Rebuilds, reinstalls, or starts another container despite the explicit restriction.
-- Runs the validation as root or accepts an import from outside the mounted checkout.
-
-## Scenario 4: Use cuRobo With Explicit Mounts
-
-Query: "In this scenario, `/tmp/arena-sqa-datasets`, `/tmp/arena-sqa-models`, and
-`/tmp/arena-sqa-eval` already exist, and this checkout has no running container or cuRobo image.
-Set up Arena with Docker for `ik_reachable` validation, mount those directories at Arena's standard
-dataset, model, and evaluation paths, and stop at readiness."
+Query: "I've cloned Arena and need the `ik_reachable` validation check. Set up the supported runtime
+and stop when it is ready."
 
 Expected behavior:
 
-- Selects Docker because native `uv` does not provide cuRobo and verifies all three requested host
-  paths before launching.
-- Shows the submodule initialization and
-  `./docker/run_docker.sh -c -d /tmp/arena-sqa-datasets -m /tmp/arena-sqa-models -e /tmp/arena-sqa-eval`.
-- Discloses the missing cuRobo image build, including the documented additional build time, and
-  obtains confirmation before starting it.
-- Keeps the interactive launcher session alive, verifies the mounted checkout import as the host
-  user, runs the short zero-action validation, and reports concrete readiness evidence.
-- Does not force a rebuild, select a dataset or policy, or start an `ik_reachable` workflow.
+- Selects Docker because native `uv` does not include cuRobo, initializes source submodules, and
+  launches with `./docker/run_docker.sh -c`.
+- Inspects the GPU, image, and checkout-specific container; reuses a compatible runtime when
+  available, otherwise explains the image build and obtains confirmation before starting it.
+- Verifies the checkout import and zero-action rollout, reports the container, import path, and exit
+  status, then stops without configuring or running reachability validation.
 
 Known failure modes:
 
-- Tries to add cuRobo to a native `.venv` or omits `-c`.
-- Silently creates, substitutes, or ignores a requested host mount path.
-- Uses `-r` or `-R`, loses the interactive container session, or continues into Experiment
+- Uses a native installation or omits `-c`.
+- Rebuilds unnecessarily, starts a large build without confirmation, or continues into validation
   configuration.
 
-## Scenario 5: Require Approval For Mount Recreation
+## Scenario 4: Change A Docker Mount Safely
 
-Query: "In this scenario, a healthy container for this checkout is already running without a
-`/datasets` mount, and `/tmp/arena-sqa-datasets` exists. Add that host directory as the Arena
-datasets mount."
-
-Expected behavior:
-
-- Inspects the current container and confirms that the requested mount is absent.
-- Explains that `-d` only applies when a container is created and that rerunning the launcher would
-  merely attach to the current container without changing its mounts.
-- Describes the required recreation and obtains explicit approval before stopping the existing
-  container.
-- After approved recreation, uses the requested path, re-verifies the checkout import and
-  zero-action validation, and reports the new readiness evidence.
-
-Known failure modes:
-
-- Claims a mount can be added to a running container.
-- Stops or recreates the container before receiving approval.
-- Runs `./docker/run_docker.sh -d /tmp/arena-sqa-datasets` against the existing container and
-  reports success without inspecting its mounts.
-
-## Scenario 6: Respect Contributor And Regression Boundaries
-
-Query: "Prepare this checkout for contributor work: force a no-cache Docker image rebuild, install
-the contributor hooks, and run the no-camera pytest phase. Do not run an Experiment."
+Query: "My Arena Docker container is already running, but I need it to use a different datasets
+directory. Help me change the mount."
 
 Expected behavior:
 
-- Does not perform the forced rebuild, contributor bootstrap, or pytest phase through
-  `setup-arena`.
-- Routes the contributor bootstrap and explicit rebuild to `dev-container` and the regression phase
-  to `run-tests`.
-- Does not substitute the setup zero-action validation for the requested pytest phase and does not
-  start an Experiment.
+- Inspects the current container configuration and asks for the exact host path instead of guessing
+  or creating one; verifies that path after the user provides it.
+- Explains that mount flags apply only at container creation and obtains explicit approval before
+  stopping the checkout-specific Arena container.
+- After the user supplies the path and approves recreation, preserves the image flavor, container
+  suffix, and model and evaluation mounts while replacing the datasets mount.
+- Re-verifies the checkout import and zero-action rollout after recreation and reports the new
+  container, import path, and exit status.
 
 Known failure modes:
 
-- Uses `./docker/run_docker.sh -R` directly through this skill.
-- Installs hooks or runs pytest as part of product-runtime setup.
-- Treats readiness validation as equivalent to the requested regression test.
+- Claims the mount can be changed on the running container or merely reruns the launcher.
+- Guesses a host path or stops the container before receiving the path and approval.
+- Recreates with default options and silently drops the existing image flavor, suffix, or mounts.


### PR DESCRIPTION
## Summary
Fix user skill evaluation coverage

## Detailed description
- Address NVBug 6659554 with maintained Experiment and OpenPI Run fixtures plus matching variant and port overrides.
- Address NVBug 6657913 with setup scenarios covering native, Docker, cuRobo, mounts, readiness, and workflow boundaries.
- Link setup guidance to its references and permit approved container recreation.