### PR TITLE
Use CPU physics + disabled fabric for policy runner rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,8 @@ env.unwrapped.device                    # access Isaac Lab device
 
 ### Rendering Safety
 
-TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this guidance once the Isaac
-Lab rendering bug is fixed.
+<!-- TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this guidance once the Isaac
+Lab rendering bug is fixed. -->
 
 Until the Isaac Lab GPU+Fabric post-rebuild rendering bug is fixed, configure every Arena
 environment that produces viewport or camera renders with CPU physics and Fabric disabled. Set

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,9 @@ env.unwrapped.device                    # access Isaac Lab device
 
 ### Rendering Safety
 
+TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this guidance once the Isaac
+Lab rendering bug is fixed.
+
 Until the Isaac Lab GPU+Fabric post-rebuild rendering bug is fixed, configure every Arena
 environment that produces viewport or camera renders with CPU physics and Fabric disabled. Set
 `ArenaEnvBuilderCfg(device="cpu", disable_fabric=True)` or the equivalent runner overrides. Kit/RTX

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ env.unwrapped.cfg                       # access Isaac Lab config
 env.unwrapped.device                    # access Isaac Lab device
 ```
 
+### Rendering Safety
+
+Until the Isaac Lab GPU+Fabric post-rebuild rendering bug is fixed, configure every Arena
+environment that produces viewport or camera renders with CPU physics and Fabric disabled. Set
+`ArenaEnvBuilderCfg(device="cpu", disable_fabric=True)` or the equivalent runner overrides. Kit/RTX
+rendering still runs on the GPU; the builder device selects the physics device. Keep a policy's
+inference device separate when applying this workaround. Direct USD thumbnail rendering does not
+build a physics environment, so Fabric does not apply to it.
+
 ### Writing Tests
 
 Simulation tests use an inner/outer function pattern to handle Isaac Sim's process lifecycle:

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -28,6 +28,7 @@ from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
 
 if TYPE_CHECKING:
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.metrics.metric_data import MetricsDataCollection
     from isaaclab_arena.policy.policy_base import PolicyBase
 
@@ -61,6 +62,25 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     return (
         "cuda" in args_cli.device and hasattr(args_cli, "distributed") and args_cli.distributed and get_world_size() > 1
     )
+
+
+def disable_fabric_for_policy_runner(arena_builder: ArenaEnvBuilder) -> None:
+    """Disable Fabric and force CPU physics for the Policy Runner environment.
+
+    Args:
+        arena_builder: Environment builder whose configuration is mutated in place.
+    """
+    # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this once the render after
+    # rebuild bug is solved in Lab. Keep Policy Runner environments on the same known-good rendering
+    # path as multi-build Experiments: CPU physics with Fabric disabled. Mutating only the builder
+    # configuration preserves the policy's configured inference device.
+    print(
+        "Disabling Fabric and forcing the CPU device for the Policy Runner environment "
+        "to avoid GPU+Fabric rendering artifacts (slower than running on GPU with Fabric).",
+        flush=True,
+    )
+    arena_builder.cfg.disable_fabric = True
+    arena_builder.cfg.device = "cpu"
 
 
 def rollout_policy(
@@ -202,6 +222,7 @@ def main():
 
         # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
         arena_builder = get_arena_builder_from_cli(args_cli, hydra_overrides=hydra_overrides)
+        disable_fabric_for_policy_runner(arena_builder)
 
         output_dir = timestamped_run_dir(args_cli.output_base_dir)
         video_cfg = VideoRecordingCfg(

--- a/isaaclab_arena/tests/test_policy_runner.py
+++ b/isaaclab_arena/tests/test_policy_runner.py
@@ -3,13 +3,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 
+from isaaclab_arena.evaluation.policy_runner import disable_fabric_for_policy_runner
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.subprocess import run_subprocess
 
 HEADLESS = True
 NUM_STEPS = 2
+
+
+def test_policy_runner_environment_uses_cpu_without_fabric():
+    builder = SimpleNamespace(cfg=SimpleNamespace(device="cuda:3", disable_fabric=False))
+
+    disable_fabric_for_policy_runner(builder)
+
+    assert builder.cfg.device == "cpu"
+    assert builder.cfg.disable_fabric
 
 
 def run_policy_runner(

--- a/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_place_banana_on_plate_one_wall_coastal.yaml
+++ b/isaaclab_arena_environments/kitchen_bench/kitchen_bench_lightwheel_place_banana_on_plate_one_wall_coastal.yaml
@@ -1,0 +1,173 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+env_name: kitchen_bench_lightwheel_place_banana_on_plate_one_wall_coastal
+embodiment:
+  id: droid
+  registry_name: droid_abs_joint_pos
+  params:
+    stand_height_m: 0.8
+    placement_bbox_stand_only: true
+    collision_mode: mesh
+background:
+  id: kitchen
+  registry_name: lightwheel_kitchen_one_wall_coastal
+  params:
+    collision_mode: mesh
+    repair_collision_mesh_non_watertight: false
+objects:
+- id: banana
+  registry_name: banana_ycb_robolab
+  params: {}
+- id: plate
+  registry_name: plate_large_vomp_robolab
+  params: {}
+- id: apple
+  registry_name: apple_01_objaverse_robolab
+  params: {}
+- id: avocado
+  registry_name: avocado01_fruits_veggies_robolab
+  params: {}
+- id: broccoli
+  registry_name: broccoli
+  params: {}
+- id: lemon
+  registry_name: lemon_01_fruits_veggies_robolab
+  params: {}
+- id: lime
+  registry_name: lime01_fruits_veggies_robolab
+  params: {}
+- id: lychee
+  registry_name: lychee01_fruits_veggies_robolab
+  params: {}
+- id: orange
+  registry_name: orange_01_fruits_veggies_robolab
+  params: {}
+- id: pomegranate
+  registry_name: pomegranate01_fruits_veggies_robolab
+  params: {}
+- id: red_onion
+  registry_name: red_onion_fruits_veggies_robolab
+  params: {}
+- id: red_bell_pepper
+  registry_name: red_bell_pepper_objaverse_robolab
+  params: {}
+- id: sweet_potato
+  registry_name: sweet_potato
+  params: {}
+- id: pumpkin
+  registry_name: pumpkinsmall_vomp_robolab
+  params: {}
+- id: pineapple
+  registry_name: pineapple_slices_can_hope_robolab
+  params: {}
+- id: peas_and_carrots
+  registry_name: peas_and_carrots_hope_robolab
+  params: {}
+object_references:
+- id: counter_top
+  parent_id: kitchen
+  prim_path: counter_main_main_group/top_geometry_right
+  object_type: base
+  params: {}
+- id: floor
+  parent_id: kitchen
+  prim_path: floor_room/geometry
+  object_type: base
+  params: {}
+relations:
+- kind: is_anchor
+  subject: counter_top
+  params: {}
+- kind: is_anchor
+  subject: floor
+  params: {}
+- kind: 'on'
+  subject: droid
+  reference: floor
+  params: {}
+- kind: next_to
+  subject: droid
+  reference: counter_top
+  params:
+    side: negative_y
+    distance_m: 0.3
+- kind: rotate_around_solution
+  subject: droid
+  params:
+    yaw_rad: 1.57
+- kind: 'on'
+  subject: banana
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: plate
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: apple
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: avocado
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: broccoli
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: lemon
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: lime
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: lychee
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: orange
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: pomegranate
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: red_onion
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: red_bell_pepper
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: sweet_potato
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: pumpkin
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: pineapple
+  reference: counter_top
+  params: {}
+- kind: 'on'
+  subject: peas_and_carrots
+  reference: counter_top
+  params: {}
+task:
+  composition: atomic
+  description: DROID picks up the banana from the counter top and places it on the plate.
+  subtasks:
+  - kind: PickAndPlaceTask
+    params:
+      pick_up_object: banana
+      destination_location: plate
+      background_scene: kitchen

--- a/skills/user/run-experiment/SKILL.md
+++ b/skills/user/run-experiment/SKILL.md
@@ -60,6 +60,10 @@ zero-action policy and requires no model or policy server.
 - Default to `--viz none` for unattended execution. Use `--viz kit` only when requested.
 - Record viewport or camera video only when requested. Camera recording enables camera support and
   can materially increase GPU memory and output size.
+- For any viewport or camera rendering, use CPU physics and disable Fabric for every rendered Run.
+  Kit/RTX rendering remains GPU-backed. Pass `--device cpu` and one
+  `runs.<name>.environment_builder.disable_fabric=true` override per rendered Run, even when the
+  Experiment performs only one build. Keep policy-server and policy-inference devices unchanged.
 - Preserve the runner's default stop-on-first-error behavior. Add `--continue_on_error` only when
   the user wants the remaining Runs attempted after a failure.
 - Use `--serve_evaluation_report` only when explicitly requested; it binds an HTTP server and keeps
@@ -105,7 +109,12 @@ Use the local override namespace:
 ```text
 shared.rollout_limit.num_episodes=4
 runs.parallel_envs.environment_builder.num_envs=8
