### PR TITLE
Add 5 more kitchen envs and droid stand xy scaling supports

### DIFF
--- a/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.gif
+++ b/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df646b118615ee51de30c0d8d3eed39e3784024e3c7e61e2cb7b3bb43ef6eafd
+size 10688567

--- a/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.gif
+++ b/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:849e7e952e26cb42af25cd22d74cfcd1ac7fc2848bd98cc278c421f074baa13d
+size 9227617

--- a/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.gif
+++ b/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e9cb89340227adc6f5e36dccd297b7559852797f99b77dda851e4d253224612
+size 8252784

--- a/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.gif
+++ b/docs/images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d12873291675c20f007b5a4a3670ea7413068fe1b5e42dcc00955159f09f4f3
+size 3336562

--- a/docs/images/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_lightwheel_kitchen_u_shaped_with_island_farmhouse2.gif
+++ b/docs/images/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_lightwheel_kitchen_u_shaped_with_island_farmhouse2.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c6731ba63de84148d8dc669b3fd3e8af6c7583761da8e9670c5c53d8485ae16
+size 16054896

--- a/docs/pages/example_workflows/example_environments.rst
+++ b/docs/pages/example_workflows/example_environments.rst
@@ -35,7 +35,7 @@ Kitchen benchmark environment graph YAMLs live under
 ``isaaclab_arena_environments/kitchen_bench/``. They define DROID manipulation
 tasks across Lightwheel RoboCasa and Replicator kitchen layouts.
 
-See :doc:`kitchen_bench_catalog` for all 21 environment specs and their Pi
+See :doc:`kitchen_bench_catalog` for all 26 environment specs and their Pi
 policy executions.
 
 Python Environment Catalog

--- a/docs/pages/example_workflows/kitchen_bench_catalog.rst
+++ b/docs/pages/example_workflows/kitchen_bench_catalog.rst
@@ -1,7 +1,7 @@
 Kitchen Benchmark Catalog
 =========================
 
-The kitchen benchmark contains 21 DROID tasks defined as environment graph
+The kitchen benchmark contains 26 DROID tasks defined as environment graph
 YAML specs under ``isaaclab_arena_environments/kitchen_bench/``. Pass a spec
 to ``policy_runner.py`` with ``--env_spec`` to run that environment.
 Each row links to the source YAML and shows a Pi policy execution recorded from
@@ -14,9 +14,25 @@ the maintained DROID external camera.
 
    * - Environment graph YAML
      - Pi policy execution
+   * - `kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.gif
+          :alt: Pi policy opening a cabinet in the U-shaped farmhouse kitchen
+          :width: 100%
+   * - `kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.gif
+          :alt: Pi policy opening the freezer in the G-shaped Scandinavian kitchen
+          :width: 100%
    * - `kitchen_bench_lightwheel_open_fridge.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge.yaml>`_
      - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_pi.gif
           :alt: Pi policy opening the refrigerator in the Lightwheel kitchen
+          :width: 100%
+   * - `kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.gif
+          :alt: Pi policy opening the refrigerator in the G-shaped Scandinavian kitchen
+          :width: 100%
+   * - `kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.gif
+          :alt: Pi policy opening the refrigerator in the U-shaped farmhouse kitchen
           :width: 100%
    * - `kitchen_bench_lightwheel_open_microwave.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_microwave.yaml>`_
      - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_open_microwave_pi.gif
@@ -25,6 +41,10 @@ the maintained DROID external camera.
    * - `kitchen_bench_lightwheel_pick_and_place.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_and_place.yaml>`_
      - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_pick_and_place_pi.gif
           :alt: Pi policy placing mustard in a bowl in the Lightwheel kitchen
+          :width: 100%
+   * - `kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml>`_
+     - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_lightwheel_kitchen_u_shaped_with_island_farmhouse2.gif
+          :alt: Pi policy picking a lemon from a shelf onto a plate in the U-shaped farmhouse kitchen
           :width: 100%
    * - `kitchen_bench_lightwheel_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml <https://github.com/isaac-sim/IsaacLab-Arena/blob/main/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2.yaml>`_
      - .. image:: ../../images/kitchen_bench/kitchen_bench_lightwheel_place_bananas_in_wooden_bowl_u_shaped_with_island_farmhouse2_pi.gif

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -37,12 +37,7 @@ from isaaclab_arena.embodiments.droid.actions import BinaryJointPositionZeroToOn
 from isaaclab_arena.embodiments.droid.observations import arm_joint_pos, ee_pos, ee_quat, gripper_pos
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import franka_stack_events
-from isaaclab_arena.embodiments.robot_on_stand_utils import (
-    RobotPrimSpec,
-    StandPrimSpec,
-    compose_on_stand_usd,
-    normalize_stand_scale_xy,
-)
+from isaaclab_arena.embodiments.robot_on_stand_utils import RobotPrimSpec, StandPrimSpec, compose_on_stand_usd
 from isaaclab_arena.relations.collision_mode import CollisionMode
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.cameras import ArenaCameraCfg
@@ -62,7 +57,7 @@ _DROID_STAND_PRIM = StandPrimSpec(
     ref_prim_path="/World/franka_table",
     payload_child_name="franka_table",
     footprint_translate_xyz=(-0.05, 0.0, 0.0),
-    footprint_scale_xy=(1.2, 1.2),
+    stand_default_footprint_xy_m=(1.08, 0.91032),
     stand_default_height=1.35,
 )
 _DROID_JOINT_NAMES = (
@@ -91,7 +86,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
     ``initial_pose`` / ``set_initial_pose`` set the base of the robot in world frame.
     ``stand_height_m`` sets the height of the stand mesh under the robot base link,
     which changes how far the stand extends below the root link.
-    ``stand_scale_xy`` scales the stand footprint in the robot-base X/Y plane.
+    ``stand_footprint_xy_m`` sets the stand footprint dimensions in the robot-base X/Y plane.
     When manually placing the robot on floor, ``set_initial_pose`` z value and
     ``stand_height_m`` should be adjusted together to keep the bottom of stand fixed.
     ``placement_bbox_stand_only`` uses the stand footprint for ``On`` / ``NextTo`` placement
@@ -109,7 +104,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
-        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
+        stand_footprint_xy_m: tuple[float, float] | list[float] = _DROID_STAND_PRIM.stand_default_footprint_xy_m,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -121,14 +116,18 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
             collision_mode=collision_mode,
         )
         self.stand_height_m = stand_height_m
