### PR TITLE
Cherry-pick: Force CPU to fix rendering after rebuild bug (#1168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ TAGS
 
 # Ignore plots
 isaaclab_arena/tests/**.png
+# Images written by tests when their SAVE_IMAGES debugging flag is turned on
+isaaclab_arena/tests/output/
 
 # Ignore core dumps produced by debugpy
 core

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -35,6 +35,33 @@ if TYPE_CHECKING:
     from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
+def disable_fabric_for_runs(experiment_cfg: ArenaExperimentCfg) -> None:
+    """Disable Fabric and force the CPU device on every run that will be built more than once.
+
+    Args:
+        experiment_cfg: Experiment whose run configurations are mutated in place.
+    """
+    # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this once the render after
+    # rebuild bug is solved in Lab.
+    # Under GPU+Fabric every in-process build after the first has rendering artifacts due to incorrect
+    # poses for some geometry (for example, the robot's gripper has been seen to appear at the origin).
+    # As a workaround, we therefore disable Fabric and force the CPU device (the bug is GPU+Fabric only)
+    # whenever this process will build the env more than once (multiple runs and/or num_rebuilds > 1).
+    builds_in_process = sum(run_cfg.num_rebuilds for run_cfg in experiment_cfg.runs.values())
+    if builds_in_process <= 1:
+        return
+    print(
+        "Disabling Fabric and forcing the CPU device for all builds: this process will build the "
+        f"environment {builds_in_process} time(s) across {len(experiment_cfg.runs)} run(s), and the "
+        "GPU+Fabric post-rebuild rendering bug corrupts every build after the first "
+        "(slower than running on GPU with Fabric).",
+        flush=True,
+    )
+    for run_cfg in experiment_cfg.runs.values():
+        run_cfg.environment_builder.disable_fabric = True
+        run_cfg.environment_builder.device = "cpu"
+
+
 def execute_experiment(
     experiment_cfg: ArenaExperimentCfg,
     output_dir: Path,
@@ -54,6 +81,8 @@ def execute_experiment(
     Returns:
         One result per attempted run, in execution order.
     """
+    disable_fabric_for_runs(experiment_cfg)
+
     results = []
     for run_cfg in experiment_cfg.runs.values():
         print(f"Running run '{run_cfg.name}'", flush=True)

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for camera rendering across an experiment-runner stage rebuild."""
+
+import os
+import torch
+from functools import partial
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+HEADLESS = True
+ENABLE_CAMERAS = True
+# Steps taken after reset before images are captured.
+NUM_STEPS = 30
+# Mean per-channel 0-255 difference tolerated per camera. Settled renders agree to well under this;
+# geometry missing from a render moves this into the hundreds.
+MAX_MEAN_ABSOLUTE_DIFFERENCE = 1.0
+# Per-channel difference above which a pixel counts as changed, and the fraction of such pixels
+# tolerated. Catches a single missing part that is too small to move the mean much.
+PIXEL_DIFFERENCE_TOLERANCE = 8
+MAX_CHANGED_PIXEL_FRACTION = 0.10
+# Minimum per-image standard deviation, so a pair of blank renders cannot pass the comparison vacuously.
+MIN_IMAGE_STD = 1.0
+# Set True to dump the compared renders as PNGs into IMAGE_OUTPUT_DIR, which is created on demand.
+SAVE_IMAGES = False
+IMAGE_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
+
+
+def _build_droid_env(disable_fabric: bool):
+    """Build a single-env, camera-enabled DROID environment on a lit packing table.
+
+    Args:
+        disable_fabric: Whether to build the environment with Fabric disabled.
+    """
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.droid.droid import DroidAbsoluteJointPositionEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+
+    asset_registry = AssetRegistry()
+    scene = Scene(
+        assets=[
+            asset_registry.get_asset_by_name("light")(),
+            asset_registry.get_asset_by_name("packing_table")(),
+        ]
+    )
+    arena_env = IsaacLabArenaEnvironment(
+        name="test_render_after_stage_rebuild",
+        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=ENABLE_CAMERAS),
+        scene=scene,
+    )
+    cli_args = ["--num_envs", "1", "--enable_cameras"]
+    if disable_fabric:
+        cli_args.append("--disable_fabric")
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(cli_args)
+    # Both builds share the builder's default seed, so reset-time joint randomization draws the same
+    # offsets and the two builds are expected to render the same scene.
+    builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli))
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    # Arena turns this off by default. Without it a reset can return while assets are still streaming,
+    # which blanks or misplaces geometry in the first frames and would be misread as a rebuild failure.
+    env_cfg.wait_for_textures = True
+    return builder.make_registered(env_cfg, env_kwargs)
+
+
+def _render_camera_images(env) -> dict[str, torch.Tensor]:
+    """Reset, step to settle the scene, and return a host copy of each camera's RGB image."""
+    env.reset()
+    with torch.inference_mode():
+        actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+        for _ in range(NUM_STEPS):
+            obs, _, _, _, _ = env.step(actions)
+    return {name: image.cpu().clone() for name, image in obs["camera_obs"].items()}
+
+
+def _save_comparison_images(
+    images_before_rebuild: dict[str, torch.Tensor],
+    images_after_rebuild: dict[str, torch.Tensor],
+) -> None:
+    """Write a before, after, and absolute-difference PNG per camera into IMAGE_OUTPUT_DIR."""
+    from PIL import Image
+
+    os.makedirs(IMAGE_OUTPUT_DIR, exist_ok=True)
+    for camera_name in sorted(images_before_rebuild.keys() & images_after_rebuild.keys()):
+        before = images_before_rebuild[camera_name][0]
+        after = images_after_rebuild[camera_name][0]
+        images_to_save = {
+            "before": before,
+            "after": after,
+            "difference": (before.float() - after.float()).abs().to(torch.uint8),
+        }
+        for tag, image in images_to_save.items():
+            output_path = os.path.join(IMAGE_OUTPUT_DIR, f"{camera_name}-{tag}.png")
+            Image.fromarray(image.numpy()).save(output_path)
+            print(f"Wrote {output_path}", flush=True)
+
+
+def _test_render_after_stage_rebuild(simulation_app, disable_fabric: bool) -> bool:
+    from isaaclab_arena.evaluation.resource_cleanup import close_environment
+
+    env = _build_droid_env(disable_fabric)
+    try:
+        images_before_rebuild = _render_camera_images(env)
+    finally:
+        # The same teardown the experiment runner performs between rebuilds.
+        close_environment(env)
+
+    env = _build_droid_env(disable_fabric)
+    try:
+        images_after_rebuild = _render_camera_images(env)
+    finally:
+        close_environment(env)
+
+    # Written before the assertions so a failing rebuild still leaves images to look at.
+    if SAVE_IMAGES:
+        _save_comparison_images(images_before_rebuild, images_after_rebuild)
+
+    assert set(images_before_rebuild) == set(images_after_rebuild), (
+        "The rebuilt environment exposes a different set of cameras; "
+        f"before: {sorted(images_before_rebuild)}, after: {sorted(images_after_rebuild)}."
+    )
+    for camera_name, before in images_before_rebuild.items():
+        after = images_after_rebuild[camera_name]
+        assert before.dtype == torch.uint8, f"Expected '{camera_name}' to render 0-255 RGB; got {before.dtype}."
+        image_std = float(before.float().std())
+        assert image_std > MIN_IMAGE_STD, (
+            f"'{camera_name}' rendered an almost uniform image (std {image_std:.3f}), "
+            "so comparing it across the rebuild would be vacuous."
+        )
+
+        absolute_difference = (before.float() - after.float()).abs()
+        mean_absolute_difference = float(absolute_difference.mean())
+        changed_pixel_fraction = float(absolute_difference.gt(PIXEL_DIFFERENCE_TOLERANCE).float().mean())
+        rebuild_diagnostics = (
+            f"'{camera_name}' renders differently after the stage rebuild "
+            f"(mean absolute difference {mean_absolute_difference:.3f}/255, "
+            f"{changed_pixel_fraction:.1%} of pixels changed by more than {PIXEL_DIFFERENCE_TOLERANCE}/255). "
+            "Scene geometry likely failed to render into the rebuilt stage."
+        )
+        assert mean_absolute_difference <= MAX_MEAN_ABSOLUTE_DIFFERENCE, rebuild_diagnostics
+        assert changed_pixel_fraction <= MAX_CHANGED_PIXEL_FRACTION, rebuild_diagnostics
+    return True
+
+
+@pytest.mark.with_cameras
+def test_render_after_stage_rebuild_without_fabric():
+    """Rebuilds render correctly with Fabric off, which is the path the experiment runner takes."""
+    assert run_function_with_persistent_simulation_app(
+        partial(_test_render_after_stage_rebuild, disable_fabric=True),
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+        force_disable_fabric=True,
+    )
+
+
+# TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Un-skip once the render after rebuild
+# bug is solved in Lab. Under GPU+Fabric every build after the first renders some geometry at the wrong
+# pose (the DROID gripper has been seen at the origin), which is what this test would catch.
+@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
+@pytest.mark.with_cameras
+def test_render_after_stage_rebuild_with_fabric():
+    """Rebuilds should also render correctly with Fabric on, which is the default outside this bug."""
+    assert run_function_with_persistent_simulation_app(
+        partial(_test_render_after_stage_rebuild, disable_fabric=False),
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+        # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
+        force_disable_fabric=False,
+    )

--- a/isaaclab_arena/tests/utils/persistent_simulation_app.py
+++ b/isaaclab_arena/tests/utils/persistent_simulation_app.py
@@ -7,7 +7,9 @@ import atexit
 import os
 import sys
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
 
 from isaaclab.app import AppLauncher
 from isaacsim import SimulationApp
@@ -91,10 +93,42 @@ def get_persistent_simulation_app(headless: bool, enable_cameras: bool = False) 
     return _PERSISTENT_SIM_APP_LAUNCHER.app
 
 
+@contextmanager
+def _fabric_disabled_for_env_builds(force_disable_fabric: bool) -> Iterator[None]:
+    """Force Fabric off for every environment built inside the ``with`` block.
+
+    Patches the builder's single ``parse_env_cfg`` call rather than the builder config, so it holds
+    for every env a test builds without each test opting in.
+
+    Args:
+        force_disable_fabric: Whether to force Fabric off. Pass False for a test that must build
+            with Fabric on, which is otherwise impossible on the shared app.
+    """
+    if not force_disable_fabric:
+        yield
+        return
+
+    # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove once the render-after-rebuild
+    # bug is fixed in Lab. The persistent app rebuilds the stage once per test, and under GPU+Fabric
+    # every build after the first renders some geometry at the wrong pose (the DROID gripper has been
+    # seen at the origin), which would surface as unrelated tests failing on their rendered output.
+    # Imported here because Lab modules are only importable once the SimulationApp is running.
+    from isaaclab_arena.environments import arena_env_builder
+
+    unpatched_parse_env_cfg = arena_env_builder.parse_env_cfg
+
+    def parse_env_cfg_without_fabric(*args, **kwargs):
+        return unpatched_parse_env_cfg(*args, **{**kwargs, "use_fabric": False})
+
+    with patch.object(arena_env_builder, "parse_env_cfg", parse_env_cfg_without_fabric):
+        yield
+
+
 def run_function_with_persistent_simulation_app(
     function: Callable[..., bool],
     headless: bool = True,
     enable_cameras: bool = False,
+    force_disable_fabric: bool = True,
     **kwargs,
 ) -> bool:
     """Run a function with the persistent SimulationApp in the current pytest process.
@@ -107,6 +141,8 @@ def run_function_with_persistent_simulation_app(
             and returns whether the test passed.
         headless: Whether to create the SimulationApp without a GUI.
         enable_cameras: Whether to enable camera rendering.
+        force_disable_fabric: Whether to force every environment built by the function to disable
+            Fabric, regardless of the builder config it was given.
         **kwargs: Additional keyword arguments forwarded to the function.
 
     Returns:
@@ -115,7 +151,8 @@ def run_function_with_persistent_simulation_app(
     # Get a persistent simulation app
     try:
         simulation_app = get_persistent_simulation_app(headless=headless, enable_cameras=enable_cameras)
-        test_result = bool(function(simulation_app, **kwargs))
+        with _fabric_disabled_for_env_builds(force_disable_fabric):
+            test_result = bool(function(simulation_app, **kwargs))
         if not test_result:
             subprocess_utils._AT_LEAST_ONE_TEST_FAILED = True
         return test_result


### PR DESCRIPTION
## Summary
Cherry-pick of #1168 onto `release/0.3.0`: force CPU to fix rendering after the stage-rebuild bug.

## Detailed description
- After a stage reset, some object poses used by the renderer could differ from the poses used by physics, rendering parts of the robot in the wrong locations.
- Workaround forces the system to run on CPU with fabrics disabled when a stage rebuild is required.
- Clean cherry-pick of squash-merge `abb14a2b9` (parent matched `release/0.3.0` HEAD); no conflicts.
- Addresses: [6657464](https://nvbugs.nvidia.com/6657464) and [6628837](https://nvbugs.nvidia.com/6628837)
