### PR TITLE
Cap DROID wrist camera decalibration at the gripper

### DIFF
--- a/docs/pages/concepts/variations/variations.rst
+++ b/docs/pages/concepts/variations/variations.rst
@@ -64,8 +64,8 @@ defaults:
      camera_extrinsics_wrist_camera (CameraExtrinsicsVariation, run-time)
        Enable: droid_abs_joint_pos.camera_extrinsics_wrist_camera.enabled=true  (default: False)
        Fields:
-         droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.high = [0.005,0.005,0.005]
-         droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.low = [-0.005,-0.005,-0.005]
+         droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.high = [0.06,0.03,0.06]
+         droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.low = [-0.06,-0.06,-0.06]
 
    Asset: light
      hdr_image (HDRImageVariation, build-time)
@@ -114,8 +114,12 @@ The same run with tunable variation control parameters spelled out:
      "droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.high=[0.01,0.01,0.01]"
 
 The ``hdr_names`` list restricts HDR sampling to the three named maps instead of the full
-registered set.  The ``sampler_cfg.low`` / ``sampler_cfg.high`` vectors widen the camera
+registered set.  The ``sampler_cfg.low`` / ``sampler_cfg.high`` vectors set the camera
 extrinsics jitter range to ±10 mm per axis.
+
+Defaults can differ per embodiment.  DROID narrows the wrist camera's ``sampler_cfg.high`` +Y
+bound to 0.03 m, because the camera is mounted just above the gripper and sinks into it beyond
+that; an override like the one above still takes precedence.
 
 To see the available variations and control parameters for a specific environment,
 see :ref:`discovering-available-variations`.

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -46,6 +46,8 @@ from isaaclab_arena.utils.pose import Pose
 if TYPE_CHECKING:
     import trimesh
 
