### PR TITLE
Add deterministic cleanup for termination-term resources.

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -66,16 +66,6 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         """Return the language instruction that is passed to the policy."""
         return self.cfg.task_description
 
-    def close(self) -> None:
-        """Close manager-term resources before Isaac Lab deletes their managers."""
-        if not self._is_closed:
-            for term_name in self.termination_manager.active_terms:
-                term = self.termination_manager.get_term_cfg(term_name).func
-                close = getattr(term, "close", None)
-                if callable(close):
-                    close()
-        super().close()
-
     def get_episode_index(self, env_id: int) -> int:
         """Return the index of the current episode in ``env_id``."""
         return self._episode_counts.get(env_id, 0)

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -66,6 +66,16 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         """Return the language instruction that is passed to the policy."""
         return self.cfg.task_description
 
+    def close(self) -> None:
+        """Close manager-term resources before Isaac Lab deletes their managers."""
+        if not self._is_closed:
+            for term_name in self.termination_manager.active_terms:
+                term = self.termination_manager.get_term_cfg(term_name).func
+                close = getattr(term, "close", None)
+                if callable(close):
+                    close()
+        super().close()
+
     def get_episode_index(self, env_id: int) -> int:
         """Return the index of the current episode in ``env_id``."""
         return self._episode_counts.get(env_id, 0)

--- a/isaaclab_arena/tasks/predicates/live_scene_geometry.py
+++ b/isaaclab_arena/tasks/predicates/live_scene_geometry.py
@@ -177,9 +177,8 @@ class AssetBaseCfgPoseReader:
 
         self._entity_name = entity_name
         self._num_envs = env.num_envs
-        self._is_closed = False
         entity_prim_path = getattr(scene.cfg, entity_name).prim_path.format(ENV_REGEX_NS=scene.env_regex_ns)
