### PR TITLE
Add regression test for fabrics after rebuild

### DIFF
--- a/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression coverage for prim transforms across an experiment-runner stage rebuild.
+
+Checks the same rebuild as ``test_render_after_stage_rebuild`` one layer lower down. Instead of
+comparing rendered pixels, it reports prims that USD places away from the origin while Fabric still
+holds an identity ``omni:fabric:worldMatrix``. The render delegate reads that attribute, so a prim
+left at identity is drawn at the world origin -- which is the mechanism behind the geometry that the
+render test sees at the wrong pose. Failing here names the offending prim paths directly, so it is
+the cheaper of the two to diagnose.
+"""
+
+import torch
+from functools import partial
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+HEADLESS = True
+# Cameras must be enabled: that selects the rendering Kit experience, which is what turns the Fabric
+# Scene Delegate on. The plain headless experience sets ``app.useFabricSceneDelegate = false`` and
+# would not exercise the render path this bug lives on.
+ENABLE_CAMERAS = True
+# Stage builds performed in one process: the first build plus the rebuilds that follow it.
+NUM_BUILDS = 2
+# Steps taken after reset before transforms are compared.
+NUM_STEPS = 5
+# Absolute tolerance on a matrix entry, both for calling a prim origin-placed and for calling its
+# Fabric matrix an identity.
+TRANSFORM_TOLERANCE = 1e-4
+IDENTITY_MATRIX = (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+# Minimum number of prims the comparison must actually reach, so a build that exposes no Fabric world
+# matrices at all cannot pass the check vacuously.
+MIN_PRIMS_COMPARED = 1
+# How many stale prim paths to name in a failure message.
+NUM_STALE_PRIMS_REPORTED = 8
+
+
+def _build_droid_env(disable_fabric: bool):
+    """Build a single-env, camera-enabled DROID environment on a lit packing table.
+
+    Args:
+        disable_fabric: Whether to build the environment on CPU with Fabric disabled, matching the
+            experiment-runner workaround.
+    """
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.droid.droid import DroidAbsoluteJointPositionEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+
+    asset_registry = AssetRegistry()
+    scene = Scene(
+        assets=[
+            asset_registry.get_asset_by_name("light")(),
+            asset_registry.get_asset_by_name("packing_table")(),
+        ]
+    )
+    arena_env = IsaacLabArenaEnvironment(
+        name="test_prims_after_stage_rebuild",
+        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=ENABLE_CAMERAS),
+        scene=scene,
+    )
+    cli_args = ["--num_envs", "1", "--enable_cameras"]
+    if disable_fabric:
+        cli_args.extend(["--disable_fabric", "--device", "cpu"])
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(cli_args)
+    builder = ArenaEnvBuilder(arena_env, arena_env_builder_cfg_from_argparse(args_cli))
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    # Arena turns this off by default. Without it a reset can return while assets are still streaming,
+    # so prims would still be settling into their poses when the transforms are read.
+    env_cfg.wait_for_textures = True
+    return builder.make_registered(env_cfg, env_kwargs)
+
+
+def _reset_and_step(env) -> None:
+    """Reset and step the environment so the scene settles before transforms are read."""
+    env.reset()
+    with torch.inference_mode():
+        actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+        for _ in range(NUM_STEPS):
+            env.step(actions)
+
+
+def _flatten(value) -> tuple[float, ...]:
+    """Flatten a nested matrix value into a flat tuple of floats."""
+    if hasattr(value, "__len__"):
+        flat: list[float] = []
+        for item in value:
+            flat.extend(_flatten(item))
+        return tuple(flat)
+    return (float(value),)
+
+
+def _prims_left_at_identity_in_fabric() -> tuple[list[str], int]:
+    """Find prims that USD places away from the origin but Fabric still reports at identity.
+
+    Returns:
+        The paths of the stale prims, and the number of prims the comparison reached at all.
+    """
+    import omni.usd
+    import usdrt
+    from isaaclab.sim.utils.stage import get_current_stage_id
+    from pxr import Usd, UsdGeom
+
+    usd_stage = omni.usd.get_context().get_stage()
+    xform_cache = UsdGeom.XformCache(Usd.TimeCode.Default())
+    usd_transforms: dict[str, tuple[float, ...]] = {}
+    for prim in usd_stage.Traverse():
+        if prim.IsA(UsdGeom.Xformable):
+            matrix = xform_cache.GetLocalToWorldTransform(prim)
+            usd_transforms[prim.GetPath().pathString] = tuple(value for row in matrix for value in row)
+
+    fabric_stage = usdrt.Usd.Stage.Attach(get_current_stage_id())
+    stale_prim_paths: list[str] = []
+    num_prims_compared = 0
+    for prim in fabric_stage.Traverse():
+        usd_value = usd_transforms.get(str(prim.GetPath()))
+        if usd_value is None:
+            continue
+        attribute = prim.GetAttribute("omni:fabric:worldMatrix")
+        if not attribute or not attribute.IsValid():
+            continue
+        value = attribute.Get()
+        if value is None:
+            continue
+        fabric_value = _flatten(value)
+        if len(fabric_value) != 16:
+            continue
+        # Only prims USD places off the origin can be distinguished from a legitimate identity.
+        if max(abs(entry) for entry in usd_value[12:15]) <= TRANSFORM_TOLERANCE:
+            continue
+        num_prims_compared += 1
+        if max(abs(a - b) for a, b in zip(fabric_value, IDENTITY_MATRIX)) <= TRANSFORM_TOLERANCE:
+            stale_prim_paths.append(str(prim.GetPath()))
+    return stale_prim_paths, num_prims_compared
+
+
+def _describe_build(build_index: int) -> str:
+    """Return a human-readable label for a build index."""
+    return "the first build" if build_index == 0 else f"rebuild {build_index}"
+
+
+def _test_prims_after_stage_rebuild(simulation_app, disable_fabric: bool) -> bool:
+    from isaaclab_arena.evaluation.resource_cleanup import close_environment
+
+    stale_prim_paths_per_build: list[list[str]] = []
+    num_prims_compared_per_build: list[int] = []
+    for _ in range(NUM_BUILDS):
+        env = _build_droid_env(disable_fabric)
+        try:
+            _reset_and_step(env)
+            stale_prim_paths, num_prims_compared = _prims_left_at_identity_in_fabric()
+        finally:
+            # The same teardown the experiment runner performs between rebuilds.
+            close_environment(env)
+        stale_prim_paths_per_build.append(stale_prim_paths)
+        num_prims_compared_per_build.append(num_prims_compared)
+        print(
+            f"[{_describe_build(len(stale_prim_paths_per_build) - 1)}] "
+            f"{len(stale_prim_paths)} of {num_prims_compared} off-origin prim(s) left at identity in Fabric.",
+            flush=True,
+        )
+
+    # Checked in both variants: the Fabric Scene Delegate mirrors USD transforms into Fabric for the
+    # renderer whenever cameras are on, independently of whether physics drives Fabric, so the
+    # Fabric-off build has world matrices to compare too.
+    for build_index, num_prims_compared in enumerate(num_prims_compared_per_build):
+        assert num_prims_compared >= MIN_PRIMS_COMPARED, (
+            f"{_describe_build(build_index).capitalize()} exposed no off-origin prim with a Fabric world "
+            "matrix, so the comparison would pass vacuously. The Fabric Scene Delegate is likely not running."
+        )
+    for build_index, stale_prim_paths in enumerate(stale_prim_paths_per_build):
+        reported_paths = ", ".join(stale_prim_paths[:NUM_STALE_PRIMS_REPORTED])
+        remaining_count = len(stale_prim_paths) - NUM_STALE_PRIMS_REPORTED
+        assert not stale_prim_paths, (
+            f"{_describe_build(build_index).capitalize()} left {len(stale_prim_paths)} of "
+            f"{num_prims_compared_per_build[build_index]} off-origin prim(s) at an identity Fabric world "
+            f"matrix, so the render delegate draws them at the world origin: {reported_paths}"
+            + (f", and {remaining_count} more." if remaining_count > 0 else ".")
+        )
+    return True
+
+
+@pytest.mark.with_cameras
+def test_prims_after_stage_rebuild_without_fabric():
+    """Rebuilds keep their transforms with Fabric off, which is the path the experiment runner takes."""
+    assert run_function_with_persistent_simulation_app(
+        partial(_test_prims_after_stage_rebuild, disable_fabric=True),
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+        force_disable_fabric=True,
+    )
+
+
+# TODO(alexmillane, 2026-09-02): [lab-render-after-rebuild-bug] Remove once the render after rebuild bug
+# is solved in Lab. Under GPU+Fabric every build after the first leaves prims at an identity Fabric world
+# matrix, which is the mechanism this test detects.
+@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds lose Fabric world matrices under GPU+Fabric.")
+@pytest.mark.with_cameras
+def test_prims_after_stage_rebuild_with_fabric():
+    """Rebuilds should keep the Fabric world matrix of every prim USD places off the origin."""
+    assert run_function_with_persistent_simulation_app(
+        partial(_test_prims_after_stage_rebuild, disable_fabric=False),
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+        # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
+        force_disable_fabric=False,
+    )

--- a/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
@@ -16,6 +16,7 @@ Regression test for the Isaac Lab render-after-rebuild bug:
 https://github.com/isaac-sim/IsaacLab/issues/7472
 """
 