-        self.stand_scale_xy = normalize_stand_scale_xy(stand_scale_xy)
+        assert len(stand_footprint_xy_m) == 2, f"stand_footprint_xy_m must have 2 values, got {stand_footprint_xy_m!r}"
+        assert all(
+            value > 0.0 for value in stand_footprint_xy_m
+        ), f"stand_footprint_xy_m must be positive, got {stand_footprint_xy_m}"
+        self.stand_footprint_xy_m = tuple(stand_footprint_xy_m)
         self.placement_bbox_stand_only = placement_bbox_stand_only
         self.scene_config = DroidSceneCfg()
         self.scene_config.robot.spawn.usd_path = compose_on_stand_usd(
             _DROID_ROBOT_PRIM,
             _DROID_STAND_PRIM,
             stand_height_m=stand_height_m,
-            stand_scale_xy=self.stand_scale_xy,
+            stand_footprint_xy_m=self.stand_footprint_xy_m,
             output_basename="droid_franka_robotiq_on_stand",
         )
         self.action_config = None
@@ -190,7 +189,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
-        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
+        stand_footprint_xy_m: tuple[float, float] | list[float] = _DROID_STAND_PRIM.stand_default_footprint_xy_m,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -201,7 +200,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
-            stand_scale_xy=stand_scale_xy,
+            stand_footprint_xy_m=stand_footprint_xy_m,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )
@@ -223,7 +222,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
-        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
+        stand_footprint_xy_m: tuple[float, float] | list[float] = _DROID_STAND_PRIM.stand_default_footprint_xy_m,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -234,7 +233,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
-            stand_scale_xy=stand_scale_xy,
+            stand_footprint_xy_m=stand_footprint_xy_m,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )
@@ -257,7 +256,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
-        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
+        stand_footprint_xy_m: tuple[float, float] | list[float] = _DROID_STAND_PRIM.stand_default_footprint_xy_m,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -268,7 +267,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
-            stand_scale_xy=stand_scale_xy,
+            stand_footprint_xy_m=stand_footprint_xy_m,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )

--- a/isaaclab_arena/embodiments/droid/droid.py
+++ b/isaaclab_arena/embodiments/droid/droid.py
@@ -37,7 +37,12 @@ from isaaclab_arena.embodiments.droid.actions import BinaryJointPositionZeroToOn
 from isaaclab_arena.embodiments.droid.observations import arm_joint_pos, ee_pos, ee_quat, gripper_pos
 from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
 from isaaclab_arena.embodiments.franka.franka import franka_stack_events
-from isaaclab_arena.embodiments.robot_on_stand_utils import RobotPrimSpec, StandPrimSpec, compose_on_stand_usd
+from isaaclab_arena.embodiments.robot_on_stand_utils import (
+    RobotPrimSpec,
+    StandPrimSpec,
+    compose_on_stand_usd,
+    normalize_stand_scale_xy,
+)
 from isaaclab_arena.relations.collision_mode import CollisionMode
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.cameras import ArenaCameraCfg
@@ -86,6 +91,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
     ``initial_pose`` / ``set_initial_pose`` set the base of the robot in world frame.
     ``stand_height_m`` sets the height of the stand mesh under the robot base link,
     which changes how far the stand extends below the root link.
+    ``stand_scale_xy`` scales the stand footprint in the robot-base X/Y plane.
     When manually placing the robot on floor, ``set_initial_pose`` z value and
     ``stand_height_m`` should be adjusted together to keep the bottom of stand fixed.
     ``placement_bbox_stand_only`` uses the stand footprint for ``On`` / ``NextTo`` placement
@@ -103,6 +109,7 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -114,12 +121,14 @@ class DroidEmbodimentBase(EmbodimentBase, ABC):
             collision_mode=collision_mode,
         )
         self.stand_height_m = stand_height_m
+        self.stand_scale_xy = normalize_stand_scale_xy(stand_scale_xy)
         self.placement_bbox_stand_only = placement_bbox_stand_only
         self.scene_config = DroidSceneCfg()
         self.scene_config.robot.spawn.usd_path = compose_on_stand_usd(
             _DROID_ROBOT_PRIM,
             _DROID_STAND_PRIM,
             stand_height_m=stand_height_m,
+            stand_scale_xy=self.stand_scale_xy,
             output_basename="droid_franka_robotiq_on_stand",
         )
         self.action_config = None
@@ -181,6 +190,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -191,6 +201,7 @@ class DroidDifferentialIKEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
+            stand_scale_xy=stand_scale_xy,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )
@@ -212,6 +223,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -222,6 +234,7 @@ class DroidRelativeJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
+            stand_scale_xy=stand_scale_xy,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )
@@ -244,6 +257,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
         concatenate_observation_terms: bool = False,
         arm_mode: ArmMode | None = None,
         stand_height_m: float = _DROID_STAND_PRIM.stand_default_height,
+        stand_scale_xy: tuple[float, float] | list[float] = _DROID_STAND_PRIM.footprint_scale_xy,
         placement_bbox_stand_only: bool = False,
         collision_mode: CollisionMode | str | None = None,
     ):
@@ -254,6 +268,7 @@ class DroidAbsoluteJointPositionEmbodiment(DroidEmbodimentBase):
             concatenate_observation_terms=concatenate_observation_terms,
             arm_mode=arm_mode,
             stand_height_m=stand_height_m,
+            stand_scale_xy=stand_scale_xy,
             placement_bbox_stand_only=placement_bbox_stand_only,
             collision_mode=collision_mode,
         )

