### PR TITLE
Clarify guidance for named constants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Lint and format tooling (`pre-commit` and the hooks it runs — black, flake8, i
 
 ## Coding style
 
+- Inline clear, single-use values. Keep named constants when reused, configurable, or when the name adds important domain meaning.
 - Prefer `assert condition, "message"` over `if not condition: raise ValueError("message")` for internal invariant checks. (Formatting, imports, and typing are enforced by `pre-commit` — see `.pre-commit-config.yaml`.)
 - PR bodies follow `.github/pull_request_template.md` — a one-line Summary plus 2–5 detail bullets. Resist the agent default of long, multi-section descriptions.
 - Attribute docstrings should be included below the attribute, rather than in the class-level docstring.


### PR DESCRIPTION
## Summary
Clarify guidance for named constants

## Detailed description
- Record the maintainer preference from the timer utility review.
- Inline clear, single-use values while retaining meaningful shared constants.
- Apply the guidance repository-wide through AGENTS.md.