### PR TITLE
Add exact RoboLab reference environments

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -14,6 +14,7 @@ from isaaclab_arena.assets.lightwheel_kitchen_factory import register_lightwheel
 from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR, ISAAC_STAGING_NUCLEUS_DIR
 from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.assets.robolab_scene_factory import register_robolab_exact_scenes
 from isaaclab_arena.utils.pose import Pose
 
 
@@ -216,6 +217,7 @@ class LightwheelKitchenBackground(LibraryBackground):
 # `globals()` makes it possible to expose the generated classes as module-level classes
 # so they can be imported like other background classes.
 register_lightwheel_kitchens(LightwheelKitchenBackground, globals())
+register_robolab_exact_scenes(LibraryBackground, globals())
 
 
 @register_asset

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -7,7 +7,8 @@ import trimesh
 
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
-from pxr import Usd
+from isaaclab.sim import UsdFileCfg
+from pxr import Usd, UsdPhysics
 
 from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.assets.object import Object
@@ -31,6 +32,8 @@ class ObjectReference(ObjectBase):
     def __init__(self, parent_asset: Object, **kwargs):
         super().__init__(**kwargs)
         self.parent_asset = parent_asset
+        if self.object_type == ObjectType.RIGID:
+            self._enable_parent_contact_reporting()
         self._parent_scale = parent_asset.scale
         # Resolve the path and pose together to avoid opening the parent USD stage multiple times.
         (
@@ -43,6 +46,14 @@ class ObjectReference(ObjectBase):
         self._collision_mesh: trimesh.Trimesh | None = None
         # None is a valid cached result for meshless prims; this flag distinguishes that from not-yet-loaded.
         self._collision_mesh_loaded = False
+
+    def _enable_parent_contact_reporting(self) -> None:
+        """Request contact-report APIs while spawning the referenced parent USD."""
+        spawn_cfg = self.parent_asset.object_cfg.spawn
+        assert isinstance(
+            spawn_cfg, UsdFileCfg
+        ), f"Rigid ObjectReference '{self.name}' requires a USD-backed parent, got {type(spawn_cfg).__name__}"
+        spawn_cfg.activate_contact_sensors = True
 
     def _build_reset_event(self):
         """Build a complete reset event for a referenced rigid body or articulation."""
@@ -138,16 +149,33 @@ class ObjectReference(ObjectBase):
             return extract_trimesh_from_prim(parent_stage, prim_path_in_usd, self._parent_scale)
 
     def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
-        # NOTE(alexmillane): Right now this requires that the object
-        # has the contact sensor enabled prior to using this reference.
-        # At the moment, for the tests, I enabled the relevant APIs in the GUI.
-        # TODO(alexmillane, 2025.09.08): Make the code automatically enable the
-        # contact reporter API.
-        # NOTE(alexmillane, 2025.11.27): I've added a function for adding
-        # the contact reporter API to a prim in a USD, perhaps that can be repurposed
-        # and used here.
-        # Just call out to the parent class method.
-        return super().get_contact_sensor_cfg(contact_against_object)
+        """Return a contact sensor rooted at the referenced subtree's rigid body."""
+        assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        filter_prim_paths = []
+        if isinstance(contact_against_object, ObjectReference):
+            filter_prim_paths.append(contact_against_object._get_contact_sensor_prim_path())
+        elif contact_against_object is not None:
+            filter_prim_paths.append(contact_against_object.get_prim_path())
+        return ContactSensorCfg(
+            prim_path=self._get_contact_sensor_prim_path(),
+            filter_prim_paths_expr=filter_prim_paths,
+        )
+
+    def _get_contact_sensor_prim_path(self) -> str:
+        """Return the runtime path of the shallowest rigid body in this reference."""
+        with open_stage(self.parent_asset.usd_path) as parent_stage:
+            reference_root = parent_stage.GetPrimAtPath(self.prim_path_in_parent_usd)
+            rigid_paths = [
+                str(prim.GetPath()) for prim in Usd.PrimRange(reference_root) if prim.HasAPI(UsdPhysics.RigidBodyAPI)
+            ]
+        assert rigid_paths, f"No rigid body found below referenced prim '{self.prim_path_in_parent_usd}'"
+        min_depth = min(path.count("/") for path in rigid_paths)
+        shallowest = [path for path in rigid_paths if path.count("/") == min_depth]
+        assert (
+            len(shallowest) == 1
+        ), f"Expected one shallowest rigid body below '{self.prim_path_in_parent_usd}', got {shallowest}"
+        relative_path = shallowest[0].removeprefix(self.prim_path_in_parent_usd)
+        return self.prim_path + relative_path
 
     def _generate_rigid_cfg(self) -> RigidObjectCfg:
         assert self.object_type == ObjectType.RIGID

--- a/isaaclab_arena/assets/robolab_scene_factory.py
+++ b/isaaclab_arena/assets/robolab_scene_factory.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Register full-scene RoboLab backgrounds used by the exact task catalog."""
+
+from pathlib import Path
+from typing import Any
+
+from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR
+
+ROBOLAB_EXACT_SCENE_NAMES = (
+    "bagel_plate_banana_bowl",
+    "banana_bowl",
+    "bin_condiments",
+    "bin_mug_mustard_marker_bowl",
+    "bottles_crate",
+    "butter_raisin_box",
+    "butter_raisin_box_grey_bin",
+    "clutter_fruit_bottle_bluebin",
+    "foodpacking_1bin_1box_1can",
+    "mustard_raisin_box",
+    "rubiks_cube_banana_bowl",
+    "rubiks_cube_bowl",
+    "tools_container",
+    "two_bin",
+    "workdesk",
+    "workdesk_bin",
+    "workdesk_snacks",
+)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LOCAL_SCENE_DIR = _REPO_ROOT / "RoboLab" / "assets" / "scenes"
+
+
+def _scene_usd_path(scene_name: str) -> str:
+    """Use the source checkout when present, otherwise the packaged Nucleus mirror."""
+    local_path = _LOCAL_SCENE_DIR / f"{scene_name}.usda"
+    if local_path.exists():
+        return str(local_path)
+    return f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/scenes/{scene_name}.usda"
+
+
+def register_robolab_exact_scenes(base_class: type, namespace: dict[str, Any]) -> None:
+    """Register scene-specific backgrounds backed by mirrored RoboLab USDAs."""
+    from isaaclab_arena.assets.register import register_asset
+
+    for scene_name in ROBOLAB_EXACT_SCENE_NAMES:
+        registry_name = f"{scene_name}_robolab_exact"
+        class_name = "".join(part.title() for part in registry_name.split("_"))
+        scene_class = type(
+            class_name,
+            (base_class,),
+            {
+                "__module__": base_class.__module__,
+                "name": registry_name,
+                "tags": ["background", "robolab", "exact"],
+                "usd_path": _scene_usd_path(scene_name),
+                "object_min_z": -0.05,
+                "reset_nested_physics": True,
+            },
+        )
+        namespace[class_name] = register_asset(scene_class)

--- a/isaaclab_arena/evaluation/legacy_graph_environment_cli.py
+++ b/isaaclab_arena/evaluation/legacy_graph_environment_cli.py
@@ -49,8 +49,13 @@ def build_arena_builder_from_legacy_graph(
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
     assert cfg.env_spec_path.endswith((".yaml", ".yml")), "legacy graph config must select a graph YAML"
-    arena_env_args = legacy_environment_args_to_cli_args({"environment": cfg.env_spec_path, **cfg.per_run_overrides})
+    per_run_overrides = dict(cfg.per_run_overrides)
+    episode_length_s = per_run_overrides.pop("episode_length_s", None)
+    arena_env_args = legacy_environment_args_to_cli_args({"environment": cfg.env_spec_path, **per_run_overrides})
     parser = get_isaaclab_arena_environments_cli_parser()
     args_cli = parser.parse_args(arena_env_args)
     arena_env = arena_env_from_graph_spec(args_cli.env_spec, args_cli)
+    if episode_length_s is not None:
+        assert float(episode_length_s) > 0.0, "episode_length_s must be greater than zero"
+        arena_env.task.episode_length_s = float(episode_length_s)
     return ArenaEnvBuilder(arena_env, environment_builder, hydra_overrides=hydra_overrides)

--- a/isaaclab_arena/tests/test_legacy_eval_config.py
+++ b/isaaclab_arena/tests/test_legacy_eval_config.py
@@ -100,7 +100,11 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
         {
             "jobs": [{
                 "name": "graph_environment",
-                "arena_env_args": {"environment": str(graph_path), "num_envs": 2},
+                "arena_env_args": {
+                    "environment": str(graph_path),
+                    "num_envs": 2,
+                    "episode_length_s": 1.5,
+                },
                 "policy_type": "zero_action",
                 "num_steps": 2,
                 "variations": {"light": {"intensity": {"enabled": True}}},
@@ -109,7 +113,7 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
         device="cuda:1",
     )
     parsed_args = SimpleNamespace(env_spec=str(graph_path))
-    expected_arena_env = object()
+    expected_arena_env = SimpleNamespace(task=SimpleNamespace(episode_length_s=70.0))
     expected_builder = object()
     captured = {}
 
@@ -145,7 +149,7 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
 
     assert builder is expected_builder
     assert captured["arguments"] == legacy_environment_args_to_cli_args(
-        {"environment": run.environment.env_spec_path, **run.environment.per_run_overrides}
+        {"environment": run.environment.env_spec_path, "num_envs": 2}
     )
     assert captured["args_cli"] is parsed_args
     assert captured["env_spec"] == str(graph_path)
@@ -154,6 +158,7 @@ def test_legacy_graph_builder_keeps_namespace_inside_graph_compatibility(monkeyp
     assert captured["builder_cfg"] is run.environment_builder
     assert captured["builder_cfg"].device == "cuda:1"
     assert captured["arena_env"] is expected_arena_env
+    assert captured["arena_env"].task.episode_length_s == 1.5
     assert captured["hydra_overrides"] == ["light.intensity.enabled=true"]
 
 

--- a/isaaclab_arena/tests/test_reference_objects.py
+++ b/isaaclab_arena/tests/test_reference_objects.py
@@ -108,6 +108,49 @@ def test_object_reference_caches_parent_usd_prim_path(monkeypatch):
     assert calls["open_count"] == 1
 
 
+def test_rigid_object_reference_enables_parent_contact_reporting():
+    from isaaclab.sim import UsdFileCfg
+
+    from isaaclab_arena.assets.object_reference import ObjectReference
+
+    spawn_cfg = UsdFileCfg(usd_path="/tmp/scene.usd")
+    obj_ref = ObjectReference.__new__(ObjectReference)
+    obj_ref.name = "referenced_object"
+    obj_ref.parent_asset = SimpleNamespace(object_cfg=SimpleNamespace(spawn=spawn_cfg))
+
+    obj_ref._enable_parent_contact_reporting()
+
+    assert spawn_cfg.activate_contact_sensors
+
+
+def test_object_reference_contact_sensor_finds_nested_rigid_body(tmp_path):
+    from isaaclab_arena.assets.object_reference import ObjectReference
+
+    usd_path = tmp_path / "nested_rigid.usda"
+    usd_path.write_text("""#usda 1.0
+(
+    defaultPrim = "World"
+)
+def Xform "World"
+{
+    def Xform "reference"
+    {
+        def Xform "body" (
+            prepend apiSchemas = ["PhysicsRigidBodyAPI"]
+        )
+        {
+        }
+    }
+}
+""")
+    obj_ref = ObjectReference.__new__(ObjectReference)
+    obj_ref.parent_asset = SimpleNamespace(usd_path=str(usd_path))
+    obj_ref._prim_path_in_parent_usd = "/World/reference"
+    obj_ref.prim_path = "{ENV_REGEX_NS}/scene/reference"
+
+    assert obj_ref._get_contact_sensor_prim_path() == "{ENV_REGEX_NS}/scene/reference/body"
+
+
 def test_object_reference_get_collision_mesh_extracts_referenced_prim(monkeypatch):
     """ObjectReference collision meshes are extracted from the referenced sub-prim."""
     import trimesh

--- a/isaaclab_arena/tests/test_robolab_exact_catalog.py
+++ b/isaaclab_arena/tests/test_robolab_exact_catalog.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checks for the generated reference-backed RoboLab exact catalog."""
+
+import json
+import yaml
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.assets.robolab_scene_factory import ROBOLAB_EXACT_SCENE_NAMES
+from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGULAR_DIR = REPO_ROOT / "isaaclab_arena_environments" / "robolab"
+EXACT_DIR = REPO_ROOT / "isaaclab_arena_environments" / "robolab_exact"
+ROBOLAB_METADATA = REPO_ROOT / "RoboLab" / "assets" / "scenes" / "_metadata" / "scene_metadata.json"
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def test_robolab_exact_catalog_matches_regular_catalog():
+    regular_scenes = sorted(path.name for path in (REGULAR_DIR / "scenes").glob("*.yaml"))
+    exact_scenes = sorted(path.name for path in (EXACT_DIR / "scenes").glob("*.yaml"))
+    regular_tasks = sorted(path.name for path in (REGULAR_DIR / "tasks").glob("*.yaml"))
+    exact_tasks = sorted(path.name for path in (EXACT_DIR / "tasks").glob("*.yaml"))
+
+    assert exact_scenes == regular_scenes
+    assert exact_tasks == regular_tasks
+    assert len(exact_scenes) == 17
+    assert len(exact_tasks) == 38
+    assert tuple(path.removesuffix(".yaml") for path in exact_scenes) == tuple(sorted(ROBOLAB_EXACT_SCENE_NAMES))
+
+
+@pytest.mark.parametrize("task_path", sorted((EXACT_DIR / "tasks").glob("*.yaml")), ids=lambda path: path.stem)
+def test_robolab_exact_task_specs_parse(task_path: Path):
+    spec = ArenaEnvGraphSpec.from_yaml(task_path)
+    scene_path = EXACT_DIR / "scenes" / Path(_load_yaml(task_path)["external_yaml"]).name
+    scene = _load_yaml(scene_path)
+
+    assert not spec.objects
+    assert spec.object_references
+    assert not spec.relations
+    assert not scene["objects"]
+    assert not scene["relations"]
+    assert all(ref.object_type.value == "rigid" for ref in spec.object_references)
+    assert all(
+        subtask.params.get("background_scene", spec.background.id) == spec.background.id
+        for subtask in spec.task.subtasks
+    )
+
+
+def test_robolab_exact_manifest_matches_source_metadata():
+    if not ROBOLAB_METADATA.exists():
+        pytest.skip("RoboLab source assets are not available")
+
+    manifest = _load_yaml(EXACT_DIR / "SOURCE_MANIFEST.yaml")
+    metadata = json.loads(ROBOLAB_METADATA.read_text(encoding="utf-8"))
+    assert set(manifest["scenes"]) == set(ROBOLAB_EXACT_SCENE_NAMES)
+
+    for scene_name, scene in manifest["scenes"].items():
+        source_name = Path(scene["source_usda"]).name
+        assert source_name == f"{scene_name}.usda"
+        records = {record["prim_path"]: record for record in metadata[source_name]}
+        for mapping in scene["object_mappings"]:
+            record = records[mapping["prim_path"]]
+            assert record["rigid_body"] is True
+            assert mapping["object_type"] == "rigid"

--- a/isaaclab_arena_environments/robolab_exact/README.md
+++ b/isaaclab_arena_environments/robolab_exact/README.md
@@ -1,0 +1,18 @@
+# RoboLab exact environments
+
+This catalog mirrors every scene and task in `isaaclab_arena_environments/robolab`.
+Unlike the regular catalog, each background loads the complete settled RoboLab
+scene USDA and exposes its task objects as rigid `ObjectReference` entries.
+Placement relations are intentionally omitted so resets restore the authored
+scene poses.
+
+Regenerate or validate the checked-in YAML files from the repository root:
+
+```bash
+python isaaclab_arena_environments/robolab_exact/scripts/generate_exact_catalog.py --update
+python isaaclab_arena_environments/robolab_exact/scripts/generate_exact_catalog.py
+```
+
+`SOURCE_MANIFEST.yaml` maps Arena object ids to prim paths in the matching
+`RoboLab/assets/scenes/<scene>.usda`. Runtime backgrounds load those scenes from
+the mirrored Arena Nucleus directory.

--- a/isaaclab_arena_environments/robolab_exact/SOURCE_MANIFEST.yaml
+++ b/isaaclab_arena_environments/robolab_exact/SOURCE_MANIFEST.yaml
@@ -1,0 +1,403 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source_scene_directory: RoboLab/assets/scenes
+nucleus_scene_directory: Arena/assets/object_library/srl_robolab_assets/scenes
+scenes:
+  bagel_plate_banana_bowl:
+    source_usda: RoboLab/assets/scenes/bagel_plate_banana_bowl.usda
+    background_registry_name: bagel_plate_banana_bowl_robolab_exact
+    object_mappings:
+    - arena_object_id: banana
+      prim_path: /world/banana
+      object_type: rigid
+    - arena_object_id: plate
+      prim_path: /world/plate_large
+      object_type: rigid
+    - arena_object_id: bagel_1
+      prim_path: /world/bagel_00
+      object_type: rigid
+    - arena_object_id: bagel_2
+      prim_path: /world/bagel_06
+      object_type: rigid
+    - arena_object_id: bowl
+      prim_path: /world/bowl
+      object_type: rigid
+  banana_bowl:
+    source_usda: RoboLab/assets/scenes/banana_bowl.usda
+    background_registry_name: banana_bowl_robolab_exact
+    object_mappings:
+    - arena_object_id: banana
+      prim_path: /world/banana
+      object_type: rigid
+    - arena_object_id: bowl
+      prim_path: /world/bowl
+      object_type: rigid
+  bin_condiments:
+    source_usda: RoboLab/assets/scenes/bin_condiments.usda
+    background_registry_name: bin_condiments_robolab_exact
+    object_mappings:
+    - arena_object_id: coffee_pot
+      prim_path: /world/coffee_pot
+      object_type: rigid
+    - arena_object_id: grey_bin
+      prim_path: /world/grey_bin
+      object_type: rigid
+    - arena_object_id: mug
+      prim_path: /world/mug
+      object_type: rigid
+    - arena_object_id: mustard
+      prim_path: /world/mustard
+      object_type: rigid
+    - arena_object_id: bowl
+      prim_path: /world/bowl
+      object_type: rigid
+    - arena_object_id: ranch_dressing
+      prim_path: /world/ranch_dressing
+      object_type: rigid
+    - arena_object_id: bbq_sauce_bottle_1
+      prim_path: /world/bbq_sauce_bottle
+      object_type: rigid
+    - arena_object_id: bbq_sauce_bottle_2
+      prim_path: /world/bbq_sauce_bottle_01
+      object_type: rigid
+    - arena_object_id: oatmeal_raisin_cookies
+      prim_path: /world/oatmeal_raisin_cookies
+      object_type: rigid
+    - arena_object_id: canned_tuna
+      prim_path: /world/canned_tuna
+      object_type: rigid
+    - arena_object_id: soft_scrub
+      prim_path: /world/soft_scrub
+      object_type: rigid
+    - arena_object_id: wood_block
+      prim_path: /world/wood_block
+      object_type: rigid
+  bin_mug_mustard_marker_bowl:
+    source_usda: RoboLab/assets/scenes/bin_mug_mustard_marker_bowl.usda
+    background_registry_name: bin_mug_mustard_marker_bowl_robolab_exact
+    object_mappings:
+    - arena_object_id: bowl
+      prim_path: /world/bowl
+      object_type: rigid
+    - arena_object_id: grey_bin
+      prim_path: /world/grey_bin
+      object_type: rigid
+    - arena_object_id: mustard
+      prim_path: /world/mustard
+      object_type: rigid
+    - arena_object_id: dry_erase_marker
+      prim_path: /world/dry_erase_marker
+      object_type: rigid
+    - arena_object_id: mug
+      prim_path: /world/mug
+      object_type: rigid
+  bottles_crate:
+    source_usda: RoboLab/assets/scenes/bottles_crate.usda
+    background_registry_name: bottles_crate_robolab_exact
+    object_mappings:
+    - arena_object_id: bbq_sauce_bottle
+      prim_path: /World/bbq_sauce_bottle
+      object_type: rigid
+    - arena_object_id: purple_crate
+      prim_path: /World/purple_crate
+      object_type: rigid
+    - arena_object_id: ceramic_mug
+      prim_path: /World/ceramic_mug
+      object_type: rigid
+    - arena_object_id: salad_dressing_bottle
+      prim_path: /World/salad_dressing_bottle
+      object_type: rigid
+  butter_raisin_box:
+    source_usda: RoboLab/assets/scenes/butter_raisin_box.usda
+    background_registry_name: butter_raisin_box_robolab_exact
+    object_mappings:
+    - arena_object_id: butter_hope_robolab
+      prim_path: /world/butter
+      object_type: rigid
+    - arena_object_id: raisin_box_hope_robolab
+      prim_path: /world/raisin_box
+      object_type: rigid
+  butter_raisin_box_grey_bin:
+    source_usda: RoboLab/assets/scenes/butter_raisin_box_grey_bin.usda
+    background_registry_name: butter_raisin_box_grey_bin_robolab_exact
+    object_mappings:
+    - arena_object_id: raisin_box
+      prim_path: /world/raisin_box
+      object_type: rigid
+    - arena_object_id: grey_bin
+      prim_path: /world/grey_bin
+      object_type: rigid
+    - arena_object_id: butter
+      prim_path: /world/butter
+      object_type: rigid
+  clutter_fruit_bottle_bluebin:
+    source_usda: RoboLab/assets/scenes/clutter_fruit_bottle_bluebin.usda
+    background_registry_name: clutter_fruit_bottle_bluebin_robolab_exact
+    object_mappings:
+    - arena_object_id: pumpkin_large
+      prim_path: /world/pumpkinlarge
+      object_type: rigid
+    - arena_object_id: pumpkin_small
+      prim_path: /world/pumpkinsmall
+      object_type: rigid
+    - arena_object_id: lemon_1
+      prim_path: /world/lemon_01
+      object_type: rigid
+    - arena_object_id: lemon_2
+      prim_path: /world/lemon_02
+      object_type: rigid
+    - arena_object_id: lime_1
+      prim_path: /world/lime01
+      object_type: rigid
+    - arena_object_id: lime_2
+      prim_path: /world/lime01_01
+      object_type: rigid
+    - arena_object_id: orange_1
+      prim_path: /world/orange_01
+      object_type: rigid
+    - arena_object_id: orange_2
+      prim_path: /world/orange_02
+      object_type: rigid
+    - arena_object_id: pomegranate
+      prim_path: /world/pomegranate01
+      object_type: rigid
+    - arena_object_id: white_packer_bottle
+      prim_path: /world/whitepackerbottle_a01
+      object_type: rigid
+    - arena_object_id: avocado
+      prim_path: /world/avocado01
+      object_type: rigid
+    - arena_object_id: crabbypenholder
+      prim_path: /world/crabbypenholder
+      object_type: rigid
+    - arena_object_id: serving_bowl
+      prim_path: /world/serving_bowl
+      object_type: rigid
+    - arena_object_id: milk_jug
+      prim_path: /world/milkjug_a01
+      object_type: rigid
+    - arena_object_id: utilityjug
+      prim_path: /world/utilityjug_a03
+      object_type: rigid
+    - arena_object_id: red_onion
+      prim_path: /world/red_onion
+      object_type: rigid
+    - arena_object_id: container_f24
+      prim_path: /world/right_bin
+      object_type: rigid
+  foodpacking_1bin_1box_1can:
+    source_usda: RoboLab/assets/scenes/foodpacking_1bin_1box_1can.usda
+    background_registry_name: foodpacking_1bin_1box_1can_robolab_exact
+    object_mappings:
+    - arena_object_id: cheez_it_box
+      prim_path: /world/cheez_it
+      object_type: rigid
+    - arena_object_id: bin_a06
+      prim_path: /world/bin_a06
+      object_type: rigid
+    - arena_object_id: mustard
+      prim_path: /world/mustard
+      object_type: rigid
+    - arena_object_id: tomato_soup_can
+      prim_path: /world/tomato_soup_can
+      object_type: rigid
+  mustard_raisin_box:
+    source_usda: RoboLab/assets/scenes/mustard_raisin_box.usda
+    background_registry_name: mustard_raisin_box_robolab_exact
+    object_mappings:
+    - arena_object_id: mustard_bottle
+      prim_path: /world/mustard_bottle
+      object_type: rigid
+    - arena_object_id: raisin_box
+      prim_path: /world/raisin_box
+      object_type: rigid
+  rubiks_cube_banana_bowl:
+    source_usda: RoboLab/assets/scenes/rubiks_cube_banana_bowl.usda
+    background_registry_name: rubiks_cube_banana_bowl_robolab_exact
+    object_mappings:
+    - arena_object_id: banana
+      prim_path: /World/banana
+      object_type: rigid
+    - arena_object_id: cube
+      prim_path: /World/rubiks_cube
+      object_type: rigid
+    - arena_object_id: bowl
+      prim_path: /World/bowl
+      object_type: rigid
+  rubiks_cube_bowl:
+    source_usda: RoboLab/assets/scenes/rubiks_cube_bowl.usda
+    background_registry_name: rubiks_cube_bowl_robolab_exact
+    object_mappings:
+    - arena_object_id: rubiks_cube
+      prim_path: /World/rubiks_cube
+      object_type: rigid
+    - arena_object_id: bowl
+      prim_path: /World/bowl
+      object_type: rigid
+  tools_container:
+    source_usda: RoboLab/assets/scenes/tools_container.usda
+    background_registry_name: tools_container_robolab_exact
+    object_mappings:
+    - arena_object_id: container_f24
+      prim_path: /world/left_bin
+      object_type: rigid
+    - arena_object_id: bin_b04
+      prim_path: /world/right_bin
+      object_type: rigid
+    - arena_object_id: spring_clamp
+      prim_path: /world/spring_clamp
+      object_type: rigid
+    - arena_object_id: red_hammer
+      prim_path: /world/red_hammer
+      object_type: rigid
+    - arena_object_id: black_hammer
+      prim_path: /world/husky_hammer
+      object_type: rigid
+    - arena_object_id: cordless_drill
+      prim_path: /world/cordless_drill
+      object_type: rigid
+  two_bin:
+    source_usda: RoboLab/assets/scenes/two_bin.usda
+    background_registry_name: two_bin_robolab_exact
+    object_mappings:
+    - arena_object_id: grey_bin_left
+      prim_path: /world/grey_bin_left
+      object_type: rigid
+    - arena_object_id: grey_bin_right
+      prim_path: /world/grey_bin_right
+      object_type: rigid
+    - arena_object_id: mustard
+      prim_path: /world/mustard
+      object_type: rigid
+  workdesk:
+    source_usda: RoboLab/assets/scenes/workdesk.usda
+    background_registry_name: workdesk_robolab_exact
+    object_mappings:
+    - arena_object_id: computer_mouse
+      prim_path: /world/computer_mouse
+      object_type: rigid
+    - arena_object_id: keyboard
+      prim_path: /world/keyboard
+      object_type: rigid
+    - arena_object_id: ceramic_mug
+      prim_path: /world/ceramic_mug
+      object_type: rigid
+    - arena_object_id: glasses
+      prim_path: /world/glasses
+      object_type: rigid
+    - arena_object_id: lizard_figurine
+      prim_path: /world/lizard_figurine
+      object_type: rigid
+    - arena_object_id: marker
+      prim_path: /world/marker
+      object_type: rigid
+    - arena_object_id: remote_control
+      prim_path: /world/remote_control
+      object_type: rigid
+    - arena_object_id: rubiks_cube
+      prim_path: /world/rubiks_cube
+      object_type: rigid
+    - arena_object_id: smartphone
+      prim_path: /world/smartphone
+      object_type: rigid
+    - arena_object_id: wooden_bowl
+      prim_path: /world/wooden_bowl
+      object_type: rigid
+    - arena_object_id: yogurt_cup
+      prim_path: /world/yogurt_cup
+      object_type: rigid
+    - arena_object_id: oatmeal_raisin_cookies
+      prim_path: /world/oatmeal_raisin_cookies
+      object_type: rigid
+    - arena_object_id: granola_bar
+      prim_path: /world/granola_bars
+      object_type: rigid
+  workdesk_bin:
+    source_usda: RoboLab/assets/scenes/workdesk_bin.usda
+    background_registry_name: workdesk_bin_robolab_exact
+    object_mappings:
+    - arena_object_id: lizard_figurine
+      prim_path: /world/lizard_figurine
+      object_type: rigid
+    - arena_object_id: grey_bin
+      prim_path: /world/grey_bin
+      object_type: rigid
+    - arena_object_id: ceramic_mug
+      prim_path: /world/ceramic_mug
+      object_type: rigid
+    - arena_object_id: keyboard
+      prim_path: /world/keyboard
+      object_type: rigid
+    - arena_object_id: glasses
+      prim_path: /world/glasses
+      object_type: rigid
+    - arena_object_id: marker
+      prim_path: /world/marker
+      object_type: rigid
+    - arena_object_id: remote_control
+      prim_path: /world/remote_control
+      object_type: rigid
+    - arena_object_id: smartphone
+      prim_path: /world/smartphone
+      object_type: rigid
+    - arena_object_id: wooden_bowl
+      prim_path: /world/wooden_bowl
+      object_type: rigid
+    - arena_object_id: spoon_big
+      prim_path: /world/spoon_big
+      object_type: rigid
+    - arena_object_id: computer_mouse
+      prim_path: /world/computer_mouse
+      object_type: rigid
+    - arena_object_id: yogurt_cup
+      prim_path: /world/yogurt_cup
+      object_type: rigid
+    - arena_object_id: granola_bar
+      prim_path: /world/granola_bars
+      object_type: rigid
+  workdesk_snacks:
+    source_usda: RoboLab/assets/scenes/workdesk_snacks.usda
+    background_registry_name: workdesk_snacks_robolab_exact
+    object_mappings:
+    - arena_object_id: apple
+      prim_path: /world/apple_01
+      object_type: rigid
+    - arena_object_id: plasticpail
+      prim_path: /world/plasticpail_a02
+      object_type: rigid
+    - arena_object_id: ceramic_mug
+      prim_path: /world/ceramic_mug
+      object_type: rigid
+    - arena_object_id: glasses
+      prim_path: /world/glasses
+      object_type: rigid
+    - arena_object_id: keyboard
+      prim_path: /world/keyboard
+      object_type: rigid
+    - arena_object_id: marker
+      prim_path: /world/marker
+      object_type: rigid
+    - arena_object_id: remote_control
+      prim_path: /world/remote_control
+      object_type: rigid
+    - arena_object_id: smartphone
+      prim_path: /world/smartphone
+      object_type: rigid
+    - arena_object_id: wooden_bowl
+      prim_path: /world/wooden_bowl
+      object_type: rigid
+    - arena_object_id: spoon_big
+      prim_path: /world/spoon_big
+      object_type: rigid
+    - arena_object_id: computer_mouse
+      prim_path: /world/computer_mouse
+      object_type: rigid
+    - arena_object_id: yogurt_cup
+      prim_path: /world/yogurt_cup
+      object_type: rigid
+    - arena_object_id: pitcher
+      prim_path: /world/pitcher
+      object_type: rigid

--- a/isaaclab_arena_environments/robolab_exact/experiment_configs/robolab_exact_all_tasks_smoke.yaml
+++ b/isaaclab_arena_environments/robolab_exact/experiment_configs/robolab_exact_all_tasks_smoke.yaml
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Smoke-test every RoboLab exact task with one environment and two short episodes.
+shared:
+  environment:
+    enable_cameras: false
+    episode_length_s: 1.0
+  environment_builder:
+    num_envs: 1
+  rollout_limit:
+    num_episodes: 2
+runs:
+  apple_and_yogurt_in_bowl:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/apple_and_yogurt_in_bowl.yaml
+    policy:
+      type: zero_action
+  bagels_on_plate:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/bagels_on_plate.yaml
+    policy:
+      type: zero_action
+  banana_in_bowl:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/banana_in_bowl.yaml
+    policy:
+      type: zero_action
+  banana_on_plate:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/banana_on_plate.yaml
+    policy:
+      type: zero_action
+  banana_then_rubiks_cube:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/banana_then_rubiks_cube.yaml
+    policy:
+      type: zero_action
+  bbq_sauce_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/bbq_sauce_in_bin.yaml
+    policy:
+      type: zero_action
+  big_pumpkin_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/big_pumpkin_in_bin.yaml
+    policy:
+      type: zero_action
+  black_items_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/black_items_in_bin.yaml
+    policy:
+      type: zero_action
+  bowl_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/bowl_in_bin.yaml
+    policy:
+      type: zero_action
+  butter_above_raisin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/butter_above_raisin.yaml
+    policy:
+      type: zero_action
+  canned_food_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/canned_food_in_bin.yaml
+    policy:
+      type: zero_action
+  clamp_in_right_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/clamp_in_right_bin.yaml
+    policy:
+      type: zero_action
+  clear_organic_objects:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/clear_organic_objects.yaml
+    policy:
+      type: zero_action
+  clutter_plastic:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/clutter_plastic.yaml
+    policy:
+      type: zero_action
+  clutter_pumpkin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/clutter_pumpkin.yaml
+    policy:
+      type: zero_action
+  coffee_pot_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/coffee_pot_in_bin.yaml
+    policy:
+      type: zero_action
+  condiments_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/condiments_in_bin.yaml
+    policy:
+      type: zero_action
+  electronics_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/electronics_in_bin.yaml
+    policy:
+      type: zero_action
+  food_packing_1_boxes:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_boxes.yaml
+    policy:
+      type: zero_action
+  food_packing_1_cans:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_cans.yaml
+    policy:
+      type: zero_action
+  hammers_in_left_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/hammers_in_left_bin.yaml
+    policy:
+      type: zero_action
+  larger_object_raisin_box_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/larger_object_raisin_box_in_bin.yaml
+    policy:
+      type: zero_action
+  marker_in_mug:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/marker_in_mug.yaml
+    policy:
+      type: zero_action
+  mouse_on_keyboard:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/mouse_on_keyboard.yaml
+    policy:
+      type: zero_action
+  mustard_above_raisin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/mustard_above_raisin.yaml
+    policy:
+      type: zero_action
+  mustard_in_left_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/mustard_in_left_bin.yaml
+    policy:
+      type: zero_action
+  mustard_in_right_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/mustard_in_right_bin.yaml
+    policy:
+      type: zero_action
+  non_hammer_tools_in_right_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/non_hammer_tools_in_right_bin.yaml
+    policy:
+      type: zero_action
+  rubiks_cube:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube.yaml
+    policy:
+      type: zero_action
+  rubiks_cube_and_banana:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_and_banana.yaml
+    policy:
+      type: zero_action
+  rubiks_cube_then_banana:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_then_banana.yaml
+    policy:
+      type: zero_action
+  sauce_bottles_crate:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/sauce_bottles_crate.yaml
+    policy:
+      type: zero_action
+  small_pumpkin_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/small_pumpkin_in_bin.yaml
+    policy:
+      type: zero_action
+  smaller_object_butter_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/smaller_object_butter_in_bin.yaml
+    policy:
+      type: zero_action
+  smartphone_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/smartphone_in_bin.yaml
+    policy:
+      type: zero_action
+  throw_away_apple:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/throw_away_apple.yaml
+    policy:
+      type: zero_action
+  throw_away_snacks:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/throw_away_snacks.yaml
+    policy:
+      type: zero_action
+  toy_in_bin:
+    environment:
+      type: isaaclab_arena_environments/robolab_exact/tasks/toy_in_bin.yaml
+    policy:
+      type: zero_action

--- a/isaaclab_arena_environments/robolab_exact/scenes/bagel_plate_banana_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/bagel_plate_banana_bowl.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 1.35
+background:
+  id: bagel_plate_banana_bowl_robolab_exact
+  registry_name: bagel_plate_banana_bowl_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: banana
+  parent_id: bagel_plate_banana_bowl_robolab_exact
+  prim_path: banana
+  object_type: rigid
+  params: {}
+- id: plate
+  parent_id: bagel_plate_banana_bowl_robolab_exact
+  prim_path: plate_large
+  object_type: rigid
+  params: {}
+- id: bagel_1
+  parent_id: bagel_plate_banana_bowl_robolab_exact
+  prim_path: bagel_00
+  object_type: rigid
+  params: {}
+- id: bagel_2
+  parent_id: bagel_plate_banana_bowl_robolab_exact
+  prim_path: bagel_06
+  object_type: rigid
+  params: {}
+- id: bowl
+  parent_id: bagel_plate_banana_bowl_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/banana_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/banana_bowl.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: banana_bowl_robolab_exact
+  registry_name: banana_bowl_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: banana
+  parent_id: banana_bowl_robolab_exact
+  prim_path: banana
+  object_type: rigid
+  params: {}
+- id: bowl
+  parent_id: banana_bowl_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/bin_condiments.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/bin_condiments.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: bin_condiments_robolab_exact
+  registry_name: bin_condiments_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: coffee_pot
+  parent_id: bin_condiments_robolab_exact
+  prim_path: coffee_pot
+  object_type: rigid
+  params: {}
+- id: grey_bin
+  parent_id: bin_condiments_robolab_exact
+  prim_path: grey_bin
+  object_type: rigid
+  params: {}
+- id: mug
+  parent_id: bin_condiments_robolab_exact
+  prim_path: mug
+  object_type: rigid
+  params: {}
+- id: mustard
+  parent_id: bin_condiments_robolab_exact
+  prim_path: mustard
+  object_type: rigid
+  params: {}
+- id: bowl
+  parent_id: bin_condiments_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+- id: ranch_dressing
+  parent_id: bin_condiments_robolab_exact
+  prim_path: ranch_dressing
+  object_type: rigid
+  params: {}
+- id: bbq_sauce_bottle_1
+  parent_id: bin_condiments_robolab_exact
+  prim_path: bbq_sauce_bottle
+  object_type: rigid
+  params: {}
+- id: bbq_sauce_bottle_2
+  parent_id: bin_condiments_robolab_exact
+  prim_path: bbq_sauce_bottle_01
+  object_type: rigid
+  params: {}
+- id: oatmeal_raisin_cookies
+  parent_id: bin_condiments_robolab_exact
+  prim_path: oatmeal_raisin_cookies
+  object_type: rigid
+  params: {}
+- id: canned_tuna
+  parent_id: bin_condiments_robolab_exact
+  prim_path: canned_tuna
+  object_type: rigid
+  params: {}
+- id: soft_scrub
+  parent_id: bin_condiments_robolab_exact
+  prim_path: soft_scrub
+  object_type: rigid
+  params: {}
+- id: wood_block
+  parent_id: bin_condiments_robolab_exact
+  prim_path: wood_block
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/bin_mug_mustard_marker_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/bin_mug_mustard_marker_bowl.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: bin_mug_mustard_marker_bowl_robolab_exact
+  registry_name: bin_mug_mustard_marker_bowl_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: bowl
+  parent_id: bin_mug_mustard_marker_bowl_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+- id: grey_bin
+  parent_id: bin_mug_mustard_marker_bowl_robolab_exact
+  prim_path: grey_bin
+  object_type: rigid
+  params: {}
+- id: mustard
+  parent_id: bin_mug_mustard_marker_bowl_robolab_exact
+  prim_path: mustard
+  object_type: rigid
+  params: {}
+- id: dry_erase_marker
+  parent_id: bin_mug_mustard_marker_bowl_robolab_exact
+  prim_path: dry_erase_marker
+  object_type: rigid
+  params: {}
+- id: mug
+  parent_id: bin_mug_mustard_marker_bowl_robolab_exact
+  prim_path: mug
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/bottles_crate.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/bottles_crate.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: bottles_crate_robolab_exact
+  registry_name: bottles_crate_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: bbq_sauce_bottle
+  parent_id: bottles_crate_robolab_exact
+  prim_path: bbq_sauce_bottle
+  object_type: rigid
+  params: {}
+- id: purple_crate
+  parent_id: bottles_crate_robolab_exact
+  prim_path: purple_crate
+  object_type: rigid
+  params: {}
+- id: ceramic_mug
+  parent_id: bottles_crate_robolab_exact
+  prim_path: ceramic_mug
+  object_type: rigid
+  params: {}
+- id: salad_dressing_bottle
+  parent_id: bottles_crate_robolab_exact
+  prim_path: salad_dressing_bottle
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/butter_raisin_box.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/butter_raisin_box.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: butter_raisin_box_robolab_exact
+  registry_name: butter_raisin_box_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: butter_hope_robolab
+  parent_id: butter_raisin_box_robolab_exact
+  prim_path: butter
+  object_type: rigid
+  params: {}
+- id: raisin_box_hope_robolab
+  parent_id: butter_raisin_box_robolab_exact
+  prim_path: raisin_box
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/butter_raisin_box_grey_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/butter_raisin_box_grey_bin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: butter_raisin_box_grey_bin_robolab_exact
+  registry_name: butter_raisin_box_grey_bin_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: raisin_box
+  parent_id: butter_raisin_box_grey_bin_robolab_exact
+  prim_path: raisin_box
+  object_type: rigid
+  params: {}
+- id: grey_bin
+  parent_id: butter_raisin_box_grey_bin_robolab_exact
+  prim_path: grey_bin
+  object_type: rigid
+  params: {}
+- id: butter
+  parent_id: butter_raisin_box_grey_bin_robolab_exact
+  prim_path: butter
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/clutter_fruit_bottle_bluebin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/clutter_fruit_bottle_bluebin.yaml
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: clutter_fruit_bottle_bluebin_robolab_exact
+  registry_name: clutter_fruit_bottle_bluebin_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: pumpkin_large
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: pumpkinlarge
+  object_type: rigid
+  params: {}
+- id: pumpkin_small
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: pumpkinsmall
+  object_type: rigid
+  params: {}
+- id: lemon_1
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: lemon_01
+  object_type: rigid
+  params: {}
+- id: lemon_2
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: lemon_02
+  object_type: rigid
+  params: {}
+- id: lime_1
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: lime01
+  object_type: rigid
+  params: {}
+- id: lime_2
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: lime01_01
+  object_type: rigid
+  params: {}
+- id: orange_1
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: orange_01
+  object_type: rigid
+  params: {}
+- id: orange_2
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: orange_02
+  object_type: rigid
+  params: {}
+- id: pomegranate
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: pomegranate01
+  object_type: rigid
+  params: {}
+- id: white_packer_bottle
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: whitepackerbottle_a01
+  object_type: rigid
+  params: {}
+- id: avocado
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: avocado01
+  object_type: rigid
+  params: {}
+- id: crabbypenholder
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: crabbypenholder
+  object_type: rigid
+  params: {}
+- id: serving_bowl
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: serving_bowl
+  object_type: rigid
+  params: {}
+- id: milk_jug
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: milkjug_a01
+  object_type: rigid
+  params: {}
+- id: utilityjug
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: utilityjug_a03
+  object_type: rigid
+  params: {}
+- id: red_onion
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: red_onion
+  object_type: rigid
+  params: {}
+- id: container_f24
+  parent_id: clutter_fruit_bottle_bluebin_robolab_exact
+  prim_path: right_bin
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/foodpacking_1bin_1box_1can.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/foodpacking_1bin_1box_1can.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: foodpacking_1bin_1box_1can_robolab_exact
+  registry_name: foodpacking_1bin_1box_1can_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: cheez_it_box
+  parent_id: foodpacking_1bin_1box_1can_robolab_exact
+  prim_path: cheez_it
+  object_type: rigid
+  params: {}
+- id: bin_a06
+  parent_id: foodpacking_1bin_1box_1can_robolab_exact
+  prim_path: bin_a06
+  object_type: rigid
+  params: {}
+- id: mustard
+  parent_id: foodpacking_1bin_1box_1can_robolab_exact
+  prim_path: mustard
+  object_type: rigid
+  params: {}
+- id: tomato_soup_can
+  parent_id: foodpacking_1bin_1box_1can_robolab_exact
+  prim_path: tomato_soup_can
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/mustard_raisin_box.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/mustard_raisin_box.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: mustard_raisin_box_robolab_exact
+  registry_name: mustard_raisin_box_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: mustard_bottle
+  parent_id: mustard_raisin_box_robolab_exact
+  prim_path: mustard_bottle
+  object_type: rigid
+  params: {}
+- id: raisin_box
+  parent_id: mustard_raisin_box_robolab_exact
+  prim_path: raisin_box
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/rubiks_cube_banana_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/rubiks_cube_banana_bowl.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: rubiks_cube_banana_bowl_robolab_exact
+  registry_name: rubiks_cube_banana_bowl_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: banana
+  parent_id: rubiks_cube_banana_bowl_robolab_exact
+  prim_path: banana
+  object_type: rigid
+  params: {}
+- id: cube
+  parent_id: rubiks_cube_banana_bowl_robolab_exact
+  prim_path: rubiks_cube
+  object_type: rigid
+  params: {}
+- id: bowl
+  parent_id: rubiks_cube_banana_bowl_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/rubiks_cube_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/rubiks_cube_bowl.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: rubiks_cube_bowl_robolab_exact
+  registry_name: rubiks_cube_bowl_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: rubiks_cube
+  parent_id: rubiks_cube_bowl_robolab_exact
+  prim_path: rubiks_cube
+  object_type: rigid
+  params: {}
+- id: bowl
+  parent_id: rubiks_cube_bowl_robolab_exact
+  prim_path: bowl
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/tools_container.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/tools_container.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: tools_container_robolab_exact
+  registry_name: tools_container_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: container_f24
+  parent_id: tools_container_robolab_exact
+  prim_path: left_bin
+  object_type: rigid
+  params: {}
+- id: bin_b04
+  parent_id: tools_container_robolab_exact
+  prim_path: right_bin
+  object_type: rigid
+  params: {}
+- id: spring_clamp
+  parent_id: tools_container_robolab_exact
+  prim_path: spring_clamp
+  object_type: rigid
+  params: {}
+- id: red_hammer
+  parent_id: tools_container_robolab_exact
+  prim_path: red_hammer
+  object_type: rigid
+  params: {}
+- id: black_hammer
+  parent_id: tools_container_robolab_exact
+  prim_path: husky_hammer
+  object_type: rigid
+  params: {}
+- id: cordless_drill
+  parent_id: tools_container_robolab_exact
+  prim_path: cordless_drill
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/two_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/two_bin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: two_bin_robolab_exact
+  registry_name: two_bin_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: grey_bin_left
+  parent_id: two_bin_robolab_exact
+  prim_path: grey_bin_left
+  object_type: rigid
+  params: {}
+- id: grey_bin_right
+  parent_id: two_bin_robolab_exact
+  prim_path: grey_bin_right
+  object_type: rigid
+  params: {}
+- id: mustard
+  parent_id: two_bin_robolab_exact
+  prim_path: mustard
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/workdesk.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/workdesk.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: workdesk_robolab_exact
+  registry_name: workdesk_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: computer_mouse
+  parent_id: workdesk_robolab_exact
+  prim_path: computer_mouse
+  object_type: rigid
+  params: {}
+- id: keyboard
+  parent_id: workdesk_robolab_exact
+  prim_path: keyboard
+  object_type: rigid
+  params: {}
+- id: ceramic_mug
+  parent_id: workdesk_robolab_exact
+  prim_path: ceramic_mug
+  object_type: rigid
+  params: {}
+- id: glasses
+  parent_id: workdesk_robolab_exact
+  prim_path: glasses
+  object_type: rigid
+  params: {}
+- id: lizard_figurine
+  parent_id: workdesk_robolab_exact
+  prim_path: lizard_figurine
+  object_type: rigid
+  params: {}
+- id: marker
+  parent_id: workdesk_robolab_exact
+  prim_path: marker
+  object_type: rigid
+  params: {}
+- id: remote_control
+  parent_id: workdesk_robolab_exact
+  prim_path: remote_control
+  object_type: rigid
+  params: {}
+- id: rubiks_cube
+  parent_id: workdesk_robolab_exact
+  prim_path: rubiks_cube
+  object_type: rigid
+  params: {}
+- id: smartphone
+  parent_id: workdesk_robolab_exact
+  prim_path: smartphone
+  object_type: rigid
+  params: {}
+- id: wooden_bowl
+  parent_id: workdesk_robolab_exact
+  prim_path: wooden_bowl
+  object_type: rigid
+  params: {}
+- id: yogurt_cup
+  parent_id: workdesk_robolab_exact
+  prim_path: yogurt_cup
+  object_type: rigid
+  params: {}
+- id: oatmeal_raisin_cookies
+  parent_id: workdesk_robolab_exact
+  prim_path: oatmeal_raisin_cookies
+  object_type: rigid
+  params: {}
+- id: granola_bar
+  parent_id: workdesk_robolab_exact
+  prim_path: granola_bars
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/workdesk_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/workdesk_bin.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: workdesk_bin_robolab_exact
+  registry_name: workdesk_bin_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: lizard_figurine
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: lizard_figurine
+  object_type: rigid
+  params: {}
+- id: grey_bin
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: grey_bin
+  object_type: rigid
+  params: {}
+- id: ceramic_mug
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: ceramic_mug
+  object_type: rigid
+  params: {}
+- id: keyboard
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: keyboard
+  object_type: rigid
+  params: {}
+- id: glasses
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: glasses
+  object_type: rigid
+  params: {}
+- id: marker
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: marker
+  object_type: rigid
+  params: {}
+- id: remote_control
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: remote_control
+  object_type: rigid
+  params: {}
+- id: smartphone
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: smartphone
+  object_type: rigid
+  params: {}
+- id: wooden_bowl
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: wooden_bowl
+  object_type: rigid
+  params: {}
+- id: spoon_big
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: spoon_big
+  object_type: rigid
+  params: {}
+- id: computer_mouse
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: computer_mouse
+  object_type: rigid
+  params: {}
+- id: yogurt_cup
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: yogurt_cup
+  object_type: rigid
+  params: {}
+- id: granola_bar
+  parent_id: workdesk_bin_robolab_exact
+  prim_path: granola_bars
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scenes/workdesk_snacks.yaml
+++ b/isaaclab_arena_environments/robolab_exact/scenes/workdesk_snacks.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params: {}
+background:
+  id: workdesk_snacks_robolab_exact
+  registry_name: workdesk_snacks_robolab_exact
+  params: {}
+objects: []
+object_references:
+- id: apple
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: apple_01
+  object_type: rigid
+  params: {}
+- id: plasticpail
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: plasticpail_a02
+  object_type: rigid
+  params: {}
+- id: ceramic_mug
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: ceramic_mug
+  object_type: rigid
+  params: {}
+- id: glasses
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: glasses
+  object_type: rigid
+  params: {}
+- id: keyboard
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: keyboard
+  object_type: rigid
+  params: {}
+- id: marker
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: marker
+  object_type: rigid
+  params: {}
+- id: remote_control
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: remote_control
+  object_type: rigid
+  params: {}
+- id: smartphone
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: smartphone
+  object_type: rigid
+  params: {}
+- id: wooden_bowl
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: wooden_bowl
+  object_type: rigid
+  params: {}
+- id: spoon_big
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: spoon_big
+  object_type: rigid
+  params: {}
+- id: computer_mouse
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: computer_mouse
+  object_type: rigid
+  params: {}
+- id: yogurt_cup
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: yogurt_cup
+  object_type: rigid
+  params: {}
+- id: pitcher
+  parent_id: workdesk_snacks_robolab_exact
+  prim_path: pitcher
+  object_type: rigid
+  params: {}
+relations: []

--- a/isaaclab_arena_environments/robolab_exact/scripts/generate_exact_catalog.py
+++ b/isaaclab_arena_environments/robolab_exact/scripts/generate_exact_catalog.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate the reference-backed RoboLab exact scene and task catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import yaml
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ROBOLAB_DIR = REPO_ROOT / "isaaclab_arena_environments" / "robolab"
+EXACT_DIR = REPO_ROOT / "isaaclab_arena_environments" / "robolab_exact"
+MANIFEST_PATH = EXACT_DIR / "SOURCE_MANIFEST.yaml"
+METADATA_PATH = REPO_ROOT / "RoboLab" / "assets" / "scenes" / "_metadata" / "scene_metadata.json"
+COPYRIGHT = """\
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as stream:
+        data = yaml.safe_load(stream)
+    assert isinstance(data, dict), f"{path} must contain a YAML mapping"
+    return data
+
+
+def _dump_yaml(data: dict[str, Any]) -> str:
+    return COPYRIGHT + yaml.safe_dump(data, sort_keys=False)
+
+
+def _expected_outputs() -> dict[Path, str]:
+    manifest = _load_yaml(MANIFEST_PATH)
+    metadata = json.loads(METADATA_PATH.read_text(encoding="utf-8"))
+    outputs: dict[Path, str] = {}
+
+    regular_scenes = {path.stem: path for path in sorted((ROBOLAB_DIR / "scenes").glob("*.yaml"))}
+    regular_tasks = sorted((ROBOLAB_DIR / "tasks").glob("*.yaml"))
+    assert set(manifest["scenes"]) == set(regular_scenes), "Manifest scenes must exactly match regular RoboLab scenes"
+
+    for scene_name, regular_path in regular_scenes.items():
+        scene_manifest = manifest["scenes"][scene_name]
+        source_name = Path(scene_manifest["source_usda"]).name
+        assert source_name == f"{scene_name}.usda"
+        source_records = {record["prim_path"]: record for record in metadata[source_name]}
+        regular = _load_yaml(regular_path)
+        regular_ids = {item["id"] for item in regular.get("objects", [])}
+        mappings = scene_manifest["object_mappings"]
+        mapped_ids = {item["arena_object_id"] for item in mappings}
+        assert mapped_ids == regular_ids, (
+            f"{scene_name}: manifest ids differ from regular scene; "
+            f"missing={sorted(regular_ids - mapped_ids)}, extra={sorted(mapped_ids - regular_ids)}"
+        )
+
+        background_id = scene_manifest["background_registry_name"]
+        references = []
+        for mapping in mappings:
+            prim_path = mapping["prim_path"]
+            assert prim_path in source_records, f"{scene_name}: missing source prim {prim_path}"
+            record = source_records[prim_path]
+            expected_type = "rigid" if record["rigid_body"] is True else "base"
+            assert (
+                mapping["object_type"] == expected_type
+            ), f"{scene_name}:{prim_path} declares {mapping['object_type']}, expected {expected_type}"
+            references.append({
+                "id": mapping["arena_object_id"],
+                "parent_id": background_id,
+                "prim_path": prim_path.split("/", 2)[2],
+                "object_type": mapping["object_type"],
+                "params": {},
+            })
+
+        exact_scene = {
+            "embodiment": regular["embodiment"],
+            "background": {
+                "id": background_id,
+                "registry_name": background_id,
+                "params": {},
+            },
+            "objects": [],
+            "object_references": references,
+            "relations": [],
+        }
+        outputs[EXACT_DIR / "scenes" / f"{scene_name}.yaml"] = _dump_yaml(exact_scene)
+
+    for task_path in regular_tasks:
+        task = _load_yaml(task_path)
+        scene_name = Path(task["external_yaml"]).stem
+        scene_manifest = manifest["scenes"][scene_name]
+        background_id = scene_manifest["background_registry_name"]
+        for subtask in task["task"]["subtasks"]:
+            if "background_scene" in subtask["params"]:
+                subtask["params"]["background_scene"] = background_id
+        outputs[EXACT_DIR / "tasks" / task_path.name] = _dump_yaml(task)
+
+    return outputs
+
+
+def _update(outputs: dict[Path, str]) -> None:
+    for path, content in outputs.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _check(outputs: dict[Path, str]) -> None:
+    stale = [
+        str(path.relative_to(REPO_ROOT))
+        for path, content in outputs.items()
+        if not path.exists() or path.read_text() != content
+    ]
+    assert not stale, f"RoboLab exact generated files are stale: {stale}"
+
+
+def main() -> None:
+    """Generate or check the RoboLab exact catalog."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--update", action="store_true", help="Write generated scene and task YAMLs.")
+    args = parser.parse_args()
+    outputs = _expected_outputs()
+    _update(outputs) if args.update else _check(outputs)
+    print(f"{'Updated' if args.update else 'Validated'} {len(outputs)} RoboLab exact YAML files.")
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena_environments/robolab_exact/scripts/validate_exact_runtime.py
+++ b/isaaclab_arena_environments/robolab_exact/scripts/validate_exact_runtime.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run one RoboLab exact task and verify that rigid references reset."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TASKS_DIR = REPO_ROOT / "isaaclab_arena_environments" / "robolab_exact" / "tasks"
+
+
+def main() -> None:
+    """Build, perturb, and reset one exact environment."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--task", required=True, help="Exact task YAML basename.")
+    known_args, remaining_args = parser.parse_known_args()
+    arena_parser = get_isaaclab_arena_cli_parser()
+    args = arena_parser.parse_args(["--num_envs", "1", *remaining_args])
+
+    with SimulationAppContext(args):
+        import torch
+
+        from isaaclab_arena.environment_spec.arena_env_graph_spec import ArenaEnvGraphSpec
+        from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+        from isaaclab_arena.evaluation.resource_cleanup import close_environment
+
+        task_path = TASKS_DIR / known_args.task
+        spec = ArenaEnvGraphSpec.from_yaml(task_path)
+        builder = ArenaEnvBuilder(spec.to_arena_env(), arena_env_builder_cfg_from_argparse(args))
+        manager_cfg, gym_kwargs = builder.compose_manager_cfg()
+        manager_cfg.recorders = {}
+        manager_cfg.episode_recorders = {}
+        env = builder.make_registered(manager_cfg, gym_kwargs)
+
+        try:
+            env.reset()
+            reference_names = [reference.id for reference in spec.object_references or []]
+            initial_poses = {name: env.unwrapped.scene[name].data.root_pose_w.torch.clone() for name in reference_names}
+            for name in reference_names:
+                asset = env.unwrapped.scene[name]
+                perturbed_pose = initial_poses[name].clone()
+                perturbed_pose[:, 0] += 1.0
+                asset.write_root_pose_to_sim(perturbed_pose)
+
+            env.reset()
+            for name, initial_pose in initial_poses.items():
+                actual_pose = env.unwrapped.scene[name].data.root_pose_w.torch
+                torch.testing.assert_close(actual_pose, initial_pose, atol=1e-5, rtol=0.0)
+            print(f"[runtime] {task_path.name}: reset {len(reference_names)} rigid references")
+        finally:
+            close_environment(env)
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena_environments/robolab_exact/tasks/apple_and_yogurt_in_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/apple_and_yogurt_in_bowl.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: apple_and_yogurt_in_bowl
+external_yaml: ../scenes/workdesk_snacks.yaml
+task:
+  composition: parallel
+  description: Put the apple and yogurt in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: apple
+      destination_location: wooden_bowl
+      background_scene: workdesk_snacks_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: yogurt_cup
+      destination_location: wooden_bowl
+      background_scene: workdesk_snacks_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/bagels_on_plate.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/bagels_on_plate.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bagels_on_plate
+external_yaml: ../scenes/bagel_plate_banana_bowl.yaml
+task:
+  composition: parallel
+  description: Put the bagels on the plate
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bagel_1
+      destination_location: plate
+      background_scene: bagel_plate_banana_bowl_robolab_exact
+      episode_length_s: 70.0
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bagel_2
+      destination_location: plate
+      background_scene: bagel_plate_banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/banana_in_bowl.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/banana_in_bowl.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: banana_in_bowl
+external_yaml: ../scenes/banana_bowl.yaml
+task:
+  composition: atomic
+  description: pick up the banana and place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/banana_on_plate.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/banana_on_plate.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: banana_on_plate
+external_yaml: ../scenes/bagel_plate_banana_bowl.yaml
+task:
+  composition: atomic
+  description: Pick up the banana and place it on the plate.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: plate
+      background_scene: bagel_plate_banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/banana_then_rubiks_cube.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/banana_then_rubiks_cube.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: banana_then_rubiks_cube
+external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
+task:
+  composition: sequential
+  description: pick up the banana and place it in the bowl ; pick up the cube and
+    place it in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: cube
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/bbq_sauce_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/bbq_sauce_in_bin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bbq_sauce_in_bin
+external_yaml: ../scenes/bin_condiments.yaml
+task:
+  composition: parallel
+  description: Put the red BBQ sauce bottles in the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bbq_sauce_bottle_1
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bbq_sauce_bottle_2
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/big_pumpkin_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/big_pumpkin_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: big_pumpkin_in_bin
+external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
+task:
+  composition: atomic
+  description: pick up the large pumpkin and place it into the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_large
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/black_items_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/black_items_in_bin.yaml
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: black_items_in_bin
+external_yaml: ../scenes/workdesk_bin.yaml
+task:
+  composition: parallel
+  description: Put the black items in the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: keyboard
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: remote_control
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: computer_mouse
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: smartphone
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: glasses
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/bowl_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/bowl_in_bin.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: bowl_in_bin
+external_yaml: ../scenes/bin_mug_mustard_marker_bowl.yaml
+task:
+  composition: atomic
+  description: Pick up the bowl and place it in the grey bin.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bowl
+      destination_location: grey_bin
+      background_scene: bin_mug_mustard_marker_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/butter_above_raisin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/butter_above_raisin.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: butter_above_raisin
+external_yaml: ../scenes/butter_raisin_box.yaml
+task:
+  composition: atomic
+  description: pick up the butter box and place it on top of the raisin box
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: butter_hope_robolab
+      destination_location: raisin_box_hope_robolab
+      background_scene: butter_raisin_box_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/canned_food_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/canned_food_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: canned_food_in_bin
+external_yaml: ../scenes/bin_condiments.yaml
+task:
+  composition: atomic
+  description: Put the canned food in the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: canned_tuna
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/clamp_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/clamp_in_right_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clamp_in_right_bin
+external_yaml: ../scenes/tools_container.yaml
+task:
+  composition: atomic
+  description: pick up the spring clamp and place it in the right bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: spring_clamp
+      destination_location: bin_b04
+      background_scene: tools_container_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/clear_organic_objects.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/clear_organic_objects.yaml
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clear_organic_objects
+external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
+task:
+  composition: parallel
+  description: Clear away the organic objects
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lemon_1
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lemon_2
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lime_1
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lime_2
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: orange_1
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: orange_2
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pomegranate
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_large
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_small
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: red_onion
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: avocado
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/clutter_plastic.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/clutter_plastic.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clutter_plastic
+external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
+task:
+  composition: parallel
+  description: Put all plastic bottles away in the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: white_packer_bottle
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: milk_jug
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: utilityjug
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/clutter_pumpkin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/clutter_pumpkin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: clutter_pumpkin
+external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
+task:
+  composition: parallel
+  description: Put all the pumpkins away in the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_large
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_small
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/coffee_pot_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/coffee_pot_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: coffee_pot_in_bin
+external_yaml: ../scenes/bin_condiments.yaml
+task:
+  composition: atomic
+  description: pick up the coffee pot and place it into the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: coffee_pot
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/condiments_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/condiments_in_bin.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: condiments_in_bin
+external_yaml: ../scenes/bin_condiments.yaml
+task:
+  composition: parallel
+  description: Sort the sauce condiments into the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: ranch_dressing
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bbq_sauce_bottle_1
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bbq_sauce_bottle_2
+      destination_location: grey_bin
+      background_scene: bin_condiments_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/electronics_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/electronics_in_bin.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: electronics_in_bin
+external_yaml: ../scenes/workdesk_bin.yaml
+task:
+  composition: parallel
+  description: Put the electronic devices in the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: smartphone
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: remote_control
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: computer_mouse
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: keyboard
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_boxes.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_boxes.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: food_packing_1_boxes
+external_yaml: ../scenes/foodpacking_1bin_1box_1can.yaml
+task:
+  composition: atomic
+  description: pick up the cheez it box and place it into the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: cheez_it_box
+      destination_location: bin_a06
+      background_scene: foodpacking_1bin_1box_1can_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_cans.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/food_packing_1_cans.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: food_packing_1_cans
+external_yaml: ../scenes/foodpacking_1bin_1box_1can.yaml
+task:
+  composition: atomic
+  description: Pack canned foods into the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: tomato_soup_can
+      destination_location: bin_a06
+      background_scene: foodpacking_1bin_1box_1can_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/hammers_in_left_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/hammers_in_left_bin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: hammers_in_left_bin
+external_yaml: ../scenes/tools_container.yaml
+task:
+  composition: parallel
+  description: Put the red hammer and black hammer in the left bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: red_hammer
+      destination_location: container_f24
+      background_scene: tools_container_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: black_hammer
+      destination_location: container_f24
+      background_scene: tools_container_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/larger_object_raisin_box_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/larger_object_raisin_box_in_bin.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: larger_object_raisin_box_in_bin
+external_yaml: ../scenes/butter_raisin_box_grey_bin.yaml
+task:
+  composition: atomic
+  description: Pick up the red raisin box and place it into the grey bin on the maple
+    table.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: raisin_box
+      destination_location: grey_bin
+      background_scene: butter_raisin_box_grey_bin_robolab_exact
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/marker_in_mug.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/marker_in_mug.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: marker_in_mug
+external_yaml: ../scenes/workdesk.yaml
+task:
+  composition: atomic
+  description: Put the whiteboard marker in the mug
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: marker
+      destination_location: ceramic_mug
+      background_scene: workdesk_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/mouse_on_keyboard.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/mouse_on_keyboard.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: mouse_on_keyboard
+external_yaml: ../scenes/workdesk.yaml
+task:
+  composition: atomic
+  description: place the computer mouse on the keyboard
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: computer_mouse
+      destination_location: keyboard
+      background_scene: workdesk_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/mustard_above_raisin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/mustard_above_raisin.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: mustard_above_raisin
+external_yaml: ../scenes/mustard_raisin_box.yaml
+task:
+  composition: atomic
+  description: Pick up the mustard bottle and place it on the raisin box.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard_bottle
+      destination_location: raisin_box
+      background_scene: mustard_raisin_box_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/mustard_in_left_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/mustard_in_left_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: mustard_in_left_bin
+external_yaml: ../scenes/two_bin.yaml
+task:
+  composition: atomic
+  description: put the mustard in the left bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard
+      destination_location: grey_bin_left
+      background_scene: two_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/mustard_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/mustard_in_right_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: mustard_in_right_bin
+external_yaml: ../scenes/two_bin.yaml
+task:
+  composition: atomic
+  description: Put the mustard in the right bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: mustard
+      destination_location: grey_bin_right
+      background_scene: two_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/non_hammer_tools_in_right_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/non_hammer_tools_in_right_bin.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: non_hammer_tools_in_right_bin
+external_yaml: ../scenes/tools_container.yaml
+task:
+  composition: parallel
+  description: Put the non-hammer tools in the right bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: cordless_drill
+      destination_location: bin_b04
+      background_scene: tools_container_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: spring_clamp
+      destination_location: bin_b04
+      background_scene: tools_container_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube
+external_yaml: ../scenes/rubiks_cube_bowl.yaml
+task:
+  composition: atomic
+  description: put the rubiks cube in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: rubiks_cube
+      destination_location: bowl
+      background_scene: rubiks_cube_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_and_banana.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_and_banana.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube_and_banana
+external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
+task:
+  composition: parallel
+  description: Put the cube and the banana in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: cube
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_then_banana.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/rubiks_cube_then_banana.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: rubiks_cube_then_banana
+external_yaml: ../scenes/rubiks_cube_banana_bowl.yaml
+task:
+  composition: sequential
+  description: Put the cube then the banana in the bowl
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: cube
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: bowl
+      background_scene: rubiks_cube_banana_bowl_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/sauce_bottles_crate.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/sauce_bottles_crate.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: sauce_bottles_crate
+external_yaml: ../scenes/bottles_crate.yaml
+task:
+  composition: atomic
+  description: place the bbq sauce bottle into the purple crate on the table
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: bbq_sauce_bottle
+      destination_location: purple_crate
+      background_scene: bottles_crate_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/small_pumpkin_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/small_pumpkin_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: small_pumpkin_in_bin
+external_yaml: ../scenes/clutter_fruit_bottle_bluebin.yaml
+task:
+  composition: atomic
+  description: Put the small pumpkin in the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: pumpkin_small
+      destination_location: container_f24
+      background_scene: clutter_fruit_bottle_bluebin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/smaller_object_butter_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/smaller_object_butter_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: smaller_object_butter_in_bin
+external_yaml: ../scenes/butter_raisin_box_grey_bin.yaml
+task:
+  composition: atomic
+  description: Place the smaller object in the grey bin.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: butter
+      destination_location: grey_bin
+      background_scene: butter_raisin_box_grey_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/smartphone_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/smartphone_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: smartphone_in_bin
+external_yaml: ../scenes/workdesk_bin.yaml
+task:
+  composition: atomic
+  description: Put the smartphone in the grey bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: smartphone
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/throw_away_apple.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/throw_away_apple.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: throw_away_apple
+external_yaml: ../scenes/workdesk_snacks.yaml
+task:
+  composition: atomic
+  description: place the apple into the plasticpail on the table
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: apple
+      destination_location: plasticpail
+      background_scene: workdesk_snacks_robolab_exact
+      episode_length_s: 70.0

--- a/isaaclab_arena_environments/robolab_exact/tasks/throw_away_snacks.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/throw_away_snacks.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: throw_away_snacks
+external_yaml: ../scenes/workdesk_snacks.yaml
+task:
+  composition: parallel
+  description: Put away the snacks in the bin
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: apple
+      destination_location: plasticpail
+      background_scene: workdesk_snacks_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: yogurt_cup
+      destination_location: plasticpail
+      background_scene: workdesk_snacks_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1

--- a/isaaclab_arena_environments/robolab_exact/tasks/toy_in_bin.yaml
+++ b/isaaclab_arena_environments/robolab_exact/tasks/toy_in_bin.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: toy_in_bin
+external_yaml: ../scenes/workdesk_bin.yaml
+task:
+  composition: atomic
+  description: place the lizard figurine into the grey bin on the table
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: lizard_figurine
+      destination_location: grey_bin
+      background_scene: workdesk_bin_robolab_exact
+      episode_length_s: 70.0
+      max_separation:
+      - 0.1
+      - 0.1
+      - 0.1


### PR DESCRIPTION
## Summary
Add exact RoboLab reference environments

## Detailed description
- Mirror all 17 RoboLab scenes and 38 tasks using authored full-scene layouts and rigid object references.
- Enable contact reporting, nested rigid-body sensor paths, reference resets, and graph experiment episode-length overrides.
- Add a source manifest, deterministic generators, catalog tests, and runtime reset validation.
- Validate all 38 tasks with two single-environment smoke episodes; local scene USDAs are used until Nucleus mirrors are available.