+import numpy as np
 import torch
 from functools import partial
 
@@ -24,10 +25,6 @@ import pytest
 from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
-# Cameras must be enabled: that selects the rendering Kit experience, which is what turns the Fabric
-# Scene Delegate on. The plain headless experience sets ``app.useFabricSceneDelegate = false`` and
-# would not exercise the render path this bug lives on.
-ENABLE_CAMERAS = True
 # Stage builds performed in one process: the first build plus the rebuilds that follow it.
 NUM_BUILDS = 2
 # Steps taken after reset before transforms are compared.
@@ -35,20 +32,16 @@ NUM_STEPS = 5
 # Absolute tolerance on a matrix entry, both for calling a prim origin-placed and for calling its
 # Fabric matrix an identity.
 TRANSFORM_TOLERANCE = 1e-4
-IDENTITY_MATRIX = (1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
 # Minimum number of prims the comparison must actually reach, so a build that exposes no Fabric world
 # matrices at all cannot pass the check vacuously.
 MIN_PRIMS_COMPARED = 1
-# How many stale prim paths to name in a failure message.
-NUM_STALE_PRIMS_REPORTED = 8
 
 
 def _build_droid_env(disable_fabric: bool):
     """Build a single-env, camera-enabled DROID environment on a lit packing table.
 
     Args:
-        disable_fabric: Whether to build the environment on CPU with Fabric disabled, matching the
-            experiment-runner workaround.
+        disable_fabric: Whether to build on CPU with Fabric disabled.
     """
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
@@ -66,7 +59,8 @@ def _build_droid_env(disable_fabric: bool):
     )
     arena_env = IsaacLabArenaEnvironment(
         name="test_prims_after_stage_rebuild",
-        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=ENABLE_CAMERAS),
+        # Enabling cameras turns on the Fabric Scene Delegate, the render path this bug lives on.
+        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=True),
         scene=scene,
     )
     cli_args = ["--num_envs", "1", "--enable_cameras"]
