### PR TITLE
Cherrypick: Make Robolab Table Backgrounds Kinematic

### DIFF
--- a/docs/pages/concepts/scene/concept_assets_design.rst
+++ b/docs/pages/concepts/scene/concept_assets_design.rst
@@ -87,6 +87,32 @@ ownership away from the background.
 Instanceable subtrees that contribute dynamic physics are materialized at spawn
 time because physics views cannot control dynamic instance proxies.
 
+Rigid-body behavior
+^^^^^^^^^^^^^^^^^^^
+
+A background's ``BASE`` type does not remove physics authored in its USD. The
+``rigid_props`` value in ``spawn_cfg_addon`` is forwarded to Isaac Lab's USD spawner.
+When ``rigid_props=None`` (the default), the spawner does not add or modify rigid-body
+properties. A prim that already has ``UsdPhysics.RigidBodyAPI`` therefore keeps its
+authored behavior; for example, an authored dynamic body can move when gravity or
+contact forces act on it.
+
+For a background fixture that must not move, such as a table used only as a fixed
+work surface, make its rigid bodies kinematic:
+
+.. code-block:: python
+
+   spawn_cfg_addon = {
+       "rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+   }
+
+A kinematic body still collides with dynamic objects, but gravity, forces, and contacts
+do not displace it. Its pose changes only when it is explicitly commanded. Do not use
+this setting when the background should respond physically. For example, a table that
+a humanoid is expected to push must remain dynamic: retain ``rigid_props=None`` when
+the USD already authors it as dynamic, or explicitly set ``kinematic_enabled=False``
+to override an authored kinematic setting.
+
 Object references
 -----------------
 

--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -205,6 +205,9 @@ class MapleTableRobolab(LibraryBackground):
     tags = ["background", "robolab"]
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/scenes/maple_table.usda"
     object_min_z = -0.05
+    spawn_cfg_addon = {
+        "rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+    }
 
 
 @register_asset
@@ -213,6 +216,9 @@ class TableOakRobolab(LibraryBackground):
     tags = ["background", "robolab"]
     usd_path = f"{ARENA_NUCLEUS_DIR}/Arena/assets/object_library/srl_robolab_assets/fixtures/table_oak.usd"
     object_min_z = -0.05
+    spawn_cfg_addon = {
+        "rigid_props": sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+    }
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Make Robolab Table Backgrounds Kinematic #1179 

## Detailed description
- Suggested by discussion [here](https://nvidia.slack.com/archives/C0BR78Z3KAR/p1788418369980489?thread_ts=1788389583.037159&cid=C0BR78Z3KAR)
- Made the maple and oak Robolab table backgrounds kinematic so they remain stationary during interaction.
- Documented how rigid_props=None preserves authored USD rigid-body behavior and when to use kinematic bodies.
- Clarified that movable backgrounds, such as humanoid-pushed tables, must remain dynamic.
