### PR TITLE
Resolve documentation and release note issues

### DIFF
--- a/docs/images/sensitivity_synthetic_continuous_marginals.png
+++ b/docs/images/sensitivity_synthetic_continuous_marginals.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f43458f16c6f10e748daf20ae1c9d56329f5703160087434037a4f2ec3e0771
+size 144805

--- a/docs/images/sensitivity_synthetic_continuous_marginals.png
+++ b/docs/images/sensitivity_synthetic_continuous_marginals.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f43458f16c6f10e748daf20ae1c9d56329f5703160087434037a4f2ec3e0771
-size 144805
+oid sha256:d3b003fa28b80eb1dd8852f425abc289d7e2f4b4d78fb38d56f8657d778a0bda
+size 157368

--- a/docs/pages/concepts/concept_sensitivity_analysis.rst
+++ b/docs/pages/concepts/concept_sensitivity_analysis.rst
@@ -126,16 +126,13 @@ Isaac Sim — useful for seeing the output shape and for validating the toolbox
 .. code-block:: bash
 
    python -m isaaclab_arena.tests.sensitivity_synthetic \
-     --kind mixed \
-     --plot-factors light_intensity object_mass camera_distance \
+     --kind continuous \
      --output eval/demo.png
 
    NO_AT_BRIDGE=1 pqiv eval/demo.png
 
-The mixed dataset contains three continuous and two categorical factors, which exercises the MNPE
-path. ``--plot-factors`` limits the displayed panels to the three continuous factors; all five
-factors remain part of the joint inference. ``--kind`` also accepts ``continuous`` to exercise the
-continuous-only NPE path.
+The continuous dataset contains three factors and exercises the NPE path. ``--kind`` also accepts
+``mixed`` to exercise the MNPE path with three continuous and two categorical factors.
 
 Reading the output
 ------------------
@@ -145,7 +142,7 @@ Reading the output
    :alt: Posterior marginals for light intensity, object mass, and camera distance conditioned on success
    :align: center
 
-   Posterior marginals from the mixed synthetic dataset, showing the three continuous factors.
+   Posterior marginals from the continuous synthetic dataset.
 
 Each blue curve is the posterior density for one factor *conditioned on success*. The dashed grey
 line is the uniform prior used to draw that factor. Where the posterior rises above the prior,
@@ -153,18 +150,16 @@ those values are more common in the success-conditioned samples than in the orig
 shaded 5–95% interval contains the central 90% of the posterior samples.
 
 Compare each curve with the prior in its own panel. Absolute density heights are not comparable
-between panels because each factor has different units and a different range. When categorical
-panels are displayed, each bar is the posterior probability of that choice; taller bars mark
-choices more strongly associated with the conditioned outcome.
+between panels because each factor has different units and a different range.
 
 The three panels recover the relationships planted in the synthetic simulator:
 
-* **Light intensity:** Density shifts toward the bright end of the range, so successful episodes
-  favor brighter lighting.
-* **Object mass:** Density is strongest at lower masses and falls toward the high end of the
+* **Light intensity:** Density shifts toward higher intensities and peaks near the bright end of
+  the range, so successful episodes favor brighter lighting.
+* **Object mass:** Density shifts toward lower masses and falls toward the high end of the
   range, so successful episodes favor lighter objects.
-* **Camera distance:** Density is highest at shorter distances and declines as the camera moves
-  farther away, so successful episodes favor a closer camera.
+* **Camera distance:** Density shifts toward shorter distances and peaks around 0.6, so successful
+  episodes favor a closer camera.
 
 These curves validate the analysis against known synthetic relationships. For evaluation data,
 read the same shapes as associations with success within the sampled sweep, not as proof that a

--- a/docs/pages/concepts/concept_sensitivity_analysis.rst
+++ b/docs/pages/concepts/concept_sensitivity_analysis.rst
@@ -127,9 +127,9 @@ Isaac Sim — useful for seeing the output shape and for validating the toolbox
 
    python -m isaaclab_arena.tests.sensitivity_synthetic \
      --kind continuous \