+runs.parallel_envs.environment_builder.disable_fabric=true
 ```
+
+When recording the viewport for every Run, add the Fabric override once for each declared Run and
+pass `--device cpu` as a runner flag. Do not add `shared.environment_builder` solely for this
+workaround when the source YAML does not already declare it; shared overrides cannot create fields.
 
 Do not prefix local overrides with `experiment_cfg.`; that prefix belongs to OSMO submission.
 Quote override tokens that contain shell-sensitive characters. Do not edit the source YAML when a

--- a/skills/user/run-experiment/SKILL.md
+++ b/skills/user/run-experiment/SKILL.md
@@ -60,10 +60,6 @@ zero-action policy and requires no model or policy server.
 - Default to `--viz none` for unattended execution. Use `--viz kit` only when requested.
 - Record viewport or camera video only when requested. Camera recording enables camera support and
   can materially increase GPU memory and output size.
-- For any viewport or camera rendering, use CPU physics and disable Fabric for every rendered Run.
-  Kit/RTX rendering remains GPU-backed. Pass `--device cpu` and one
-  `runs.<name>.environment_builder.disable_fabric=true` override per rendered Run, even when the
-  Experiment performs only one build. Keep policy-server and policy-inference devices unchanged.
 - Preserve the runner's default stop-on-first-error behavior. Add `--continue_on_error` only when
   the user wants the remaining Runs attempted after a failure.
 - Use `--serve_evaluation_report` only when explicitly requested; it binds an HTTP server and keeps
@@ -109,12 +105,7 @@ Use the local override namespace:
 ```text
 shared.rollout_limit.num_episodes=4
 runs.parallel_envs.environment_builder.num_envs=8
-runs.parallel_envs.environment_builder.disable_fabric=true
 ```
-
-When recording the viewport for every Run, add the Fabric override once for each declared Run and
-pass `--device cpu` as a runner flag. Do not add `shared.environment_builder` solely for this
-workaround when the source YAML does not already declare it; shared overrides cannot create fields.
 
 Do not prefix local overrides with `experiment_cfg.`; that prefix belongs to OSMO submission.
 Quote override tokens that contain shell-sensitive characters. Do not edit the source YAML when a


### PR DESCRIPTION
## Summary
Use CPU physics + disabled fabric for policy runner rendering

## Detailed description
- Disable Fabric and force the Policy Runner environment onto CPU physics while preserving the policy inference device. 
- Document the safe rendering configuration for agents and Experiment execution.

Before
<img width="945" height="562" alt="Screenshot from 2026-09-02 09-39-06" src="https://github.com/user-attachments/assets/f5af8000-46bb-4fe1-b872-8b1640a7cf75" />
After
<img width="959" height="563" alt="Screenshot from 2026-09-02 23-42-31" src="https://github.com/user-attachments/assets/5bf22638-87a9-48e3-b929-7f519faf051f" />