--- a/isaaclab_arena/embodiments/franka/franka.py
+++ b/isaaclab_arena/embodiments/franka/franka.py
@@ -60,7 +60,7 @@ _FRANKA_STAND_PRIM = StandPrimSpec(
     ref_prim_path="/Stand",
     payload_child_name="Stand",
     footprint_translate_xyz=(-0.05, 0.0, 0.0),
-    footprint_scale_xy=(1.2, 1.2),
+    stand_default_footprint_xy_m=(0.3888, 0.3888),
     stand_default_height=0.8755,
 )
 _FRANKA_JOINT_NAMES = (

--- a/isaaclab_arena/embodiments/robot_on_stand_utils.py
+++ b/isaaclab_arena/embodiments/robot_on_stand_utils.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import functools
 import os
 import tempfile
 from collections.abc import Sequence

--- a/isaaclab_arena/embodiments/robot_on_stand_utils.py
+++ b/isaaclab_arena/embodiments/robot_on_stand_utils.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import functools
 import os
 import tempfile
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -56,13 +57,21 @@ class StandPrimSpec:
     stand_default_height: float
 
 
-@functools.cache
+def normalize_stand_scale_xy(stand_scale_xy: Sequence[float]) -> tuple[float, float]:
+    """Return a positive ``(x, y)`` stand footprint scale."""
+    assert len(stand_scale_xy) == 2, f"stand_scale_xy must have 2 values, got {stand_scale_xy!r}"
+    sx, sy = float(stand_scale_xy[0]), float(stand_scale_xy[1])
+    assert sx > 0.0 and sy > 0.0, f"stand_scale_xy must be positive, got {(sx, sy)}"
+    return (sx, sy)
+
+
 def compose_on_stand_usd(
     robot: RobotPrimSpec,
     stand: StandPrimSpec,
     *,
     stand_height_m: float,
     output_basename: str,
+    stand_scale_xy: Sequence[float] | None = None,
 ) -> str:
     """Build a robot+stand USD with stand under the robot base link.
 
@@ -74,15 +83,27 @@ def compose_on_stand_usd(
         stand: Stand reference and footprint parameters.
         stand_height_m: Target absolute stand height after align.
         output_basename: Stable basename for the composed USD (embodiment-specific).
+        stand_scale_xy: Footprint ``(x, y)`` scale. ``None`` uses ``stand.footprint_scale_xy``.
 
     Returns:
         Local path to the composed on-stand USD.
     """
     assert stand_height_m > 0.0, f"stand_height_m must be positive, got {stand_height_m}"
+    scale_xy = normalize_stand_scale_xy(stand_scale_xy if stand_scale_xy is not None else stand.footprint_scale_xy)
+    return _compose_on_stand_usd_cached(robot, stand, stand_height_m, output_basename, scale_xy)
 
+
+def _compose_on_stand_usd_cached(
+    robot: RobotPrimSpec,
+    stand: StandPrimSpec,
+    stand_height_m: float,
+    output_basename: str,
+    stand_scale_xy: tuple[float, float],
+) -> str:
     cache_root = get_arena_asset_cache_dir().parent / "usd" / _ROBOT_ON_STAND_USD_CACHE_DIR
     cache_root.mkdir(parents=True, exist_ok=True)
-    out_path = cache_root / f"{output_basename}_{stand_height_m:.3f}.usd"
+    sx, sy = stand_scale_xy
+    out_path = cache_root / f"{output_basename}_{stand_height_m:.3f}_{sx:.3f}x{sy:.3f}.usd"
 
     with tempfile.NamedTemporaryFile(suffix=".usd", dir=cache_root, delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)
@@ -94,7 +115,7 @@ def compose_on_stand_usd(
         root.GetReferences().AddReference(robot_resolved, robot.root_prim_path)
         stage.SetDefaultPrim(root)
 
-        _mount_stand_normalized(stage, robot, stand, stand_height_m)
+        _mount_stand_normalized(stage, robot, stand, stand_height_m, stand_scale_xy)
         assert stage.GetRootLayer().Save(), f"failed to save composed on-stand USD to {tmp_path}"
         os.replace(tmp_path, out_path)
     except Exception:
@@ -109,6 +130,7 @@ def _mount_stand_normalized(
     robot: RobotPrimSpec,
     stand: StandPrimSpec,
     stand_height_m: float,
+    stand_scale_xy: tuple[float, float],
 ) -> None:
     """Parent a stand payload under the robot base link, scale, and align to the robot base.
 
@@ -116,7 +138,7 @@ def _mount_stand_normalized(
 
         /panda/panda_link0/stand_instanceable     # outer mount
           translate: (footprint_xy, align_z)
-          scale:    (footprint_xy, stand_height_m / native_height)
+          scale:    (stand_scale_xy, stand_height_m / native_height)
           /<payload_child_name>/                   # inner payload
             reference: stand USD @ ref_prim_path
 
@@ -125,6 +147,7 @@ def _mount_stand_normalized(
         robot: Robot prim layout under the composed default prim.
         stand: Stand reference and footprint parameters.
         stand_height_m: Target stand height after align.
+        stand_scale_xy: Footprint ``(x, y)`` scale applied on the outer mount.
     """
     # Robot-only stage: bottom of the base link is the align target (before stand exists).
     robot_base = stage.GetPrimAtPath(robot.robot_base_prim_path)
@@ -136,7 +159,7 @@ def _mount_stand_normalized(
 
     stand_resolved = retrieve_file_path(stand.stand_usd_path)
     tx, ty, tz = stand.footprint_translate_xyz
-    sx, sy = stand.footprint_scale_xy
+    sx, sy = stand_scale_xy
     stand_prim_path = robot.stand_prim_path
 
     # Outer mount under link0; Z scale stays at 1 until native height is measured.

--- a/isaaclab_arena/embodiments/robot_on_stand_utils.py
+++ b/isaaclab_arena/embodiments/robot_on_stand_utils.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import functools
-import hashlib
 import os
 import tempfile
 from dataclasses import dataclass
@@ -107,9 +106,8 @@ def _compose_on_stand_usd_cached(
 ) -> str:
     cache_root = get_arena_asset_cache_dir().parent / "usd" / _ROBOT_ON_STAND_USD_CACHE_DIR
     cache_root.mkdir(parents=True, exist_ok=True)
-    cache_args = (robot, stand, stand_height_m, stand_footprint_xy_m)
-    cache_digest = hashlib.sha256(repr(cache_args).encode()).hexdigest()
-    out_path = cache_root / f"{output_basename}_{cache_digest}.usd"
+    footprint_x_m, footprint_y_m = stand_footprint_xy_m
+    out_path = cache_root / f"{output_basename}_{stand_height_m}_{footprint_x_m}x{footprint_y_m}.usd"
 
     with tempfile.NamedTemporaryFile(suffix=".usd", dir=cache_root, delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)

--- a/isaaclab_arena/embodiments/robot_on_stand_utils.py
+++ b/isaaclab_arena/embodiments/robot_on_stand_utils.py
@@ -7,9 +7,10 @@
 
 from __future__ import annotations
 
+import functools
+import hashlib
 import os
 import tempfile
-from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from isaaclab_arena.assets.asset_cache import get_arena_asset_cache_dir
 _ROBOT_ON_STAND_USD_CACHE_DIR = "robot_on_stand"
 
 _HEIGHT_ATOL = 1e-3
+_FOOTPRINT_ATOL = 1e-3
 _ALIGN_ATOL = 5e-2
 
 
@@ -52,16 +54,8 @@ class StandPrimSpec:
     ref_prim_path: str
     payload_child_name: str
     footprint_translate_xyz: tuple[float, float, float]
-    footprint_scale_xy: tuple[float, float]
+    stand_default_footprint_xy_m: tuple[float, float]
     stand_default_height: float
-
-
-def normalize_stand_scale_xy(stand_scale_xy: Sequence[float]) -> tuple[float, float]:
-    """Return a positive ``(x, y)`` stand footprint scale."""
-    assert len(stand_scale_xy) == 2, f"stand_scale_xy must have 2 values, got {stand_scale_xy!r}"
-    sx, sy = float(stand_scale_xy[0]), float(stand_scale_xy[1])
-    assert sx > 0.0 and sy > 0.0, f"stand_scale_xy must be positive, got {(sx, sy)}"
-    return (sx, sy)
 
 
 def compose_on_stand_usd(
@@ -70,7 +64,7 @@ def compose_on_stand_usd(
     *,
     stand_height_m: float,
     output_basename: str,
-    stand_scale_xy: Sequence[float] | None = None,
+    stand_footprint_xy_m: tuple[float, float] | None = None,
 ) -> str:
     """Build a robot+stand USD with stand under the robot base link.
 
@@ -82,27 +76,40 @@ def compose_on_stand_usd(
         stand: Stand reference and footprint parameters.
         stand_height_m: Target absolute stand height after align.
         output_basename: Stable basename for the composed USD (embodiment-specific).
-        stand_scale_xy: Footprint ``(x, y)`` scale. ``None`` uses ``stand.footprint_scale_xy``.
+        stand_footprint_xy_m: Target footprint ``(x, y)`` dimensions in meters. ``None`` uses the default.
 
     Returns:
         Local path to the composed on-stand USD.
     """
     assert stand_height_m > 0.0, f"stand_height_m must be positive, got {stand_height_m}"
-    scale_xy = normalize_stand_scale_xy(stand_scale_xy if stand_scale_xy is not None else stand.footprint_scale_xy)
-    return _compose_on_stand_usd_cached(robot, stand, stand_height_m, output_basename, scale_xy)
+    if stand_footprint_xy_m is None:
+        stand_footprint_xy_m = stand.stand_default_footprint_xy_m
+    assert len(stand_footprint_xy_m) == 2, f"stand_footprint_xy_m must have 2 values, got {stand_footprint_xy_m!r}"
+    assert all(
+        value > 0.0 for value in stand_footprint_xy_m
+    ), f"stand_footprint_xy_m must be positive, got {stand_footprint_xy_m}"
+    return _compose_on_stand_usd_cached(
+        robot,
+        stand,
+        stand_height_m,
+        output_basename,
+        stand_footprint_xy_m,
+    )
 
 
+@functools.cache
 def _compose_on_stand_usd_cached(
     robot: RobotPrimSpec,
     stand: StandPrimSpec,
     stand_height_m: float,
     output_basename: str,
-    stand_scale_xy: tuple[float, float],
+    stand_footprint_xy_m: tuple[float, float],
 ) -> str:
     cache_root = get_arena_asset_cache_dir().parent / "usd" / _ROBOT_ON_STAND_USD_CACHE_DIR
     cache_root.mkdir(parents=True, exist_ok=True)
-    sx, sy = stand_scale_xy
-    out_path = cache_root / f"{output_basename}_{stand_height_m:.3f}_{sx:.3f}x{sy:.3f}.usd"
+    cache_args = (robot, stand, stand_height_m, stand_footprint_xy_m)
+    cache_digest = hashlib.sha256(repr(cache_args).encode()).hexdigest()
+    out_path = cache_root / f"{output_basename}_{cache_digest}.usd"
 
     with tempfile.NamedTemporaryFile(suffix=".usd", dir=cache_root, delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)
@@ -114,7 +121,7 @@ def _compose_on_stand_usd_cached(
         root.GetReferences().AddReference(robot_resolved, robot.root_prim_path)
         stage.SetDefaultPrim(root)
 
-        _mount_stand_normalized(stage, robot, stand, stand_height_m, stand_scale_xy)
+        _add_stand(stage, robot, stand, stand_height_m, stand_footprint_xy_m)
         assert stage.GetRootLayer().Save(), f"failed to save composed on-stand USD to {tmp_path}"
         os.replace(tmp_path, out_path)
     except Exception:
@@ -124,20 +131,20 @@ def _compose_on_stand_usd_cached(
     return str(out_path)
 
 
-def _mount_stand_normalized(
+def _add_stand(
     stage: Usd.Stage,
     robot: RobotPrimSpec,
     stand: StandPrimSpec,
     stand_height_m: float,
-    stand_scale_xy: tuple[float, float],
+    stand_footprint_xy_m: tuple[float, float],
 ) -> None:
-    """Parent a stand payload under the robot base link, scale, and align to the robot base.
+    """Add a stand under the robot base link with the requested size and alignment.
 
     Composed USD hierarchy::
 
         /panda/panda_link0/stand_instanceable     # outer mount
           translate: (footprint_xy, align_z)
-          scale:    (stand_scale_xy, stand_height_m / native_height)
+          scale:    (stand_footprint_xy_m / native_footprint_xy_m, stand_height_m / native_height)
           /<payload_child_name>/                   # inner payload
             reference: stand USD @ ref_prim_path
 
@@ -146,7 +153,7 @@ def _mount_stand_normalized(
         robot: Robot prim layout under the composed default prim.
         stand: Stand reference and footprint parameters.
         stand_height_m: Target stand height after align.
-        stand_scale_xy: Footprint ``(x, y)`` scale applied on the outer mount.
+        stand_footprint_xy_m: Target footprint ``(x, y)`` dimensions in meters.
     """
     # Robot-only stage: bottom of the base link is the align target (before stand exists).
     robot_base = stage.GetPrimAtPath(robot.robot_base_prim_path)
@@ -158,15 +165,15 @@ def _mount_stand_normalized(
 
     stand_resolved = retrieve_file_path(stand.stand_usd_path)
     tx, ty, tz = stand.footprint_translate_xyz
-    sx, sy = stand_scale_xy
+    footprint_x_m, footprint_y_m = stand_footprint_xy_m
     stand_prim_path = robot.stand_prim_path
 
-    # Outer mount under link0; Z scale stays at 1 until native height is measured.
+    # Outer mount under link0 stays at unit scale until the source stand dimensions are measured.
     stand_xf = UsdGeom.Xform.Define(stage, stand_prim_path)
     translate_op = stand_xf.AddTranslateOp()
     translate_op.Set(Gf.Vec3d(tx, ty, tz))
     scale_op = stand_xf.AddScaleOp()
-    scale_op.Set(Gf.Vec3d(sx, sy, 1.0))
+    scale_op.Set(Gf.Vec3d(1.0, 1.0, 1.0))
 
     payload_prim = stage.DefinePrim(f"{stand_prim_path}/{stand.payload_child_name}")
     payload_prim.GetReferences().AddReference(stand_resolved, stand.ref_prim_path)
@@ -174,12 +181,14 @@ def _mount_stand_normalized(
     stand_prim = stand_xf.GetPrim()
     bbox_cache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_])
 
-    # Native height at footprint XY scale; then scale Z to the requested stand height.
+    # Scale the source stand to the requested physical dimensions.
     stand_range = bbox_cache.ComputeWorldBound(stand_prim).ComputeAlignedRange()
     assert not stand_range.IsEmpty(), f"empty stand bounds at {stand_prim.GetPath()}"
-    native_height = float(stand_range.GetSize()[2])
+    native_size = stand_range.GetSize()
+    native_x_m, native_y_m, native_height = (float(value) for value in native_size)
+    assert native_x_m > 0.0 and native_y_m > 0.0, f"non-positive stand footprint at {stand_prim.GetPath()}"
     assert native_height > 0.0, f"non-positive stand height at {stand_prim.GetPath()}"
-    scale_op.Set(Gf.Vec3d(sx, sy, stand_height_m / native_height))
+    scale_op.Set(Gf.Vec3d(footprint_x_m / native_x_m, footprint_y_m / native_y_m, stand_height_m / native_height))
 
     # Raise/lower outer translate so stand top meets robot_min_z.
     translate_op.Set(Gf.Vec3d(tx, ty, robot_min_z))
@@ -187,7 +196,10 @@ def _mount_stand_normalized(
     # Verify stand/robot alignment and stand height on a fresh BBoxCache.
     verify_cache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_])
     stand_range = verify_cache.ComputeWorldBound(stand_prim).ComputeAlignedRange()
-    stand_height = float(stand_range.GetSize()[2])
+    stand_size = stand_range.GetSize()
+    stand_x_m, stand_y_m, stand_height = (float(value) for value in stand_size)
     stand_max_z = float(stand_range.GetMax()[2])
+    assert abs(stand_x_m - footprint_x_m) < _FOOTPRINT_ATOL, stand_x_m
+    assert abs(stand_y_m - footprint_y_m) < _FOOTPRINT_ATOL, stand_y_m
     assert abs(stand_height - stand_height_m) < _HEIGHT_ATOL, stand_height
     assert abs(stand_max_z - robot_min_z) < _ALIGN_ATOL, (stand_max_z, robot_min_z)

--- a/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
+++ b/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
@@ -33,6 +33,7 @@ def _test_kitchen_bench_yaml_env_bringup(simulation_app, *, yaml_path: Path) -> 
         env.reset()
 
         assert env.unwrapped.cfg is not None
+        assert spec.env_name == yaml_path.stem
         assert arena_env.name == spec.env_name
         assert "robot" in env.unwrapped.scene.keys(), f"robot missing from scene for {yaml_path.name}"
     except Exception as exc:

--- a/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
+++ b/isaaclab_arena/tests/test_kitchen_bench_yaml_env.py
@@ -33,7 +33,6 @@ def _test_kitchen_bench_yaml_env_bringup(simulation_app, *, yaml_path: Path) -> 
         env.reset()
 
         assert env.unwrapped.cfg is not None
-        assert spec.env_name == yaml_path.stem
         assert arena_env.name == spec.env_name
         assert "robot" in env.unwrapped.scene.keys(), f"robot missing from scene for {yaml_path.name}"
     except Exception as exc:

--- a/isaaclab_arena/tests/test_robot_on_stand_utils.py
+++ b/isaaclab_arena/tests/test_robot_on_stand_utils.py
@@ -21,7 +21,7 @@ _ROOT_WRITE_ATOL = 5e-3
 # Root-pose X delta used to verify ``write_root_pose_to_sim``
 _ROOT_WRITE_DELTA_X = 1.0
 _CUSTOM_DROID_STAND_HEIGHT_M = 2.0
-_CUSTOM_DROID_STAND_SCALE_XY = (2.0, 1.5)
+_CUSTOM_DROID_STAND_FOOTPRINT_XY_M = (0.45, 0.65)
 _XY_ATOL = 1e-2
 
 
@@ -31,7 +31,7 @@ def _assert_compose_on_stand_usd(
     *,
     stand_height_m: float,
     output_basename: str,
-    stand_scale_xy: tuple[float, float] | None = None,
+    stand_footprint_xy_m: tuple[float, float] | None = None,
     check_orient_180z: bool = False,
 ) -> str:
     from pxr import Usd, UsdGeom
@@ -42,7 +42,7 @@ def _assert_compose_on_stand_usd(
         robot_spec,
         stand_spec,
         stand_height_m=stand_height_m,
-        stand_scale_xy=stand_scale_xy,
+        stand_footprint_xy_m=stand_footprint_xy_m,
         output_basename=output_basename,
     )
     assert Path(usd_path).is_file()
@@ -138,6 +138,7 @@ def _test_droid_on_stand_usd_compose(simulation_app) -> bool:
         _DROID_STAND_PRIM,
         DroidAbsoluteJointPositionEmbodiment,
     )
+    from isaaclab_arena.embodiments.robot_on_stand_utils import _compose_on_stand_usd_cached, compose_on_stand_usd
 
     try:
         default_usd = _assert_compose_on_stand_usd(
@@ -163,30 +164,55 @@ def _test_droid_on_stand_usd_compose(simulation_app) -> bool:
             < _HEIGHT_ATOL
         )
 
-        scaled_usd = _assert_compose_on_stand_usd(
+        custom_footprint_usd = _assert_compose_on_stand_usd(
             _DROID_ROBOT_PRIM,
             _DROID_STAND_PRIM,
             stand_height_m=_DROID_STAND_PRIM.stand_default_height,
-            stand_scale_xy=_CUSTOM_DROID_STAND_SCALE_XY,
+            stand_footprint_xy_m=_CUSTOM_DROID_STAND_FOOTPRINT_XY_M,
             output_basename="droid_franka_robotiq_on_stand",
         )
-        assert scaled_usd != default_usd
+        assert custom_footprint_usd != default_usd
         default_xy = _stand_world_xy_m(Usd.Stage.Open(default_usd), _DROID_ROBOT_PRIM.stand_prim_path)
-        scaled_xy = _stand_world_xy_m(Usd.Stage.Open(scaled_usd), _DROID_ROBOT_PRIM.stand_prim_path)
-        default_sx, default_sy = _DROID_STAND_PRIM.footprint_scale_xy
-        custom_sx, custom_sy = _CUSTOM_DROID_STAND_SCALE_XY
-        assert abs(scaled_xy[0] / default_xy[0] - custom_sx / default_sx) < _XY_ATOL
-        assert abs(scaled_xy[1] / default_xy[1] - custom_sy / default_sy) < _XY_ATOL
-        scaled_height = _stand_world_height_m(Usd.Stage.Open(scaled_usd), _DROID_ROBOT_PRIM.stand_prim_path)
-        assert abs(scaled_height - _DROID_STAND_PRIM.stand_default_height) < _HEIGHT_ATOL
+        custom_xy = _stand_world_xy_m(Usd.Stage.Open(custom_footprint_usd), _DROID_ROBOT_PRIM.stand_prim_path)
+        for actual, expected in zip(default_xy, _DROID_STAND_PRIM.stand_default_footprint_xy_m):
+            assert abs(actual - expected) < _XY_ATOL
+        for actual, expected in zip(custom_xy, _CUSTOM_DROID_STAND_FOOTPRINT_XY_M):
+            assert abs(actual - expected) < _XY_ATOL
+        custom_footprint_height = _stand_world_height_m(
+            Usd.Stage.Open(custom_footprint_usd), _DROID_ROBOT_PRIM.stand_prim_path
+        )
+        assert abs(custom_footprint_height - _DROID_STAND_PRIM.stand_default_height) < _HEIGHT_ATOL
+
+        nearby_footprint_usd = _assert_compose_on_stand_usd(
+            _DROID_ROBOT_PRIM,
+            _DROID_STAND_PRIM,
+            stand_height_m=_DROID_STAND_PRIM.stand_default_height,
+            stand_footprint_xy_m=(_CUSTOM_DROID_STAND_FOOTPRINT_XY_M[0] + 1e-4, 0.65),
+            output_basename="droid_franka_robotiq_on_stand",
+        )
+        assert nearby_footprint_usd != custom_footprint_usd
+
+        cache_hits = _compose_on_stand_usd_cached.cache_info().hits
+        assert (
+            compose_on_stand_usd(
+                _DROID_ROBOT_PRIM,
+                _DROID_STAND_PRIM,
+                stand_height_m=_DROID_STAND_PRIM.stand_default_height,
+                output_basename="droid_franka_robotiq_on_stand",
+            )
+            == default_usd
+        )
+        assert _compose_on_stand_usd_cached.cache_info().hits == cache_hits + 1
 
         default_emb = DroidAbsoluteJointPositionEmbodiment()
         custom_emb = DroidAbsoluteJointPositionEmbodiment(stand_height_m=_CUSTOM_DROID_STAND_HEIGHT_M)
-        scaled_emb = DroidAbsoluteJointPositionEmbodiment(stand_scale_xy=_CUSTOM_DROID_STAND_SCALE_XY)
+        custom_footprint_emb = DroidAbsoluteJointPositionEmbodiment(
+            stand_footprint_xy_m=_CUSTOM_DROID_STAND_FOOTPRINT_XY_M
+        )
         assert not hasattr(default_emb.scene_config, "stand")
         assert custom_emb.scene_config.robot.spawn.usd_path != default_emb.scene_config.robot.spawn.usd_path
-        assert scaled_emb.scene_config.robot.spawn.usd_path != default_emb.scene_config.robot.spawn.usd_path
-        assert scaled_emb.stand_scale_xy == _CUSTOM_DROID_STAND_SCALE_XY
+        assert custom_footprint_emb.scene_config.robot.spawn.usd_path != default_emb.scene_config.robot.spawn.usd_path
+        assert custom_footprint_emb.stand_footprint_xy_m == _CUSTOM_DROID_STAND_FOOTPRINT_XY_M
         assert abs(custom_emb.scene_config.robot.init_state.pos[2]) < 1e-6
     except Exception as e:
         print(f"Error: {e}")

--- a/isaaclab_arena/tests/test_robot_on_stand_utils.py
+++ b/isaaclab_arena/tests/test_robot_on_stand_utils.py
@@ -21,6 +21,8 @@ _ROOT_WRITE_ATOL = 5e-3
 # Root-pose X delta used to verify ``write_root_pose_to_sim``
 _ROOT_WRITE_DELTA_X = 1.0
 _CUSTOM_DROID_STAND_HEIGHT_M = 2.0
+_CUSTOM_DROID_STAND_SCALE_XY = (2.0, 1.5)
+_XY_ATOL = 1e-2
 
 
 def _assert_compose_on_stand_usd(
@@ -29,6 +31,7 @@ def _assert_compose_on_stand_usd(
     *,
     stand_height_m: float,
     output_basename: str,
+    stand_scale_xy: tuple[float, float] | None = None,
     check_orient_180z: bool = False,
 ) -> str:
     from pxr import Usd, UsdGeom
@@ -39,6 +42,7 @@ def _assert_compose_on_stand_usd(
         robot_spec,
         stand_spec,
         stand_height_m=stand_height_m,
+        stand_scale_xy=stand_scale_xy,
         output_basename=output_basename,
     )
     assert Path(usd_path).is_file()
@@ -58,6 +62,16 @@ def _assert_compose_on_stand_usd(
         mesh_xf = UsdGeom.Xformable(payload).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
         assert mesh_xf[0][0] < 0.0 and mesh_xf[1][1] < 0.0, mesh_xf
     return usd_path
+
+
+def _stand_world_xy_m(stage, stand_prim_path: str) -> tuple[float, float]:
+    from pxr import Usd, UsdGeom
+
+    stand = stage.GetPrimAtPath(stand_prim_path)
+    assert stand.IsValid(), f"missing stand prim at {stand_prim_path!r}"
+    cache = UsdGeom.BBoxCache(Usd.TimeCode.Default(), [UsdGeom.Tokens.default_])
+    size = cache.ComputeWorldBound(stand).ComputeAlignedRange().GetSize()
+    return float(size[0]), float(size[1])
 
 
 def _stand_world_height_m(stage, stand_prim_path: str) -> float:
@@ -116,7 +130,7 @@ def _assert_root_write_moves_link0(env) -> None:
 
 
 def _test_droid_on_stand_usd_compose(simulation_app) -> bool:
-    """Droid compose: height, align, orient, distinct paths per height, embodiment wiring."""
+    """Droid compose: height, footprint XY, align, orient, distinct paths, embodiment wiring."""
     from pxr import Usd
 
     from isaaclab_arena.embodiments.droid.droid import (
@@ -149,10 +163,30 @@ def _test_droid_on_stand_usd_compose(simulation_app) -> bool:
             < _HEIGHT_ATOL
         )
 
+        scaled_usd = _assert_compose_on_stand_usd(
+            _DROID_ROBOT_PRIM,
+            _DROID_STAND_PRIM,
+            stand_height_m=_DROID_STAND_PRIM.stand_default_height,
+            stand_scale_xy=_CUSTOM_DROID_STAND_SCALE_XY,
+            output_basename="droid_franka_robotiq_on_stand",
+        )
+        assert scaled_usd != default_usd
+        default_xy = _stand_world_xy_m(Usd.Stage.Open(default_usd), _DROID_ROBOT_PRIM.stand_prim_path)
+        scaled_xy = _stand_world_xy_m(Usd.Stage.Open(scaled_usd), _DROID_ROBOT_PRIM.stand_prim_path)
+        default_sx, default_sy = _DROID_STAND_PRIM.footprint_scale_xy
+        custom_sx, custom_sy = _CUSTOM_DROID_STAND_SCALE_XY
+        assert abs(scaled_xy[0] / default_xy[0] - custom_sx / default_sx) < _XY_ATOL
+        assert abs(scaled_xy[1] / default_xy[1] - custom_sy / default_sy) < _XY_ATOL
+        scaled_height = _stand_world_height_m(Usd.Stage.Open(scaled_usd), _DROID_ROBOT_PRIM.stand_prim_path)
+        assert abs(scaled_height - _DROID_STAND_PRIM.stand_default_height) < _HEIGHT_ATOL
+
         default_emb = DroidAbsoluteJointPositionEmbodiment()
         custom_emb = DroidAbsoluteJointPositionEmbodiment(stand_height_m=_CUSTOM_DROID_STAND_HEIGHT_M)
+        scaled_emb = DroidAbsoluteJointPositionEmbodiment(stand_scale_xy=_CUSTOM_DROID_STAND_SCALE_XY)
         assert not hasattr(default_emb.scene_config, "stand")
         assert custom_emb.scene_config.robot.spawn.usd_path != default_emb.scene_config.robot.spawn.usd_path
+        assert scaled_emb.scene_config.robot.spawn.usd_path != default_emb.scene_config.robot.spawn.usd_path
+        assert scaled_emb.stand_scale_xy == _CUSTOM_DROID_STAND_SCALE_XY
         assert abs(custom_emb.scene_config.robot.init_state.pos[2]) < 1e-6
     except Exception as e:
         print(f"Error: {e}")

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 1.3
+    stand_scale_xy: [0.6, 1.2]
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: cabinet
+  parent_id: kitchen
+  prim_path: cab_main_main_group
+  object_type: articulation
+  params:
+    openable_joint_name: left_door_joint
+- id: shelf
+  parent_id: kitchen
+  prim_path: shelves_main_group/corpus/board_0
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry_right
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: cabinet
+  params: {}
+- kind: is_anchor
+  subject: shelf
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+    distance_m: 0.3
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+task:
+  composition: atomic
+  description: Open the cabinet door next to the shelf.
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: cabinet
+      openness_threshold: 0.2
+      reset_openness: 0.0

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_cabinet_u_shaped_with_island_farmhouse2.yaml
@@ -9,7 +9,7 @@ embodiment:
   registry_name: droid_abs_joint_pos
   params:
     stand_height_m: 1.3
-    stand_scale_xy: [0.6, 1.2]
+    stand_footprint_xy_m: [0.54, 0.91032]
     placement_bbox_stand_only: true
     collision_mode: mesh
 background:
@@ -75,5 +75,7 @@ task:
   - kind: OpenDoorTask
     params:
       openable_object: cabinet
+      # NOTE: Pi currently has 0% success despite moving the joint about 0.25;
+      # keep this threshold as the intended hard-benchmark target.
       openness_threshold: 0.2
       reset_openness: 0.0

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
@@ -53,7 +53,7 @@ relations:
     yaw_rad: 0.0
 task:
   composition: atomic
-  description: Open the freezer door.
+  description: Open the freezer right door.
   subtasks:
   - kind: OpenDoorTask
     params:

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_g_shaped_large_scandinavian
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: fridge
+  parent_id: kitchen
+  prim_path: fridge_right_group
+  object_type: articulation
+  params:
+    openable_joint_name: freezer_door_joint
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: fridge
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: fridge
+  params:
+    side: negative_x
+    distance_m: 0.6
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 0.0
+task:
+  composition: atomic
+  description: Open the fridge right door to 0.4 openness.
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: fridge
+      openness_threshold: 0.4
+      reset_openness: 0.0

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_freezer_g_shaped_large_scandinavian.yaml
@@ -53,7 +53,7 @@ relations:
     yaw_rad: 0.0
 task:
   composition: atomic
-  description: Open the fridge right door to 0.4 openness.
+  description: Open the freezer door.
   subtasks:
   - kind: OpenDoorTask
     params:

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
@@ -53,7 +53,7 @@ relations:
     yaw_rad: 0.0
 task:
   composition: atomic
-  description: Open the fridge left door to 0.4 openness.
+  description: Open the fridge door.
   subtasks:
   - kind: OpenDoorTask
     params:

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
@@ -53,7 +53,7 @@ relations:
     yaw_rad: 0.0
 task:
   composition: atomic
-  description: Open the fridge door.
+  description: Open the fridge left door.
   subtasks:
   - kind: OpenDoorTask
     params:

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian.yaml
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: kitchen_bench_lightwheel_open_fridge_g_shaped_large_scandinavian
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_g_shaped_large_scandinavian
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: fridge
+  parent_id: kitchen
+  prim_path: fridge_right_group
+  object_type: articulation
+  params:
+    openable_joint_name: fridge_door_joint
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: fridge
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: fridge
+  params:
+    side: negative_x
+    distance_m: 0.6
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 0.0
+task:
+  composition: atomic
+  description: Open the fridge left door to 0.4 openness.
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: fridge
+      openness_threshold: 0.4
+      reset_openness: 0.0

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
@@ -1,3 +1,8 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 env_name: kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2
 embodiment:
   id: droid

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
@@ -1,0 +1,54 @@
+env_name: kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    stand_scale_xy: [0.3, 1.2]
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects: []
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: fridge
+  parent_id: kitchen
+  prim_path: fridge_right_group
+  object_type: articulation
+  params:
+    openable_joint_name: fridge_door_joint
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: fridge
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: fridge
+  params:
+    side: negative_x
+    distance_m: 0.5
+    # cross_position_ratio: 0.5
+task:
+  composition: atomic
+  description: Open the fridge door to an openness threshold of 0.2.
+  subtasks:
+  - kind: OpenDoorTask
+    params:
+      openable_object: fridge
+      openness_threshold: 0.2

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_open_fridge_u_shaped_with_island_farmhouse2.yaml
@@ -9,7 +9,7 @@ embodiment:
   registry_name: droid_abs_joint_pos
   params:
     stand_height_m: 0.8
-    stand_scale_xy: [0.3, 1.2]
+    stand_footprint_xy_m: [0.27, 0.91032]
     placement_bbox_stand_only: true
     collision_mode: mesh
 background:
@@ -48,10 +48,9 @@ relations:
   params:
     side: negative_x
     distance_m: 0.5
-    # cross_position_ratio: 0.5
 task:
   composition: atomic
-  description: Open the fridge door to an openness threshold of 0.2.
+  description: Open the fridge door.
   subtasks:
   - kind: OpenDoorTask
     params:

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: droid_place_fruit_in_plate
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 1.2
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_u_shaped_with_island_farmhouse2
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects:
+- id: bowl
+  registry_name: bowl_ycb_robolab
+  params: {}
+- id: lemon
+  registry_name: lemon_01_fruits_veggies_robolab
+  params: {}
+- id: orange
+  registry_name: orange_01_fruits_veggies_robolab
+  params: {}
+- id: apple
+  registry_name: apple_01_objaverse_robolab
+  params: {}
+- id: plate
+  registry_name: plate_large_vomp_robolab
+  params: {}
+object_references:
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+- id: counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry_right
+  object_type: base
+  params: {}
+- id: shelf
+  parent_id: kitchen
+  prim_path: shelves_main_group/corpus/board_0
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: is_anchor
+  subject: shelf
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+    distance_m: 0.3
+    cross_position_ratio: -0.4
+- kind: 'on'
+  subject: plate
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: lemon
+  reference: shelf
+  params: {}
+- kind: 'on'
+  subject: bowl
+  reference: shelf
+  params: {}
+- kind: next_to
+  subject: lemon
+  reference: bowl
+  params:
+    side: negative_y
+    distance_m: 0.05
+- kind: 'on'
+  subject: orange
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: apple
+  reference: counter_top
+  params: {}
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+task:
+  composition: atomic
+  description: Pick up the fruit from the shelf and place it into the plate.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lemon
+      destination_location: plate
+      background_scene: kitchen
+      destination_object: plate

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-env_name: droid_place_fruit_in_plate
+env_name: kitchen_bench_lightwheel_pick_lemon_shelf_on_plate_u_shaped_with_island_farmhouse2
 embodiment:
   id: droid
   registry_name: droid_abs_joint_pos


### PR DESCRIPTION
## Summary
Short description of the change (max 50 chars)

## Detailed description
- Added stand xy scaling into droid params, allowing fitting kitchens with narrower stand footprint
- Added LW kitchen envs: 1x multi-level PnP, 1 open-cabinet(hard), 2x fridge (left door) opening, 1x freezer(right door) opening.
- Tested with PI, only cabinet env has 0 SR but small joint (0.25) movement 