-     --output eval/demo.png
+     --output eval/sensitivity_synthetic_continuous_marginals.png
 
-   NO_AT_BRIDGE=1 pqiv eval/demo.png
+   NO_AT_BRIDGE=1 pqiv eval/sensitivity_synthetic_continuous_marginals.png
 
 The continuous dataset contains three factors and exercises the NPE path. ``--kind`` also accepts
 ``mixed`` to exercise the MNPE path with three continuous and two categorical factors.

--- a/docs/pages/concepts/concept_sensitivity_analysis.rst
+++ b/docs/pages/concepts/concept_sensitivity_analysis.rst
@@ -125,25 +125,50 @@ Isaac Sim — useful for seeing the output shape and for validating the toolbox
 
 .. code-block:: bash
 
-   # mixed: three continuous + two categorical factors (MNPE)
-   python -m isaaclab_arena.tests.sensitivity_synthetic --kind mixed --output eval/demo.png
+   python -m isaaclab_arena.tests.sensitivity_synthetic \
+     --kind mixed \
+     --plot-factors light_intensity object_mass camera_distance \
+     --output eval/demo.png
 
-``--kind`` also accepts ``continuous`` (continuous-only factors, which exercises the NPE path).
+   NO_AT_BRIDGE=1 pqiv eval/demo.png
+
+The mixed dataset contains three continuous and two categorical factors, which exercises the MNPE
+path. ``--plot-factors`` limits the displayed panels to the three continuous factors; all five
+factors remain part of the joint inference. ``--kind`` also accepts ``continuous`` to exercise the
+continuous-only NPE path.
 
 Reading the output
 ------------------
 
-.. todo::
+.. figure:: ../../images/sensitivity_synthetic_continuous_marginals.png
+   :width: 100%
+   :alt: Posterior marginals for light intensity, object mass, and camera distance conditioned on success
+   :align: center
 
-   Add a sample report figure here and walk through reading it.
+   Posterior marginals from the mixed synthetic dataset, showing the three continuous factors.
 
-Each panel is the posterior over one factor *conditioned on success*. Intuitively it answers
-"given the policy succeeded, which values of this factor were responsible?" More precisely,
-among the successful episodes it shows the probability density that the factor took each
-value. For a continuous factor, mass concentrated at one end of its range means success
-favoured that end — e.g. a curve rising toward bright light means successful episodes were
-almost all bright ones, i.e. the policy needs bright light to succeed.
-For a categorical factor, the tallest bar is the value most associated with success.
+Each blue curve is the posterior density for one factor *conditioned on success*. The dashed grey
+line is the uniform prior used to draw that factor. Where the posterior rises above the prior,
+those values are more common in the success-conditioned samples than in the original sweep. The
+shaded 5–95% interval contains the central 90% of the posterior samples.
+
+Compare each curve with the prior in its own panel. Absolute density heights are not comparable
+between panels because each factor has different units and a different range. When categorical
+panels are displayed, each bar is the posterior probability of that choice; taller bars mark
+choices more strongly associated with the conditioned outcome.
+
+The three panels recover the relationships planted in the synthetic simulator:
+
+* **Light intensity:** Density shifts toward the bright end of the range, so successful episodes
+  favor brighter lighting.
+* **Object mass:** Density is strongest at lower masses and falls toward the high end of the
+  range, so successful episodes favor lighter objects.
+* **Camera distance:** Density is highest at shorter distances and declines as the camera moves
+  farther away, so successful episodes favor a closer camera.
+
+These curves validate the analysis against known synthetic relationships. For evaluation data,
+read the same shapes as associations with success within the sampled sweep, not as proof that a
+factor caused the outcome.
 
 Current scope
 -------------
@@ -161,7 +186,4 @@ Current scope
   fix is to balance the draws in the sweep.
 - The estimators run on CPU and do not require Isaac Sim, so a report can be generated
   anywhere the evaluation JSONL is available.