+    from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariationCfg
+
 _DROID_ROBOT_PRIM = RobotPrimSpec(
     robot_usd_path=f"{ARENA_NUCLEUS_DIR}/Arena/assets/robot_library/droid/franka_robotiq_2f_85_flattened.usd",
     root_prim_path="/panda",
@@ -75,6 +77,13 @@ _DROID_JOINT_NAMES = (
     "left_inner_finger_knuckle_joint",
     "left_inner_finger_joint",
 )
+_DROID_WRIST_CAMERA_NAME = "wrist_camera"
+# Decalibration bounds for the wrist camera, in its ROS optical frame (+X right, +Y down,
+# +Z forward). +Y is capped well below the other five bounds because the camera sits just above the
+# Robotiq gripper: past roughly 0.03 m the camera sinks into the gripper body and its view of the
+# scene is occluded.
+_DROID_WRIST_CAMERA_DECALIBRATION_LOW = (-0.06, -0.06, -0.06)
+_DROID_WRIST_CAMERA_DECALIBRATION_HIGH = (0.06, 0.03, 0.06)
 
 
 class DroidEmbodimentBase(EmbodimentBase, ABC):
@@ -131,6 +140,20 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         self.reward_config = None
         self.mimic_env = None
         self.add_camera_variations(self.camera_config)
+
+    def get_camera_extrinsics_variation_cfg(self, camera_name: str) -> CameraExtrinsicsVariationCfg | None:
+        """Return the wrist camera's mount-constrained decalibration bounds, or ``None`` for the rest."""
+        from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariationCfg
+        from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
+
+        if camera_name != _DROID_WRIST_CAMERA_NAME:
+            return None
+        return CameraExtrinsicsVariationCfg(
+            sampler_cfg=UniformSamplerCfg(
+                low=list(_DROID_WRIST_CAMERA_DECALIBRATION_LOW),
+                high=list(_DROID_WRIST_CAMERA_DECALIBRATION_HIGH),
+            )
+        )
 
     def get_bounding_box(self) -> AxisAlignedBoundingBox:
         """Return root-relative placement bounds from the composed on-stand USD spawn.

--- a/isaaclab_arena/embodiments/embodiment_base.py
+++ b/isaaclab_arena/embodiments/embodiment_base.py
@@ -24,6 +24,8 @@ from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 if TYPE_CHECKING:
     import trimesh
 
+    from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariationCfg
+
 
 @dataclass(frozen=True)
 class ArticulationGeometrySpec:
@@ -231,13 +233,28 @@ class EmbodimentBase(PlaceableAsset):
         ), f"Expected camera_config to inherit from ArenaCameraCfg; got {type(self.camera_config).__name__}."
         return self.camera_config.get_cfg()
 
+    def get_camera_extrinsics_variation_cfg(self, camera_name: str) -> CameraExtrinsicsVariationCfg | None:
+        """Return the extrinsics variation cfg for ``camera_name``, or ``None`` for the variation's own default.
+
+        Override this where an embodiment's mounting geometry bounds how far a camera may be
+        decalibrated before it intersects the robot. The returned cfg becomes the variation's
+        starting point, so an Experiment or Hydra override still wins over it.
+
+        Args:
+            camera_name: Scene-entity name of the camera the variation targets.
+        """
+
     def add_camera_variations(self, camera_rig: ArenaCameraCfg) -> None:
         """Register extrinsics and intrinsics variations for every camera in ``camera_rig``."""
         from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariation
         from isaaclab_arena.variations.camera_intrinsics_variation import CameraIntrinsicsVariation
 
         for camera_name in camera_rig.camera_names():
-            self.add_variation(CameraExtrinsicsVariation(camera_name=camera_name))
+            self.add_variation(
+                CameraExtrinsicsVariation(
+                    camera_name=camera_name, cfg=self.get_camera_extrinsics_variation_cfg(camera_name)
+                )
+            )
             self.add_variation(CameraIntrinsicsVariation(camera_name=camera_name, camera_rig=camera_rig))
 
     def _update_scene_cfg_with_robot_initial_pose(self, scene_config: Any, pose: Pose) -> Any:

--- a/isaaclab_arena/tests/test_camera_extrinsics_variation.py
+++ b/isaaclab_arena/tests/test_camera_extrinsics_variation.py
@@ -16,6 +16,9 @@ CAMERA_NAME = "wrist_cam"
 EVENT_NAME = f"{CAMERA_NAME}_extrinsics_variation"
 TEST_DECALIBRATION_VECTOR = [0.01, -0.02, 0.03]
 
+DROID_WRIST_CAMERA_DECALIBRATION_LOW = [-0.06, -0.06, -0.06]
+DROID_WRIST_CAMERA_DECALIBRATION_HIGH = [0.06, 0.03, 0.06]
+
 
 def get_test_environment(*, camera_extrinsics_enabled: bool):
     """Build a minimal arena env with an optional enabled camera extrinsics variation."""
@@ -124,6 +127,25 @@ def _test_camera_extrinsics_variation_realized_at_runtime(simulation_app):
     return True
 
 
+def _test_droid_wrist_camera_extrinsics_bounds_clear_the_gripper(simulation_app):
+    from isaaclab_arena.embodiments.droid.droid import DroidAbsoluteJointPositionEmbodiment
+    from isaaclab_arena.variations.camera_extrinsics_variation import CameraExtrinsicsVariationCfg
+
+    embodiment = DroidAbsoluteJointPositionEmbodiment(enable_cameras=ENABLE_CAMERAS)
+
+    # The wrist camera is mounted just above the gripper, so DROID narrows its +Y bound.
+    wrist_sampler_cfg = embodiment.get_variation("camera_extrinsics_wrist_camera").cfg.sampler_cfg
+    assert list(wrist_sampler_cfg.low) == DROID_WRIST_CAMERA_DECALIBRATION_LOW
+    assert list(wrist_sampler_cfg.high) == DROID_WRIST_CAMERA_DECALIBRATION_HIGH
+
+    # The externally mounted cameras are unobstructed and keep the variation's own default bounds.
+    default_sampler_cfg = CameraExtrinsicsVariationCfg().sampler_cfg
+    external_sampler_cfg = embodiment.get_variation("camera_extrinsics_external_camera").cfg.sampler_cfg
+    assert list(external_sampler_cfg.low) == list(default_sampler_cfg.low)
+    assert list(external_sampler_cfg.high) == list(default_sampler_cfg.high)
+    return True
+
+
 @pytest.mark.with_cameras
 def test_disabled_camera_extrinsics_variation_not_in_events_cfg():
     assert run_function_with_persistent_simulation_app(
@@ -146,6 +168,15 @@ def test_enabled_camera_extrinsics_variation_in_events_cfg():
 def test_camera_extrinsics_variation_realized_at_runtime():
     assert run_function_with_persistent_simulation_app(
         _test_camera_extrinsics_variation_realized_at_runtime,
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+    )
+
+
+@pytest.mark.with_cameras
+def test_droid_wrist_camera_extrinsics_bounds_clear_the_gripper():
+    assert run_function_with_persistent_simulation_app(
+        _test_droid_wrist_camera_extrinsics_bounds_clear_the_gripper,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
     )

--- a/isaaclab_arena_environments/experiment_configs/droid_pnp_camera_sensitivity_openpi_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/droid_pnp_camera_sensitivity_openpi_experiment.yaml
@@ -25,6 +25,5 @@ runs:
       num_episodes: 10
     # The variations to enable for this run.
     variations:
+      # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
       droid_abs_joint_pos.camera_extrinsics_wrist_camera.enabled: true
-      droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.low: [-0.03, -0.03, -0.03]
-      droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.high: [0.03, 0.03, 0.03]

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_18_tasks_pi0_and_cosmos.yaml
@@ -24,10 +24,8 @@ shared:
         hdr_names: ["home_office_robolab"]
     droid_abs_joint_pos:
       camera_extrinsics_wrist_camera:
+        # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
         enabled: false
-        sampler_cfg:
-          low: [-0.05, -0.05, -0.05]
-          high: [0.05, 0.05, 0.05]
 
 runs:
 

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0.yaml
@@ -24,10 +24,8 @@ shared:
         hdr_names: ["home_office_robolab"]
     droid_abs_joint_pos:
       camera_extrinsics_wrist_camera:
+        # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
         enabled: false
-        sampler_cfg:
-          low: [-0.05, -0.05, -0.05]
-          high: [0.05, 0.05, 0.05]
 
 runs:
 

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_20_tasks_pi0_and_cosmos.yaml
@@ -24,10 +24,8 @@ shared:
         hdr_names: ["home_office_robolab"]
     droid_abs_joint_pos:
       camera_extrinsics_wrist_camera:
+        # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
         enabled: false
-        sampler_cfg:
-          low: [-0.05, -0.05, -0.05]
-          high: [0.05, 0.05, 0.05]
 
 runs:
 

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_2_tasks_pi0.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_2_tasks_pi0.yaml
@@ -23,10 +23,8 @@ shared:
         hdr_names: ["home_office_robolab"]
     droid_abs_joint_pos:
       camera_extrinsics_wrist_camera:
+        # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
         enabled: false
-        sampler_cfg:
-          low: [-0.05, -0.05, -0.05]
-          high: [0.05, 0.05, 0.05]
 
 runs:
 

--- a/isaaclab_arena_environments/robolab/experiment_configs/robolab_2_tasks_pi0_and_cosmos.yaml
+++ b/isaaclab_arena_environments/robolab/experiment_configs/robolab_2_tasks_pi0_and_cosmos.yaml
@@ -23,10 +23,8 @@ shared:
         hdr_names: ["home_office_robolab"]
     droid_abs_joint_pos:
       camera_extrinsics_wrist_camera:
+        # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
         enabled: false
-        sampler_cfg:
-          low: [-0.05, -0.05, -0.05]
-          high: [0.05, 0.05, 0.05]
 
 runs:
 

--- a/isaaclab_arena_environments/robolab/run_benchmark/submit_osmo_workflows.py
+++ b/isaaclab_arena_environments/robolab/run_benchmark/submit_osmo_workflows.py
@@ -25,9 +25,8 @@ POOL = "isaac-dev-l40s-04"
 PLATFORM = "ovx-l40s"
 VARIATIONS = (
     "light.hdr_image.enabled=true "
+    # Decalibration bounds come from the DROID embodiment, which caps +Y at the gripper.
     "droid_abs_joint_pos.camera_extrinsics_wrist_camera.enabled=true "
-    "droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.high=[0.05,0.05,0.05] "
-    "droid_abs_joint_pos.camera_extrinsics_wrist_camera.sampler_cfg.low=[-0.05,-0.05,-0.05] "
     "light.hdr_image.hdr_names=[home_office_robolab]"
 )
 


### PR DESCRIPTION
## Summary
Bound DROID wrist camera decalibration

## Detailed description
- The camera extrinsics variation drew offsets from a symmetric cube, so large +Y draws pushed the DROID wrist camera into the gripper body. Rendering 100 wrist frames across the sampled range showed the jaws intruding from about +0.01 m and the view substantially or fully occluded beyond +0.03 m.
- Added an overridable `EmbodimentBase.get_camera_extrinsics_variation_cfg` hook so an embodiment can seed per-camera decalibration bounds, and had DROID bound its wrist camera to `[-0.06, -0.06, -0.06]`..`[0.06, 0.03, 0.06]` in the ROS optical frame. The external cameras are unobstructed and keep the variation default.
- Dropped the duplicated wrist camera ranges from the robolab and camera sensitivity Experiments and from the OSMO benchmark submission script; they now inherit the embodiment bounds, and an explicit Experiment or Hydra override still takes precedence.
- Impact: any Experiment enabling this variation on DROID now gets 0.06 m of decalibration per axis instead of the 0.005 m default, capped at 0.03 m in +Y. Covered by a new case in `test_camera_extrinsics_variation.py`; the variations concept doc is updated to match.