-        self._frame_view = FrameView(
+        self._frame_view: FrameView | None = FrameView(
             entity_prim_path,
             device=env.device,
             stage=scene.stage,
@@ -199,16 +198,17 @@ class AssetBaseCfgPoseReader:
             )
 
     def close(self) -> None:
-        """Close the term-owned frame view."""
-        if not self._is_closed:
+        """Close the term-owned frame view. Safe to call more than once."""
+        if self._frame_view is not None:
             self._frame_view.close()
-            self._is_closed = True
+            self._frame_view = None
 
     def get_pose_in_world_frame(self) -> torch.Tensor:
         """Return ``T_W_R``, taking points from reference frame ``R`` to world frame ``W``.
 
         Poses are encoded as ``(x, y, z, qx, qy, qz, qw)``.
         """
+        assert self._frame_view is not None, f"Pose reader for '{self._entity_name}' is closed."
         position_w_buffer, orientation_w_buffer = self._frame_view.get_world_poses()
         T_W_R = torch.cat((position_w_buffer.torch, orientation_w_buffer.torch), dim=-1)
         assert T_W_R.shape == (self._num_envs, 7), (

--- a/isaaclab_arena/tasks/predicates/live_scene_geometry.py
+++ b/isaaclab_arena/tasks/predicates/live_scene_geometry.py
@@ -177,6 +177,7 @@ class AssetBaseCfgPoseReader:
 
         self._entity_name = entity_name
         self._num_envs = env.num_envs
+        self._is_closed = False
         entity_prim_path = getattr(scene.cfg, entity_name).prim_path.format(ENV_REGEX_NS=scene.env_regex_ns)
         self._frame_view = FrameView(
             entity_prim_path,
@@ -196,6 +197,12 @@ class AssetBaseCfgPoseReader:
                 f"AssetBaseCfg scene entry '{entity_name}' pose row {environment_id} belongs to '{prim_path}', "
                 f"not environment '{environment_prim_path}'."
             )
+
+    def close(self) -> None:
+        """Close the term-owned frame view."""
+        if not self._is_closed:
+            self._frame_view.close()
+            self._is_closed = True
 
     def get_pose_in_world_frame(self) -> torch.Tensor:
         """Return ``T_W_R``, taking points from reference frame ``R`` to world frame ``W``.

--- a/isaaclab_arena/tasks/predicates/object_on_destination_term.py
+++ b/isaaclab_arena/tasks/predicates/object_on_destination_term.py
@@ -78,21 +78,11 @@ class ObjectOnDestinationTerm(ManagerTermBase):
             self._destination_asset_base_pose_reader = None
 
     def __del__(self):
-        """Release the frame view when the termination manager drops this term.
-
-        A FrameView holds per-view Fabric index attributes on its prims, and those linger
-        until something releases them. Isaac Lab's ManagerTermBase has no teardown hook, so
-        the release is driven from here, mirroring how RecorderManager drives
-        RecorderTerm.close from its own destructor. Isaac Lab's env close deletes the
-        managers explicitly, which drops the last reference to their terms and runs this.
-        """
+        """Release the frame view when the termination manager drops this term."""
         # TODO(amillane, 2026-08-31): Move this upstream post v0.3.0 -- ManagerTermBase should
         # grow a teardown hook that each manager calls for its own terms, so resource-owning
         # terms no longer need their own destructor.
-        # hasattr: __init__ can raise before the reader is assigned, and an AttributeError
-        # raised here would only print over the traceback that actually matters.
-        if hasattr(self, "_destination_asset_base_pose_reader"):
-            self.close()
+        self.close()
 
     def __call__(
         self,

--- a/isaaclab_arena/tasks/predicates/object_on_destination_term.py
+++ b/isaaclab_arena/tasks/predicates/object_on_destination_term.py
@@ -72,10 +72,27 @@ class ObjectOnDestinationTerm(ManagerTermBase):
             assert False, unsupported_destination_message
 
     def close(self) -> None:
-        """Close resources owned by this termination term."""
+        """Release the frame view owned by this term. Safe to call more than once."""
         if self._destination_asset_base_pose_reader is not None:
             self._destination_asset_base_pose_reader.close()
             self._destination_asset_base_pose_reader = None
+
+    def __del__(self):
+        """Release the frame view when the termination manager drops this term.
+
+        A FrameView holds per-view Fabric index attributes on its prims, and those linger
+        until something releases them. Isaac Lab's ManagerTermBase has no teardown hook, so
+        the release is driven from here, mirroring how RecorderManager drives
+        RecorderTerm.close from its own destructor. Isaac Lab's env close deletes the
+        managers explicitly, which drops the last reference to their terms and runs this.
+        """
+        # TODO(amillane, 2026-08-31): Move this upstream post v0.3.0 -- ManagerTermBase should
+        # grow a teardown hook that each manager calls for its own terms, so resource-owning
+        # terms no longer need their own destructor.
+        # hasattr: __init__ can raise before the reader is assigned, and an AttributeError
+        # raised here would only print over the traceback that actually matters.
+        if hasattr(self, "_destination_asset_base_pose_reader"):
+            self.close()
 
     def __call__(
         self,

--- a/isaaclab_arena/tasks/predicates/object_on_destination_term.py
+++ b/isaaclab_arena/tasks/predicates/object_on_destination_term.py
@@ -71,6 +71,12 @@ class ObjectOnDestinationTerm(ManagerTermBase):
             )
             assert False, unsupported_destination_message
 
+    def close(self) -> None:
+        """Close resources owned by this termination term."""
+        if self._destination_asset_base_pose_reader is not None:
+            self._destination_asset_base_pose_reader.close()
+            self._destination_asset_base_pose_reader = None
+
     def __call__(
         self,
         env: ManagerBasedEnv,

--- a/isaaclab_arena/tests/test_object_on_destination_term.py
+++ b/isaaclab_arena/tests/test_object_on_destination_term.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import math
 import torch
 from types import SimpleNamespace
@@ -232,13 +233,8 @@ def _check_object_on_destination_term(
             raise AssertionError("The term accepted a destination that did not match its cached geometry.")
 
 
-def _check_owned_resource_cleanup(
-    live_scene_geometry,
-    object_on_destination_term_module,
-    arena_env_type,
-    manager_based_rl_env_type,
-) -> None:
-    """Check that term-owned views close once and before the termination manager is deleted."""
+def _check_owned_resource_cleanup(live_scene_geometry, object_on_destination_term_module) -> None:
+    """Check that term-owned views close exactly once, and that dropping the term releases them."""
 
     class DummyClosable:
         def __init__(self):
@@ -250,7 +246,6 @@ def _check_owned_resource_cleanup(
     frame_view = DummyClosable()
     pose_reader = object.__new__(live_scene_geometry.AssetBaseCfgPoseReader)
     pose_reader._frame_view = frame_view
-    pose_reader._is_closed = False
     pose_reader.close()
     pose_reader.close()
     assert frame_view.close_calls == 1
@@ -262,40 +257,22 @@ def _check_owned_resource_cleanup(
     term.close()
     assert term_reader.close_calls == 1
 
-    closable_term = DummyClosable()
-
-    class DummyTerminationManager:
-        active_terms = ["success", "time_out"]
-
-        def get_term_cfg(self, term_name):
-            if term_name == "success":
-                return SimpleNamespace(func=closable_term)
-            return SimpleNamespace(func=lambda: None)
-
-    env = object.__new__(arena_env_type)
-    env._is_closed = False
-    env.termination_manager = DummyTerminationManager()
-
-    def close_parent(parent_env):
-        assert closable_term.close_calls == 1
-        parent_env._is_closed = True
-
-    with patch.object(manager_based_rl_env_type, "close", autospec=True, side_effect=close_parent) as parent_close:
-        env.close()
-        env.close()
-
-    assert closable_term.close_calls == 1
-    assert parent_close.call_count == 2
+    # Dropping the term releases the reader, so no env-level bookkeeping is needed. This
+    # mirrors RecorderManager driving RecorderTerm.close from its own destructor.
+    dropped_reader = DummyClosable()
+    dropped_term = object.__new__(object_on_destination_term_module.ObjectOnDestinationTerm)
+    dropped_term._destination_asset_base_pose_reader = dropped_reader
+    del dropped_term
+    gc.collect()
+    assert dropped_reader.close_calls == 1
 
 
 def _test_object_on_destination_term(_simulation_app) -> bool:
-    from isaaclab.envs import ManagerBasedRLEnv
     from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
 
     import isaaclab_arena.tasks.predicates.live_scene_geometry as live_scene_geometry
     import isaaclab_arena.tasks.predicates.object_on_destination_term as object_on_destination_term
     import isaaclab_arena.tasks.predicates.spatial as spatial
-    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnv
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
     _check_bounds_center_over_destination(spatial, AxisAlignedBoundingBox)
@@ -307,12 +284,7 @@ def _test_object_on_destination_term(_simulation_app) -> bool:
         SceneEntityCfg,
         TerminationTermCfg,
     )
-    _check_owned_resource_cleanup(
-        live_scene_geometry,
-        object_on_destination_term,
-        IsaacLabArenaManagerBasedRLEnv,
-        ManagerBasedRLEnv,
-    )
+    _check_owned_resource_cleanup(live_scene_geometry, object_on_destination_term)
     return True
 
 

--- a/isaaclab_arena/tests/test_object_on_destination_term.py
+++ b/isaaclab_arena/tests/test_object_on_destination_term.py
@@ -232,12 +232,70 @@ def _check_object_on_destination_term(
             raise AssertionError("The term accepted a destination that did not match its cached geometry.")
 
 
+def _check_owned_resource_cleanup(
+    live_scene_geometry,
+    object_on_destination_term_module,
+    arena_env_type,
+    manager_based_rl_env_type,
+) -> None:
+    """Check that term-owned views close once and before the termination manager is deleted."""
+
+    class DummyClosable:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    frame_view = DummyClosable()
+    pose_reader = object.__new__(live_scene_geometry.AssetBaseCfgPoseReader)
+    pose_reader._frame_view = frame_view
+    pose_reader._is_closed = False
+    pose_reader.close()
+    pose_reader.close()
+    assert frame_view.close_calls == 1
+
+    term_reader = DummyClosable()
+    term = object.__new__(object_on_destination_term_module.ObjectOnDestinationTerm)
+    term._destination_asset_base_pose_reader = term_reader
+    term.close()
+    term.close()
+    assert term_reader.close_calls == 1
+
+    closable_term = DummyClosable()
+
+    class DummyTerminationManager:
+        active_terms = ["success", "time_out"]
+
+        def get_term_cfg(self, term_name):
+            if term_name == "success":
+                return SimpleNamespace(func=closable_term)
+            return SimpleNamespace(func=lambda: None)
+
+    env = object.__new__(arena_env_type)
+    env._is_closed = False
+    env.termination_manager = DummyTerminationManager()
+
+    def close_parent(parent_env):
+        assert closable_term.close_calls == 1
+        parent_env._is_closed = True
+
+    with patch.object(manager_based_rl_env_type, "close", autospec=True, side_effect=close_parent) as parent_close:
+        env.close()
+        env.close()
+
+    assert closable_term.close_calls == 1
+    assert parent_close.call_count == 2
+
+
 def _test_object_on_destination_term(_simulation_app) -> bool:
+    from isaaclab.envs import ManagerBasedRLEnv
     from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
 
     import isaaclab_arena.tasks.predicates.live_scene_geometry as live_scene_geometry
     import isaaclab_arena.tasks.predicates.object_on_destination_term as object_on_destination_term
     import isaaclab_arena.tasks.predicates.spatial as spatial
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnv
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
     _check_bounds_center_over_destination(spatial, AxisAlignedBoundingBox)
@@ -248,6 +306,12 @@ def _test_object_on_destination_term(_simulation_app) -> bool:
         AxisAlignedBoundingBox,
         SceneEntityCfg,
         TerminationTermCfg,
+    )
+    _check_owned_resource_cleanup(
+        live_scene_geometry,
+        object_on_destination_term,
+        IsaacLabArenaManagerBasedRLEnv,
+        ManagerBasedRLEnv,
     )
     return True
 


### PR DESCRIPTION
## Summary
Add deterministic cleanup for termination-term resources. 

## Detailed description

- IsaacLabArenaManagerBasedRLEnv.close() now invokes close() on active termination terms before Isaac Lab deletes their manager.
- ObjectOnDestinationTerm.close() closes and releases its destination pose reader.
- AssetBaseCfgPoseReader.close() idempotently closes its owned Fabric FrameView.

This prevents FrameView resources from being garbage-collected at an arbitrary point during later simulation frames.

## TODO
Update CI docker image