-- The analysis assumes the ``episode_results.jsonl`` is a single coherent slice — one
-  policy, task, and embodiment. **TODO:** add a filter (in the spirit of robolab's
-  ``--filter-policy`` / ``--filter-task``) to select that slice from a larger JSONL,
-  rather than relying on the caller to pre-filter it.
+- Every row in ``episode_results.jsonl`` must come from the same policy, task, and embodiment.

--- a/docs/pages/quickstart/arena_env.rst
+++ b/docs/pages/quickstart/arena_env.rst
@@ -173,11 +173,15 @@ For more detail, see :doc:`Assets <../concepts/scene/concept_assets_design>`,
 :doc:`Tasks <../concepts/task/index>`, and
 :doc:`Environment Builder <../concepts/environment/env_builder>`.
 
-.. dropdown:: Full source: ``pick_and_place_maple_table_environment.py``
+.. dropdown:: Environment definition: ``pick_and_place_maple_table_environment.py``
    :animate: fade-in
 
    .. literalinclude:: ../../../isaaclab_arena_environments/pick_and_place_maple_table_environment.py
       :language: python
+      :start-at: @dataclass
+      :end-at: return isaaclab_arena_environment
+
+See the `complete source <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/pick_and_place_maple_table_environment.py>`_.
 
 
 Next Steps

--- a/docs/pages/references/release_notes.rst
+++ b/docs/pages/references/release_notes.rst
@@ -57,7 +57,7 @@ such as PIP packaging.
 
 **Limitations**
 
-- pip install support is coming soon (current installation method is Docker-based).
+- Installation from a published Python package is not yet supported; use the native ``uv`` source workflow or Docker.
 - Performance is not yet hardened for production-scale workloads in Alpha stage.
 
 

--- a/isaaclab_arena/tests/sensitivity_synthetic.py
+++ b/isaaclab_arena/tests/sensitivity_synthetic.py
@@ -13,12 +13,14 @@ reflects it.
 
 Ground truth (single-sourced in the factor definitions below):
   - light_intensity is continuous; brighter raises success (LIGHT.weight > 0).
-  - grasp_offset is continuous; a *smaller* offset raises success (GRASP_OFFSET.weight < 0).
+  - object_mass is continuous; a lighter object raises success (OBJECT_MASS.weight < 0).
+  - camera_distance is continuous; a closer camera raises success (CAMERA_DISTANCE.weight < 0).
+  - object_type is categorical; OBJECT_TYPE makes cube the most successful, mug the least.
   - table_material is categorical; MATERIAL makes oak the most successful, bamboo the least.
   - success is a binary outcome drawn from Bernoulli(sigmoid(logit)).
 
 make_mixed_dataset exercises the MNPE path (continuous + categorical); make_continuous_dataset
-exercises the NPE path with two continuous factors (NPE restricts to a Gaussian on 1-D theta).
+exercises the NPE path with the three continuous factors.
 """
 
 from __future__ import annotations
@@ -80,10 +82,9 @@ class _CategoricalFactor:
         return codes.float()
 
 
-# Planted ground truth: brighter light, a smaller grasp offset, a lighter object, a closer
-# camera, and the leading category (oak / cube) all raise success.
+# Planted ground truth: brighter light, a lighter object, a closer camera, and the leading
+# category (oak / cube) all raise success.
 LIGHT = _ContinuousFactor("light_intensity", (0.0, 5000.0), weight=2.5)
-GRASP_OFFSET = _ContinuousFactor("grasp_offset", (0.0, 0.2), weight=-2.5)
 OBJECT_MASS = _ContinuousFactor("object_mass", (0.05, 2.0), weight=-1.5)
 CAMERA_DISTANCE = _ContinuousFactor("camera_distance", (0.3, 1.5), weight=-1.5)
 MATERIAL = _CategoricalFactor("table_material", {"oak": 1.5, "walnut": 0.0, "bamboo": -1.5})
@@ -112,17 +113,23 @@ def _build_dataset(
 
 
 def make_continuous_dataset(seed: int, num_episodes: int = 2000) -> SensitivityDataset:
-    """Two continuous factors (light_intensity, grasp_offset) driving success.
+    """Three continuous factors (light, mass, camera distance) driving success.
 
-    Uses the NPE path. Both effects are planted — brighter light and a smaller grasp offset
-    raise success — so conditioning the posterior on success should favor high light values
-    and low offset values. Two factors keep theta 2-D, away from NPE's 1-D Gaussian fallback.
+    Uses the NPE path. Every effect is planted — brighter light, a lighter object, and a
+    closer camera raise success — so conditioning the posterior on success should recover
+    all three relationships.
     """
     torch.manual_seed(seed)
     light = LIGHT.sample(num_episodes)
