### PR TITLE
Add progress to front page of the report.

### DIFF
--- a/isaaclab_arena/tests/test_report.py
+++ b/isaaclab_arena/tests/test_report.py
@@ -136,6 +136,53 @@ def test_build_report_writes_distinct_pages_for_slug_collisions(tmp_path):
     assert "my+run" in (pages / "job_my_run_2.html").read_text(encoding="utf-8")
 
 
+def test_overview_shows_mean_progress_beside_success_rate(tmp_path):
+    for policy, scores in (("pi0", (1.0, 0.6)), ("cosmos", (0.0, 0.2))):
+        run_dir = tmp_path / f"banana_in_bowl_{policy}"
+        run_dir.mkdir()
+        records = [
+            {"env_id": 0, "episode_in_env": index, "success": score == 1.0, "progress": {"overall_score": score}}
+            for index, score in enumerate(scores)
+        ]
+        (run_dir / "episode_results_rebuild0.jsonl").write_text(
+            "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+        )
+
+    build_report(tmp_path)
+
+    index = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert '<div class="label">Mean progress</div><div class="value">45%</div>' in index
+    assert "80% mean progress" in index and "10% mean progress" in index
+    assert '<span class="sub">80% progress</span>' in index
+    assert "Mean progress covers the" not in index
+
+
+def test_overview_flags_progress_that_covers_only_some_episodes(tmp_path):
+    run_dir = tmp_path / "banana_in_bowl_pi0"
+    run_dir.mkdir()
+    records = [
+        {"env_id": 0, "episode_in_env": 0, "success": False, "progress": {"overall_score": 0.5}},
+        {"env_id": 0, "episode_in_env": 1, "success": False},
+    ]
+    (run_dir / "episode_results_rebuild0.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8"
+    )
+
+    build_report(tmp_path)
+
+    index = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "Mean progress covers the 1 of 2 episode(s) that recorded a progress score" in index
+
+
+def test_overview_says_when_no_episode_recorded_progress(tmp_path):
+    _write_run(tmp_path, "banana_in_bowl_pi0")
+
+    build_report(tmp_path)
+
+    index = (tmp_path / "index.html").read_text(encoding="utf-8")
+    assert "No episode recorded a task progress score" in index
+
+
 def test_sparse_task_policy_matrix_stays_grouped(tmp_path):
     _write_run(tmp_path, "banana_in_bowl_pi0")
     _write_run(tmp_path, "banana_in_bowl_cosmos")

--- a/isaaclab_arena/tests/test_report_data.py
+++ b/isaaclab_arena/tests/test_report_data.py
@@ -229,6 +229,33 @@ def test_outcome_disagreeing_with_progress_is_detected():
     assert not no_progress_block.outcome_disagrees_with_progress
 
 
+def test_summary_mean_progress_averages_scored_episodes_across_runs(tmp_path):
+    def record(episode: int, score: float | None) -> dict:
+        entry = {"env_id": 0, "episode_in_env": episode, "success": False}
+        return entry if score is None else {**entry, "progress": {"overall_score": score}}
+
+    _write_run(tmp_path, "banana_pi0", [record(0, 0.25), record(1, 0.75)])
+    _write_run(tmp_path, "bowl_pi0", [record(0, 0.5), record(1, None)])
+    _write_run(tmp_path, "banana_cosmos", [record(0, 1.0)])
+
+    summary = build_experiment_summary(tmp_path, "Report")
+
+    # The unscored episode is left out of both the run mean and the aggregates above it.
+    assert summary.tasks[1].job_for_policy("pi0").mean_progress == 0.5
+    assert summary.mean_progress_for_policy("pi0") == 0.5
+    assert summary.mean_progress_for_policy("cosmos") == 1.0
+    assert summary.overall_mean_progress == 0.625
+
+
+def test_summary_mean_progress_is_none_without_recorded_progress(tmp_path):
+    _write_run(tmp_path, "banana_pi0", [{"env_id": 0, "episode_in_env": 0, "success": True}])
+
+    summary = build_experiment_summary(tmp_path, "Report")
+
+    assert summary.overall_mean_progress is None
+    assert summary.mean_progress_for_policy("pi0") is None
+
+
 def test_summary_groups_sparse_runs_by_repeated_policy_tokens(tmp_path):
     _write_run(tmp_path, "banana_pi0", [{"env_id": 0, "episode_in_env": 0, "success": True}])
     _write_run(tmp_path, "banana_cosmos", [{"env_id": 0, "episode_in_env": 0, "success": False}])

--- a/isaaclab_arena/visualization/report_data.py
+++ b/isaaclab_arena/visualization/report_data.py
@@ -180,9 +180,13 @@ class JobSummary:
         return None if scored == 0 else self.num_successes / scored
 
     @property
+    def progress_fractions(self) -> list[float]:
+        """Per-episode progress fractions, skipping episodes recorded without a progress score."""
+        return [episode.progress_fraction for episode in self.episodes if episode.progress_fraction is not None]
+
+    @property
     def mean_progress(self) -> float | None:
-        fractions = [episode.progress_fraction for episode in self.episodes if episode.progress_fraction is not None]
-        return None if not fractions else sum(fractions) / len(fractions)
+        return _mean(self.progress_fractions)
 
     @property
     def num_videos(self) -> int:
@@ -312,6 +316,9 @@ class ExperimentSummary:
         scored = sum(job.num_scored_episodes for job in jobs)
         return None if scored == 0 else sum(job.num_successes for job in jobs) / scored
 
+    def mean_progress_for_policy(self, policy: str) -> float | None:
+        return _mean([fraction for job in self.jobs if job.policy == policy for fraction in job.progress_fractions])
+
     def num_episodes_for_policy(self, policy: str) -> int:
         return sum(job.num_episodes for job in self.jobs if job.policy == policy)
 
@@ -319,6 +326,14 @@ class ExperimentSummary:
     def overall_success_rate(self) -> float | None:
         scored = sum(job.num_scored_episodes for job in self.jobs)
         return None if scored == 0 else sum(job.num_successes for job in self.jobs) / scored
+
+    @property
+    def overall_mean_progress(self) -> float | None:
+        return _mean([fraction for job in self.jobs for fraction in job.progress_fractions])
+
+    @property
+    def num_progress_episodes(self) -> int:
+        return sum(len(job.progress_fractions) for job in self.jobs)
 
 
 @dataclass
@@ -468,6 +483,11 @@ def _events_by_objective_and_index(record: dict[str, Any]) -> dict[str, dict[int
         if objective_name is not None and index is not None:
             result.setdefault(objective_name, {})[index] = event
     return result
+
+
+def _mean(values: list[float]) -> float | None:
+    """Return the mean of ``values``, or None when there is nothing to average."""
+    return None if not values else sum(values) / len(values)
 
 
 def _as_int(value: object) -> int | None:

--- a/isaaclab_arena/visualization/report_render.py
+++ b/isaaclab_arena/visualization/report_render.py
@@ -136,11 +136,14 @@ def _render_matrix(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> st
             if job is None or rate is None:
                 cells.append(f'<td class="cell missing" data-sort-col="{index}" data-value="">&mdash;</td>')
                 continue
+            progress = job.mean_progress
+            tooltip = f"{job.name}: {job.num_successes}/{job.num_scored_episodes} episodes"
+            if progress is not None:
+                tooltip += f", mean progress {progress * 100:.0f}%"
             cells.append(
                 f'<td class="cell" data-rank="{_ramp_rank(rate)}" data-sort-col="{index}" data-value="{rate:.6f}">'
-                f'<a href="{_href(task_hrefs[task.name])}"'
-                f' title="{html.escape(job.name)}: {job.num_successes}/{job.num_scored_episodes} episodes">'
-                f"{_percent(rate)}</a></td>"
+                f'<a href="{_href(task_hrefs[task.name])}" title="{html.escape(tooltip)}">'
+                f'{_percent(rate)}<span class="sub">{_percent(progress)} progress</span></a></td>'
             )
         rows.append("<tr>" + "".join(cells) + "</tr>")
 
@@ -150,7 +153,8 @@ def _render_matrix(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> st
         f"{header_cells}</tr></thead><tbody>\n"
         + "\n".join(rows)
         + "</tbody></table>"
-        '<p class="note">Click a task to see where its episodes failed. Click a column heading to sort.</p>'
+        '<p class="note">Each cell shows the success rate above the mean task progress.'
+        " Click a task to see where its episodes failed. Click a column heading to sort.</p>"
         "</section>"
     )
 
@@ -164,12 +168,14 @@ def _render_ungrouped_job_list(summary: ExperimentSummary, task_hrefs: dict[str,
     rows = "\n".join(
         f'<tr><th><a href="{_href(task_hrefs[job.task])}">{html.escape(job.name or "results")}</a></th>'
         f'<td class="num">{job.num_episodes}</td>'
-        f'<td class="num">{_percent(job.success_rate)}</td></tr>'
+        f'<td class="num">{_percent(job.success_rate)}</td>'
+        f'<td class="num">{_percent(job.mean_progress)}</td></tr>'
         for job in summary.jobs
     )
     return (
         "<section><h2>Runs</h2>"
-        "<table><thead><tr><th>run</th><th>episodes</th><th>success rate</th></tr></thead>"
+        "<table><thead><tr><th>run</th><th>episodes</th><th>success rate</th>"
+        "<th>mean progress</th></tr></thead>"
         f"<tbody>\n{rows}\n</tbody></table></section>"
     )
 
@@ -181,6 +187,7 @@ def render_index(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> str:
         _tile("Runs", str(len(summary.jobs))),
         _tile("Episodes", f"{summary.num_episodes:,}"),
         _tile("Success rate", _percent(summary.overall_success_rate)),
+        _tile("Mean progress", _percent(summary.overall_mean_progress)),
     ]
     if summary.is_grouped:
         tiles.insert(1, _tile("Policies", str(len(summary.policies))))
@@ -189,6 +196,7 @@ def render_index(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> str:
             _tile(
                 policy,
                 _percent(summary.success_rate_for_policy(policy)),
+                f"{_percent(summary.mean_progress_for_policy(policy))} mean progress &middot; "
                 f"{summary.num_episodes_for_policy(policy):,} episodes",
             )
         )
@@ -197,7 +205,7 @@ def render_index(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> str:
         _render_matrix(summary, task_hrefs) if summary.is_grouped else _render_ungrouped_job_list(summary, task_hrefs)
     )
     content = (
-        f'<div class="tiles">{"".join(tiles)}</div>'
+        f'<div class="tiles">{"".join(tiles)}</div>{_render_progress_coverage_note(summary)}'
         f"{_render_failed_runs_section(summary.run_executions)}"
         f"{_render_issues(summary.issues)}{body}"
     )
@@ -211,6 +219,19 @@ def render_index(summary: ExperimentSummary, task_hrefs: dict[str, str]) -> str:
         breadcrumb=f'<span class="current">{html.escape(summary.title)}</span>',
         summary=_experiment_summary_line(summary),
         content=content,
+    )
+
+
+def _render_progress_coverage_note(summary: ExperimentSummary) -> str:
+    """Warn when progress is averaged over fewer episodes than the success rate, so the two differ in base."""
+    scored = summary.num_progress_episodes
+    if scored == summary.num_episodes:
+        return ""
+    if scored == 0:
+        return '<p class="note">No episode recorded a task progress score, so mean progress is unavailable.</p>'
+    return (
+        f'<p class="note">Mean progress covers the {scored:,} of {summary.num_episodes:,} episode(s) that'
+        " recorded a progress score; the success rate covers them all.</p>"
     )
 
 

--- a/isaaclab_arena/visualization/report_template.html
+++ b/isaaclab_arena/visualization/report_template.html
@@ -104,6 +104,7 @@
     font-variant-numeric: tabular-nums; text-align: right;
   }
   .matrix td.cell a:hover { outline: 2px solid var(--text-primary); outline-offset: -2px; }
+  .matrix td.cell a .sub { display: block; font-size: 0.7rem; font-weight: 500; opacity: 0.75; }
   .cell[data-rank="0"] { background: #233b04; color: #ffffff; }
   .cell[data-rank="1"] { background: #355508; color: #ffffff; }
   .cell[data-rank="2"] { background: #48710e; color: #ffffff; }


### PR DESCRIPTION
## Summary
Add progress to front page of the report.

## Detailed description
- The average progress is a useful metric for comparison policies
- Before, we only displayed progress in the detailed view _per run_
- This exposes it to _per policy_
