### PR TITLE
Add timer utility

### DIFF
--- a/isaaclab_arena/tests/test_timer.py
+++ b/isaaclab_arena/tests/test_timer.py
@@ -63,7 +63,7 @@ class TestTimerStats:
 
     def test_reservoir_sampling_does_not_modify_global_random_state(self) -> None:
         """Verify reservoir sampling does not affect application randomness."""
-        stats = TimerStats(reservoir_size=1)
+        stats = TimerStats(percentile_approximation_reservoir_size=1)
         global_random_state = random.getstate()
 
         stats.update(1.0)
@@ -83,7 +83,7 @@ class TestTimerStats:
         for _ in range(num_samples // 100):
             values.append(synthetic_data_random_generator.uniform(80.0, 200.0))
 
-        exact = TimerStats(reservoir_size=len(values))
+        exact = TimerStats(percentile_approximation_reservoir_size=len(values))
         approx = TimerStats()
         for value in values:
             exact.update(value)

--- a/isaaclab_arena/tests/test_timer.py
+++ b/isaaclab_arena/tests/test_timer.py
@@ -10,6 +10,7 @@ import random
 
 import pytest
 
+import isaaclab_arena.utils.timer as timer_module
 from isaaclab_arena.utils.timer import (
     Timer,
     TimerStats,
@@ -60,19 +61,27 @@ class TestTimerStats:
         assert stats.percentile(50) == 50.0
         assert stats.percentile(90) == 90.0
 
-    def test_reservoir_accuracy(self) -> None:
+    def test_reservoir_sampling_does_not_modify_global_random_state(self) -> None:
+        """Verify reservoir sampling does not affect application randomness."""
+        stats = TimerStats(reservoir_size=1)
+        global_random_state = random.getstate()
+
+        stats.update(1.0)
+        stats.update(2.0)
+
+        assert random.getstate() == global_random_state
+
+    def test_reservoir_accuracy(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Verify reservoir sampling percentiles track the exact ones on skewed data."""
         seed = 32
-        # Seed both the module RNG used by TimerStats reservoir sampling and the local RNG
-        # used to generate this test's synthetic timing data.
-        random.seed(seed)
-        rng = random.Random(seed)
+        monkeypatch.setattr(timer_module, "_reservoir_random_generator", random.Random(seed))
+        synthetic_data_random_generator = random.Random(seed)
         num_samples = 10_000
 
-        values = [rng.gauss(20.0, 5.0) for _ in range(num_samples)]
+        values = [synthetic_data_random_generator.gauss(20.0, 5.0) for _ in range(num_samples)]
         # Sprinkle in ~1% outliers.
         for _ in range(num_samples // 100):
-            values.append(rng.uniform(80.0, 200.0))
+            values.append(synthetic_data_random_generator.uniform(80.0, 200.0))
 
         exact = TimerStats(reservoir_size=len(values))
         approx = TimerStats()

--- a/isaaclab_arena/tests/test_timer.py
+++ b/isaaclab_arena/tests/test_timer.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Timer context manager and TimerStats."""
+
+import json
+import random
+
+import pytest
+
+from isaaclab_arena.utils.timer import (
+    Timer,
+    TimerStats,
+    get_timer_stats,
+    get_timer_stats_json,
+    merge_timer_stats_json,
+    print_timer_stats,
+    reset_timer_stats,
+    write_timer_stats_json,
+)
+
+
+class TestTimerStats:
+    """Tests for the TimerStats dataclass."""
+
+    def test_initial_state(self) -> None:
+        """Verify default state of a fresh TimerStats."""
+        stats = TimerStats()
+        assert stats.count == 0
+        assert stats.total_ms == 0.0
+        assert stats.min_ms == float("inf")
+        assert stats.max_ms == float("-inf")
+        assert stats.mean_ms == 0.0
+
+    def test_accumulation(self) -> None:
+        """Verify min/max/mean/total after multiple measurements."""
+        stats = TimerStats()
+        stats.update(10.0)
+        stats.update(20.0)
+        stats.update(30.0)
+        assert stats.count == 3
+        assert stats.total_ms == 60.0
+        assert stats.min_ms == 10.0
+        assert stats.max_ms == 30.0
+        assert stats.mean_ms == pytest.approx(20.0)
+
+    def test_percentile_empty(self) -> None:
+        """Verify percentile returns None when no data recorded."""
+        stats = TimerStats()
+        assert stats.percentile(50) is None
+
+    def test_percentile_values(self) -> None:
+        """Verify approximate percentiles on a known distribution."""
+        stats = TimerStats()
+        for i in range(1, 101):
+            stats.update(float(i))
+        assert stats.percentile(10) == 10.0
+        assert stats.percentile(50) == 50.0
+        assert stats.percentile(90) == 90.0
+
+    def test_reservoir_accuracy(self) -> None:
+        """Verify reservoir sampling percentiles track the exact ones on skewed data."""
+        seed = 32
+        # Seed both the module RNG used by TimerStats reservoir sampling and the local RNG
+        # used to generate this test's synthetic timing data.
+        random.seed(seed)
+        rng = random.Random(seed)
+        num_samples = 10_000
+
+        values = [rng.gauss(20.0, 5.0) for _ in range(num_samples)]
+        # Sprinkle in ~1% outliers.
+        for _ in range(num_samples // 100):
+            values.append(rng.uniform(80.0, 200.0))
+
+        exact = TimerStats(reservoir_size=len(values))
+        approx = TimerStats()
+        for value in values:
+            exact.update(value)
+            approx.update(value)
+
+        for p in (10, 50, 90):
+            assert approx.percentile(p) == pytest.approx(exact.percentile(p), rel=0.05)
+
+
+class TestTimer:
+    """Tests for the Timer context manager."""
+
+    def setup_method(self) -> None:
+        """Reset timer registry before each test."""
+        reset_timer_stats()
+
+    def test_basic_timing(self) -> None:
+        """Verify a single timer records one measurement."""
+        with Timer("test_op"):
+            pass
+
+        stats = get_timer_stats()
+        assert "test_op" in stats
+        assert stats["test_op"].count == 1
+        assert stats["test_op"].total_ms >= 0.0
+
+    def test_multiple_names(self) -> None:
+        """Verify distinct timer names produce separate stats."""
+        with Timer("op_a"):
+            pass
+        with Timer("op_b"):
+            pass
+
+        stats = get_timer_stats()
+        assert stats["op_a"].count == 1
+        assert stats["op_b"].count == 1
+
+    def test_accumulation(self) -> None:
+        """Verify repeated use of the same timer name accumulates."""
+        for _ in range(5):
+            with Timer("repeated"):
+                pass
+
+        assert get_timer_stats()["repeated"].count == 5
+
+    def test_nesting(self) -> None:
+        """Verify nested timers both record and outer >= inner."""
+        with Timer("outer"):
+            with Timer("inner"):
+                pass
+
+        stats = get_timer_stats()
+        assert stats["outer"].total_ms >= stats["inner"].total_ms
+
+    def test_exception_propagation(self) -> None:
+        """Verify exceptions propagate and stats are still recorded."""
+        with pytest.raises(ValueError, match="test error"):
+            with Timer("failing_op"):
+                raise ValueError("test error")
+
+        assert get_timer_stats()["failing_op"].count == 1
+
+    def test_timer_returns_self(self) -> None:
+        """Verify the context manager yields the Timer instance."""
+        with Timer("self_test") as timer:
+            assert timer.name == "self_test"
+
+
+class TestPrintTimerStats:
+    """Tests for print_timer_stats output formatting."""
+
+    def setup_method(self) -> None:
+        """Reset timer registry before each test."""
+        reset_timer_stats()
+
+    def test_empty_stats(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify output when no timers have been recorded."""
+        print_timer_stats()
+        assert "No timer stats recorded." in capsys.readouterr().out
+
+    def test_output_format(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Verify the printed table has header, separator, and data row."""
+        with Timer("my_operation"):
+            pass
+
+        print_timer_stats()
+        lines = capsys.readouterr().out.strip().split("\n")
+        assert len(lines) == 4  # units line, header, separator, one data row
+        assert "Name" in lines[1]
+        assert "p50" in lines[1]
+        assert "my_operation" in lines[3]
+
+
+class TestGetTimerStatsJson:
+    """Tests for get_timer_stats_json."""
+
+    def setup_method(self) -> None:
+        """Reset timer registry before each test."""
+        reset_timer_stats()
+
+    def test_records(self) -> None:
+        """Verify one record per timer, each tagged with the app name and expected keys."""
+        with Timer("op_a"):
+            pass
+        with Timer("op_b"):
+            pass
+
+        records = get_timer_stats_json(app_name="test_app")
+        assert len(records) == 2
+        assert all(record["app_name"] == "test_app" for record in records)
+        assert all(record["type"] == "timing" for record in records)
+        assert set(records[0].keys()) == {
+            "type",
+            "name",
+            "app_name",
+            "count",
+            "mean_ms",
+            "total_ms",
+            "min_ms",
+            "max_ms",
+            "p10_ms",
+            "p50_ms",
+            "p90_ms",
+        }
+
+
+class TestMergeTimerStatsJson:
+    """Tests for merge_timer_stats_json."""
+
+    @staticmethod
+    def _record(name: str, count: int, total_ms: float, min_ms: float, max_ms: float) -> dict:
+        return {
+            "type": "timing",
+            "name": name,
+            "app_name": "some_app",
+            "count": count,
+            "mean_ms": total_ms / count,
+            "total_ms": total_ms,
+            "min_ms": min_ms,
+            "max_ms": max_ms,
+            "p50_ms": min_ms,
+        }
+
+    def test_empty_input(self) -> None:
+        """Verify merging nothing produces nothing."""
+        assert merge_timer_stats_json([]) == []
+
+    def test_combines_records_that_share_a_name(self) -> None:
+        """Verify counts and totals add while min and max span every record."""
+        merged = merge_timer_stats_json([
+            self._record("step", count=2, total_ms=10.0, min_ms=3.0, max_ms=7.0),
+            self._record("step", count=3, total_ms=30.0, min_ms=1.0, max_ms=20.0),
+        ])
+
+        assert merged == [{"name": "step", "count": 5, "total_ms": 40.0, "min_ms": 1.0, "max_ms": 20.0, "mean_ms": 8.0}]
+
+    def test_separate_names_sorted(self) -> None:
+        """Verify distinct names stay separate and come back sorted by name."""
+        merged = merge_timer_stats_json([
+            self._record("b_op", count=1, total_ms=2.0, min_ms=2.0, max_ms=2.0),
+            self._record("a_op", count=1, total_ms=1.0, min_ms=1.0, max_ms=1.0),
+        ])
+
+        assert [record["name"] for record in merged] == ["a_op", "b_op"]
+
+    def test_percentiles_are_dropped(self) -> None:
+        """Verify percentile fields are not carried into the merged record."""
+        merged = merge_timer_stats_json([self._record("step", count=1, total_ms=5.0, min_ms=5.0, max_ms=5.0)])
+
+        assert set(merged[0]) == {"name", "count", "total_ms", "min_ms", "max_ms", "mean_ms"}
+
+    def test_merges_recorded_stats(self) -> None:
+        """Verify merging one process's own records reproduces its totals."""
+        reset_timer_stats()
+        for _ in range(3):
+            with Timer("op"):
+                pass
+
+        records = get_timer_stats_json(app_name="test_app")
+        merged = merge_timer_stats_json(records)
+        assert merged[0]["count"] == 3
+        assert merged[0]["total_ms"] == pytest.approx(records[0]["total_ms"])
+
+
+class TestWriteTimerStatsJson:
+    """Tests for write_timer_stats_json."""
+
+    def setup_method(self) -> None:
+        """Reset timer registry before each test."""
+        reset_timer_stats()
+
+    def test_written_file_round_trips(self, tmp_path) -> None:
+        """Verify the written file parses back to the in-memory records."""
+        with Timer("op_a"):
+            pass
+
+        output_path = write_timer_stats_json(tmp_path / "timings.json", app_name="test_app")
+        written_records = json.loads(output_path.read_text(encoding="utf-8"))
+        assert written_records == get_timer_stats_json(app_name="test_app")
+        assert written_records[0]["name"] == "op_a"
+
+    def test_empty_registry_writes_empty_list(self, tmp_path) -> None:
+        """Verify a file is still written when no timers were recorded."""
+        output_path = write_timer_stats_json(tmp_path / "timings.json", app_name="test_app")
+        assert json.loads(output_path.read_text(encoding="utf-8")) == []
+
+
+class TestResetTimerStats:
+    """Tests for reset_timer_stats."""
+
+    def test_reset_clears_all(self) -> None:
+        """Verify reset removes all recorded stats and new timers start fresh."""
+        with Timer("first_run"):
+            pass
+
+        assert len(get_timer_stats()) > 0
+        reset_timer_stats()
+        assert len(get_timer_stats()) == 0
+
+        with Timer("second_run"):
+            pass
+
+        stats = get_timer_stats()
+        assert "first_run" not in stats
+        assert stats["second_run"].count == 1

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -30,6 +30,9 @@ from typing import Any
 
 DEFAULT_RESERVOIR_SIZE = 1024
 
+# Keep reservoir sampling independent from application randomness.
+_reservoir_random_generator = random.Random()
+
 # Timing statistics accumulated over the process lifetime, keyed by timer name.
 _timer_registry: dict[str, TimerStats] = {}
 
@@ -67,9 +70,9 @@ class TimerStats:
         if len(self._reservoir) < self.reservoir_size:
             self._reservoir.append(elapsed_ms)
         else:
-            j = random.randint(0, self.count - 1)
-            if j < self.reservoir_size:
-                self._reservoir[j] = elapsed_ms
+            replacement_index = _reservoir_random_generator.randint(0, self.count - 1)
+            if replacement_index < self.reservoir_size:
+                self._reservoir[replacement_index] = elapsed_ms
 
     def percentile(self, p: float) -> float | None:
         """Return the approximate p-th percentile (0-100), or None if nothing was recorded.

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -28,8 +28,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-DEFAULT_RESERVOIR_SIZE = 1024
-
 # Keep reservoir sampling independent from application randomness.
 _reservoir_random_generator = random.Random()
 
@@ -44,7 +42,7 @@ class TimerStats:
     Maintains a reservoir sample for approximate percentile estimation.
     """
 
-    reservoir_size: int = DEFAULT_RESERVOIR_SIZE
+    percentile_approximation_reservoir_size: int = 1024
     count: int = 0
     total_ms: float = 0.0
     min_ms: float = field(default=float("inf"))
@@ -67,11 +65,11 @@ class TimerStats:
 
         # Reservoir sampling (Algorithm R). Maintain a small representative sample and compute
         # percentiles on it as a proxy, avoiding unbounded memory growth.
-        if len(self._reservoir) < self.reservoir_size:
+        if len(self._reservoir) < self.percentile_approximation_reservoir_size:
             self._reservoir.append(elapsed_ms)
         else:
             replacement_index = _reservoir_random_generator.randint(0, self.count - 1)
-            if replacement_index < self.reservoir_size:
+            if replacement_index < self.percentile_approximation_reservoir_size:
                 self._reservoir[replacement_index] = elapsed_ms
 
     def percentile(self, p: float) -> float | None:
@@ -90,23 +88,20 @@ class TimerStats:
         return sorted_buf[idx]
 
 
-def _update_stats(name: str, elapsed_ms: float, reservoir_size: int) -> None:
+def _update_stats(name: str, elapsed_ms: float) -> None:
     """Create or update the registry entry for the given timer name."""
     if name in _timer_registry:
         _timer_registry[name].update(elapsed_ms)
     else:
-        stats = TimerStats(reservoir_size=reservoir_size)
-        stats.update(elapsed_ms)
-        _timer_registry[name] = stats
+        timer_stats = TimerStats()
+        timer_stats.update(elapsed_ms)
+        _timer_registry[name] = timer_stats
 
 
 class Timer:
-    """Context manager that records the wall-clock duration of a code block under a name.
+    """Context manager that records wall-clock durations under a name.
 
-    Repeated use of the same name accumulates into one set of statistics. Each block also
-    pushes an NVTX range for Nsight Systems visibility. Call Timer.set_sync_cuda(True) to
-    insert torch.cuda.synchronize() on enter and exit for all Timer instances, which is
-    needed to attribute GPU work to the block that launched it.
+    Measurements accumulate in a process-wide registry until reset_timer_stats() is called.
     """
 
     _sync_cuda: bool = False
@@ -116,15 +111,13 @@ class Timer:
         """Enable or disable CUDA synchronization for all Timer instances."""
         cls._sync_cuda = enabled
 
-    def __init__(self, name: str, reservoir_size: int = DEFAULT_RESERVOIR_SIZE) -> None:
+    def __init__(self, name: str) -> None:
         """Create a new timer with the given name.
 
         Args:
             name: Registry key that this block's measurements accumulate under.
-            reservoir_size: Number of samples retained for percentile estimation.
         """
         self.name = name
-        self._reservoir_size = reservoir_size
         self._start_time: float = 0.0
 
     def __enter__(self) -> Timer:
@@ -145,7 +138,7 @@ class Timer:
             torch.cuda.synchronize()
         torch.cuda.nvtx.range_pop()
         elapsed_ms = (time.perf_counter() - self._start_time) * 1e3
-        _update_stats(self.name, elapsed_ms, self._reservoir_size)
+        _update_stats(self.name, elapsed_ms)
 
 
 def get_timer_stats() -> dict[str, TimerStats]:

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightweight timer context manager with wall-time measurement and NVTX integration.
+
+Adapted from nvblox_next.system.timer.
+
+Usage:
+    from isaaclab_arena.utils.timer import Timer, print_timer_stats
+
+    for episode in episodes:
+        with Timer("rollout"):
+            rollout_policy(env, policy)
+
+    print_timer_stats()
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import time
+import torch
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+DEFAULT_RESERVOIR_SIZE = 1024
+
+# Timing statistics accumulated over the process lifetime, keyed by timer name.
+_timer_registry: dict[str, TimerStats] = {}
+
+
+@dataclass
+class TimerStats:
+    """Accumulated timing statistics for a named timer.
+
+    Maintains a reservoir sample for approximate percentile estimation.
+    """
+
+    reservoir_size: int = DEFAULT_RESERVOIR_SIZE
+    count: int = 0
+    total_ms: float = 0.0
+    min_ms: float = field(default=float("inf"))
+    max_ms: float = field(default=float("-inf"))
+    _reservoir: list[float] = field(default_factory=list)
+
+    @property
+    def mean_ms(self) -> float:
+        """Return the mean elapsed time in milliseconds."""
+        if self.count == 0:
+            return 0.0
+        return self.total_ms / self.count
+
+    def update(self, elapsed_ms: float) -> None:
+        """Record a new timing measurement."""
+        self.count += 1
+        self.total_ms += elapsed_ms
+        self.min_ms = min(self.min_ms, elapsed_ms)
+        self.max_ms = max(self.max_ms, elapsed_ms)
+
+        # Reservoir sampling (Algorithm R). Maintain a small representative sample and compute
+        # percentiles on it as a proxy, avoiding unbounded memory growth.
+        if len(self._reservoir) < self.reservoir_size:
+            self._reservoir.append(elapsed_ms)
+        else:
+            j = random.randint(0, self.count - 1)
+            if j < self.reservoir_size:
+                self._reservoir[j] = elapsed_ms
+
+    def percentile(self, p: float) -> float | None:
+        """Return the approximate p-th percentile (0-100), or None if nothing was recorded.
+
+        Args:
+            p: Percentile to estimate, between 0 and 100.
+
+        Returns:
+            The estimated percentile in milliseconds, or None when no measurements exist.
+        """
+        if not self._reservoir:
+            return None
+        sorted_buf = sorted(self._reservoir)
+        idx = int(p / 100.0 * (len(sorted_buf) - 1))
+        return sorted_buf[idx]
+
+
+def _update_stats(name: str, elapsed_ms: float, reservoir_size: int) -> None:
+    """Create or update the registry entry for the given timer name."""
+    if name in _timer_registry:
+        _timer_registry[name].update(elapsed_ms)
+    else:
+        stats = TimerStats(reservoir_size=reservoir_size)
+        stats.update(elapsed_ms)
+        _timer_registry[name] = stats
+
+
+class Timer:
+    """Context manager that records the wall-clock duration of a code block under a name.
+
+    Repeated use of the same name accumulates into one set of statistics. Each block also
+    pushes an NVTX range for Nsight Systems visibility. Call Timer.set_sync_cuda(True) to
+    insert torch.cuda.synchronize() on enter and exit for all Timer instances, which is
+    needed to attribute GPU work to the block that launched it.
+    """
+
+    _sync_cuda: bool = False
+
+    @classmethod
+    def set_sync_cuda(cls, enabled: bool) -> None:
+        """Enable or disable CUDA synchronization for all Timer instances."""
+        cls._sync_cuda = enabled
+
+    def __init__(self, name: str, reservoir_size: int = DEFAULT_RESERVOIR_SIZE) -> None:
+        """Create a new timer with the given name.
+
+        Args:
+            name: Registry key that this block's measurements accumulate under.
+            reservoir_size: Number of samples retained for percentile estimation.
+        """
+        self.name = name
+        self._reservoir_size = reservoir_size
+        self._start_time: float = 0.0
+
+    def __enter__(self) -> Timer:
+        """Start the timer, recording wall time and pushing an NVTX range."""
+        if torch.compiler.is_compiling():
+            return self
+        if Timer._sync_cuda:
+            torch.cuda.synchronize()
+        self._start_time = time.perf_counter()
+        torch.cuda.nvtx.range_push(self.name)
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Stop the timer, popping the NVTX range and recording the elapsed wall time."""
+        if torch.compiler.is_compiling():
+            return
+        if Timer._sync_cuda:
+            torch.cuda.synchronize()
+        torch.cuda.nvtx.range_pop()
+        elapsed_ms = (time.perf_counter() - self._start_time) * 1e3
+        _update_stats(self.name, elapsed_ms, self._reservoir_size)
+
+
+def get_timer_stats() -> dict[str, TimerStats]:
+    """Return a copy of the timer registry."""
+    return dict(_timer_registry)
+
+
+def get_timer_stats_json(app_name: str) -> list[dict]:
+    """Return the timer statistics as a list of JSON-serializable dictionaries.
+
+    Args:
+        app_name: Identifier for the application that produced these results (for example
+            "experiment_runner"). Included in every returned dictionary so that results from
+            different apps can be distinguished when stored together.
+
+    Returns:
+        One dictionary per recorded timer name.
+    """
+    return [
+        {
+            "type": "timing",
+            "name": name,
+            "app_name": app_name,
+            "count": timer_stats.count,
+            "mean_ms": timer_stats.mean_ms,
+            "total_ms": timer_stats.total_ms,
+            "min_ms": timer_stats.min_ms,
+            "max_ms": timer_stats.max_ms,
+            "p10_ms": timer_stats.percentile(10),
+            "p50_ms": timer_stats.percentile(50),
+            "p90_ms": timer_stats.percentile(90),
+        }
+        for name, timer_stats in get_timer_stats().items()
+    ]
+
+
+def merge_timer_stats_json(records: Iterable[Mapping[str, Any]]) -> list[dict]:
+    """Combine timer records that share a name into one total per name, sorted by name.
+
+    Use this to summarize records produced by several processes, such as one Experiment Runner per Run.
+    Percentiles are dropped because they cannot be recovered from per-process summaries.
+
+    Args:
+        records: Timer records as produced by get_timer_stats_json.
+
+    Returns:
+        One record per distinct timer name, holding the combined count, total, mean, min, and max.
+    """
+    merged_by_name: dict[str, dict] = {}
+    for record in records:
+        name = record["name"]
+        merged = merged_by_name.get(name)
+        if merged is None:
+            merged_by_name[name] = {
+                "name": name,
+                "count": record["count"],
+                "total_ms": record["total_ms"],
+                "min_ms": record["min_ms"],
+                "max_ms": record["max_ms"],
+            }
+            continue
+        merged["count"] += record["count"]
+        merged["total_ms"] += record["total_ms"]
+        merged["min_ms"] = min(merged["min_ms"], record["min_ms"])
+        merged["max_ms"] = max(merged["max_ms"], record["max_ms"])
+
+    return [
+        {**merged, "mean_ms": merged["total_ms"] / merged["count"] if merged["count"] else 0.0}
+        for _, merged in sorted(merged_by_name.items())
+    ]
+
+
+def write_timer_stats_json(output_path: str | Path, app_name: str) -> Path:
+    """Write the timer statistics to a JSON file and return the path written.
+
+    Args:
+        output_path: File to write the timer statistics to. Parent directories must exist.
+        app_name: Identifier for the application that produced these results, recorded in every entry.
+
+    Returns:
+        The path that was written.
+    """
+    output_path = Path(output_path)
+    output_path.write_text(
+        json.dumps(get_timer_stats_json(app_name), allow_nan=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def print_timer_stats() -> None:
+    """Print a formatted table of timer statistics."""
+    stats = get_timer_stats()
+    if not stats:
+        print("No timer stats recorded.")
+        return
+
+    name_length = max(len(name) for name in stats) + 2
+    cols = [
+        f"{'Name':<{name_length}}",
+        f"{'Count':>8}",
+        f"{'Mean':>10}",
+        f"{'Total':>12}",
+        f"{'Min':>10}",
+        f"{'p10':>10}",
+        f"{'p50':>10}",
+        f"{'p90':>10}",
+        f"{'Max':>10}",
+    ]
+    header = " ".join(cols)
+    print(f"{'(all times in ms)':>30}")
+    print(header)
+    print("-" * len(header))
+    for name, s in sorted(stats.items()):
+        p10 = s.percentile(10)
+        p50 = s.percentile(50)
+        p90 = s.percentile(90)
+        vals = [
+            f"{name:<{name_length}}",
+            f"{s.count:>8d}",
+            f"{s.mean_ms:>10.3f}",
+            f"{s.total_ms:>12.3f}",
+            f"{s.min_ms:>10.3f}",
+            f"{p10:>10.3f}" if p10 is not None else f"{'-':>10}",
+            f"{p50:>10.3f}" if p50 is not None else f"{'-':>10}",
+            f"{p90:>10.3f}" if p90 is not None else f"{'-':>10}",
+            f"{s.max_ms:>10.3f}",
+        ]
+        print(" ".join(vals))
+
+
+def reset_timer_stats() -> None:
+    """Clear the timer registry."""
+    _timer_registry.clear()


### PR DESCRIPTION
## Summary
Add a reusable timer utility

## Detailed description
- Extract Alex's timer utility and focused tests from #1145.
- Provide named wall-time statistics, NVTX ranges, optional CUDA synchronization, table output, and JSON helpers.
- Leave experiment, policy, video, and OSMO instrumentation out of this PR.
- Existing runtime behavior is unchanged until callers adopt the utility.