### PR TITLE
Add industrial tool-sort benchmark

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 docs/images/ filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
+isaaclab_arena/assets/industrial_tool_sort/industrial__fr3_robotiq_2f85/franka_fr3_v1/Payload/GeometryLibrary.usdc filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ TAGS
 # Datasets
 *datasets/
 
+# Local industrial tool-sort assets
+/isaaclab_arena/assets/industrial_tool_sort/
+
 # Training logs and outputs
 *wandb/
 

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from typing import Any
 
 import isaaclab.sim as sim_utils
@@ -15,6 +16,8 @@ from isaaclab_arena.assets.lightwheel_utils import acquire_lightwheel_asset
 from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR, ISAAC_STAGING_NUCLEUS_DIR
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
+
+_INDUSTRIAL_TOOL_SORT_ASSET_ROOT = Path(__file__).resolve().parent / "industrial_tool_sort"
 
 
 class LibraryBackground(Background):
@@ -239,6 +242,18 @@ class TableOakRobolab(LibraryBackground):
     tags = ["background", "robolab"]
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/table_oak.usd"
     object_min_z = -0.05
+
+
+@register_asset
+class IndustrialFr3WorkcellTable(LibraryBackground):
+    """Industrial FR3 workcell table used by the tool-sorting benchmark."""
+
+    name = "industrial__fr3_workcell_table"
+    tags = ["background", "industrial", "tool_sort"]
+    usd_path = str(
+        _INDUSTRIAL_TOOL_SORT_ASSET_ROOT / "industrial__fr3_workcell_table" / "industrial__fr3_workcell_table.usda"
+    )
+    object_min_z = 0.0
 
 
 # -----------------------------------------------------------------------------

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -6,6 +6,7 @@
 
 import copy
 from abc import ABC
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import isaaclab.sim as sim_utils
@@ -32,6 +33,8 @@ from isaaclab_arena.assets.object_utils import (
 )
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.utils.pose import Pose
+
+_INDUSTRIAL_TOOL_SORT_ASSET_ROOT = Path(__file__).resolve().parent / "industrial_tool_sort"
 
 
 class LibraryObject(Object):
@@ -1893,6 +1896,117 @@ class GreyBinRobolab(LibraryObject):
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/grey_bin.usd"
     # USD has 0.07 scale which is ignored by spawner. Setting it back again.
     scale = (0.007, 0.007, 0.007)