-    grasp_offset = GRASP_OFFSET.sample(num_episodes)
-    success = _sample_success(LIGHT.logit(light) + GRASP_OFFSET.logit(grasp_offset))
-    return _build_dataset([(LIGHT, light), (GRASP_OFFSET, grasp_offset)], success)
+    object_mass = OBJECT_MASS.sample(num_episodes)
+    camera_distance = CAMERA_DISTANCE.sample(num_episodes)
+    success = _sample_success(
+        LIGHT.logit(light) + OBJECT_MASS.logit(object_mass) + CAMERA_DISTANCE.logit(camera_distance)
+    )
+    return _build_dataset(
+        [(LIGHT, light), (OBJECT_MASS, object_mass), (CAMERA_DISTANCE, camera_distance)],
+        success,
+    )
 
 
 def make_mixed_dataset(seed: int, num_episodes: int = 3000) -> SensitivityDataset:
@@ -158,39 +165,6 @@ def make_mixed_dataset(seed: int, num_episodes: int = 3000) -> SensitivityDatase
     )
 
 
-def _select_factors_for_plot(
-    dataset: SensitivityDataset,
-    posterior_samples: torch.Tensor,
-    factor_names: list[str] | None,
-) -> tuple[SensitivityDataset, torch.Tensor]:
-    """Return aligned dataset and posterior columns for the requested plot panels."""
-    if factor_names is None:
-        return dataset, posterior_samples
-
-    assert len(factor_names) == len(set(factor_names)), "--plot-factors must not contain duplicate names."
-    available_factor_names = [factor.name for factor in dataset.factors]
-    unknown_factor_names = [factor_name for factor_name in factor_names if factor_name not in available_factor_names]
-    assert not unknown_factor_names, (
-        f"Unknown --plot-factors: {', '.join(unknown_factor_names)}. "
-        f"Available factors: {', '.join(available_factor_names)}."
-    )
-
-    requested_factor_names = set(factor_names)
-    selected_factors = [factor for factor in dataset.factors if factor.name in requested_factor_names]
-    factor_columns = dataset.factor_columns
-    selected_theta = torch.cat([dataset.theta[:, factor_columns[factor.name]] for factor in selected_factors], dim=1)
-    selected_posterior_samples = torch.cat(
-        [posterior_samples[:, factor_columns[factor.name]] for factor in selected_factors], dim=1
-    )
-    selected_dataset = SensitivityDataset(
-        selected_factors,
-        selected_theta,
-        dataset.x,
-        outcome_names=dataset.outcome_names,
-    )
-    return selected_dataset, selected_posterior_samples
-
-
 def _demo():
     """Run the full pipeline on a synthetic dataset and save the marginals plot.
 
@@ -198,8 +172,7 @@ def _demo():
     data needed. Run as::
 
         python -m isaaclab_arena.tests.sensitivity_synthetic \\
-          --kind mixed \\
-          --plot-factors light_intensity object_mass camera_distance \\
+          --kind continuous \\
           --output eval/demo.png
     """
     parser = argparse.ArgumentParser(description="Run the sensitivity pipeline on a synthetic dataset and plot it.")
@@ -216,16 +189,6 @@ def _demo():
     )
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--num-episodes", type=int, default=2000)
-    parser.add_argument(
-        "--plot-factors",
-        type=str,
-        nargs="+",
-        default=None,
-        help=(
-            "Factor names to display, in dataset order. Inference still uses every factor in the selected dataset "
-            "kind. Defaults to every factor."
-        ),
-    )
     args = parser.parse_args()
 
     builder = {"mixed": make_mixed_dataset, "continuous": make_continuous_dataset}[args.kind]
