### PR TITLE
Fail fast on missing inference credentials

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -88,6 +88,26 @@ def resolve_inference_endpoint(name: str | None = None) -> InferenceEndpoint:
     return INFERENCE_ENDPOINTS[resolved]
 
 
+def require_inference_api_key(endpoint: str | None = None, api_key: str | None = None) -> tuple[InferenceEndpoint, str]:
+    """Resolve an inference endpoint and require its API key.
+
+    Args:
+        endpoint: Inference endpoint name, or ``None`` to use the environment/default.
+        api_key: Explicit API key, or ``None`` to read the selected endpoint's environment variable.
+
+    Returns:
+        The selected endpoint and its resolved API key.
+    """
+    inference_endpoint = resolve_inference_endpoint(endpoint)
+    resolved_api_key = api_key or os.getenv(inference_endpoint.api_key_env_var)
+    assert resolved_api_key, (
+        f"API key required for the {inference_endpoint.name!r} inference endpoint: set "
+        f"{inference_endpoint.api_key_env_var} or pass api_key. Select another endpoint with "
+        f"{INFERENCE_ENDPOINT_ENV_VAR}."
+    )
+    return inference_endpoint, resolved_api_key
+
+
 # -----------------------------------------------------------------------------
 # Inference backend
 # -----------------------------------------------------------------------------
@@ -138,13 +158,7 @@ class InferenceBackend:
         assert (
             0 <= max_retries < MAX_RETRIES_LIMIT
         ), f"max_retries must be in [0, {MAX_RETRIES_LIMIT}), got {max_retries}"
-        inference_endpoint = resolve_inference_endpoint(endpoint)
-        resolved_api_key = api_key or os.getenv(inference_endpoint.api_key_env_var)
-        assert resolved_api_key, (
-            f"API key required for the {inference_endpoint.name!r} inference endpoint: set "
-            f"{inference_endpoint.api_key_env_var} or pass api_key. Select another endpoint with "
-            f"{INFERENCE_ENDPOINT_ENV_VAR}."
-        )
+        inference_endpoint, resolved_api_key = require_inference_api_key(endpoint, api_key)
         resolved_base_url = base_url or inference_endpoint.base_url
         resolved_model = model or inference_endpoint.model
         print(

--- a/isaaclab_arena/tests/test_inference_backend.py
+++ b/isaaclab_arena/tests/test_inference_backend.py
@@ -19,6 +19,7 @@ from isaaclab_arena.agentic_environment_generation.inference_backend import (
     PUBLIC_ENDPOINT,
     InferenceBackend,
     StructuredOutputRequest,
+    require_inference_api_key,
     resolve_inference_endpoint,
 )
 from isaaclab_arena.tests.utils.agentic_environment_generation import chat_response, inference_backend
@@ -69,6 +70,24 @@ class TestResolveInferenceEndpoint:
     def test_raises_on_an_unknown_name(self):
         with pytest.raises(AssertionError, match="Unknown inference endpoint"):
             resolve_inference_endpoint("staging")
+
+
+class TestRequireInferenceApiKey:
+    def test_returns_selected_endpoint_and_environment_key(self, monkeypatch):
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "public-key")
+        assert require_inference_api_key(PUBLIC_ENDPOINT.name) == (PUBLIC_ENDPOINT, "public-key")
+
+    def test_explicit_key_overrides_environment(self, monkeypatch):
+        monkeypatch.setenv(PUBLIC_ENDPOINT.api_key_env_var, "env-key")
+        assert require_inference_api_key(PUBLIC_ENDPOINT.name, "explicit-key") == (PUBLIC_ENDPOINT, "explicit-key")
+
+    def test_error_lists_recovery_paths(self):
+        with pytest.raises(AssertionError) as exc_info:
+            require_inference_api_key(PUBLIC_ENDPOINT.name)
+        message = str(exc_info.value)
+        assert PUBLIC_ENDPOINT.api_key_env_var in message
+        assert "api_key" in message
+        assert INFERENCE_ENDPOINT_ENV_VAR in message
 
 
 class TestInit:

--- a/isaaclab_arena_examples/agentic_environment_generation/cli_runner.py
+++ b/isaaclab_arena_examples/agentic_environment_generation/cli_runner.py
@@ -38,7 +38,11 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from isaaclab_arena.agentic_environment_generation.inference_backend import DEFAULT_ENDPOINT_NAME, INFERENCE_ENDPOINTS
+from isaaclab_arena.agentic_environment_generation.inference_backend import (
+    DEFAULT_ENDPOINT_NAME,
+    INFERENCE_ENDPOINTS,
+    require_inference_api_key,
+)
 from isaaclab_arena.agentic_environment_generation.spec_io import (
     DEFAULT_AGENTIC_OUTPUT_DIR,
     write_env_graph_spec,
@@ -376,6 +380,8 @@ def main() -> int:
             build_env_and_run_policy(_resolved_graph_spec_yaml(args_cli), args_cli)
         return 0
 
+    # Validate inference endpoint credentials before full mode starts Isaac Sim.
+    require_inference_api_key(args_cli.inference_endpoint)
     with SimulationAppContext(args_cli):
         env_graph_spec_path = resolve_env_spec(args_cli)
         if env_graph_spec_path is None:


### PR DESCRIPTION
## Summary
Validate inference credentials before simulation

## Detailed description
- Prevent missing API keys from starting Isaac Sim unnecessarily
- Reuse credential resolution in the inference backend and CLI preflight
- Cover environment, explicit-key, and recovery-path behavior

Fix for v0.3 VDR