### PR TITLE
Document coordinate-frame naming convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, i
 Use active target-source notation for Arena-owned poses and transforms:
 
 - `T_A_B` maps points from frame `B` into frame `A`.
+- `T_A_B = (t_A_B, q_A_B)` consists of translation `t_A_B` and rotation
+  `q_A_B`, with the rotation represented as a quaternion.
 - For example, `T_W_O` maps points from object frame `O` into world frame `W`.
 - Transform composition follows `T_C_A = T_C_B * T_B_A`.
 - Frame letters are contextual. Define each near its first use when its meaning is not obvious.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,9 +67,11 @@ Use active target-source notation for Arena-owned poses and transforms:
 - `T_A_B` maps points from frame `B` into frame `A`.
 - For example, `T_W_O` maps points from object frame `O` into world frame `W`.
 - Transform composition follows `T_C_A = T_C_B * T_B_A`.
-- Define frame letters near their first use when their meaning is not obvious.
-- Preserve external API names such as Isaac Lab's `root_pose_w`. When using these values in Arena frame
-  composition, bind them to the corresponding explicit transform name, for example
+- Frame letters are contextual. Define each near its first use when its meaning is not obvious.
+- Preserve external API names such as Isaac Lab's `root_pose_w`. Its lowercase `_w`, `_e`, and `_b` suffixes
+  denote the simulation world, local environment, and robot base frames, respectively.
+- A lowercase API suffix names only the frame in which a quantity is expressed. When both source and target
+  frames matter in Arena calculations, bind the value to an explicit transform name, for example
   `T_W_O = object.data.root_pose_w`.
 
 ### Wrapped Environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,18 @@ Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, i
 
 ## Conventions
 
+### Coordinate-frame naming
+
+Use active target-source notation for Arena-owned poses and transforms:
+
+- `T_A_B` maps points from frame `B` into frame `A`.
+- For example, `T_W_O` maps points from object frame `O` into world frame `W`.
+- Transform composition follows `T_C_A = T_C_B * T_B_A`.
+- Define frame letters near their first use when their meaning is not obvious.
+- Preserve external API names such as Isaac Lab's `root_pose_w`. When using these values in Arena frame
+  composition, bind them to the corresponding explicit transform name, for example
+  `T_W_O = object.data.root_pose_w`.
+
 ### Wrapped Environment
 
 `ArenaEnvBuilder.make_registered()` returns the gym-wrapped env (not the base env). Use `env.unwrapped` explicitly to access Isaac Lab-specific attributes (`cfg`, `device`, `step_dt`, etc.) that are not forwarded by gymnasium's `OrderEnforcing` wrapper:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ Use active target-source notation for Arena-owned poses and transforms:
 - `T_A_B` maps points from frame `B` into frame `A`.
 - For example, `T_W_O` maps points from object frame `O` into world frame `W`.
 - Transform composition follows `T_C_A = T_C_B * T_B_A`.
-- Define frame letters near their first use when their meaning is not obvious.
-- Preserve external API names such as Isaac Lab's `root_pose_w`. When using these values in Arena frame
-  composition, bind them to the corresponding explicit transform name, for example
+- Frame letters are contextual. Define each near its first use when its meaning is not obvious.
+- Preserve external API names such as Isaac Lab's `root_pose_w`. Its lowercase `_w`, `_e`, and `_b` suffixes
+  denote the simulation world, local environment, and robot base frames, respectively.
+- A lowercase API suffix names only the frame in which a quantity is expressed. When both source and target
+  frames matter in Arena calculations, bind the value to an explicit transform name, for example
   `T_W_O = object.data.root_pose_w`.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,7 @@ This document describes the rules for contributing to Isaac Lab-Arena
 
 ### Coordinate-frame naming
 