+
+
+# ---------------------------------------------------------------------------
+# Industrial tool-sort assets
+# ---------------------------------------------------------------------------
+
+
+class IndustrialToolSortObject(LibraryObject):
+    """Base for rigid tools imported from the industrial benchmark."""
+
+    tags = ["object", "graspable", "industrial", "tool_sort"]
+
+    def get_world_bounding_box(self):
+        initial_pose = self.get_initial_pose()
+        if self.is_anchor and isinstance(initial_pose, Pose):
+            return (
+                self.get_bounding_box()
+                .enclosing_after_rotation(initial_pose.rotation_xyzw)
+                .translated(initial_pose.position_xyz)
+            )
+        return super().get_world_bounding_box()
+
+
+@register_asset
+class IndustrialToolSortHammer(IndustrialToolSortObject):
+    """Hammer manipuland from the industrial tool-sorting benchmark."""
+
+    name = "vabar_tool_sort__hammer"
+    usd_path = str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / name / f"{name}.usda")
+
+
+@register_asset
+class IndustrialToolSortDrill(IndustrialToolSortObject):
+    """Drill manipuland from the industrial tool-sorting benchmark."""
+
+    name = "vabar_tool_sort__drill"
+    usd_path = str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / name / f"{name}.usda")
+
+
+@register_asset
+class IndustrialToolSortRoundNut(IndustrialToolSortObject):
+    """Round-nut manipuland from the industrial tool-sorting benchmark."""
+
+    name = "vabar_tool_sort__round_nut"
+    usd_path = str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / name / f"{name}.usda")
+
+
+@register_asset
+class IndustrialToolSortClamp(IndustrialToolSortObject):
+    """Clamp manipuland from the industrial tool-sorting benchmark."""
+
+    name = "vabar_tool_sort__clamp"
+    usd_path = str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / name / f"{name}.usda")
+
+
+@register_asset
+class IndustrialToolSortBin(Object):
+    """Source or compartmented destination bin for industrial tool sorting."""
+
+    name = "industrial__tool_sort_bin"
+    tags = ["object", "container", "industrial", "tool_sort"]
+
+    def __init__(
+        self,
+        instance_name: str = "tool_sort_bin",
+        side: str = "destination",
+        appearance: str = "default",
+        initial_pose: Pose | None = None,
+        **kwargs,
+    ):
+        assert side in {"source", "destination"}, f"Invalid tool-sort bin side: {side!r}"
+        assert appearance == "default", "Only the vendored default bin appearance is available."
+        leaf = "bin1.usda" if side == "source" else "bin2_default.usda"
+        super().__init__(
+            name=instance_name,
+            tags=self.tags,
+            usd_path=str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / self.name / leaf),
+            object_type=ObjectType.RIGID,
+            initial_pose=initial_pose,
+            collision_mode="mesh",
+            spawn_cfg_addon={
+                "rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+            },
+            **kwargs,
+        )
+
+
+@register_asset
+class IndustrialHdrShadowReceiver(Object):
+    """Visual shadow receiver used by the industrial workcell."""
+
+    name = "industrial__hdr_shadow_receiver"
+    tags = ["floor", "visual", "industrial", "tool_sort"]
+
+    def __init__(
+        self,
+        instance_name: str = "hdr_shadow_receiver",
+        ground_z: float = 0.0,
+        initial_pose: Pose | None = None,
+        **kwargs,
+    ):
+        if initial_pose is None:
+            initial_pose = Pose(position_xyz=(0.0, 0.0, ground_z + 0.0005))
+        super().__init__(
+            name=instance_name,
+            tags=self.tags,
+            usd_path=str(_INDUSTRIAL_TOOL_SORT_ASSET_ROOT / self.name / "industrial__hdr_shadow_receiver.usda"),
+            object_type=ObjectType.BASE,
+            initial_pose=initial_pose,
+            **kwargs,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/assets/retargeter_library.py
+++ b/isaaclab_arena/assets/retargeter_library.py
@@ -123,6 +123,17 @@ class DroidDifferentialIKKeyboardRetargeter(RetargetterBase):
 
 
 @register_retargeter
+class IndustrialFr3RobotiqKeyboardRetargeter(RetargetterBase):
+    """Route keyboard SE(3) commands directly to the industrial FR3 IK action."""
+
+    device = "keyboard"
+    embodiment = "industrial_fr3_robotiq_2f85_differential_ik"
+
+    def get_pipeline_builder(self, embodiment: object) -> Callable | None:
+        return None
+
+
+@register_retargeter
 class AgibotKeyboardRetargeter(RetargetterBase):
     device = "keyboard"
     embodiment = "agibot"

--- a/isaaclab_arena/embodiments/__init__.py
+++ b/isaaclab_arena/embodiments/__init__.py
@@ -9,4 +9,5 @@ from .franka.franka import *
 from .g1.g1 import *
 from .galbot.galbot import *
 from .gr1t2.gr1t2 import *
+from .industrial_fr3.industrial_fr3 import *
 from .kuka_allegro.kuka_allegro import *

--- a/isaaclab_arena/embodiments/industrial_fr3/__init__.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Industrial FR3 embodiments."""
+
+from .industrial_fr3 import (
+    IndustrialFr3Robotiq2f85DifferentialIKEmbodiment,
+    IndustrialFr3Robotiq2f85Embodiment,
+    IndustrialFr3Robotiq2f85EmbodimentBase,
+)
+
+__all__ = [
+    "IndustrialFr3Robotiq2f85DifferentialIKEmbodiment",
+    "IndustrialFr3Robotiq2f85Embodiment",
+    "IndustrialFr3Robotiq2f85EmbodimentBase",
+]

--- a/isaaclab_arena/embodiments/industrial_fr3/actions.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/actions.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Actions for the industrial FR3 Robotiq embodiments."""
+
+import torch
+
+from isaaclab.controllers.differential_ik_cfg import DifferentialIKControllerCfg
+from isaaclab.envs.mdp.actions.actions_cfg import DifferentialInverseKinematicsActionCfg, JointPositionActionCfg
+from isaaclab.envs.mdp.actions.joint_actions import JointPositionAction
+from isaaclab.envs.mdp.actions.task_space_actions import DifferentialInverseKinematicsAction
+from isaaclab.managers import ActionTermCfg
+from isaaclab.utils.configclass import configclass
+
+from isaaclab_arena.embodiments.droid.droid import BinaryJointPositionZeroToOneActionCfg
+
+from .config import (
+    ARM_JOINT_NAMES,
+    END_EFFECTOR_BODY_NAME,
+    GRIPPER_CLOSED_ANGLE,
+    GRIPPER_JOINT_NAME,
+    _newton_native_actuators_in_use,
+)
+
+
+class GravityCompensatedJointPositionAction(JointPositionAction):
+    """Apply absolute joint targets plus PhysX gravity feed-forward."""
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        self._gravity_compensation_supported: bool | None = None
+
+    def apply_actions(self) -> None:
+        super().apply_actions()
+        if _newton_native_actuators_in_use():
+            return
+        if self._gravity_compensation_supported is False:
+            return
+        try:
+            gravity = self._asset.data.gravity_compensation_forces.torch[:, self._joint_ids]
+        except NotImplementedError:
+            # Newton routes gravity compensation through solver attributes.
+            self._gravity_compensation_supported = False
+            return
+        self._gravity_compensation_supported = True
+        self._asset.set_joint_effort_target_index(target=gravity, joint_ids=self._joint_ids)
+
+
+@configclass
+class GravityCompensatedJointPositionActionCfg(JointPositionActionCfg):
+    """Absolute joint action with PhysX gravity feed-forward."""
+
+    class_type: type[GravityCompensatedJointPositionAction] = GravityCompensatedJointPositionAction
+
+
+class HoldingDifferentialInverseKinematicsAction(DifferentialInverseKinematicsAction):
+    """Preserve the last Cartesian target while the relative command is idle."""
+
+    def __init__(self, cfg, env):
+        super().__init__(cfg, env)
+        self._hold_initialized = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+        self._gravity_compensation_supported: bool | None = None
+
+    def process_actions(self, actions: torch.Tensor):
+        previous_pos = self._ik_controller.ee_pos_des.clone()
+        previous_quat = self._ik_controller.ee_quat_des.clone()
+        super().process_actions(actions)
+        inactive = torch.linalg.vector_norm(actions, dim=1) <= self.cfg.hold_deadband
+        restore = self._hold_initialized & inactive
+        self._ik_controller.ee_pos_des[restore] = previous_pos[restore]
+        self._ik_controller.ee_quat_des[restore] = previous_quat[restore]
+        self._hold_initialized.fill_(True)
+
+    def apply_actions(self) -> None:
+        super().apply_actions()
+        if _newton_native_actuators_in_use():
+            return
+        if self._gravity_compensation_supported is False:
+            return
+
+        try:
+            gravity = self._asset.data.gravity_compensation_forces.torch[:, self._jacobi_joint_ids]
+        except NotImplementedError:
+            # Newton routes gravity compensation through solver attributes.
+            self._gravity_compensation_supported = False
+            return
+
+        self._gravity_compensation_supported = True
+        self._asset.set_joint_effort_target_index(target=gravity, joint_ids=self._joint_ids)
+
+    def reset(self, env_ids=None) -> None:
+        super().reset(env_ids)
+        self._hold_initialized[env_ids] = False
+
+
+@configclass
+class HoldingDifferentialInverseKinematicsActionCfg(DifferentialInverseKinematicsActionCfg):
+    """Relative IK that retains its Cartesian target while input is idle."""
+
+    class_type: type[HoldingDifferentialInverseKinematicsAction] = HoldingDifferentialInverseKinematicsAction
+    hold_deadband: float = 1.0e-6
+
+
+@configclass
+class IndustrialFr3RobotiqActionsCfg:
+    """Seven ordered absolute arm targets and a zero-to-one gripper command."""
+
+    arm_action: ActionTermCfg = GravityCompensatedJointPositionActionCfg(
+        asset_name="robot",
+        joint_names=ARM_JOINT_NAMES,
+        preserve_order=True,
+        use_default_offset=False,
+    )
+    gripper_action: ActionTermCfg = BinaryJointPositionZeroToOneActionCfg(
+        asset_name="robot",
+        joint_names=[GRIPPER_JOINT_NAME],
+        open_command_expr={GRIPPER_JOINT_NAME: 0.0},
+        close_command_expr={GRIPPER_JOINT_NAME: GRIPPER_CLOSED_ANGLE},
+    )
+
+
+@configclass
+class IndustrialFr3RobotiqDifferentialIKActionsCfg:
+    """Relative Cartesian FR3 commands and a zero-to-one gripper command."""
+
+    arm_action: ActionTermCfg = HoldingDifferentialInverseKinematicsActionCfg(
+        asset_name="robot",
+        joint_names=ARM_JOINT_NAMES,
+        body_name=END_EFFECTOR_BODY_NAME,
+        controller=DifferentialIKControllerCfg(
+            command_type="pose",
+            use_relative_mode=True,
+            ik_method="dls",
+        ),
+        scale=0.5,
+    )
+    gripper_action: ActionTermCfg = BinaryJointPositionZeroToOneActionCfg(
+        asset_name="robot",
+        joint_names=[GRIPPER_JOINT_NAME],
+        open_command_expr={GRIPPER_JOINT_NAME: 0.0},
+        close_command_expr={GRIPPER_JOINT_NAME: GRIPPER_CLOSED_ANGLE},
+    )

--- a/isaaclab_arena/embodiments/industrial_fr3/camera_variations.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/camera_variations.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Camera variations shared by the industrial FR3 control modes."""
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+import warp as wp
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
+from pxr import Sdf
+
+from isaaclab_arena.variations.camera_extrinsics_variation import (
+    CameraExtrinsicsVariation,
+    apply_camera_extrinsics_from_sampler,
+)
+from isaaclab_arena.variations.continuous_sampler import ContinuousSampler
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+    from isaaclab.sensors import Camera, TiledCamera
+
+
+class ApplyCameraExtrinsicsAndRefresh(apply_camera_extrinsics_from_sampler):
+    """Keep Newton's camera frame and the RTX-rendered USD camera in sync."""
+
+    def __call__(
+        self,
+        env: ManagerBasedEnv,
+        env_ids: torch.Tensor,
+        asset_cfg: SceneEntityCfg,
+        sampler: ContinuousSampler,
+    ) -> None:
+        super().__call__(env, env_ids, asset_cfg, sampler)
+
+        view = self._camera._view
+        assert view is not None, "Camera view was not initialized."
+        if view.count != 1:
+            raise RuntimeError("Rendered FR3 camera variations require num_envs=1 under Newton.")
+        translations, _ = view.get_local_poses(wp.from_torch(env_ids))
+        _write_usd_camera_translations(self._camera, env_ids, translations.torch)
+        self._camera.reset(env_ids)
+
+
+class RenderedCameraExtrinsicsVariation(CameraExtrinsicsVariation):
+    """Camera translation variation whose rendered pixels follow its sampled pose."""
+
+    def build_event_cfg(self) -> tuple[str, EventTermCfg]:
+        event_name, event_cfg = super().build_event_cfg()
+        event_cfg.func = ApplyCameraExtrinsicsAndRefresh
+        return event_name, event_cfg
+
+
+def _write_usd_camera_translations(
+    camera: Camera | TiledCamera,
+    env_ids: torch.Tensor,
+    translations: torch.Tensor,
+) -> None:
+    """Write sampled local translations to the camera prims consumed by RTX."""
+
+    indices = [int(value) for value in env_ids.detach().cpu().tolist()]
+    values = translations.detach().cpu().tolist()
+    with Sdf.ChangeBlock():
+        for index, xyz in zip(indices, values, strict=True):
+            prim = camera._sensor_prims[index].GetPrim()
+            attr = prim.GetAttribute("xformOp:translate")
+            current = attr.Get()
+            if current is None:
+                raise RuntimeError(f"Camera prim '{prim.GetPath()}' has no authored xformOp:translate")
+            updated = type(current)(*(float(value) for value in xyz))
+            if not attr.Set(updated):
+                raise RuntimeError(f"Failed to update camera prim '{prim.GetPath()}' xformOp:translate")

--- a/isaaclab_arena/embodiments/industrial_fr3/cameras.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/cameras.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Physical camera definitions for the industrial FR3 workcell."""
+
+from __future__ import annotations
+
+import torch
+
+import isaaclab.sim as sim_utils
+from isaaclab.sensors import CameraCfg
+from isaaclab.utils.configclass import configclass
+from isaaclab_physx.renderers import IsaacRtxRendererCfg
+
+from isaaclab_arena.utils.cameras import ArenaCameraCfg
+
+CAMERA_WIDTH = 1280
+CAMERA_HEIGHT = 720
+
+
+def _ros_optical_quaternion(eye: tuple[float, float, float], target: tuple[float, float, float]):
+    """Return a ROS optical camera orientation aimed from ``eye`` to ``target``."""
+
+    from isaaclab.utils.math import create_rotation_matrix_from_view, quat_from_matrix
+
+    eye_tensor = torch.tensor([eye], dtype=torch.float32)
+    target_tensor = torch.tensor([target], dtype=torch.float32)
+    opengl_to_ros = torch.diag(torch.tensor([1.0, -1.0, -1.0]))
+    rotation = create_rotation_matrix_from_view(eye_tensor, target_tensor, "Z")[0] @ opengl_to_ros
+    return tuple(quat_from_matrix(rotation).tolist())
+
+
+_WORKSPACE_TARGET = (0.1, 0.015, 0.82)
+_TOP_CAMERA_EYE = (1.25, 0.0, 1.75)
+_EXTERIOR_LEFT_EYE = (0.9, 0.75, 1.8)
+_EXTERIOR_RIGHT_EYE = (0.9, -0.75, 1.8)
+_WRIST_EYE = (0.0, 0.12, -0.02)
+_WRIST_TARGET = (0.0, 0.12, 0.25)
+_EXTERIOR_PINHOLE = dict(
+    focal_length=2.1,
+    focus_distance=28.0,
+    horizontal_aperture=5.376,
+    vertical_aperture=3.024,
+)
+_WRIST_PRIM = (
+    "{ENV_REGEX_NS}/Robot/Geometry/base/fr3_link0/fr3_link1/"
+    "fr3_link2/fr3_link3/fr3_link4/fr3_link5/fr3_link6/"
+    "fr3_link7/robotiq_attach/Geometry/robotiq_base/wrist_camera"
+)
+
+
+@configclass
+class IndustrialFr3RobotiqCameraCfg(ArenaCameraCfg):
+    """One wrist, two exterior, and one top camera for the FR3 workcell."""
+
+    exterior_left_camera: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/exterior_left_camera",
+        height=CAMERA_HEIGHT,
+        width=CAMERA_WIDTH,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(**_EXTERIOR_PINHOLE),
+        renderer_cfg=IsaacRtxRendererCfg(),
+        offset=CameraCfg.OffsetCfg(
+            pos=_EXTERIOR_LEFT_EYE,
+            rot=_ros_optical_quaternion(_EXTERIOR_LEFT_EYE, _WORKSPACE_TARGET),
+            convention="ros",
+        ),
+    )
+    exterior_right_camera: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/exterior_right_camera",
+        height=CAMERA_HEIGHT,
+        width=CAMERA_WIDTH,
+        data_types=["rgb"],
+        spawn=sim_utils.PinholeCameraCfg(**_EXTERIOR_PINHOLE),
+        renderer_cfg=IsaacRtxRendererCfg(),
+        offset=CameraCfg.OffsetCfg(
+            pos=_EXTERIOR_RIGHT_EYE,
+            rot=_ros_optical_quaternion(_EXTERIOR_RIGHT_EYE, _WORKSPACE_TARGET),
+            convention="ros",
+        ),
+    )
+    wrist_camera: CameraCfg = CameraCfg(
+        prim_path=_WRIST_PRIM,
+        # The prim rides the wrist; without this the reported pose stays at
+        # its spawn value, so anything projecting depth through it lands the
+        # result where the hand was at reset rather than where it is now.
+        update_latest_camera_pose=True,
+        height=CAMERA_HEIGHT,
+        width=CAMERA_WIDTH,
+        data_types=["rgb", "distance_to_image_plane"],
+        renderer_cfg=IsaacRtxRendererCfg(),
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=2.8,
+            focus_distance=28.0,
+            horizontal_aperture=5.376,
+            vertical_aperture=3.024,
+        ),
+        offset=CameraCfg.OffsetCfg(
+            pos=_WRIST_EYE,
+            rot=_ros_optical_quaternion(_WRIST_EYE, _WRIST_TARGET),
+            convention="ros",
+        ),
+    )
+    top_camera: CameraCfg = CameraCfg(
+        prim_path="{ENV_REGEX_NS}/top_camera",
+        update_period=0.0,
+        update_latest_camera_pose=True,
+        height=CAMERA_HEIGHT,
+        width=CAMERA_WIDTH,
+        data_types=["rgb", "distance_to_image_plane"],
+        renderer_cfg=IsaacRtxRendererCfg(),
+        spawn=sim_utils.PinholeCameraCfg(
+            focal_length=5.0,
+            focus_distance=28.0,
+            horizontal_aperture=5.376,
+            vertical_aperture=3.024,
+        ),
+        offset=CameraCfg.OffsetCfg(
+            pos=_TOP_CAMERA_EYE,
+            rot=_ros_optical_quaternion(_TOP_CAMERA_EYE, _WORKSPACE_TARGET),
+            convention="ros",
+        ),
+    )

--- a/isaaclab_arena/embodiments/industrial_fr3/config.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/config.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static scene and observation configurations for the selected FR3 asset."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+import isaaclab.sim as sim_utils
+from isaaclab.actuators import ImplicitActuatorCfg
+from isaaclab.assets.articulation.articulation_cfg import ArticulationCfg
+from isaaclab.managers import EventTermCfg
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.physics import PhysicsEvent, PhysicsManager
+from isaaclab.sim.schemas.schemas_cfg import JointDriveBaseCfg
+from isaaclab.sim.spawners.from_files import from_files
+from isaaclab.sim.utils import clone
+from isaaclab.utils.configclass import configclass
+from isaaclab_newton.physics.newton_manager import NewtonManager
+from isaaclab_newton.physics.newton_manager_cfg import NewtonCfg
+from isaaclab_newton.sim.schemas.schemas_cfg import MujocoJointDrivePropertiesCfg, MujocoRigidBodyPropertiesCfg
+from newton.solvers import SolverMuJoCo
+from pxr import UsdPhysics
+
+ROBOT_USD_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "assets"
+    / "industrial_tool_sort"
+    / "industrial__fr3_robotiq_2f85"
+    / "franka_fr3_robotiq_2f85.usda"
+)
+
+ARM_JOINT_NAMES = [f"fr3_joint{index}" for index in range(1, 8)]
+GRIPPER_JOINT_NAME = "left_driver_joint"
+END_EFFECTOR_BODY_NAME = "robotiq_base"
+# The authored driver upper limit is 51.5662 degrees.
+GRIPPER_CLOSED_ANGLE = math.radians(51.5662)
+_DROID_WORKING_HEIGHT_M = 1.35
+_NEWTON_GRAVCOMP_EXCLUDED_BODY_NAMES = {"base", "fr3_link0"}
+
+
+def _newton_native_actuators_in_use() -> bool:
+    """Whether this spawn must seed Newton's position target mode."""
+    from isaaclab.sim import SimulationContext
+
+    sim = SimulationContext.instance()
+    return sim is not None and bool(getattr(sim.cfg, "use_newton_actuators", False))
+
+
+def _deactivate_mjc_actuators(root_prim) -> None:
+    """Let Isaac Lab own FR3 commands on every physics backend.
+
+    The source USD contains MuJoCo position actuators for standalone MuJoCo
+    use. Newton imports them in addition to the Isaac Lab articulation
+    actuators, so their zero-valued controls fight the IK joint targets.
+    Tendons and equality constraints remain active because they describe the
+    Robotiq linkage rather than a second command source.
+    """
+
+    pending = list(root_prim.GetChildren())
+    while pending:
+        prim = pending.pop()
+        pending.extend(prim.GetChildren())
+        if prim.GetTypeName() == "MjcActuator":
+            prim.SetActive(False)
+
+
+def _ensure_newton_position_drives(root_prim) -> None:
+    """Make commanded FR3 drives position-controlled before Newton imports them.
+
+    The asset authors the arm drives with zero stiffness, and Newton must also
+    discover the Robotiq driver in position target mode before Isaac Lab applies
+    the configured implicit-actuator gains. A small positive import-time
+    stiffness establishes that mode; the actuator model replaces it with the
+    configured gains during initialization.
+    """
+
+    drive_cfg = JointDriveBaseCfg(stiffness=1.0e-3)
+    pending = list(reversed(root_prim.GetChildren()))
+    while pending:
+        prim = pending.pop()
+        pending.extend(reversed(prim.GetChildren()))
+        if str(prim.GetName()) in (*ARM_JOINT_NAMES, GRIPPER_JOINT_NAME):
+            sim_utils.modify_joint_drive_properties(prim.GetPath(), drive_cfg)
+
+
+def _configure_newton_gravity_compensation(root_prim) -> None:
+    """Match Newton's FR3 IK gravity routing without touching gripper joints."""
+
+    body_cfg = MujocoRigidBodyPropertiesCfg(gravcomp=1.0)
+    joint_cfg = MujocoJointDrivePropertiesCfg(actuatorgravcomp=True)
+    pending = list(root_prim.GetChildren())
+    while pending:
+        prim = pending.pop()
+        pending.extend(prim.GetChildren())
+        name = str(prim.GetName())
+        has_api = getattr(prim, "HasAPI", None)
+        is_rigid_body = prim.GetTypeName() == "PhysicsRigidBody" or (
+            has_api is not None and prim.HasAPI(UsdPhysics.RigidBodyAPI)
+        )
+        if is_rigid_body and name not in _NEWTON_GRAVCOMP_EXCLUDED_BODY_NAMES:
+            sim_utils.modify_rigid_body_properties(prim.GetPath(), body_cfg)
+        if name in ARM_JOINT_NAMES:
+            sim_utils.modify_joint_drive_properties(prim.GetPath(), joint_cfg)
+
+
+def _configure_newton_builder_gravity(builder) -> None:
+    """Route FR3 gravity compensation into Newton's solver custom arrays."""
+
+    required = {"mujoco:gravcomp", "mujoco:jnt_actgravcomp"}
+    if not required.issubset(builder.custom_attributes):
+        SolverMuJoCo.register_custom_attributes(builder)
+
+    gravcomp = builder.custom_attributes["mujoco:gravcomp"]
+    if gravcomp.values is None:
+        gravcomp.values = {}
+    for body_index, label in enumerate(builder.body_label):
+        path = str(label)
+        name = path.rsplit("/", 1)[-1]
+        if "/Robot/" in path and name not in _NEWTON_GRAVCOMP_EXCLUDED_BODY_NAMES:
+            gravcomp.values[body_index] = 1.0
+
+    actuator_gravcomp = builder.custom_attributes["mujoco:jnt_actgravcomp"]
+    if actuator_gravcomp.values is None:
+        actuator_gravcomp.values = {}
+    for joint_index, label in enumerate(builder.joint_label):
+        if str(label).rsplit("/", 1)[-1] in ARM_JOINT_NAMES:
+            dof_index = int(builder.joint_qd_start[joint_index])
+            actuator_gravcomp.values[dof_index] = True
+
+
+def _on_newton_model_init(_payload) -> None:
+    builder = NewtonManager._builder
+    if builder is not None:
+        # A prebuilt one-environment model can bypass Newton's cloner callback,
+        # leaving the actuator adapter without the divisor for its flat layout.
+        # Avoid forcing the much slower replication path for this num_envs=1 repo.
+        if NewtonManager._num_envs is None:
+            NewtonManager._num_envs = max(1, int(builder.world_count))
+        _configure_newton_builder_gravity(builder)
+
+
+def _register_newton_gravity_callback() -> None:
+    """Install the builder hook only when the active backend is Newton."""
+
+    if not isinstance(PhysicsManager._cfg, NewtonCfg):
+        return
+    NewtonManager.register_callback(
+        _on_newton_model_init,
+        PhysicsEvent.MODEL_INIT,
+        name="industrial_fr3_newton_gravity",
+        wrap_weak_ref=False,
+    )
+
+
+@clone
+def spawn_fr3_without_mjc_actuators(
+    prim_path: str,
+    cfg: sim_utils.UsdFileCfg,
+    translation: tuple[float, float, float] | None = None,
+    orientation: tuple[float, float, float, float] | None = None,
+    **kwargs,
+):
+    """Spawn the FR3 while suppressing duplicate authored command sources."""
+
+    root_prim = from_files._spawn_from_usd_file(
+        prim_path,
+        cfg.usd_path,
+        cfg,
+        translation,
+        orientation,
+        **kwargs,
+    )
+    _deactivate_mjc_actuators(root_prim)
+    if _newton_native_actuators_in_use():
+        _ensure_newton_position_drives(root_prim)
+    _configure_newton_gravity_compensation(root_prim)
+    _register_newton_gravity_callback()
+    return root_prim
+
+
+@configclass
+class IndustrialFr3RobotiqSceneCfg:
+    """A fixed FR3 in the air, with no stand or auxiliary mount asset."""
+
+    robot: ArticulationCfg = ArticulationCfg(
+        prim_path="{ENV_REGEX_NS}/Robot",
+        spawn=sim_utils.UsdFileCfg(
+            func=spawn_fr3_without_mjc_actuators,
+            usd_path=str(ROBOT_USD_PATH),
+            activate_contact_sensors=True,
+            # Root fixation is the only generic physics override; Newton gravity
+            # routing is applied selectively by the custom spawner above.
+            articulation_props=sim_utils.ArticulationRootPropertiesCfg(fix_root_link=False),
+        ),
+        init_state=ArticulationCfg.InitialStateCfg(
+            pos=(0.0, 0.0, _DROID_WORKING_HEIGHT_M),
+            joint_pos={
+                "fr3_joint1": 0.0,
+                "fr3_joint2": -math.pi / 5,
+                "fr3_joint3": 0.0,
+                "fr3_joint4": -4 * math.pi / 5,
+                "fr3_joint5": 0.0,
+                "fr3_joint6": 3 * math.pi / 5,
+                "fr3_joint7": 0.0,
+                GRIPPER_JOINT_NAME: 0.0,
+            },
+        ),
+        soft_joint_pos_limit_factor=1.0,
+        actuators={
+            "fr3_joint_1_2": ImplicitActuatorCfg(
+                joint_names_expr=["fr3_joint[1-2]"],
+                effort_limit_sim=87.0,
+                velocity_limit_sim=2.175,
+                stiffness=650.0,
+                damping=100.0,
+            ),
+            "fr3_joint_3_4": ImplicitActuatorCfg(
+                joint_names_expr=["fr3_joint[3-4]"],
+                effort_limit_sim=87.0,
+                velocity_limit_sim=2.175,
+                stiffness=650.0,
+                damping=100.0,
+            ),
+            "fr3_joint_5_7": ImplicitActuatorCfg(
+                joint_names_expr=["fr3_joint[5-7]"],
+                effort_limit_sim=12.0,
+                velocity_limit_sim=2.61,
+                stiffness=650.0,
+                damping=100.0,
+            ),
+            "robotiq_driver": ImplicitActuatorCfg(
+                joint_names_expr=[GRIPPER_JOINT_NAME],
+                stiffness=100.0,
+                effort_limit_sim=5.0,
+                velocity_limit_sim=2.0,
+                damping=10.0,
+            ),
+        },
+    )
+
+
+@configclass
+class IndustrialFr3RobotiqEventCfg:
+    """Restore the robot's configured working pose on every reset."""
+
+    reset_robot_joints: EventTermCfg = EventTermCfg(
+        func=mdp_isaac_lab.reset_joints_by_offset,
+        mode="reset",
+        params={
+            "position_range": (0.0, 0.0),
+            "velocity_range": (0.0, 0.0),
+            "asset_cfg": SceneEntityCfg("robot"),
+        },
+    )
+
+
+@configclass
+class IndustrialFr3RobotiqObservationsCfg:
+    """DROID-compatible keys for arm, gripper, and Robotiq base state."""
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        actions = ObsTerm(func=mdp_isaac_lab.last_action)
+        robot_joint_pos = ObsTerm(func=mdp_isaac_lab.joint_pos, params={"asset_cfg": SceneEntityCfg("robot")})
+
+        def __post_init__(self):
+            from .observations import arm_joint_pos, ee_pos, ee_quat, gripper_pos
+
+            self.joint_pos = ObsTerm(func=arm_joint_pos)
+            self.gripper_pos = ObsTerm(func=gripper_pos)
+            self.eef_pos = ObsTerm(func=ee_pos)
+            self.eef_quat = ObsTerm(func=ee_quat)
+            self.enable_corruption = False
+            self.concatenate_terms = False
+
+    policy: PolicyCfg = PolicyCfg()

--- a/isaaclab_arena/embodiments/industrial_fr3/industrial_fr3.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/industrial_fr3.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena embodiments for the industrial FR3 with a Robotiq 2F-85."""
+
+from __future__ import annotations
+
+from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.embodiments.common.arm_mode import ArmMode
+from isaaclab_arena.embodiments.embodiment_base import EmbodimentBase
+from isaaclab_arena.utils.pose import Pose
+
+from .actions import IndustrialFr3RobotiqActionsCfg, IndustrialFr3RobotiqDifferentialIKActionsCfg
+from .camera_variations import RenderedCameraExtrinsicsVariation
+from .cameras import IndustrialFr3RobotiqCameraCfg
+from .config import (
+    ARM_JOINT_NAMES,
+    END_EFFECTOR_BODY_NAME,
+    IndustrialFr3RobotiqEventCfg,
+    IndustrialFr3RobotiqObservationsCfg,
+    IndustrialFr3RobotiqSceneCfg,
+)
+
+
+class IndustrialFr3Robotiq2f85EmbodimentBase(EmbodimentBase):
+    """Shared FR3/Robotiq scene setup for each arm control mode."""
+
+    default_arm_mode = ArmMode.SINGLE_ARM
+    action_config_type = None
+
+    def __init__(
+        self,
+        enable_cameras: bool = False,
+        initial_pose: Pose | None = None,
+        initial_joint_pose: list[float] | None = None,
+        concatenate_observation_terms: bool = False,
+        arm_mode: ArmMode | None = None,
+    ):
+        super().__init__(
+            enable_cameras,
+            initial_pose,
+            concatenate_observation_terms,
+            arm_mode,
+        )
+        assert self.action_config_type is not None, "An industrial FR3 action configuration is required."
+        self.scene_config = IndustrialFr3RobotiqSceneCfg()
+        self.action_config = self.action_config_type()
+        self.observation_config = IndustrialFr3RobotiqObservationsCfg()
+        self.observation_config.policy.concatenate_terms = concatenate_observation_terms
+        self.camera_config = IndustrialFr3RobotiqCameraCfg()
+        self.camera_config.use_tiled_camera = False
+        self.event_config = IndustrialFr3RobotiqEventCfg()
+        self.reward_config = None
+        self.mimic_env = None
+
+        if initial_joint_pose is not None:
+            assert len(initial_joint_pose) == len(
+                ARM_JOINT_NAMES
+            ), f"Expected {len(ARM_JOINT_NAMES)} FR3 arm positions, got {len(initial_joint_pose)}."
+            self.scene_config.robot.init_state.joint_pos.update(
+                dict(zip(ARM_JOINT_NAMES, initial_joint_pose, strict=True))
+            )
+
+        self.add_variation(RenderedCameraExtrinsicsVariation(camera_name="wrist_camera"))
+        self.add_variation(RenderedCameraExtrinsicsVariation(camera_name="top_camera"))
+
+    def get_ee_frame_name(self, arm_mode: ArmMode) -> str:
+        return END_EFFECTOR_BODY_NAME
+
+    def get_command_body_name(self) -> str:
+        return END_EFFECTOR_BODY_NAME
+
+
+@register_asset
+class IndustrialFr3Robotiq2f85Embodiment(IndustrialFr3Robotiq2f85EmbodimentBase):
+    """Fixed-base FR3 absolute-joint embodiment with DROID-compatible streams."""
+
+    name = "industrial_fr3_robotiq_2f85"
+    tags = ["embodiment"]
+    action_config_type = IndustrialFr3RobotiqActionsCfg
+
+
+@register_asset
+class IndustrialFr3Robotiq2f85DifferentialIKEmbodiment(IndustrialFr3Robotiq2f85EmbodimentBase):
+    """FR3 relative Cartesian control for keyboard teleoperation."""
+
+    name = "industrial_fr3_robotiq_2f85_differential_ik"
+    tags = ["embodiment"]
+    action_config_type = IndustrialFr3RobotiqDifferentialIKActionsCfg

--- a/isaaclab_arena/embodiments/industrial_fr3/observations.py
+++ b/isaaclab_arena/embodiments/industrial_fr3/observations.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DROID-shaped observations with fail-closed FR3 name selection."""
+
+from __future__ import annotations
+
+import torch
+
+import warp as wp
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import SceneEntityCfg
+
+from .config import ARM_JOINT_NAMES, END_EFFECTOR_BODY_NAME, GRIPPER_CLOSED_ANGLE, GRIPPER_JOINT_NAME
+
+
+def _robot(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg):
+    return env.scene[asset_cfg.name]
+
+
+def _index(names: list[str], expected: str, kind: str) -> int:
+    try:
+        return names.index(expected)
+    except ValueError as error:
+        raise ValueError(f"expected {kind} {expected!r} was not found") from error
+
+
+def arm_joint_pos(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Return FR3 arm positions in the declared action order."""
+
+    robot = _robot(env, asset_cfg)
+    joint_indices = [_index(robot.data.joint_names, name, "joint") for name in ARM_JOINT_NAMES]
+    return wp.to_torch(robot.data.joint_pos)[:, joint_indices]
+
+
+def gripper_pos(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Return the driver angle normalized to DROID's zero-open, one-closed convention."""
+
+    robot = _robot(env, asset_cfg)
+    joint_index = _index(robot.data.joint_names, GRIPPER_JOINT_NAME, "joint")
+    position = wp.to_torch(robot.data.joint_pos)[:, joint_index : joint_index + 1]
+    return torch.clamp(position / GRIPPER_CLOSED_ANGLE, min=0.0, max=1.0)
+
+
+def ee_pos(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Return the world-frame position of the Robotiq base."""
+
+    robot = _robot(env, asset_cfg)
+    body_index = _index(robot.data.body_names, END_EFFECTOR_BODY_NAME, "body")
+    return wp.to_torch(robot.data.body_pos_w)[:, body_index, :]
+
+
+def ee_quat(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Return the world-frame quaternion of the Robotiq base (w, x, y, z)."""
+
+    robot = _robot(env, asset_cfg)
+    body_index = _index(robot.data.body_names, END_EFFECTOR_BODY_NAME, "body")
+    return wp.to_torch(robot.data.body_quat_w)[:, body_index, :]

--- a/isaaclab_arena/tasks/objects_in_regions_task.py
+++ b/isaaclab_arena/tasks/objects_in_regions_task.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""A geometric success task for placing paired objects in oriented regions."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+import torch
+from dataclasses import MISSING
+from typing import TYPE_CHECKING, Any
+
+import isaaclab.envs.mdp as mdp_isaac_lab
+import warp as wp
+from isaaclab.envs.common import ViewerCfg
+from isaaclab.managers import TerminationTermCfg
+from isaaclab.utils.configclass import configclass
+from isaaclab.utils.math import subtract_frame_transforms
+
+from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.register import register_task
+from isaaclab_arena.metrics.metric_base import MetricBase
+from isaaclab_arena.metrics.success_rate import SuccessRateMetric
+from isaaclab_arena.tasks.task_base import TaskBase
+from isaaclab_arena.tasks.terminations import SuccessMode, check_success
+from isaaclab_arena.utils.cameras import get_viewer_cfg_look_at_object
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+Bounds = tuple[float, float, float, float, float, float]
+
+
+def points_in_oriented_regions(
+    object_positions_w: torch.Tensor,
+    region_positions_w: torch.Tensor,
+    region_quaternions_w: torch.Tensor,
+    bounds_xyzxyz: torch.Tensor,
+) -> torch.Tensor:
+    """Return whether every corresponding point lies in its oriented local box.
+
+    The bounds are expressed in the local coordinates of their paired region and
+    are inclusive, so a point lying exactly on a face is successful.
+    """
+
+    object_pos_region, _ = subtract_frame_transforms(
+        region_positions_w,
+        region_quaternions_w,
+        object_positions_w,
+    )
+    lower = bounds_xyzxyz[:, :3]
+    upper = bounds_xyzxyz[:, 3:]
+    return ((object_pos_region >= lower) & (object_pos_region <= upper)).all(dim=-1)
+
+
+def objects_in_regions(
+    env: ManagerBasedRLEnv,
+    object_names: list[str],
+    region_names: list[str],
+    bounds_xyzxyz: list[Bounds],
+) -> torch.Tensor:
+    """Return success only where all paired objects are inside their regions."""
+
+    if not object_names or len(object_names) != len(region_names) or len(object_names) != len(bounds_xyzxyz):
+        raise ValueError("objects, regions, and bounds must be non-empty lists of the same length")
+
+    pair_results: list[torch.Tensor] = []
+    for object_name, region_name, bounds in zip(object_names, region_names, bounds_xyzxyz, strict=True):
+        object_instance: Any = env.scene[object_name]
+        region_instance: Any = env.scene[region_name]
+        object_positions_w = wp.to_torch(object_instance.data.root_pos_w)
+        if hasattr(region_instance, "data"):
+            region_positions_w = wp.to_torch(region_instance.data.root_pos_w)
+            region_quaternions_w = wp.to_torch(region_instance.data.root_quat_w)
+        else:
+            region_positions_w, region_quaternions_w = (
+                wp.to_torch(value) for value in region_instance.get_world_poses()
+            )
+        bounds_tensor = torch.as_tensor(bounds, dtype=object_positions_w.dtype, device=object_positions_w.device)
+        pair_results.append(
+            points_in_oriented_regions(
+                object_positions_w,
+                region_positions_w,
+                region_quaternions_w,
+                bounds_tensor.unsqueeze(0).expand(env.num_envs, -1),
+            )
+        )
+    return torch.stack(pair_results, dim=0).all(dim=0)
+
+
+@register_task
+class ObjectsInRegionsTask(TaskBase):
+    """Require every object to be within the local bounds of its paired region."""
+
+    def __init__(
+        self,
+        object_list: list[Asset],
+        region_list: list[Asset],
+        bounds_xyzxyz: list[Bounds],
+        episode_length_s: float = 480.0,
+        task_description: str | None = None,
+    ):
+        self._validate_inputs(object_list, region_list, bounds_xyzxyz)
+        super().__init__(
+            episode_length_s=episode_length_s,
+            task_description=task_description or "Place every object inside its paired region.",
+        )
+        self.objects = list(object_list)
+        self.regions = list(region_list)
+        self.bounds = [tuple(float(value) for value in bounds) for bounds in bounds_xyzxyz]
+        self.events_cfg = None
+        self.termination_cfg = self.make_termination_cfg()
+        self.metrics = [SuccessRateMetric()]
+
+    @staticmethod
+    def _validate_inputs(object_list: list[Asset], region_list: list[Asset], bounds_xyzxyz: list[Bounds]) -> None:
+        if not object_list or not region_list or not bounds_xyzxyz:
+            raise ValueError("objects, regions, and bounds must contain at least one paired entry")
+        if len(object_list) != len(region_list) or len(object_list) != len(bounds_xyzxyz):
+            raise ValueError("objects, regions, and bounds must have the same length")
+        for bounds in bounds_xyzxyz:
+            if not isinstance(bounds, (list, tuple)) or len(bounds) != 6:
+                raise ValueError("each region bounds entry must contain exactly six values")
+            try:
+                values = tuple(float(value) for value in bounds)
+            except (TypeError, ValueError) as error:
+                raise ValueError("region bounds must be numeric") from error
+            if not all(math.isfinite(value) for value in values):
+                raise ValueError("region bounds must be finite")
+            if any(lower > upper for lower, upper in zip(values[:3], values[3:], strict=True)):
+                raise ValueError("region bounds lower values must not exceed upper values")
+
+    def get_scene_cfg(self):
+        return None
+
+    def make_termination_cfg(self):
+        region_predicate = TerminationTermCfg(
+            func=objects_in_regions,
+            params={
+                "object_names": [object_.name for object_ in self.objects],
+                "region_names": [region.name for region in self.regions],
+                "bounds_xyzxyz": self.bounds,
+            },
+        )
+        return TerminationsCfg(
+            success=TerminationTermCfg(
+                func=check_success,
+                params={"mode": SuccessMode.ALL, "predicates": [region_predicate]},
+            )
+        )
+
+    def get_termination_cfg(self):
+        return self.termination_cfg
+
+    def get_events_cfg(self):
+        return self.events_cfg
+
+    def get_mimic_env_cfg(self, _arm_mode):
+        return None
+
+    def get_metrics(self) -> list[MetricBase]:
+        return self.metrics
+
+    def get_viewer_cfg(self) -> ViewerCfg:
+        return get_viewer_cfg_look_at_object(
+            lookat_object=self.objects[0],
+            offset=np.array([-1.5, -1.5, 1.5]),
+        )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination configuration for :class:`ObjectsInRegionsTask`."""
+
+    time_out: TerminationTermCfg = TerminationTermCfg(func=mdp_isaac_lab.time_out)
+    success: TerminationTermCfg = MISSING

--- a/isaaclab_arena/tasks/task_library.py
+++ b/isaaclab_arena/tasks/task_library.py
@@ -14,6 +14,7 @@ from isaaclab_arena.tasks import (  # noqa: F401
     goal_pose_task,
     lift_object_task,
     no_task,
+    objects_in_regions_task,
     open_door_task,
     pick_and_place_task,
     place_upright_task,

--- a/isaaclab_arena/tests/test_industrial_tool_sort_environment.py
+++ b/isaaclab_arena/tests/test_industrial_tool_sort_environment.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coverage for the industrial tool-sort environment."""
+
+import re
+from pathlib import Path
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ASSET_ROOT = REPO_ROOT / "isaaclab_arena" / "assets" / "industrial_tool_sort"
+ENVIRONMENT_NAME = "vabar_tool_sort__sort_all_newton"
+EXPECTED_ASSETS = {
+    "industrial__fr3_workcell_table",
+    "industrial__hdr_shadow_receiver",
+    "industrial__tool_sort_bin",
+    "vabar_tool_sort__hammer",
+    "vabar_tool_sort__drill",
+    "vabar_tool_sort__round_nut",
+    "vabar_tool_sort__clamp",
+    "industrial_fr3_robotiq_2f85",
+    "industrial_fr3_robotiq_2f85_differential_ik",
+}
+ASSET_ENTRYPOINTS = [
+    "industrial__fr3_workcell_table/industrial__fr3_workcell_table.usda",
+    "industrial__hdr_shadow_receiver/industrial__hdr_shadow_receiver.usda",
+    "industrial__tool_sort_bin/bin1.usda",
+    "industrial__tool_sort_bin/bin2_default.usda",
+    "vabar_tool_sort__hammer/vabar_tool_sort__hammer.usda",
+    "vabar_tool_sort__drill/vabar_tool_sort__drill.usda",
+    "vabar_tool_sort__round_nut/vabar_tool_sort__round_nut.usda",
+    "vabar_tool_sort__clamp/vabar_tool_sort__clamp.usda",
+    "industrial__fr3_robotiq_2f85/franka_fr3_robotiq_2f85.usda",
+]
+
+
+def test_vendored_usd_dependency_closure_is_complete():
+    """Every retained file is reachable from a registered USD entry point."""
+    reachable: set[Path] = set()
+    pending = [ASSET_ROOT / relative_path for relative_path in ASSET_ENTRYPOINTS]
+    while pending:
+        usd_file = pending.pop().resolve()
+        assert usd_file.is_relative_to(ASSET_ROOT.resolve())
+        assert usd_file.exists(), f"Missing USD dependency: {usd_file.relative_to(ASSET_ROOT)}"
+        if usd_file in reachable:
+            continue
+        reachable.add(usd_file)
+        if usd_file.suffix not in {".usd", ".usda"}:
+            continue
+        try:
+            contents = usd_file.read_text()
+        except UnicodeDecodeError:
+            continue
+        for reference in re.findall(r"@([^@]+)@", contents):
+            if "://" in reference:
+                continue
+            pending.append(usd_file.parent / reference)
+
+    retained_files = {path.resolve() for path in ASSET_ROOT.rglob("*") if path.is_file()}
+    assert retained_files == reachable
+    assert {path.suffix for path in retained_files} <= {".usd", ".usda", ".usdc", ".png"}
+
+
+def _test_tool_sort_registration_and_factory(_simulation_app) -> bool:
+    import argparse
+
+    from isaaclab_arena.assets.registries import AssetRegistry, EnvironmentRegistry, RetargeterRegistry, TaskRegistry
+    from isaaclab_arena_environments.cli import add_environment_cli_args, build_environment_from_cli
+    from isaaclab_arena_environments.industrial_tool_sort_environment import (
+        IndustrialToolSortEnvironment,
+        IndustrialToolSortEnvironmentCfg,
+    )
+
+    asset_registry = AssetRegistry()
+    assert EXPECTED_ASSETS <= set(asset_registry.get_all_keys())
+    assert TaskRegistry().is_registered("ObjectsInRegionsTask")
+    assert EnvironmentRegistry().is_registered(ENVIRONMENT_NAME, ensure_loaded=False)
+
+    parser = argparse.ArgumentParser(exit_on_error=False)
+    add_environment_cli_args(parser, IndustrialToolSortEnvironment)
+    args = parser.parse_args([
+        "--embodiment",
+        "industrial_fr3_robotiq_2f85_differential_ik",
+        "--teleop_device",
+        "keyboard",
+    ])
+    args.enable_cameras = False
+    arena_env = build_environment_from_cli(IndustrialToolSortEnvironment, args)
+    assert arena_env.name == ENVIRONMENT_NAME
+    assert arena_env.embodiment.name == "industrial_fr3_robotiq_2f85_differential_ik"
+    assert arena_env.teleop_device.name == "keyboard"
+    assert arena_env.task.episode_length_s == 192.0
+    assert [asset.name for asset in arena_env.task.objects] == ["hammer_0", "drill_0", "round_nut_0", "clamp_0"]
+    assert RetargeterRegistry().is_registered(
+        "keyboard__industrial_fr3_robotiq_2f85_differential_ik",
+        ensure_loaded=False,
+    )
+
+    camera_env = IndustrialToolSortEnvironment().build(
+        IndustrialToolSortEnvironmentCfg(
+            enable_cameras=True,
+            top_camera_position=[1.0, 2.0, 3.0],
+            top_camera_rotation_wxyz=[1.0, 0.0, 0.0, 0.0],
+        )
+    )
+    top_camera = camera_env.embodiment.camera_config.top_camera
+    assert top_camera.width == 1280
+    assert top_camera.height == 720
+    assert top_camera.offset.pos == (1.0, 2.0, 3.0)
+    assert top_camera.offset.rot == (1.0, 0.0, 0.0, 0.0)
+    return True
+
+
+def test_tool_sort_registration_and_factory():
+    assert run_function_with_persistent_simulation_app(_test_tool_sort_registration_and_factory)
+
+
+def _test_shared_tool_sort_assets_spawn_with_physx(_simulation_app) -> bool:
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.no_task import NoTask
+    from isaaclab_arena.utils.pose import Pose
+
+    registry = AssetRegistry()
+    background = registry.get_asset_by_name("industrial__fr3_workcell_table")()
+    background.set_initial_pose(Pose(position_xyz=(-0.5, -0.1, 0.912)))
+    assets = [background, registry.get_asset_by_name("industrial__hdr_shadow_receiver")()]
+    for index, name in enumerate([
+        "industrial__tool_sort_bin",
+        "vabar_tool_sort__hammer",
+        "vabar_tool_sort__drill",
+        "vabar_tool_sort__round_nut",
+        "vabar_tool_sort__clamp",
+    ]):
+        asset = registry.get_asset_by_name(name)(instance_name=f"industrial_asset_{index}")
+        asset.set_initial_pose(Pose(position_xyz=(float(index), 0.0, 2.0)))
+        assets.append(asset)
+
+    arena_env = IsaacLabArenaEnvironment(
+        name="industrial_tool_sort_assets_physx",
+        embodiment=NoEmbodiment(),
+        scene=Scene(assets=assets),
+        task=NoTask(),
+    )
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli)).make_registered()
+    try:
+        env.reset()
+        assert {asset.name for asset in assets} <= set(env.unwrapped.scene.keys())
+    finally:
+        env.close()
+    return True
+
+
+def test_shared_tool_sort_assets_spawn_with_physx():
+    assert run_function_with_persistent_simulation_app(_test_shared_tool_sort_assets_spawn_with_physx)
+
+
+def _test_tool_sort_newton_smoke(_simulation_app) -> bool:
+    import torch
+
+    from isaaclab_arena.assets.registries import EnvironmentRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+
+    registry = EnvironmentRegistry()
+    factory_type = registry.get_component_by_name(ENVIRONMENT_NAME)
+    cfg_type = registry.get_environment_cfg_type(factory_type)
+    arena_env = factory_type().build(cfg_type())
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1"])
+    env = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli)).make_registered()
+    try:
+        assert env.unwrapped.cfg.sim.dt == 1.0 / 50.0
+        assert env.unwrapped.cfg.sim.physics.num_substeps == 10
+        observation, _ = env.reset()
+        assert all(torch.isfinite(value).all() for value in observation["policy"].values())
+        action = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+        observation, _, _, _, _ = env.step(action)
+        assert all(torch.isfinite(value).all() for value in observation["policy"].values())
+    finally:
+        env.close()
+    return True
+
+
+def test_tool_sort_newton_smoke():
+    assert run_function_with_persistent_simulation_app(_test_tool_sort_newton_smoke)

