### PR TITLE
Correct kitchen catalogue docs rendering

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -133,3 +133,11 @@ table.gallery th {
 .nv-green-grid-header p {
     margin: 0;
 }
+
+/* Wrap the long spec names, so the catalog's ``:widths:`` hold and the GIFs get
+   their share. The anchor needs the rule too: the theme's ``a`` sets
+   ``break-word``, which beats inheritance and does not shrink min-content. */
+.kitchen-bench-catalog td:first-child,
+.kitchen-bench-catalog td:first-child a {
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
Short description of the change (max 50 chars)

## Detailed description
- Short description of the change (max 50 chars)
- We changed the kitchen_bench task names which cased the table in the docs to not render nicely due to the longer names.
- This fixes this.