-Use active target-source notation for Arena-owned poses and transforms:
-
-- `T_A_B` maps points from frame `B` into frame `A`.
-- For example, `T_W_O` maps points from object frame `O` into world frame `W`.
-- Transform composition follows `T_C_A = T_C_B * T_B_A`.
-- Frame letters are contextual. Define each near its first use when its meaning is not obvious.
-- Preserve external API names such as Isaac Lab's `root_pose_w`. Its lowercase `_w`, `_e`, and `_b` suffixes
-  denote the simulation world, local environment, and robot base frames, respectively.
-- A lowercase API suffix names only the frame in which a quantity is expressed. When both source and target
-  frames matter in Arena calculations, bind the value to an explicit transform name, for example
-  `T_W_O = object.data.root_pose_w`.
+See [Coordinate-frame naming](AGENTS.md#coordinate-frame-naming) in `AGENTS.md`.
 
 
 #### Signing Your Work

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,19 @@
 This document describes the rules for contributing to Isaac Lab-Arena
 
 
+### Coordinate-frame naming
+
+Use active target-source notation for Arena-owned poses and transforms:
+
+- `T_A_B` maps points from frame `B` into frame `A`.
+- For example, `T_W_O` maps points from object frame `O` into world frame `W`.
+- Transform composition follows `T_C_A = T_C_B * T_B_A`.
+- Define frame letters near their first use when their meaning is not obvious.
+- Preserve external API names such as Isaac Lab's `root_pose_w`. When using these values in Arena frame
+  composition, bind them to the corresponding explicit transform name, for example
+  `T_W_O = object.data.root_pose_w`.
+
+
 #### Signing Your Work
 
 * We require that all contributors "sign-off" on their commits.

--- a/isaaclab_arena/tests/test_pose.py
+++ b/isaaclab_arena/tests/test_pose.py
@@ -47,6 +47,29 @@ def test_pose_composition():
     assert T_C_A.rotation_xyzw == (0.0, 0.0, 0.0, 1.0)
 
 
+def test_pose_composition_rotates_inner_translation():
+    """Check that the outer rotation is applied to the inner translation."""
+    square_root_of_half = math.sqrt(0.5)
+    quarter_turn_about_z_xyzw = (0.0, 0.0, square_root_of_half, square_root_of_half)
+    T_B_A = Pose(position_xyz=(1.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+    T_C_B = Pose(position_xyz=(2.0, 0.0, 0.0), rotation_xyzw=quarter_turn_about_z_xyzw)
+
+    T_C_A = T_C_B.multiply(T_B_A)
+
+    torch.testing.assert_close(
+        torch.tensor(T_C_A.position_xyz),
+        torch.tensor((2.0, 1.0, 0.0)),
+        rtol=0.0,
+        atol=1e-6,
+    )
+    torch.testing.assert_close(
+        torch.tensor(T_C_A.rotation_xyzw),
+        torch.tensor(quarter_turn_about_z_xyzw),
+        rtol=0.0,
+        atol=1e-6,
+    )
+
+
 def test_rotate_points_by_yaw_batch_matches_scalar():
     """Batch rotation with per-element yaws produces the same result as scalar rotation per row."""
     points = torch.tensor([[1.0, 2.0, 0.5], [3.0, -1.0, 1.0], [0.0, 4.0, -0.3]])

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -9,19 +9,16 @@ from dataclasses import dataclass
 
 @dataclass
 class Pose:
-    """Transform taking frame A to frame B.
+    """Pose mapping points from frame B into frame A.
 
-    T_A_B = (t_B_A, q_B_A)
-
-    p_B = p_A + t_B_A
-    q_B = q_A * q_B_A
+    ``T_A_B = (t_A_B, q_A_B)`` and ``p_A = R_A_B p_B + t_A_B``.
     """
 
     position_xyz: tuple[float, float, float] = (0.0, 0.0, 0.0)
-    """Translation vector from frame A to frame B."""
+    """Translation from frame B to frame A, expressed in frame A."""
 
     rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
-    """Quaternion from frame A to frame B. Order is (x, y, z, w)."""
+    """Quaternion mapping frame B coordinates into frame A. Order is (x, y, z, w)."""
 
     def __post_init__(self):
         assert isinstance(self.position_xyz, tuple)

--- a/isaaclab_arena/utils/pose.py
+++ b/isaaclab_arena/utils/pose.py
@@ -15,7 +15,7 @@ class Pose:
     """
 
     position_xyz: tuple[float, float, float] = (0.0, 0.0, 0.0)
-    """Translation from frame B to frame A, expressed in frame A."""
+    """Position of frame B's origin, expressed in frame A."""
 
     rotation_xyzw: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0)
     """Quaternion mapping frame B coordinates into frame A. Order is (x, y, z, w)."""


### PR DESCRIPTION
## Summary
Document target-source frame naming.

## Detailed description
- Define `T_A_B` as mapping points from frame `B` into frame `A`.
- Preserve external API names such as `root_pose_w` at the access boundary.
- Correct `Pose` documentation to match its existing composition semantics.