@@ -234,8 +197,7 @@ def _demo():
     analyzer.fit()
     observation = dataset.default_observation()
     samples = analyzer.sample_posterior(observation)
-    plot_dataset, plot_samples = _select_factors_for_plot(dataset, samples, args.plot_factors)
-    plot_marginals(plot_samples, plot_dataset, observation, output_path=args.output)
+    plot_marginals(samples, dataset, observation, output_path=args.output)
     print(f"[INFO] Wrote synthetic sensitivity report → {args.output}")
 
 

--- a/isaaclab_arena/tests/sensitivity_synthetic.py
+++ b/isaaclab_arena/tests/sensitivity_synthetic.py
@@ -158,13 +158,49 @@ def make_mixed_dataset(seed: int, num_episodes: int = 3000) -> SensitivityDatase
     )
 
 
+def _select_factors_for_plot(
+    dataset: SensitivityDataset,
+    posterior_samples: torch.Tensor,
+    factor_names: list[str] | None,
+) -> tuple[SensitivityDataset, torch.Tensor]:
+    """Return aligned dataset and posterior columns for the requested plot panels."""
+    if factor_names is None:
+        return dataset, posterior_samples
+
+    assert len(factor_names) == len(set(factor_names)), "--plot-factors must not contain duplicate names."
+    available_factor_names = [factor.name for factor in dataset.factors]
+    unknown_factor_names = [factor_name for factor_name in factor_names if factor_name not in available_factor_names]
+    assert not unknown_factor_names, (
+        f"Unknown --plot-factors: {', '.join(unknown_factor_names)}. "
+        f"Available factors: {', '.join(available_factor_names)}."
+    )
+
+    requested_factor_names = set(factor_names)
+    selected_factors = [factor for factor in dataset.factors if factor.name in requested_factor_names]
+    factor_columns = dataset.factor_columns
+    selected_theta = torch.cat([dataset.theta[:, factor_columns[factor.name]] for factor in selected_factors], dim=1)
+    selected_posterior_samples = torch.cat(
+        [posterior_samples[:, factor_columns[factor.name]] for factor in selected_factors], dim=1
+    )
+    selected_dataset = SensitivityDataset(
+        selected_factors,
+        selected_theta,
+        dataset.x,
+        outcome_names=dataset.outcome_names,
+    )
+    return selected_dataset, selected_posterior_samples
+
+
 def _demo():
     """Run the full pipeline on a synthetic dataset and save the marginals plot.
 
     Runs the pipeline end to end on generated data: simulate → fit → plot, with no eval
     data needed. Run as::
 
-        python -m isaaclab_arena.tests.sensitivity_synthetic --kind mixed --output eval/demo.png
+        python -m isaaclab_arena.tests.sensitivity_synthetic \\
+          --kind mixed \\
+          --plot-factors light_intensity object_mass camera_distance \\
+          --output eval/demo.png
     """
     parser = argparse.ArgumentParser(description="Run the sensitivity pipeline on a synthetic dataset and plot it.")
     parser.add_argument(
@@ -180,6 +216,16 @@ def _demo():
     )
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--num-episodes", type=int, default=2000)
+    parser.add_argument(
+        "--plot-factors",
+        type=str,
+        nargs="+",
+        default=None,
+        help=(
+            "Factor names to display, in dataset order. Inference still uses every factor in the selected dataset "
+            "kind. Defaults to every factor."
+        ),
+    )
     args = parser.parse_args()
 
     builder = {"mixed": make_mixed_dataset, "continuous": make_continuous_dataset}[args.kind]
@@ -188,7 +234,8 @@ def _demo():
     analyzer.fit()
     observation = dataset.default_observation()
     samples = analyzer.sample_posterior(observation)
-    plot_marginals(samples, dataset, observation, output_path=args.output)
+    plot_dataset, plot_samples = _select_factors_for_plot(dataset, samples, args.plot_factors)
+    plot_marginals(plot_samples, plot_dataset, observation, output_path=args.output)
     print(f"[INFO] Wrote synthetic sensitivity report → {args.output}")
 
 