--- a/isaaclab_arena_environments/industrial_tool_sort_environment.py
+++ b/isaaclab_arena_environments/industrial_tool_sort_environment.py
@@ -1,0 +1,218 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Industrial FR3 tool-sorting environment."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from isaaclab.utils.configclass import configclass
+from isaaclab_newton.physics import MJWarpSolverCfg, NewtonShapeCfg
+
+from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env_cfg import IsaacLabArenaManagerBasedRLEnvCfg
+
+
+@configclass
+class _IndustrialToolSortSolverCfg(MJWarpSolverCfg):
+    """MJWarp solver settings required by the industrial assets."""
+
+    enable_multiccd: bool = True
+
+
+@configclass
+class _IndustrialToolSortShapeCfg(NewtonShapeCfg):
+    """Newton contact gains required by the industrial assets."""
+
+    ke: float = 60000.0
+    kd: float = 500.0
+
+
+def configure_industrial_tool_sort_physics(
+    env_cfg: IsaacLabArenaManagerBasedRLEnvCfg,
+) -> IsaacLabArenaManagerBasedRLEnvCfg:
+    """Apply the benchmark's 50 Hz, ten-substep Newton configuration."""
+    from isaaclab_newton.physics import NewtonCfg
+
+    env_cfg.sim.dt = 1.0 / 50.0
+    env_cfg.sim.render_interval = 1
+    env_cfg.sim.gravity = (0.0, 0.0, -9.81)
+    env_cfg.sim.use_newton_actuators = True
+    env_cfg.decimation = 1
+    env_cfg.sim.physics = NewtonCfg(
+        solver_cfg=_IndustrialToolSortSolverCfg(
+            solver="newton",
+            integrator="euler",
+            nconmax=5000,
+            njmax=5000,
+            iterations=100,
+            ls_iterations=50,
+            impratio=20.0,
+            cone="elliptic",
+            use_mujoco_contacts=True,
+        ),
+        default_shape_cfg=_IndustrialToolSortShapeCfg(gap=0.002),
+        num_substeps=10,
+        use_cuda_graph=True,
+        debug_mode=False,
+    )
+    env_cfg.scene.num_envs = 1
+    env_cfg.scene.replicate_physics = False
+    return env_cfg
+
+
+@dataclass
+class IndustrialToolSortEnvironmentCfg(ArenaEnvironmentCfg):
+    """Configure the industrial FR3 tool-sorting environment."""
+
+    embodiment: str = "industrial_fr3_robotiq_2f85"
+    teleop_device: str | None = None
+    top_camera_position: list[float] | None = None
+    top_camera_rotation_wxyz: list[float] | None = None
+
+
+@register_environment
+class IndustrialToolSortEnvironment(ArenaEnvironmentFactory[IndustrialToolSortEnvironmentCfg]):
+    """Sort four industrial tools into the matching destination-bin regions."""
+
+    name = "vabar_tool_sort__sort_all_newton"
+    _legacy_argparse_cfg_type = IndustrialToolSortEnvironmentCfg
+
+    def build(self, cfg: IndustrialToolSortEnvironmentCfg) -> IsaacLabArenaEnvironment:
+        """Build the workcell, fixed tool layout, task, and Newton profile."""
+        from isaaclab_arena.assets.hdr_image_library import EmptyWarehouseHDRRobolab
+        from isaaclab_arena.assets.object_base import ObjectType
+        from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.tasks.objects_in_regions_task import ObjectsInRegionsTask
+        from isaaclab_arena.utils.pose import Pose
+
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(
+            enable_cameras=cfg.enable_cameras,
+            initial_pose=Pose(position_xyz=(-0.5, -0.1, 0.912)),
+        )
+        self._configure_top_camera(embodiment, cfg)
+
+        background = self.asset_registry.get_asset_by_name("industrial__fr3_workcell_table")()
+        background.set_initial_pose(Pose(position_xyz=(-0.5, -0.1, 0.912)))
+        table = ObjectReference(
+            name="table",
+            prim_path="{ENV_REGEX_NS}/industrial__fr3_workcell_table/placement_surface",
+            parent_asset=background,
+            object_type=ObjectType.BASE,
+        )
+
+        source_bin = self.asset_registry.get_asset_by_name("industrial__tool_sort_bin")(
+            instance_name="bin1",
+            side="source",
+            initial_pose=Pose(position_xyz=(0.1, -0.25, 0.8)),
+        )
+        destination_bin = self.asset_registry.get_asset_by_name("industrial__tool_sort_bin")(
+            instance_name="bin2",
+            side="destination",
+            initial_pose=Pose(position_xyz=(0.1, 0.28, 0.8)),
+        )
+        self._anchor_bin(source_bin, table, x=0.1, y=-0.25)
+        self._anchor_bin(destination_bin, table, x=0.1, y=0.28)
+
+        tool_specs = (
+            (
+                "hammer_0",
+                "vabar_tool_sort__hammer",
+                (0.055071812123060226, -0.2918435335159302, 0.8555317521095276),
+                (-0.4180590510368347, -0.4858432114124298, -0.44771748781204224, -0.6234837770462036),
+            ),
+            (
+                "drill_0",
+                "vabar_tool_sort__drill",
+                (0.22463268041610718, -0.13386666774749756, 0.905187974),
+                (-0.1799403727054596, -0.17290718853473663, 0.7333788275718689, 0.6323607563972473),
+            ),
+            (
+                "round_nut_0",
+                "vabar_tool_sort__round_nut",
+                (0.1308548003435135, -0.18529225885868073, 0.8305647373199463),
+                (0.006598883308470249, 0.009126810356974602, 0.9815715551376343, 0.1907627433538437),
+            ),
+            (
+                "clamp_0",
+                "vabar_tool_sort__clamp",
+                (0.15202291309833527, -0.336628258228302, 0.8376063704490662),
+                (-0.014119562692940235, -0.08092429488897324, 0.5865128636360168, -0.805763304233551),
+            ),
+        )
+        tools = []
+        for instance_name, registry_name, position, rotation in tool_specs:
+            tool = self.asset_registry.get_asset_by_name(registry_name)(
+                instance_name=instance_name,
+                initial_pose=Pose(position_xyz=position, rotation_xyzw=rotation),
+            )
+            tools.append(tool)
+
+        shadow_receiver = self.asset_registry.get_asset_by_name("industrial__hdr_shadow_receiver")()
+        light = self.asset_registry.get_asset_by_name("light")(hdr=EmptyWarehouseHDRRobolab())
+        scene = Scene(
+            assets=[
+                background,
+                shadow_receiver,
+                source_bin,
+                destination_bin,
+                *tools,
+                light,
+                table,
+            ]
+        )
+        task = ObjectsInRegionsTask(
+            object_list=tools,
+            region_list=[destination_bin] * len(tools),
+            bounds_xyzxyz=[
+                (-0.095, 0.035, 0.8, 0.1, 0.28, 0.95),
+                (0.1, 0.035, 0.8, 0.295, 0.28, 0.95),
+                (-0.095, 0.28, 0.8, 0.1, 0.525, 0.95),
+                (0.1, 0.28, 0.8, 0.295, 0.525, 0.95),
+            ],
+            episode_length_s=192.0,
+            task_description="Sort all tools from bin1 into the compartment of bin2 labelled for their type.",
+        )
+        teleop_device = (
+            self.device_registry.get_device_by_name(cfg.teleop_device)() if cfg.teleop_device is not None else None
+        )
+        return IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=scene,
+            task=task,
+            teleop_device=teleop_device,
+            env_cfg_callback=configure_industrial_tool_sort_physics,
+        )
+
+    # TODO(qianl, 2026-09-01): Can we use variation instead?
+    @staticmethod
+    def _configure_top_camera(embodiment, cfg: IndustrialToolSortEnvironmentCfg) -> None:
+        """Apply an optional finite top-camera pose override."""
+        position_values = cfg.top_camera_position
+        rotation_values = cfg.top_camera_rotation_wxyz
+        assert (position_values is None) == (
+            rotation_values is None
+        ), "Top camera position and rotation must be set together."
+        if position_values is None or rotation_values is None:
+            return
+        position = tuple(float(value) for value in position_values)
+        rotation = tuple(float(value) for value in rotation_values)
+        assert (
+            len(position) == 3 and len(rotation) == 4
+        ), "Top camera pose must contain three position and four rotation values."
+        assert all(math.isfinite(value) for value in (*position, *rotation)), "Top camera pose values must be finite."
+        top_camera = embodiment.camera_config.top_camera
+        top_camera.offset.pos = position
+        top_camera.offset.rot = rotation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,12 @@ namespaces = false
 # because the environment spec directories are not packages of their own.
 [tool.setuptools.package-data]
 "*" = ["**/*.yaml", "**/*.yml", "**/*.json", "**/*.jsonl", "**/*.html"]
+"isaaclab_arena" = [
+    "assets/industrial_tool_sort/**/*.usd",
+    "assets/industrial_tool_sort/**/*.usda",
+    "assets/industrial_tool_sort/**/*.usdc",
+    "assets/industrial_tool_sort/**/*.png",
+]
 
 [tool.setuptools.exclude-package-data]
 "*" = ["tests/test_data/**", "test_data/**"]


### PR DESCRIPTION
## Summary
Add the industrial tool-sort benchmark

## Detailed description
- Add shared industrial assets and FR3 embodiments
- Add absolute-joint, differential-IK, and keyboard teleoperation support
- Add the object-region task and Newton environment configuration
- Add focused registration, asset, camera, and simulation tests