@@ -139,14 +133,9 @@ def _prims_left_at_identity_in_fabric() -> tuple[list[str], int]:
         if max(abs(entry) for entry in usd_value[12:15]) <= TRANSFORM_TOLERANCE:
             continue
         num_prims_compared += 1
-        if max(abs(a - b) for a, b in zip(fabric_value, IDENTITY_MATRIX)) <= TRANSFORM_TOLERANCE:
+        if np.allclose(fabric_value, np.identity(4).flatten(), atol=TRANSFORM_TOLERANCE):
             stale_prim_paths.append(str(prim.GetPath()))
     return stale_prim_paths, num_prims_compared
-
-
-def _describe_build(build_index: int) -> str:
-    """Return a human-readable label for a build index."""
-    return "the first build" if build_index == 0 else f"rebuild {build_index}"
 
 
 def _test_prims_after_stage_rebuild(simulation_app, disable_fabric: bool) -> bool:
@@ -154,7 +143,7 @@ def _test_prims_after_stage_rebuild(simulation_app, disable_fabric: bool) -> boo
 
     stale_prim_paths_per_build: list[list[str]] = []
     num_prims_compared_per_build: list[int] = []
-    for _ in range(NUM_BUILDS):
+    for build_index in range(NUM_BUILDS):
         env = _build_droid_env(disable_fabric)
         try:
             _reset_and_step(env)
@@ -165,7 +154,7 @@ def _test_prims_after_stage_rebuild(simulation_app, disable_fabric: bool) -> boo
         stale_prim_paths_per_build.append(stale_prim_paths)
         num_prims_compared_per_build.append(num_prims_compared)
         print(
-            f"[{_describe_build(len(stale_prim_paths_per_build) - 1)}] "
+            f"[build {build_index}] "
             f"{len(stale_prim_paths)} of {num_prims_compared} off-origin prim(s) left at identity in Fabric.",
             flush=True,
         )