--- a/isaaclab_arena/tests/sensitivity_synthetic.py
+++ b/isaaclab_arena/tests/sensitivity_synthetic.py
@@ -173,7 +173,7 @@ def _demo():
 
         python -m isaaclab_arena.tests.sensitivity_synthetic \\
           --kind continuous \\
-          --output eval/demo.png
+          --output eval/sensitivity_synthetic_continuous_marginals.png
     """
     parser = argparse.ArgumentParser(description="Run the sensitivity pipeline on a synthetic dataset and plot it.")
     parser.add_argument(

--- a/isaaclab_arena/tests/test_sensitivity_analysis.py
+++ b/isaaclab_arena/tests/test_sensitivity_analysis.py
@@ -29,11 +29,49 @@ from isaaclab_arena.tests.sensitivity_synthetic import (
     MATERIAL,
     OBJECT_MASS,
     OBJECT_TYPE,
+    _select_factors_for_plot,
     make_continuous_dataset,
     make_mixed_dataset,
 )
 
 _NUM_SAMPLES = 5000
+
+
+def test_plot_factor_selection_preserves_mixed_inference_dataset():
+    """Selecting display panels keeps the full mixed dataset and aligns the selected sample columns."""
+    dataset = make_mixed_dataset(seed=0, num_episodes=8)
+
+    selected_dataset, selected_samples = _select_factors_for_plot(
+        dataset,
+        dataset.theta,
+        ["light_intensity", "object_mass", "camera_distance"],
+    )
+
+    assert [factor.name for factor in dataset.factors] == [
+        "light_intensity",
+        "object_mass",
+        "camera_distance",
+        "object_type",
+        "table_material",
+    ]
+    assert dataset.has_categorical_factors
+    assert [factor.name for factor in selected_dataset.factors] == [
+        "light_intensity",
+        "object_mass",
+        "camera_distance",
+    ]
+    assert not selected_dataset.has_categorical_factors
+    assert torch.equal(selected_samples, dataset.theta[:, :3])
+
+
+def test_plot_factor_selection_rejects_invalid_names():
+    """Display-factor selection rejects duplicate and unknown names before plotting."""
+    dataset = make_mixed_dataset(seed=0, num_episodes=8)
+
+    with pytest.raises(AssertionError, match="duplicate"):
+        _select_factors_for_plot(dataset, dataset.theta, ["light_intensity", "light_intensity"])
+    with pytest.raises(AssertionError, match="Unknown.*missing_factor"):
+        _select_factors_for_plot(dataset, dataset.theta, ["missing_factor"])
 
 
 def _factor_samples(analyzer: SensitivityAnalyzer, samples: torch.Tensor, factor_name: str) -> np.ndarray:

--- a/isaaclab_arena/tests/test_sensitivity_analysis.py
+++ b/isaaclab_arena/tests/test_sensitivity_analysis.py
@@ -9,7 +9,7 @@ Each test fits a SensitivityAnalyzer on a dataset whose factor→outcome relatio
 planted by the synthetic module (brighter / lighter / closer / cube / oak raise success),
 then asserts the posterior conditioned on success recovers them. The data is built in
 memory, so these run on CPU without Isaac Sim. They cover both estimator paths: MNPE for a
-mixed schema, NPE for a continuous-only one (2-D theta).
+mixed schema, NPE for a continuous-only one (3-D theta).
 """
 
 from __future__ import annotations
@@ -24,54 +24,15 @@ from isaaclab_arena.analysis.sensitivity.analyzer import SensitivityAnalyzer
 from isaaclab_arena.analysis.sensitivity.episode_results_reader import dataset_from_episode_results
 from isaaclab_arena.tests.sensitivity_synthetic import (
     CAMERA_DISTANCE,
-    GRASP_OFFSET,
     LIGHT,
     MATERIAL,
     OBJECT_MASS,
     OBJECT_TYPE,
-    _select_factors_for_plot,
     make_continuous_dataset,
     make_mixed_dataset,
 )
 
 _NUM_SAMPLES = 5000
