### PR TITLE
Clarify agentic env gen doc from VDR feedback

### DIFF
--- a/docs/pages/advanced/private_omniverse.rst
+++ b/docs/pages/advanced/private_omniverse.rst
@@ -21,7 +21,7 @@ To generate those, follow the instructions on the
 .. code-block:: bash
 
     export OMNI_USER='$omni-api-token'
-    export OMNI_PASS=<your_generated_api_token>
+    export OMNI_PASS="YOUR_GENERATED_API_TOKEN"
 
 Where:
 

--- a/docs/pages/concepts/agentic_environment_generation/cli_runner.rst
+++ b/docs/pages/concepts/agentic_environment_generation/cli_runner.rst
@@ -6,6 +6,11 @@ the generation interface, resolving a prompt, building an existing graph spec,
 or running the complete pipeline. Run it inside the Isaac Lab-Arena development
 container:
 
+.. note::
+
+   Modes ``schema``, ``catalog``, ``prim_tree``, and ``build`` do not call a
+   remote model and do not require an inference API key.
+
 .. code-block:: bash
 
    python isaaclab_arena_examples/agentic_environment_generation/cli_runner.py \

--- a/docs/pages/concepts/agentic_environment_generation/cli_runner.rst
+++ b/docs/pages/concepts/agentic_environment_generation/cli_runner.rst
@@ -56,8 +56,11 @@ The ``--mode`` option selects which parts of the
        zero-action policy in one process. This is the default.
      - **Prompt** through **evaluation**, without a manual-edit pause.
 
-Use ``resolve`` followed by ``build`` when the generated YAML needs manual
-review:
+.. warning::
+
+   ``full`` does not pause for review between generation and evaluation.
+   Generated specs should be reviewed before evaluation. For reviewable
+   workflows, use ``resolve``, review or edit the YAML, and then use ``build``:
 
 .. code-block:: bash
 

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -52,7 +52,7 @@ container. This step is required only once per host environment.
 
       .. code-block:: bash
 
-         export NVIDIA_API_KEY=<your-ngc-api-key>
+         export NVIDIA_API_KEY="YOUR_NGC_API_KEY"
 
    .. tab-item:: NVIDIA Internal Endpoint
 
@@ -62,7 +62,7 @@ container. This step is required only once per host environment.
 
       .. code-block:: bash
 
-         export NV_API_KEY=<your-internal-api-key>
+         export NV_API_KEY="YOUR_INTERNAL_API_KEY"
 
       .. note::
 
@@ -80,7 +80,7 @@ container. This step is required only once per host environment.
 
       .. code-block:: bash
 
-         export OPENAI_API_KEY=<your-openai-api-key>
+         export OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 
       .. note::
 


### PR DESCRIPTION
## Summary
Clarify agentic env gen doc from VDR feedback

## Detailed description
- Identify agentic CLI modes that do not require API keys
- Warn that `full` skips review and recommend `resolve` then `build`
- Make published credential export examples valid Bash syntax