@@ -175,17 +164,13 @@ def _test_prims_after_stage_rebuild(simulation_app, disable_fabric: bool) -> boo
     # Fabric-off build has world matrices to compare too.
     for build_index, num_prims_compared in enumerate(num_prims_compared_per_build):
         assert num_prims_compared >= MIN_PRIMS_COMPARED, (
-            f"{_describe_build(build_index).capitalize()} exposed no off-origin prim with a Fabric world "
-            "matrix, so the comparison would pass vacuously. The Fabric Scene Delegate is likely not running."
+            f"Build {build_index} exposed no off-origin prim with a Fabric world matrix, so the comparison "
+            "would pass vacuously. The Fabric Scene Delegate is likely not running."
         )
     for build_index, stale_prim_paths in enumerate(stale_prim_paths_per_build):
-        reported_paths = ", ".join(stale_prim_paths[:NUM_STALE_PRIMS_REPORTED])
-        remaining_count = len(stale_prim_paths) - NUM_STALE_PRIMS_REPORTED
         assert not stale_prim_paths, (
-            f"{_describe_build(build_index).capitalize()} left {len(stale_prim_paths)} of "
-            f"{num_prims_compared_per_build[build_index]} off-origin prim(s) at an identity Fabric world "
-            f"matrix, so the render delegate draws them at the world origin: {reported_paths}"
-            + (f", and {remaining_count} more." if remaining_count > 0 else ".")
+            f"Build {build_index} left {len(stale_prim_paths)} of {num_prims_compared_per_build[build_index]} "
+            f"off-origin prim(s) at identity in Fabric, drawn at the origin: {', '.join(stale_prim_paths)}"
         )
     return True
 
@@ -196,7 +181,7 @@ def test_prims_after_stage_rebuild_without_fabric():
     assert run_function_with_persistent_simulation_app(
         partial(_test_prims_after_stage_rebuild, disable_fabric=True),
         headless=HEADLESS,
-        enable_cameras=ENABLE_CAMERAS,
+        enable_cameras=True,
         force_disable_fabric=True,
     )
 
@@ -211,7 +196,7 @@ def test_prims_after_stage_rebuild_with_fabric():
     assert run_function_with_persistent_simulation_app(
         partial(_test_prims_after_stage_rebuild, disable_fabric=False),
         headless=HEADLESS,
-        enable_cameras=ENABLE_CAMERAS,
+        enable_cameras=True,
         # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
         force_disable_fabric=False,
     )

--- a/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
@@ -11,6 +11,9 @@ holds an identity ``omni:fabric:worldMatrix``. The render delegate reads that at
 left at identity is drawn at the world origin -- which is the mechanism behind the geometry that the
 render test sees at the wrong pose. Failing here names the offending prim paths directly, so it is
 the cheaper of the two to diagnose.
+
+Regression test for the Isaac Lab render-after-rebuild bug:
+https://github.com/isaac-sim/IsaacLab/issues/7472
 """
 
 import torch

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -30,7 +30,7 @@ MAX_CHANGED_PIXEL_FRACTION = 0.10
 # Minimum per-image standard deviation, so a pair of blank renders cannot pass the comparison vacuously.
 MIN_IMAGE_STD = 1.0
 # Set True to dump the compared renders as PNGs into IMAGE_OUTPUT_DIR, which is created on demand.
-SAVE_IMAGES = True
+SAVE_IMAGES = False
 IMAGE_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
 
 
@@ -173,7 +173,7 @@ def test_render_after_stage_rebuild_without_fabric():
 # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Un-skip once the render after rebuild
 # bug is solved in Lab. Under GPU+Fabric every build after the first renders some geometry at the wrong
 # pose (the DROID gripper has been seen at the origin), which is what this test would catch.
-# @pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
+@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
 @pytest.mark.with_cameras
 def test_render_after_stage_rebuild_with_fabric():
     """Rebuilds should also render correctly with Fabric on, which is the default outside this bug."""

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -3,7 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression coverage for camera rendering across an experiment-runner stage rebuild."""
+"""Regression coverage for camera rendering across an experiment-runner stage rebuild.
+
+Regression test for the Isaac Lab render-after-rebuild bug:
+https://github.com/isaac-sim/IsaacLab/issues/7472
+"""
 
 import os
 import torch

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -27,7 +27,7 @@ MAX_CHANGED_PIXEL_FRACTION = 0.10
 # Minimum per-image standard deviation, so a pair of blank renders cannot pass the comparison vacuously.
 MIN_IMAGE_STD = 1.0
 # Set True to dump the compared renders as PNGs into IMAGE_OUTPUT_DIR, which is created on demand.
-SAVE_IMAGES = False
+SAVE_IMAGES = True
 IMAGE_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "output")
 
 
