### PR TITLE
Switch public inference default model to DeepSeek in Agentic Env Gen

### DIFF
--- a/docs/pages/concepts/agentic_environment_generation/model_selection.rst
+++ b/docs/pages/concepts/agentic_environment_generation/model_selection.rst
@@ -43,7 +43,8 @@ Selecting the Model
 Each endpoint preset has its own default model, so switching endpoints switches models (see
 :ref:`agentic-env-gen-prerequisites`). The CLI runner overrides it per run with ``--model`` and
 ``--temperature``; the GUI runner selects the endpoint in the generation panel and uses that
-endpoint's default model. For the public endpoint, any model in the
+endpoint's default model. The public endpoint defaults to ``deepseek-ai/deepseek-v4-pro-0813``.
+For the public endpoint, any model in the
 `NVIDIA NIM LLM API reference <https://docs.api.nvidia.com/nim/reference/llm-apis>`_ works, as long
 as it supports strict structured outputs — a larger context window buys more reliable prim path
 resolution.
@@ -86,9 +87,8 @@ resolution.
 .. note::
    The benchmark ran each of five documented prompts three times. Pass rate is the fraction of
    generated specs that matched the expected structure; runtime is the mean end-to-end
-   ``generate_spec`` runtime. The two public models were measured at commit ``97c92a1f2``.
-   These results are snapshots rather than guarantees: model output is non-deterministic, and
-   service load affects runtime.
+   ``generate_spec`` runtime. These results are snapshots rather than guarantees: model output is
+   non-deterministic, and service load affects runtime.
 
 In this snapshot, DeepSeek produced the expected structure for all 15 runs. Nemotron produced the
 expected structure for all nine tabletop runs but failed all six kitchen runs, primarily by

--- a/docs/pages/concepts/agentic_environment_generation/model_selection.rst
+++ b/docs/pages/concepts/agentic_environment_generation/model_selection.rst
@@ -43,8 +43,7 @@ Selecting the Model
 Each endpoint preset has its own default model, so switching endpoints switches models (see
 :ref:`agentic-env-gen-prerequisites`). The CLI runner overrides it per run with ``--model`` and
 ``--temperature``; the GUI runner selects the endpoint in the generation panel and uses that
-endpoint's default model. The public endpoint defaults to ``deepseek-ai/deepseek-v4-pro-0813``.
-For the public endpoint, any model in the
+endpoint's default model. For the public endpoint, any model in the
 `NVIDIA NIM LLM API reference <https://docs.api.nvidia.com/nim/reference/llm-apis>`_ works, as long
 as it supports strict structured outputs — a larger context window buys more reliable prim path
 resolution.
@@ -55,7 +54,7 @@ resolution.
 
    * - ``ARENA_INFERENCE_ENDPOINT``
      - Accessibility
-     - Model
+     - Default model
      - API key variable
      - Pass rate
      - Mean runtime
@@ -65,12 +64,6 @@ resolution.
      - ``NVIDIA_API_KEY``
      - 15/15 (100%)
      - 150.66 s
-   * - ``public`` (comparison)
-     - Public (free)
-     - ``nvidia/nemotron-3-ultra-550b-a55b``
-     - ``NVIDIA_API_KEY``
-     - 9/15 (60%)
-     - 149.86 s
    * - ``internal``
      - NVIDIA internal
      - ``openai/openai/gpt-5.6-terra``
@@ -88,7 +81,10 @@ resolution.
    The benchmark ran each of five documented prompts three times. Pass rate is the fraction of
    generated specs that matched the expected structure; runtime is the mean end-to-end
    ``generate_spec`` runtime. These results are snapshots rather than guarantees: model output is
-   non-deterministic, and service load affects runtime.
+   non-deterministic, and service load affects runtime. On the public endpoint, overriding the
+   default with ``--model nvidia/nemotron-3-ultra-550b-a55b`` passed 9/15 runs (60%) with a
+   149.86-second mean runtime; ``--model openai/gpt-oss-20b`` passed 7/15 runs (46.7%) with a
+   333.17-second mean runtime.
 
 Reviewing the Generated Spec
 ----------------------------

