### PR TITLE
Instrument evaluation with timers

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment_result.py
+++ b/isaaclab_arena/evaluation/arena_experiment_result.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 
 ARENA_EXPERIMENT_RESULT_FILENAME = "arena_experiment_result.json"
+ARENA_EXPERIMENT_TIMINGS_FILENAME = "arena_experiment_timings.json"
 
 
 class ArenaEpisodeResultData(TypedDict):

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -10,7 +10,11 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
-from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult, build_arena_run_result_metadata
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+    ArenaExperimentResult,
+    build_arena_run_result_metadata,
+)
 from isaaclab_arena.evaluation.arena_run import ArenaRunResult, build_runs_info_table
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
 from isaaclab_arena.evaluation.legacy_experiment_runner import (
@@ -22,6 +26,7 @@ from isaaclab_arena.evaluation.run_execution import build_arena_builder_from_run
 from isaaclab_arena.hydra.typed_experiment_yaml_search import typed_experiment_requires_cameras
 from isaaclab_arena.metrics.metrics_logger import MetricsLogger
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+from isaaclab_arena.utils.timer import Timer, print_timer_stats, write_timer_stats_json
 from isaaclab_arena.video.video_recording import timestamped_run_dir
 from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 
@@ -141,11 +146,12 @@ def main():
     experiment_output_directory.mkdir(parents=True, exist_ok=True)
 
     with SimulationAppContext(args_cli):
-        experiment_cfg = load_arena_experiment_from_config_file(
-            experiment_config_path,
-            device=args_cli.device,
-            overrides=experiment_overrides,
-        )
+        with Timer("experiment/load_config"):
+            experiment_cfg = load_arena_experiment_from_config_file(
+                experiment_config_path,
+                device=args_cli.device,
+                overrides=experiment_overrides,
+            )
         for run_name in experiment_cfg.runs:
             ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
         _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
@@ -156,13 +162,14 @@ def main():
         if args_cli.record_viewport_video:
             print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_directory}")
 
-        run_results = execute_experiment(
-            experiment_cfg,
-            output_dir=experiment_output_directory,
-            record_viewport_video=args_cli.record_viewport_video,
-            record_camera_video=args_cli.record_camera_video,
-            continue_on_error=args_cli.continue_on_error,
-        )
+        with Timer("experiment/execute_runs"):
+            run_results = execute_experiment(
+                experiment_cfg,
+                output_dir=experiment_output_directory,
+                record_viewport_video=args_cli.record_viewport_video,
+                record_camera_video=args_cli.record_camera_video,
+                continue_on_error=args_cli.continue_on_error,
+            )
         for run_result in run_results:
             if run_result.metrics is not None:
                 metrics_logger.append_job_metrics(run_result.run_name, run_result.metrics)
@@ -173,7 +180,18 @@ def main():
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
 
         # Write HTML report.
-        report_path = build_report(experiment_output_directory)
+        with Timer("experiment/build_report"):
+            report_path = build_report(experiment_output_directory)
+
+        # Report where the Experiment spent its time. Isaac Sim startup is not covered here, it is
+        # reported separately by the AppLauncher startup marker.
+        print_timer_stats()
+        timings_path = write_timer_stats_json(
+            experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+            app_name="experiment_runner",
+        )
+        print(f"Wrote Arena Experiment timings to: {timings_path}")
+
         if args_cli.serve_evaluation_report:
             serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
 

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -23,6 +23,7 @@ from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
+from isaaclab_arena.utils.timer import Timer
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, timestamped_run_dir, wrap_env_for_video
 from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