-
-
-def test_plot_factor_selection_preserves_mixed_inference_dataset():
-    """Selecting display panels keeps the full mixed dataset and aligns the selected sample columns."""
-    dataset = make_mixed_dataset(seed=0, num_episodes=8)
-
-    selected_dataset, selected_samples = _select_factors_for_plot(
-        dataset,
-        dataset.theta,
-        ["light_intensity", "object_mass", "camera_distance"],
-    )
-
-    assert [factor.name for factor in dataset.factors] == [
-        "light_intensity",
-        "object_mass",
-        "camera_distance",
-        "object_type",
-        "table_material",
-    ]
-    assert dataset.has_categorical_factors
-    assert [factor.name for factor in selected_dataset.factors] == [
-        "light_intensity",
-        "object_mass",
-        "camera_distance",
-    ]
-    assert not selected_dataset.has_categorical_factors
-    assert torch.equal(selected_samples, dataset.theta[:, :3])
-
-
-def test_plot_factor_selection_rejects_invalid_names():
-    """Display-factor selection rejects duplicate and unknown names before plotting."""
-    dataset = make_mixed_dataset(seed=0, num_episodes=8)
-
-    with pytest.raises(AssertionError, match="duplicate"):
-        _select_factors_for_plot(dataset, dataset.theta, ["light_intensity", "light_intensity"])
-    with pytest.raises(AssertionError, match="Unknown.*missing_factor"):
-        _select_factors_for_plot(dataset, dataset.theta, ["missing_factor"])
 
 
 def _factor_samples(analyzer: SensitivityAnalyzer, samples: torch.Tensor, factor_name: str) -> np.ndarray:
@@ -112,8 +73,8 @@ def test_mnpe_recovers_all_planted_effects():
     assert _most_likely_choice(analyzer, samples, "table_material", MATERIAL.choices) == "oak"
 
 
-def test_npe_recovers_two_continuous_effects():
-    """Two continuous factors (NPE): recover that bright light and a small grasp offset drive success."""
+def test_npe_recovers_three_continuous_effects():
+    """Three continuous factors (NPE): recover the planted light, mass, and camera effects."""
     dataset = make_continuous_dataset(seed=0)
     analyzer = SensitivityAnalyzer(dataset)
     assert analyzer._select_inference_class().__name__.startswith("NPE"), "continuous-only schema should select NPE"
@@ -122,10 +83,10 @@ def test_npe_recovers_two_continuous_effects():
     analyzer.fit()
     samples = analyzer.sample_posterior(num_samples=_NUM_SAMPLES)  # conditions on success=1 by default
 
-    # Brighter light raises success → light posterior skews high.
+    # Brighter light, a lighter object, and a closer camera raise success.
     assert _factor_samples(analyzer, samples, "light_intensity").mean() > _midpoint(LIGHT)
-    # A smaller grasp offset raises success → offset posterior skews low.
-    assert _factor_samples(analyzer, samples, "grasp_offset").mean() < _midpoint(GRASP_OFFSET)
+    assert _factor_samples(analyzer, samples, "object_mass").mean() < _midpoint(OBJECT_MASS)
+    assert _factor_samples(analyzer, samples, "camera_distance").mean() < _midpoint(CAMERA_DISTANCE)
 
 
 def _write_jsonl(path, rows: list[dict]) -> None:


### PR DESCRIPTION
## Summary
Resolve documentation and release note issues from NVBug 6658667.

## Detailed description
- Use a three-factor continuous synthetic dataset so NPE analyzes exactly the light-intensity, object-mass, and camera-distance factors shown in the report, without display-only filtering.
- Add the generated posterior plot, a descriptive output filename and `pqiv` command, and an explanation of the three planted relationships.
- State explicitly that every sensitivity-analysis input row must use the same policy, task, and embodiment.
- Keep the First Arena Environment dropdown focused on the configuration and `build()` method discussed on the page, with a link to the complete source file.
- Correct the Release Notes to distinguish the unavailable published Python package from the supported native `uv` source and Docker workflows.