@@ -83,10 +83,17 @@ def _render_camera_images(env) -> dict[str, torch.Tensor]:
 def _save_comparison_images(
     images_before_rebuild: dict[str, torch.Tensor],
     images_after_rebuild: dict[str, torch.Tensor],
+    disable_fabric: bool,
 ) -> None:
-    """Write a before, after, and absolute-difference PNG per camera into IMAGE_OUTPUT_DIR."""
+    """Write a before, after, and absolute-difference PNG per camera into IMAGE_OUTPUT_DIR.
+
+    Args:
+        disable_fabric: Whether the images were rendered with Fabric disabled; recorded in the
+            filename so on- and off-Fabric renders don't overwrite each other.
+    """
     from PIL import Image
 
+    fabric_tag = "fabric-off" if disable_fabric else "fabric-on"
     os.makedirs(IMAGE_OUTPUT_DIR, exist_ok=True)
     for camera_name in sorted(images_before_rebuild.keys() & images_after_rebuild.keys()):
         before = images_before_rebuild[camera_name][0]
@@ -97,7 +104,7 @@ def _save_comparison_images(
             "difference": (before.float() - after.float()).abs().to(torch.uint8),
         }
         for tag, image in images_to_save.items():
-            output_path = os.path.join(IMAGE_OUTPUT_DIR, f"{camera_name}-{tag}.png")
+            output_path = os.path.join(IMAGE_OUTPUT_DIR, f"{camera_name}-{fabric_tag}-{tag}.png")
             Image.fromarray(image.numpy()).save(output_path)
             print(f"Wrote {output_path}", flush=True)
 
@@ -120,7 +127,7 @@ def _test_render_after_stage_rebuild(simulation_app, disable_fabric: bool) -> bo
 
     # Written before the assertions so a failing rebuild still leaves images to look at.
     if SAVE_IMAGES:
-        _save_comparison_images(images_before_rebuild, images_after_rebuild)
+        _save_comparison_images(images_before_rebuild, images_after_rebuild, disable_fabric)
 
     assert set(images_before_rebuild) == set(images_after_rebuild), (
         "The rebuilt environment exposes a different set of cameras; "
@@ -163,7 +170,7 @@ def test_render_after_stage_rebuild_without_fabric():
 # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Un-skip once the render after rebuild
 # bug is solved in Lab. Under GPU+Fabric every build after the first renders some geometry at the wrong
 # pose (the DROID gripper has been seen at the origin), which is what this test would catch.
-@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
+# @pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
 @pytest.mark.with_cameras
 def test_render_after_stage_rebuild_with_fabric():
     """Rebuilds should also render correctly with Fabric on, which is the default outside this bug."""

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -18,7 +18,6 @@ import pytest
 from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
 
 HEADLESS = True
-ENABLE_CAMERAS = True
 # Steps taken after reset before images are captured.
 NUM_STEPS = 30
 # Mean per-channel 0-255 difference tolerated per camera. Settled renders agree to well under this;
@@ -57,7 +56,7 @@ def _build_droid_env(disable_fabric: bool):
     )
     arena_env = IsaacLabArenaEnvironment(
         name="test_render_after_stage_rebuild",
-        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=ENABLE_CAMERAS),
+        embodiment=DroidAbsoluteJointPositionEmbodiment(enable_cameras=True),
         scene=scene,
     )
     cli_args = ["--num_envs", "1", "--enable_cameras"]
@@ -166,7 +165,7 @@ def test_render_after_stage_rebuild_without_fabric():
     assert run_function_with_persistent_simulation_app(
         partial(_test_render_after_stage_rebuild, disable_fabric=True),
         headless=HEADLESS,
-        enable_cameras=ENABLE_CAMERAS,
+        enable_cameras=True,
         force_disable_fabric=True,
     )
 
@@ -181,7 +180,7 @@ def test_render_after_stage_rebuild_with_fabric():
     assert run_function_with_persistent_simulation_app(
         partial(_test_render_after_stage_rebuild, disable_fabric=False),
         headless=HEADLESS,
-        enable_cameras=ENABLE_CAMERAS,
+        enable_cameras=True,
         # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
         force_disable_fabric=False,
     )


### PR DESCRIPTION
## Summary
Adds a test that tests fabric poses of prims after a stage rebuild.

## Detailed description
- The tests: https://github.com/isaac-sim/IsaacLab/issues/7472
- Currently, the test with fabrics on is disabled, reflecting the fact that this property is currently not preserved.