--- a/docs/pages/concepts/agentic_environment_generation/model_selection.rst
+++ b/docs/pages/concepts/agentic_environment_generation/model_selection.rst
@@ -90,11 +90,6 @@ resolution.
    ``generate_spec`` runtime. These results are snapshots rather than guarantees: model output is
    non-deterministic, and service load affects runtime.
 
-In this snapshot, DeepSeek produced the expected structure for all 15 runs. Nemotron produced the
-expected structure for all nine tabletop runs but failed all six kitchen runs, primarily by
-omitting background object references and spatial relations. Their mean runtimes were nearly the
-same, so DeepSeek is the public default based on spec quality rather than speed.
-
 Reviewing the Generated Spec
 ----------------------------
 

--- a/docs/pages/concepts/agentic_environment_generation/model_selection.rst
+++ b/docs/pages/concepts/agentic_environment_generation/model_selection.rst
@@ -54,16 +54,22 @@ resolution.
 
    * - ``ARENA_INFERENCE_ENDPOINT``
      - Accessibility
-     - Default model
+     - Model
      - API key variable
      - Pass rate
      - Mean runtime
    * - ``public`` (default)
      - Public (free)
-     - ``openai/gpt-oss-120b``
+     - ``deepseek-ai/deepseek-v4-pro-0813``
      - ``NVIDIA_API_KEY``
-     - 13/15 (86.7%)
-     - 22.28 s
+     - 15/15 (100%)
+     - 150.66 s
+   * - ``public`` (comparison)
+     - Public (free)
+     - ``nvidia/nemotron-3-ultra-550b-a55b``
+     - ``NVIDIA_API_KEY``
+     - 9/15 (60%)
+     - 149.86 s
    * - ``internal``
      - NVIDIA internal
      - ``openai/openai/gpt-5.6-terra``
@@ -80,8 +86,14 @@ resolution.
 .. note::
    The benchmark ran each of five documented prompts three times. Pass rate is the fraction of
    generated specs that matched the expected structure; runtime is the mean end-to-end
-   ``generate_spec`` runtime. These results are snapshots rather than guarantees: model output is
-   non-deterministic, and service load affects runtime.
+   ``generate_spec`` runtime. The two public models were measured at commit ``97c92a1f2``.
+   These results are snapshots rather than guarantees: model output is non-deterministic, and
+   service load affects runtime.
+
+In this snapshot, DeepSeek produced the expected structure for all 15 runs. Nemotron produced the
+expected structure for all nine tabletop runs but failed all six kitchen runs, primarily by
+omitting background object references and spatial relations. Their mean runtimes were nearly the
+same, so DeepSeek is the public default based on spec quality rather than speed.
 
 Reviewing the Generated Spec
 ----------------------------

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -50,7 +50,6 @@ INTERNAL_ENDPOINT = InferenceEndpoint(
 PUBLIC_ENDPOINT = InferenceEndpoint(
     name="public",
     base_url="https://integrate.api.nvidia.com/v1",
-    # If you cannot access the model in your region, try "nvidia/nemotron-3-super-120b-a12b".
     model="deepseek-ai/deepseek-v4-pro-0813",
     api_key_env_var="NVIDIA_API_KEY",
 )

--- a/isaaclab_arena/agentic_environment_generation/inference_backend.py
+++ b/isaaclab_arena/agentic_environment_generation/inference_backend.py
@@ -51,7 +51,7 @@ PUBLIC_ENDPOINT = InferenceEndpoint(
     name="public",
     base_url="https://integrate.api.nvidia.com/v1",
     # If you cannot access the model in your region, try "nvidia/nemotron-3-super-120b-a12b".
-    model="openai/gpt-oss-120b",
+    model="deepseek-ai/deepseek-v4-pro-0813",
     api_key_env_var="NVIDIA_API_KEY",
 )
 """Publicly reachable build.nvidia.com endpoint, reached with an NGC API key."""


### PR DESCRIPTION
## Summary
Switch public inference model to DeepSeek

## Detailed description
- gpt-oss-120b has been deprecated today without prior notice, caught by SQA regression tests
- Switched to deepseek-v4-pro as it has been tested on all 5 example workflows
- The inference call time increases to 100+sec from 10+sec, but given the quality outperforms than nemotran, the cost is acceptable.
- Updated doc to track perf 