@@ -74,9 +75,10 @@ def rollout_policy(
 
     pbar = None
     try:
-        obs, _ = env.reset()
-        policy.reset()
-        policy.set_task_description(env.unwrapped.get_language_instruction())
+        with Timer("rollout/initial_reset"):
+            obs, _ = env.reset()
+            policy.reset()
+            policy.set_task_description(env.unwrapped.get_language_instruction())
 
         # Setup progress bar based on num_steps or num_episodes
         if num_steps is not None:
@@ -88,9 +90,11 @@ def rollout_policy(
         num_steps_completed = 0
 
         while True:
-            with torch.inference_mode():
-                actions = policy.get_action(env, obs)
-                obs, _, terminated, truncated, _ = env.step(actions)
+            with torch.inference_mode(), Timer("rollout/step_total"):
+                with Timer("rollout/policy_get_action"):
+                    actions = policy.get_action(env, obs)
+                with Timer("rollout/env_step"):
+                    obs, _, terminated, truncated, _ = env.step(actions)
 
                 if terminated.any() or truncated.any():
                     # Only reset policy for those envs that are terminated or truncated
@@ -99,12 +103,14 @@ def rollout_policy(
                         f" and truncated env_ids: {truncated.nonzero().flatten()}"
                     )
                     env_ids = (terminated | truncated).nonzero().flatten()
-                    policy.reset(env_ids=env_ids)
+                    with Timer("rollout/policy_reset"):
+                        policy.reset(env_ids=env_ids)
                     # Break if number of episodes is reached
                     completed_episodes = env_ids.shape[0]
                     num_episodes_completed += completed_episodes
                     if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-                        metrics = env.unwrapped.compute_metrics()
+                        with Timer("rollout/compute_metrics"):
+                            metrics = env.unwrapped.compute_metrics()
                         tqdm.tqdm.write(
                             f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
                             f" {metrics_to_plain_python_types(metrics)}"

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -24,6 +24,7 @@ from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
 from isaaclab_arena.evaluation.policy_runner import rollout_policy
 from isaaclab_arena.evaluation.resource_cleanup import close_run_resources
 from isaaclab_arena.metrics.aggregate_metrics import aggregate_metrics
+from isaaclab_arena.utils.timer import Timer
 from isaaclab_arena.variations.variations_hydra import overrides_from_dict
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
 
@@ -134,23 +135,27 @@ def build_and_run(
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
             )
             rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
-            env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
+            with Timer("run/build_environment"):
+                env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
             results_path = os.path.join(output_dir, f"episode_results_rebuild{rebuild_index}.jsonl")
             env.unwrapped.episode_recorder.set_job_name(cfg.name)
             env.unwrapped.episode_recorder.set_output_path(results_path)
 
-            policy = _build_policy_from_cfg(rebuild_cfg)
+            with Timer("run/build_policy"):
+                policy = _build_policy_from_cfg(rebuild_cfg)
             num_steps, num_episodes = _resolve_rollout_limit(
                 cfg,
                 policy,
                 num_episodes,
             )
             env = wrap_env_for_video(env, rebuild_video_cfg, num_steps, num_episodes)
-            metrics = rollout_policy(env, policy, num_steps=num_steps, num_episodes=num_episodes)
+            with Timer("run/rollout_policy"):
+                metrics = rollout_policy(env, policy, num_steps=num_steps, num_episodes=num_episodes)
             if metrics is not None:
                 metrics_per_rebuild.append(metrics)
         finally:
-            close_run_resources(policy, env)
+            with Timer("run/close_resources"):
+                close_run_resources(policy, env)
 
     return ArenaRunResult(
         run_name=cfg.name,

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -18,7 +18,15 @@ from unittest.mock import patch
 
 import pytest
 
-from isaaclab_arena.video.camera_observation_video_recorder import CAMERA_OBS_GROUP_KEY, CameraObsVideoRecorder
+from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
+from isaaclab_arena.utils.timer import get_timer_stats, reset_timer_stats
+from isaaclab_arena.video.camera_observation_video_recorder import (
+    CAMERA_FINALIZE_TIMER_NAME,
+    CAMERA_FRAME_WRITE_TIMER_NAME,
+    CAMERA_OBS_GROUP_KEY,
+    CameraObsVideoRecorder,
+)
+from isaaclab_arena.video.video_recording import STEP_WITHOUT_VIDEO_TIMER_NAME, VideoRecordingCfg, wrap_env_for_video
 
 # ---------------------------------------------------------------------------
 # Minimal gym.Env stub — satisfies gymnasium.Wrapper's isinstance check
@@ -226,6 +234,77 @@ def test_no_video_written_for_empty_episode(tmp_path):
         # per-episode results record).
         assert not any(writer.filename.endswith("env0-front-episode-0.mp4") for writer in writers)
         assert env.get_episode_index(0) == 1
+
+
+def test_frame_writing_is_timed_separately_from_finalizing(tmp_path):
+    """Frame writes are timed on every recorded step; finalizing is timed only on a reset."""
+    reset_timer_stats()
+    env = _make_env()
+    with _patched_writers():
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)
+        recorder.step(None)
+
+        stats = get_timer_stats()
+        assert stats[CAMERA_FRAME_WRITE_TIMER_NAME].count == 2
+        assert CAMERA_FINALIZE_TIMER_NAME not in stats
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)
+
+        stats = get_timer_stats()
+        assert stats[CAMERA_FRAME_WRITE_TIMER_NAME].count == 3
+        assert stats[CAMERA_FINALIZE_TIMER_NAME].count == 1
+
+
+def test_wrap_env_for_video_times_the_step_below_the_recorders(tmp_path):
+    """The recording stack puts the step timer below the recorders, so the two costs separate."""
+    reset_timer_stats()
+    env = _make_env()
+    _configure_step(env)
+
+    wrapped = wrap_env_for_video(
+        env,
+        VideoRecordingCfg(record_camera_video=True, video_base_dir=str(tmp_path)),
+        num_steps=1,
+        num_episodes=None,
+    )
+
+    assert isinstance(wrapped, CameraObsVideoRecorder)
+    assert isinstance(wrapped.env, EnvStepTimerWrapper)
+    assert wrapped.env.env is env
+
+    with _patched_writers():
+        wrapped.step(None)
+
+    stats = get_timer_stats()
+    assert stats[STEP_WITHOUT_VIDEO_TIMER_NAME].count == 1
+    assert stats[CAMERA_FRAME_WRITE_TIMER_NAME].count == 1
+
+
+def test_wrap_env_for_video_adds_no_timer_when_recording_is_disabled(tmp_path):
+    """With no recorder requested the env is returned unchanged and nothing is timed."""
+    reset_timer_stats()
+    env = _make_env()
+
+    wrapped = wrap_env_for_video(env, VideoRecordingCfg(video_base_dir=str(tmp_path)), 1, None)
+
+    assert wrapped is env
+    assert get_timer_stats() == {}
+
+
+def test_no_timing_recorded_without_camera_observations(tmp_path):
+    """A step carrying no camera observations does no recording work, so nothing is timed."""
+    reset_timer_stats()
+    env = _make_env()
+    with _patched_writers():
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        recorder.step(None)  # _StubEnv returns an empty obs until _configure_step is called
+
+        assert CAMERA_FRAME_WRITE_TIMER_NAME not in get_timer_stats()
 
 
 def test_post_reset_frame_not_recorded(tmp_path):

--- a/isaaclab_arena/tests/test_env_step_timer.py
+++ b/isaaclab_arena/tests/test_env_step_timer.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for EnvStepTimerWrapper. No Isaac Sim or GPU required."""
+
+import gymnasium as gym
+
+from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
+from isaaclab_arena.utils.timer import get_timer_stats, reset_timer_stats
+
+
+class _StubEnv(gym.Env):
+    """Minimal env that returns a fixed step result."""
+
+    observation_space = gym.spaces.Dict({})
+    action_space = gym.spaces.Discrete(1)
+
+    def __init__(self):
+        super().__init__()
+        self.num_steps = 0
+
+    def reset(self, **kwargs):
+        return {}, {}
+
+    def step(self, action):
+        self.num_steps += 1
+        return {}, 0.0, False, False, {}
+
+
+def test_records_one_measurement_per_step():
+    """Each step through the wrapper adds one measurement under the configured name."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="test/inner_step")
+
+    for _ in range(3):
+        env.step(None)
+
+    stats = get_timer_stats()
+    assert stats["test/inner_step"].count == 3
+    assert env.env.num_steps == 3
+
+
+def test_step_result_is_passed_through():
+    """The wrapper returns the wrapped env's step result unchanged."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="test/inner_step")
+
+    assert env.step(None) == ({}, 0.0, False, False, {})
+
+
+def test_reset_is_not_timed():
+    """Only step is measured, so a reset leaves the registry untouched."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="test/inner_step")
+
+    env.reset()
+
+    assert "test/inner_step" not in get_timer_stats()

--- a/isaaclab_arena/tests/test_osmo_build_experiment_output.py
+++ b/isaaclab_arena/tests/test_osmo_build_experiment_output.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 
-from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_RESULT_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ARENA_EXPERIMENT_RESULT_FILENAME,
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+)
 from isaaclab_arena.evaluation.arena_run import RunStatus
 from isaaclab_arena.visualization.report import RunExecutionReport
 from osmo.scripts.build_experiment_output import (
@@ -42,6 +45,34 @@ def _write_run_output(run_output_directory: Path, run_name: str, success: bool) 
     }
     (run_output_directory / "episode_results_rebuild0.jsonl").write_text(
         json.dumps(episode_result) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timing_record(name: str, count: int, total_ms: float) -> dict[str, object]:
+    return {
+        "type": "timing",
+        "name": name,
+        "app_name": "experiment_runner",
+        "count": count,
+        "mean_ms": total_ms / count,
+        "total_ms": total_ms,
+        "min_ms": total_ms / count,
+        "max_ms": total_ms / count,
+        "p10_ms": total_ms / count,
+        "p50_ms": total_ms / count,
+        "p90_ms": total_ms / count,
+    }
+
+
+def _write_run_timings(
+    experiment_runner_output_directory: Path,
+    timing_records: list[dict[str, object]],
+) -> None:
+    """Write the timings the Experiment Runner leaves beside its Run output directory."""
+    experiment_runner_output_directory.mkdir(parents=True, exist_ok=True)
+    (experiment_runner_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).write_text(
+        json.dumps(timing_records) + "\n",
         encoding="utf-8",
     )
 
@@ -148,6 +179,7 @@ def test_rejects_completed_experiment_runner_output_without_the_requested_run(tm
 def test_collects_run_outputs_without_building_report(tmp_path):
     experiment_runner_output_directory = tmp_path / "experiment-runner-0-output"
     _write_run_output(experiment_runner_output_directory / "first", "first", True)
+    _write_run_timings(experiment_runner_output_directory, [_timing_record("run/rollout_policy", 1, 10.0)])
     first_run_metadata = _run_metadata("first-environment", "pi05")
     _write_experiment_runner_result(
         experiment_runner_output_directory,
@@ -173,7 +205,25 @@ def test_collects_run_outputs_without_building_report(tmp_path):
     }
     assert (experiment_output_directory / "first/episode_results_rebuild0.jsonl").is_file()
     assert (experiment_output_directory / "first" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
+    assert (experiment_output_directory / "first" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
     assert not (experiment_output_directory / "index.html").exists()
+
+
+def test_rejects_completed_experiment_runner_output_without_timings(tmp_path):
+    experiment_runner_output_directory = tmp_path / "experiment-runner-0-output"
+    _write_run_output(experiment_runner_output_directory / "first", "first", True)
+    _write_experiment_runner_result(
+        experiment_runner_output_directory,
+        RunStatus.COMPLETED,
+        0,
+        {"first": _run_metadata("first-environment", "pi05")},
+    )
+
+    with pytest.raises(AssertionError, match="Completed Run 'first' is missing its timings file"):
+        collect_run_outputs_into_experiment_output(
+            {"first": experiment_runner_output_directory},
+            tmp_path / "experiment-output",
+        )
 
 
 def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_path):
@@ -183,6 +233,14 @@ def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_pa
     second_run_output_directory = second_experiment_runner_output_directory / "second"
     _write_run_output(first_run_output_directory, "first", True)
     _write_run_output(second_run_output_directory, "second", False)
+    _write_run_timings(
+        first_experiment_runner_output_directory,
+        [_timing_record("run/rollout_policy", 1, 10.0), _timing_record("run/build_environment", 1, 4.0)],
+    )
+    _write_run_timings(
+        second_experiment_runner_output_directory,
+        [_timing_record("run/rollout_policy", 3, 30.0)],
+    )
     _write_experiment_runner_result(
         first_experiment_runner_output_directory,
         RunStatus.COMPLETED,
@@ -230,6 +288,20 @@ def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_pa
     }]
     assert set(first_run_result) == {"environment", "policy_variant", "status", "rebuilds"}
     assert experiment_result["runs"]["second"]["policy_variant"] == "cosmos"
+    assert (experiment_output_directory / "first" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    assert (experiment_output_directory / "second" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert experiment_timings["totals"] == [
+        {"name": "run/build_environment", "count": 1, "total_ms": 4.0, "min_ms": 4.0, "max_ms": 4.0, "mean_ms": 4.0},
+        {"name": "run/rollout_policy", "count": 4, "total_ms": 40.0, "min_ms": 10.0, "max_ms": 10.0, "mean_ms": 10.0},
+    ]
+    assert [(record["run_name"], record["name"]) for record in experiment_timings["runs"]] == [
+        ("first", "run/rollout_policy"),
+        ("first", "run/build_environment"),
+        ("second", "run/rollout_policy"),
+    ]
     report_contents = report_path.read_text(encoding="utf-8")
     assert "first" in report_contents
     assert "second" in report_contents
@@ -242,6 +314,8 @@ def test_reports_failed_runner_without_its_partial_artifacts(tmp_path):
     failed_runner_output_directory = tmp_path / "failed-runner-output"
     _write_run_output(completed_runner_output_directory / "completed-run", "completed-run", True)
     _write_run_output(failed_runner_output_directory / "failed-run", "failed-run", False)
+    _write_run_timings(completed_runner_output_directory, [_timing_record("run/rollout_policy", 1, 10.0)])
+    _write_run_timings(failed_runner_output_directory, [_timing_record("run/rollout_policy", 1, 99.0)])
     _write_experiment_runner_result(
         completed_runner_output_directory,
         RunStatus.COMPLETED,
@@ -267,6 +341,14 @@ def test_reports_failed_runner_without_its_partial_artifacts(tmp_path):
 
     assert (experiment_output_directory / "completed-run/episode_results_rebuild0.jsonl").is_file()
     assert not (experiment_output_directory / "failed-run/episode_results_rebuild0.jsonl").exists()
+    # A failed Run's timings describe a partial execution, so they are excluded like its episode results.
+    assert (experiment_output_directory / "completed-run" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    assert not (experiment_output_directory / "failed-run" / ARENA_EXPERIMENT_TIMINGS_FILENAME).exists()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert [record["run_name"] for record in experiment_timings["runs"]] == ["completed-run"]
+    assert experiment_timings["totals"][0]["total_ms"] == 10.0
     failed_result_path = experiment_output_directory / "failed-run" / EXPERIMENT_RUNNER_RESULT_FILE_NAME
     assert json.loads(failed_result_path.read_text(encoding="utf-8")) == {
         "execution_status": RunStatus.FAILED.value,
@@ -317,6 +399,10 @@ def test_builds_failure_report_when_every_runner_failed(tmp_path):
 
     assert (experiment_output_directory / "first" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
     assert (experiment_output_directory / "second" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert experiment_timings == {"totals": [], "runs": []}
     experiment_result = json.loads(
         (experiment_output_directory / ARENA_EXPERIMENT_RESULT_FILENAME).read_text(encoding="utf-8")
     )

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -282,11 +282,9 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     experiment_output_script_file = _task_file(experiment_output_task, _REMOTE_BUILD_EXPERIMENT_OUTPUT_SCRIPT_PATH)
     assert "localpath" not in experiment_output_script_file
     assert "def build_experiment_output" in experiment_output_script_file["contents"]
-    assert (
-        "from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult"
-        in experiment_output_script_file["contents"]
-    )
+    assert "from isaaclab_arena.evaluation.arena_experiment_result import" in experiment_output_script_file["contents"]
     assert EXPERIMENT_RUNNER_RESULT_FILE_NAME in experiment_output_script_file["contents"]
+    assert "def aggregate_experiment_timings" in experiment_output_script_file["contents"]
     experiment_output_command = _task_file(experiment_output_task, "/tmp/entry.sh")["contents"]
     assert experiment_output_command.startswith("set -euo pipefail")
     assert _REMOTE_BUILD_EXPERIMENT_OUTPUT_SCRIPT_PATH in experiment_output_command

--- a/isaaclab_arena/utils/env_step_timer.py
+++ b/isaaclab_arena/utils/env_step_timer.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gym wrapper that times the env it wraps, so the cost of the wrappers above it can be separated."""
+
+from __future__ import annotations
+
+import gymnasium as gym
+
+from isaaclab_arena.utils.timer import Timer
+
+
+class EnvStepTimerWrapper(gym.Wrapper):
+    """Record the wall time of the wrapped env's step under a timer name.
+
+    The timer covers everything below this wrapper and nothing above it, so placing it under a
+    stack of wrappers attributes the difference against an outer measurement to those wrappers.
+    """
+
+    def __init__(self, env: gym.Env, timer_name: str) -> None:
+        """Wrap an env and record each of its steps under the given timer name.
+
+        Args:
+            env: The env whose step is timed.
+            timer_name: Registry key the measurements accumulate under.
+        """
+        super().__init__(env)
+        self.timer_name = timer_name
+
+    def step(self, action):
+        """Step the wrapped env, recording how long it took."""
+        with Timer(self.timer_name):
+            return self.env.step(action)

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -32,7 +32,15 @@ from dataclasses import dataclass
 
 from moviepy.video.io.ffmpeg_writer import FFMPEG_VideoWriter
 
+from isaaclab_arena.utils.timer import Timer
+
 CAMERA_OBS_GROUP_KEY = "camera_obs"
+
+CAMERA_FRAME_WRITE_TIMER_NAME = "video/camera_frame_write"
+"""Timer covering the per-step camera frame copy and encoder writes."""
+
+CAMERA_FINALIZE_TIMER_NAME = "video/camera_finalize"
+"""Timer covering the encoder shutdown that finalises one episode's mp4 files."""
 
 # Regular expression to parse the filename of an episode video.
 _EPISODE_VIDEO_FILENAME_PATTERN = re.compile(
@@ -142,15 +150,19 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_envs = (terminated | truncated).nonzero().flatten().tolist()
             done_set = set(done_envs)
 
-            for camera_name, frames in cam_obs.items():
-                if camera_name not in self.writers:
-                    self.writers[camera_name] = [None] * n_envs
-                for env_idx in range(n_envs):
-                    if env_idx not in done_set:
-                        self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
+            # Timed separately from the env step: this covers the device-to-host copy of every
+            # camera frame and the encoder writes, which is the per-step cost of recording.
+            with Timer(CAMERA_FRAME_WRITE_TIMER_NAME):
+                for camera_name, frames in cam_obs.items():
+                    if camera_name not in self.writers:
+                        self.writers[camera_name] = [None] * n_envs
+                    for env_idx in range(n_envs):
+                        if env_idx not in done_set:
+                            self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
 
             if done_envs:
-                self._finish_envs(done_envs)
+                with Timer(CAMERA_FINALIZE_TIMER_NAME):
+                    self._finish_envs(done_envs)
 
         return result
 

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -10,7 +10,17 @@ import datetime
 import os
 from gymnasium.wrappers import RecordVideo
 
+from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
 from isaaclab_arena.video.camera_observation_video_recorder import CameraObsVideoRecorder
+
+STEP_WITHOUT_VIDEO_TIMER_NAME = "rollout/env_step_without_video"
+"""Timer covering the env step below every recorder, so recording cost can be separated from it.
+
+The Experiment Runner's ``rollout/env_step`` measures the outermost wrapper, so the difference
+between it and this timer is the total cost of recording. ``video/camera_frame_write`` and
+``video/camera_finalize`` break out the camera recorder's share; whatever remains is the viewport
+recorder's ``env.render()``. This timer only exists while a recorder is enabled.
+"""
 
 
 @dataclasses.dataclass
@@ -82,6 +92,9 @@ def wrap_env_for_video(
         return env
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
+
+    # Sits below every recorder so its measurement excludes them.
+    env = EnvStepTimerWrapper(env, timer_name=STEP_WITHOUT_VIDEO_TIMER_NAME)
 
     # Record the kit viewport (via env.render()).
     if video_cfg.record_viewport_video:

--- a/osmo/scripts/build_experiment_output.py
+++ b/osmo/scripts/build_experiment_output.py
@@ -9,7 +9,7 @@ The input JSON maps each Run name to its Experiment Runner task's output directo
 its ``<run-name>/...`` output is included. Completed Run directories are copied into the
 ``<experiment-output>/<run-name>`` layout, while failed results are preserved without partial Run artifacts. The
 ``arena_experiment_result.json`` and ``index.html`` report list every Run execution and include episode details only
-from completed Runs.
+from completed Runs. ``arena_experiment_timings.json`` holds each completed Run's timings and their per-timer totals.
 """
 
 from __future__ import annotations
@@ -17,11 +17,12 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME, ArenaExperimentResult
 from isaaclab_arena.evaluation.arena_run import RunStatus
+from isaaclab_arena.utils.timer import merge_timer_stats_json
 from isaaclab_arena.visualization.report import RunExecutionReport, build_report
 
 EXPERIMENT_RUNNER_RESULT_FILE_NAME = "experiment_runner_result.json"
@@ -147,10 +148,56 @@ def collect_run_outputs_into_experiment_output(
             experiment_runner_result_path,
             destination_run_output_directory / EXPERIMENT_RUNNER_RESULT_FILE_NAME,
         )
+        # The runner writes its timings beside the Run directory, so copy them in alongside the episode results.
+        source_run_timings_path = experiment_runner_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
+        assert (
+            source_run_timings_path.is_file()
+        ), f"Completed Run '{run_name}' is missing its timings file: '{source_run_timings_path}'"
+        shutil.copy2(
+            source_run_timings_path,
+            destination_run_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+        )
     return (
         sorted(run_execution_reports, key=lambda run_execution_report: run_execution_report.run_name),
         run_metadata_by_name,
     )
+
+
+def aggregate_experiment_timings(
+    experiment_output_directory: Path,
+    run_execution_reports: Sequence[RunExecutionReport],
+) -> Path:
+    """Combine every completed Run's timings into one Experiment timings file.
+
+    Args:
+        experiment_output_directory: Experiment output containing one collected directory per Run.
+        run_execution_reports: Validated execution results for every declared Run.
+
+    Returns:
+        Path to the written Experiment timings file.
+    """
+    run_records: list[dict[str, object]] = []
+    for run_execution_report in run_execution_reports:
+        if run_execution_report.status is not RunStatus.COMPLETED:
+            continue
+        run_name = run_execution_report.run_name
+        run_timings_path = experiment_output_directory / run_name / ARENA_EXPERIMENT_TIMINGS_FILENAME
+        run_records.extend(
+            {"run_name": run_name, **record} for record in json.loads(run_timings_path.read_text(encoding="utf-8"))
+        )
+
+    experiment_timings_path = experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
+    experiment_timings_path.write_text(
+        json.dumps(
+            {"totals": merge_timer_stats_json(run_records), "runs": run_records},
+            allow_nan=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote Arena Experiment timings to: {experiment_timings_path}")
+    return experiment_timings_path
 
 
 def build_experiment_output(
@@ -173,6 +220,7 @@ def build_experiment_output(
         experiment_output_directory,
     )
     ArenaExperimentResult(experiment_output_directory, run_metadata_by_name).write()
+    aggregate_experiment_timings(experiment_output_directory, run_execution_reports)
     return build_report(experiment_output_directory, run_executions=run_execution_reports)
 
 

--- a/osmo/tasks/collect_experiment_outputs_task.py
+++ b/osmo/tasks/collect_experiment_outputs_task.py
@@ -32,9 +32,9 @@ class CollectExperimentOutputsTask(BaseTask):
 
     For each Run, OSMO exposes its Experiment Runner task output at ``{{input:<runner-task>}}``. The embedded script
     copies completed Run outputs to ``{{output}}/<run-name>/...``, preserves failed runner results without partial Run
-    artifacts, and writes ``{{output}}/arena_experiment_result.json`` plus ``{{output}}/index.html``. Both list failed
-    Run executions but exclude their partial episode artifacts. Only this final task output is published to Swift;
-    the Experiment Runner task outputs remain workflow-local.
+    artifacts, and writes ``{{output}}/arena_experiment_result.json``, ``{{output}}/arena_experiment_timings.json``,
+    plus ``{{output}}/index.html``. These list failed Run executions but exclude their partial episode artifacts.
+    Only this final task output is published to Swift; the Experiment Runner task outputs remain workflow-local.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
Times the evaluation pipeline using the merged `Timer` utility.

## Detailed description
- We would like to measure the performance of sections of the code over time. The `Timer` utility this builds on has since landed on `main`, so this branch now only adds the instrumentation.
- Wraps Experiment Runner config load, run execution and report build, plus each Run's environment build, policy build, rollout and cleanup, and the per-step policy inference, env step, reset and metrics.
- Adds `EnvStepTimerWrapper` beneath the video recorders so the recording cost (camera frame writes and encoder finalize) separates from the env step itself.
- Writes `arena_experiment_timings.json` beside each Experiment Runner output, and the OSMO collect task merges every completed Run's timings into one Experiment-level file with per-timer totals.