### PR TITLE
Centralize object pose queries

### DIFF
--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 import torch
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-import warp as wp
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
-from isaaclab.sim.views import FrameView
 from isaaclab_tasks.contrib.stack.mdp.franka_stack_events import randomize_object_pose
 
 # Re-export ObjectType from the lightweight module so existing
@@ -26,6 +25,9 @@ from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
 from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.velocity import Velocity
 from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnv
 
 __all__ = [
     "ObjectBase",
@@ -52,16 +54,6 @@ class ObjectBase(PlaceableAsset, ABC):
             self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None
         self.object_cfg = None
-        self._base_frame_view: FrameView | None = None
-        self._base_frame_view_stage = None
-
-    def _close_base_frame_view(self) -> None:
-        """Release the cached frame view. Safe to call more than once."""
-        frame_view = self._base_frame_view
-        if frame_view is not None:
-            frame_view.close()
-            self._base_frame_view = None
-            self._base_frame_view_stage = None
 
     def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
         """Store the pose and write its construction values into the object config."""
@@ -157,11 +149,11 @@ class ObjectBase(PlaceableAsset, ABC):
             raise ValueError(f"Invalid object type: {self.object_type}")
         return object_cfg
 
-    def get_object_pose(self, env: ManagerBasedEnv, is_relative: bool = True) -> torch.Tensor:
+    def get_object_pose(self, env: IsaacLabArenaManagerBasedRLEnv, is_relative: bool = True) -> torch.Tensor:
         """Get the pose of the object in the environment.
 
         Args:
-            env: The environment.
+            env: The wrapped or unwrapped Arena manager-based environment.
             is_relative: Whether to return the pose in the relative frame of the environment.
 
         Returns:
@@ -170,36 +162,9 @@ class ObjectBase(PlaceableAsset, ABC):
         """
         # We require that the asset has been added to the scene under its name.
         assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if (self.object_type == ObjectType.RIGID) or (self.object_type == ObjectType.ARTICULATION):
-            object_pose = wp.to_torch(env.unwrapped.scene[self.name].data.root_pose_w).clone()
-        elif self.object_type == ObjectType.BASE:
-            scene = env.unwrapped.scene
-            stage = scene.stage
-            if self._base_frame_view is None or self._base_frame_view_stage is not stage:
-                self._close_base_frame_view()
-                asset_cfg = scene[self.name]
-                frame_view = FrameView(asset_cfg.prim_path, device=env.unwrapped.device, stage=stage)
-                try:
-                    prim_paths = frame_view.prim_paths
-                    assert len(prim_paths) == env.unwrapped.num_envs, (
-                        f"AssetBaseCfg scene entry '{self.name}' resolved to {len(prim_paths)} prims; "
-                        f"expected {env.unwrapped.num_envs}."
-                    )
-                    for environment_id, prim_path in enumerate(prim_paths):
-                        environment_prim_path = scene.env_prim_paths[environment_id]
-                        assert str(prim_path).startswith(f"{environment_prim_path}/"), (
-                            f"AssetBaseCfg scene entry '{self.name}' pose row {environment_id} belongs to"
-                            f" '{prim_path}', not environment '{environment_prim_path}'."
-                        )
-                except Exception:
-                    frame_view.close()
-                    raise
-                self._base_frame_view = frame_view
-                self._base_frame_view_stage = stage
-            position_w, orientation_w = self._base_frame_view.get_world_poses()
-            object_pose = torch.cat((position_w.torch, orientation_w.torch), dim=-1)
-        else:
+        if self.object_type not in (ObjectType.RIGID, ObjectType.ARTICULATION, ObjectType.BASE):
             raise ValueError(f"Function not implemented for object type: {self.object_type}")
+        object_pose = env.unwrapped.arena_world.get_pose_w(self.name).clone()
         if is_relative:
             object_pose[:, :3] -= env.unwrapped.scene.env_origins
         return object_pose

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import torch
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
 from isaaclab.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
@@ -25,9 +24,6 @@ from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
 from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.velocity import Velocity
 from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
-
-if TYPE_CHECKING:
-    from isaaclab_arena.environments.isaaclab_arena_manager_based_env import IsaacLabArenaManagerBasedRLEnv
 
 __all__ = [
     "ObjectBase",
@@ -148,26 +144,6 @@ class ObjectBase(PlaceableAsset, ABC):
         else:
             raise ValueError(f"Invalid object type: {self.object_type}")
         return object_cfg
-
-    def get_object_pose(self, env: IsaacLabArenaManagerBasedRLEnv, is_relative: bool = True) -> torch.Tensor:
-        """Get the pose of the object in the environment.
-
-        Args:
-            env: The wrapped or unwrapped Arena manager-based environment.
-            is_relative: Whether to return the pose in the relative frame of the environment.
-
-        Returns:
-            The pose of the object in each environment. The shape is (num_envs, 7).
-            The order is (x, y, z, qx, qy, qz, qw).
-        """
-        # We require that the asset has been added to the scene under its name.
-        assert self.name in env.unwrapped.scene.keys(), f"Asset {self.name} not found in scene"
-        if self.object_type not in (ObjectType.RIGID, ObjectType.ARTICULATION, ObjectType.BASE):
-            raise ValueError(f"Function not implemented for object type: {self.object_type}")
-        object_pose = env.unwrapped.arena_world.get_pose_w(self.name).clone()
-        if is_relative:
-            object_pose[:, :3] -= env.unwrapped.scene.env_origins
-        return object_pose
 
     def set_object_pose(self, env: ManagerBasedEnv, pose: Pose, env_ids: torch.Tensor | None = None) -> None:
         """Set the pose of the object in the environment.

--- a/isaaclab_arena/environments/arena_world.py
+++ b/isaaclab_arena/environments/arena_world.py
@@ -5,11 +5,9 @@
 
 """Query live Arena scene state and cache derived geometry.
 
-Arena pose and transform names use target-source notation: T_A_B maps points
-from frame B into frame A. Here W is the simulation world. For a rigid object
-or articulation, F is its root-link frame; for a scene extra, F is the selected
-prim's frame. Geometry helpers use P for a USD prim's local frame. Isaac Lab's
-root_pose_w supplies T_W_F for rigid objects and articulations.
+Arena poses and transforms use target-source notation: T_A_B maps points from
+frame B into frame A. W is the simulation world. F is the root-link frame for
+a rigid object or articulation, and the configured prim frame for a scene extra.
 """
 
 from __future__ import annotations
@@ -23,14 +21,7 @@ from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
 class ArenaWorld:
-    """Provide name-based pose, velocity, and geometry queries.
-
-    Poses are read live for rigid objects, articulations, and scene extras. Root linear velocities are supported for
-    rigid objects only. Local-frame geometry bounds are supported for rigid objects and scene extras; they are
-    computed lazily from the cloned prim hierarchy and cached for the environment lifetime. They remain valid under
-    whole-subtree motion, but not when descendants move relative to frame F. A moving part must therefore have its
-    own supported scene key.
-    """
+    """Provide name-based pose, velocity, and geometry queries."""
 
     def __init__(self, scene: InteractiveScene):
         self._scene = scene
@@ -84,7 +75,10 @@ class ArenaWorld:
         return root_linear_velocity_w
 
     def get_aabb_in_local_frame(self, scene_key: str) -> AxisAlignedBoundingBox:
-        """Return cached geometry bounds expressed in the selected local frame F."""
+        """Return cached rigid-object or scene-extra geometry bounds in local frame F.
+
+        The cache assumes descendants remain fixed relative to F.
+        """
         scene = self._scene
         if scene_key not in self._aabbs_in_local_frame_cache:
             aabb_F = scene_access.compute_spawned_geometry_bounds_in_local_frame(scene, scene_key)

--- a/isaaclab_arena/environments/arena_world.py
+++ b/isaaclab_arena/environments/arena_world.py
@@ -6,10 +6,10 @@
 """Query live Arena scene state and cache derived geometry.
 
 Arena pose and transform names use target-source notation: T_A_B maps points
-from frame B into frame A. Here W is the simulation world, F is the frame of
-the rigid object or scene extra selected by a scene key, and geometry helpers
-use P for a USD prim's local frame. For a rigid object, Isaac Lab's root_pose_w
-supplies the value represented here as T_W_F.
+from frame B into frame A. Here W is the simulation world. For a rigid object
+or articulation, F is its root-link frame; for a scene extra, F is the selected
+prim's frame. Geometry helpers use P for a USD prim's local frame. Isaac Lab's
+root_pose_w supplies T_W_F for rigid objects and articulations.
 """
 
 from __future__ import annotations
@@ -23,12 +23,13 @@ from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
 class ArenaWorld:
-    """Provide name-based runtime access to rigid objects and scene extras.
+    """Provide name-based pose, velocity, and geometry queries.
 
-    Poses are read live for both supported scene categories, along with root linear velocities for rigid objects.
-    Local-frame geometry bounds are computed lazily from the cloned prim hierarchy and cached for the environment
-    lifetime. They remain valid under whole-subtree motion, but not when descendants move relative to frame F.
-    A moving part must therefore have its own supported scene key.
+    Poses are read live for rigid objects, articulations, and scene extras. Root linear velocities are supported for
+    rigid objects only. Local-frame geometry bounds are supported for rigid objects and scene extras; they are
+    computed lazily from the cloned prim hierarchy and cached for the environment lifetime. They remain valid under
+    whole-subtree motion, but not when descendants move relative to frame F. A moving part must therefore have its
+    own supported scene key.
     """
 
     def __init__(self, scene: InteractiveScene):
@@ -37,23 +38,27 @@ class ArenaWorld:
         self._scene_extra_pose_reader_cache: dict[str, scene_access.SceneExtraPoseReader] = {}
 
     def get_pose_w(self, scene_key: str) -> torch.Tensor:
-        """Return the current world-frame pose for a rigid-object or scene-extra key.
+        """Return the world-frame pose of a rigid-object root link, articulation root link, or scene extra.
 
         The tensor has shape (num_envs, 7), with each pose ordered as
         (x, y, z, qx, qy, qz, qw).
         """
         scene = self._scene
         is_rigid_object = scene_key in scene.rigid_objects
+        is_articulation = scene_key in scene.articulations
         is_scene_extra = scene_key in scene.extras
-        assert is_rigid_object or is_scene_extra, (
-            "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects or "
-            f"InteractiveScene.extras; '{scene_key}' is registered in neither."
+        assert is_rigid_object or is_articulation or is_scene_extra, (
+            "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects, "
+            "InteractiveScene.articulations, or InteractiveScene.extras; "
+            f"'{scene_key}' is registered in none of them."
         )
 
-        # Rigid objects expose live root state directly. Scene extras are plain cloned prims,
-        # so their live post-clone poses require a FrameView-backed reader.
+        # Rigid objects and articulations expose their live root-link poses directly. Scene
+        # extras are plain cloned prims, so their live post-clone poses require a FrameView-backed reader.
         if is_rigid_object:
             T_W_F = scene.rigid_objects[scene_key].data.root_pose_w.torch
+        elif is_articulation:
+            T_W_F = scene.articulations[scene_key].data.root_pose_w.torch
         else:
             pose_reader = self._get_scene_extra_pose_reader(scene, scene_key)
             T_W_F = pose_reader.get_pose_w()

--- a/isaaclab_arena/environments/arena_world.py
+++ b/isaaclab_arena/environments/arena_world.py
@@ -5,9 +5,11 @@
 
 """Query live Arena scene state and cache derived geometry.
 
-Arena poses and transforms use target-source notation: T_A_B maps points from
-frame B into frame A. W is the simulation world. F is the root-link frame for
-a rigid object or articulation, and the configured prim frame for a scene extra.
+Arena transforms use target-source notation: T_A_B maps points from frame B
+into frame A. W is the simulation world, and F is the queried root-link or prim
+frame. E is each Isaac Lab local environment frame, aligned with W and located
+at the corresponding row of scene.env_origins. Pose method suffixes _w and _e
+indicate whether a pose is expressed in W or E.
 """
 
 from __future__ import annotations
@@ -59,6 +61,16 @@ class ArenaWorld:
             7,
         ), f"Pose for scene key '{scene_key}' has shape {tuple(T_W_F.shape)}; expected ({scene.num_envs}, 7)."
         return T_W_F
+
+    def get_pose_e(self, scene_key: str) -> torch.Tensor:
+        """Return poses relative to their respective environment origins.
+
+        The returned tensor is a copy with shape (num_envs, 7), with each pose
+        ordered as (x, y, z, qx, qy, qz, qw).
+        """
+        T_E_F = self.get_pose_w(scene_key).clone()
+        T_E_F[:, :3] -= self._scene.env_origins
+        return T_E_F
 
     def get_root_linear_velocity_w(self, rigid_object_name: str) -> torch.Tensor:
         """Return a rigid object's current world-frame root linear velocity.

--- a/isaaclab_arena/tests/test_arena_world_scene_access.py
+++ b/isaaclab_arena/tests/test_arena_world_scene_access.py
@@ -45,15 +45,11 @@ def _check_rigid_object_reads_and_local_aabb_cache(
     """Check live rigid-object reads and one cached AABB per scene key."""
     import torch
 
-    class RuntimeBufferDouble:
-        def __init__(self, tensor: torch.Tensor):
-            self.torch = tensor
-
     class RigidObjectDouble:
         def __init__(self, T_W_F: torch.Tensor, root_linear_velocity_w: torch.Tensor):
             self.data = SimpleNamespace(
-                root_pose_w=RuntimeBufferDouble(T_W_F),
-                root_lin_vel_w=RuntimeBufferDouble(root_linear_velocity_w),
+                root_pose_w=SimpleNamespace(torch=T_W_F),
+                root_lin_vel_w=SimpleNamespace(torch=root_linear_velocity_w),
             )
 
     class SceneDouble:
@@ -141,15 +137,11 @@ def _check_articulation_pose_reads(arena_world_module) -> None:
     """Check that articulation root poses are read live."""
     import torch
 
-    class RuntimeBufferDouble:
-        def __init__(self, tensor: torch.Tensor):
-            self.torch = tensor
-
     T_W_F_initial = torch.tensor([
         [0.0, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0],
         [1.0, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0],
     ])
-    articulation = SimpleNamespace(data=SimpleNamespace(root_pose_w=RuntimeBufferDouble(T_W_F_initial)))
+    articulation = SimpleNamespace(data=SimpleNamespace(root_pose_w=SimpleNamespace(torch=T_W_F_initial)))
     scene = SimpleNamespace(
         num_envs=2,
         rigid_objects={},

--- a/isaaclab_arena/tests/test_arena_world_scene_access.py
+++ b/isaaclab_arena/tests/test_arena_world_scene_access.py
@@ -60,6 +60,10 @@ def _check_rigid_object_reads_and_local_aabb_cache(
         def __init__(self):
             self.num_envs = 2
             self.device = "cpu"
+            self.env_origins = torch.tensor([
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+            ])
             self.rigid_objects = {
                 "object": RigidObjectDouble(
                     T_W_F=torch.tensor([
@@ -99,7 +103,11 @@ def _check_rigid_object_reads_and_local_aabb_cache(
         )
 
     T_W_O_initial = scene.rigid_objects["object"].data.root_pose_w.torch.clone()
+    T_E_O_initial = T_W_O_initial.clone()
+    T_E_O_initial[:, :3] -= scene.env_origins
     initial_root_linear_velocity_w = scene.rigid_objects["object"].data.root_lin_vel_w.torch.clone()
+    torch.testing.assert_close(arena_world.get_pose_w("object"), T_W_O_initial)
+    torch.testing.assert_close(arena_world.get_pose_e("object"), T_E_O_initial)
     torch.testing.assert_close(arena_world.get_pose_w("object"), T_W_O_initial)
     torch.testing.assert_close(arena_world.get_root_linear_velocity_w("object"), initial_root_linear_velocity_w)
 
@@ -108,6 +116,10 @@ def _check_rigid_object_reads_and_local_aabb_cache(
     changed_root_linear_velocity_w = initial_root_linear_velocity_w + 0.5
     scene.rigid_objects["object"].data.root_pose_w.torch = T_W_O_moved
     scene.rigid_objects["object"].data.root_lin_vel_w.torch = changed_root_linear_velocity_w
+    T_E_O_moved = T_W_O_moved.clone()
+    T_E_O_moved[:, :3] -= scene.env_origins
+    torch.testing.assert_close(arena_world.get_pose_w("object"), T_W_O_moved)
+    torch.testing.assert_close(arena_world.get_pose_e("object"), T_E_O_moved)
     torch.testing.assert_close(arena_world.get_pose_w("object"), T_W_O_moved)
     torch.testing.assert_close(arena_world.get_root_linear_velocity_w("object"), changed_root_linear_velocity_w)
 

--- a/isaaclab_arena/tests/test_arena_world_scene_access.py
+++ b/isaaclab_arena/tests/test_arena_world_scene_access.py
@@ -79,6 +79,7 @@ def _check_rigid_object_reads_and_local_aabb_cache(
                     root_linear_velocity_w=torch.zeros((2, 3)),
                 ),
             }
+            self.articulations = {}
             self.extras = {}
 
     scene = SceneDouble()
@@ -124,6 +125,35 @@ def _check_rigid_object_reads_and_local_aabb_cache(
     assert geometry_build_calls == ["object", "destination"]
 
 
+def _check_articulation_pose_reads(arena_world_module) -> None:
+    """Check that articulation root poses are read live."""
+    import torch
+
+    class RuntimeBufferDouble:
+        def __init__(self, tensor: torch.Tensor):
+            self.torch = tensor
+
+    T_W_F_initial = torch.tensor([
+        [0.0, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0],
+        [1.0, 0.0, 0.4, 0.0, 0.0, 0.0, 1.0],
+    ])
+    articulation = SimpleNamespace(data=SimpleNamespace(root_pose_w=RuntimeBufferDouble(T_W_F_initial)))
+    scene = SimpleNamespace(
+        num_envs=2,
+        rigid_objects={},
+        articulations={"cabinet": articulation},
+        extras={},
+    )
+    arena_world = arena_world_module.ArenaWorld(scene)
+
+    torch.testing.assert_close(arena_world.get_pose_w("cabinet"), T_W_F_initial)
+
+    T_W_F_moved = T_W_F_initial.clone()
+    T_W_F_moved[:, 2] += 0.1
+    articulation.data.root_pose_w.torch = T_W_F_moved
+    torch.testing.assert_close(arena_world.get_pose_w("cabinet"), T_W_F_moved)
+
+
 def _check_arena_world_reuses_scene_extra_pose_reader(
     arena_world_module,
     scene_access_module,
@@ -135,6 +165,7 @@ def _check_arena_world_reuses_scene_extra_pose_reader(
         def __init__(self):
             self.num_envs = 1
             self.rigid_objects = {}
+            self.articulations = {}
             self.extras = {"reference": object()}
 
     class PoseReaderDouble:
@@ -166,7 +197,7 @@ def _check_arena_world_reuses_scene_extra_pose_reader(
 def _check_arena_world_rejects_unsupported_pose_scene_key(arena_world_module) -> None:
     """Check that a pose query reports ArenaWorld's supported scene categories."""
 
-    scene = SimpleNamespace(rigid_objects={}, extras={})
+    scene = SimpleNamespace(rigid_objects={}, articulations={}, extras={})
     arena_world = arena_world_module.ArenaWorld(scene)
 
     try:
@@ -174,8 +205,8 @@ def _check_arena_world_rejects_unsupported_pose_scene_key(arena_world_module) ->
     except AssertionError as error:
         assert (
             str(error)
-            == "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects or "
-            "InteractiveScene.extras; 'robot' is registered in neither."
+            == "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects, "
+            "InteractiveScene.articulations, or InteractiveScene.extras; 'robot' is registered in none of them."
         )
     else:
         raise AssertionError("ArenaWorld accepted an unsupported pose scene key.")
@@ -249,6 +280,7 @@ def _test_arena_world_scene_access(_simulation_app) -> bool:
         scene_access,
         AxisAlignedBoundingBox,
     )
+    _check_articulation_pose_reads(arena_world)
     _check_arena_world_reuses_scene_extra_pose_reader(arena_world, scene_access)
     _check_arena_world_rejects_unsupported_pose_scene_key(arena_world)
     _check_scene_extra_pose_reader_uses_current_frame_view_poses(scene_access)

--- a/isaaclab_arena/tests/test_assembly_task.py
+++ b/isaaclab_arena/tests/test_assembly_task.py
@@ -171,8 +171,8 @@ def _test_peg_insert_assembly_single(simulation_app) -> bool:
 
     def assert_assembled(env: ManagerBasedEnv, terminated: torch.Tensor):
         # Check if objects are close together (assembled)
-        peg_pos = peg.get_object_pose(env, is_relative=True)[:, :3]
-        hole_pos = hole.get_object_pose(env, is_relative=True)[:, :3]
+        peg_pos = env.unwrapped.arena_world.get_pose_e(peg.name)[:, :3]
+        hole_pos = env.unwrapped.arena_world.get_pose_e(hole.name)[:, :3]
         distance = torch.norm(peg_pos - hole_pos, dim=-1)
 
         print(f"Distance between peg and hole: {distance.item():.4f}m")
@@ -187,7 +187,7 @@ def _test_peg_insert_assembly_single(simulation_app) -> bool:
         print("Testing peg insert assembly (single env)...")
 
         # Manually place hole on peg to simulate successful assembly - use absolute world coordinates
-        peg_pose = peg.get_object_pose(env, is_relative=False)
+        peg_pose = env.unwrapped.arena_world.get_pose_w(peg.name)
         env.scene[hole.name].write_root_pose_to_sim(peg_pose, env_ids=torch.tensor([0], device=env.device))
 
         step_zeros_and_call(env, NUM_STEPS, assert_assembled)
@@ -213,8 +213,8 @@ def _test_gear_mesh_assembly_single(simulation_app) -> bool:
 
     def assert_assembled(env: ManagerBasedEnv, terminated: torch.Tensor):
         # Check if gears are close together (meshed)
-        base_pos = gear_base.get_object_pose(env, is_relative=True)[:, :3]
-        medium_pos = medium_gear.get_object_pose(env, is_relative=True)[:, :3]
+        base_pos = env.unwrapped.arena_world.get_pose_e(gear_base.name)[:, :3]
+        medium_pos = env.unwrapped.arena_world.get_pose_e(medium_gear.name)[:, :3]
         distance = torch.norm(base_pos - medium_pos, dim=-1)
 
         print(f"Distance between gear base and medium gear: {distance.item():.4f}m")
@@ -229,7 +229,7 @@ def _test_gear_mesh_assembly_single(simulation_app) -> bool:
         print("Testing gear mesh assembly (single env)...")
 
         # Manually place medium gear on gear base to simulate successful assembly - use absolute world coordinates
-        base_pose = gear_base.get_object_pose(env, is_relative=False)
+        base_pose = env.unwrapped.arena_world.get_pose_w(gear_base.name)
         env.scene[medium_gear.name].write_root_pose_to_sim(base_pose, env_ids=torch.tensor([0], device=env.device))
 
         step_zeros_and_call(env, NUM_STEPS, assert_assembled)
@@ -256,14 +256,14 @@ def _test_peg_insert_assembly_multi(simulation_app) -> bool:
             print("Testing peg insert assembly (multi env)...")
 
             # Assemble in both environments - use absolute world coordinates
-            peg_poses = peg.get_object_pose(env, is_relative=False)
+            peg_poses = env.unwrapped.arena_world.get_pose_w(peg.name)
             env.scene[hole.name].write_root_pose_to_sim(peg_poses, env_ids=None)
 
             step_zeros_and_call(env, NUM_STEPS)
 
             # Check distances
-            peg_pos = peg.get_object_pose(env, is_relative=True)[:, :3]
-            hole_pos = hole.get_object_pose(env, is_relative=True)[:, :3]
+            peg_pos = env.unwrapped.arena_world.get_pose_e(peg.name)[:, :3]
+            hole_pos = env.unwrapped.arena_world.get_pose_e(hole.name)[:, :3]
             distances = torch.norm(peg_pos - hole_pos, dim=-1)
 
             print(f"Distances in both envs: {distances}")
@@ -292,14 +292,14 @@ def _test_gear_mesh_assembly_multi(simulation_app) -> bool:
             print("Testing gear mesh assembly (multi env)...")
 
             # Assemble in both environments - use absolute world coordinates
-            base_poses = gear_base.get_object_pose(env, is_relative=False)
+            base_poses = env.unwrapped.arena_world.get_pose_w(gear_base.name)
             env.scene[medium_gear.name].write_root_pose_to_sim(base_poses, env_ids=None)
 
             step_zeros_and_call(env, NUM_STEPS)
 
             # Check distances
-            base_pos = gear_base.get_object_pose(env, is_relative=True)[:, :3]
-            medium_pos = medium_gear.get_object_pose(env, is_relative=True)[:, :3]
+            base_pos = env.unwrapped.arena_world.get_pose_e(gear_base.name)[:, :3]
+            medium_pos = env.unwrapped.arena_world.get_pose_e(medium_gear.name)[:, :3]
             distances = torch.norm(base_pos - medium_pos, dim=-1)
 
             print(f"Distances in both envs: {distances}")

--- a/isaaclab_arena/tests/test_duplicate_asset.py
+++ b/isaaclab_arena/tests/test_duplicate_asset.py
@@ -99,8 +99,8 @@ def _test_duplicate_asset(simulation_app) -> bool:
             assert dex_cube_2.name in env.unwrapped.scene.keys(), "Cube 2 object is None"
 
             # Get positions (subtract env origin to get local positions)
-            cube_1_pos = dex_cube_1.get_object_pose(env)[0, :3]
-            cube_2_pos = dex_cube_2.get_object_pose(env)[0, :3]
+            cube_1_pos = env.unwrapped.arena_world.get_pose_e(dex_cube_1.name)[0, :3]
+            cube_2_pos = env.unwrapped.arena_world.get_pose_e(dex_cube_2.name)[0, :3]
 
             print(f"Cube 1 position: {cube_1_pos}")
             print(f"Cube 2 position: {cube_2_pos}")

--- a/isaaclab_arena/tests/test_events.py
+++ b/isaaclab_arena/tests/test_events.py
@@ -88,7 +88,7 @@ def _test_set_object_pose_per_env_event(simulation_app):
 
         # Check the pose right after reset, before the box is stepped: the reset event is the unit under
         # test, so we verify each env received its assigned pose rather than where physics carries it.
-        cracker_box_poses = cracker_box.get_object_pose(env)
+        cracker_box_poses = env.unwrapped.arena_world.get_pose_e(cracker_box.name)
         initial_poses = torch.cat(
             (
                 pose_list[0].to_tensor(device=env.unwrapped.device).unsqueeze(0),

--- a/isaaclab_arena/tests/test_object_of_type_base.py
+++ b/isaaclab_arena/tests/test_object_of_type_base.py
@@ -72,7 +72,7 @@ def _test_object_of_type_base(simulation_app):
                 env.step(actions)
 
             # Check the the object is floating.
-            position_after_simulation = cone.get_object_pose(env)[:, :3]
+            position_after_simulation = env.unwrapped.arena_world.get_pose_e(cone.name)[:, :3]
             movement = position_after_simulation.cpu() - position_before_simulation.cpu()
             assert torch.norm(movement).item() < MOVEMENT_EPS, "Object moved. Should not have physics."
 

--- a/isaaclab_arena/tests/test_object_on_microwave_tray.py
+++ b/isaaclab_arena/tests/test_object_on_microwave_tray.py
@@ -104,11 +104,36 @@ def _test_object_on_microwave_tray_termination(simulation_app) -> bool:
     return True
 
 
-def _record_arena_world_pose_count(_simulation_app, pose_counts: list[int]) -> bool:
-    env, _microwave, _dex_cube, destination_ref = _make_microwave_tray_environment()
+def _check_object_pose_queries_use_arena_world(_simulation_app) -> bool:
+    import torch
+
+    env, microwave, dex_cube, destination_ref = _make_microwave_tray_environment()
     try:
-        destination_pose_w = env.unwrapped.arena_world.get_pose_w(destination_ref.name)
-        pose_counts.append(destination_pose_w.shape[0])
+        scene = env.unwrapped.scene
+        arena_world = env.unwrapped.arena_world
+        microwave_root_pose_w = scene.articulations[microwave.name].data.root_pose_w.torch
+        torch.testing.assert_close(arena_world.get_pose_w(microwave.name), microwave_root_pose_w)
+
+        for scene_object in (dex_cube, microwave, destination_ref):
+            world_pose_before_relative_query = arena_world.get_pose_w(scene_object.name).clone()
+
+            torch.testing.assert_close(
+                scene_object.get_object_pose(env, is_relative=False),
+                world_pose_before_relative_query,
+            )
+
+            expected_environment_relative_pose = world_pose_before_relative_query.clone()
+            expected_environment_relative_pose[:, :3] -= scene.env_origins
+            torch.testing.assert_close(
+                scene_object.get_object_pose(env, is_relative=True),
+                expected_environment_relative_pose,
+            )
+
+            # The compatibility conversion must not modify ArenaWorld's live pose buffer.
+            torch.testing.assert_close(
+                arena_world.get_pose_w(scene_object.name),
+                world_pose_before_relative_query,
+            )
     finally:
         env.close()
     return True
@@ -119,15 +144,12 @@ def test_object_on_microwave_tray_termination():
     assert result, "Test failed"
 
 
-def test_arena_world_scene_extra_pose_covers_cloned_environments():
-    pose_counts = []
+def test_object_pose_queries_use_arena_world():
     result = run_function_with_persistent_simulation_app(
-        _record_arena_world_pose_count,
+        _check_object_pose_queries_use_arena_world,
         headless=HEADLESS,
-        pose_counts=pose_counts,
     )
-    assert result, "Failed to inspect the AssetBaseCfg scene extra."
-    assert pose_counts == [NUM_ENVS]
+    assert result, "Object pose queries did not preserve ArenaWorld poses and relative-frame conversion."
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_object_on_microwave_tray.py
+++ b/isaaclab_arena/tests/test_object_on_microwave_tray.py
@@ -104,7 +104,7 @@ def _test_object_on_microwave_tray_termination(simulation_app) -> bool:
     return True
 
 
-def _check_object_pose_queries_use_arena_world(_simulation_app) -> bool:
+def _check_arena_world_pose_frames(_simulation_app) -> bool:
     import torch
 
     env, microwave, dex_cube, destination_ref = _make_microwave_tray_environment()
@@ -114,25 +114,17 @@ def _check_object_pose_queries_use_arena_world(_simulation_app) -> bool:
         microwave_root_pose_w = scene.articulations[microwave.name].data.root_pose_w.torch
         torch.testing.assert_close(arena_world.get_pose_w(microwave.name), microwave_root_pose_w)
 
-        for scene_object in (dex_cube, microwave, destination_ref):
-            world_pose_before_relative_query = arena_world.get_pose_w(scene_object.name).clone()
+        for scene_key in (dex_cube.name, microwave.name, destination_ref.name):
+            T_W_F = arena_world.get_pose_w(scene_key).clone()
+            expected_T_E_F = T_W_F.clone()
+            expected_T_E_F[:, :3] -= scene.env_origins
 
-            torch.testing.assert_close(
-                scene_object.get_object_pose(env, is_relative=False),
-                world_pose_before_relative_query,
-            )
+            torch.testing.assert_close(arena_world.get_pose_e(scene_key), expected_T_E_F)
 
-            expected_environment_relative_pose = world_pose_before_relative_query.clone()
-            expected_environment_relative_pose[:, :3] -= scene.env_origins
+            # Environment-frame conversion must not modify the live world-frame pose.
             torch.testing.assert_close(
-                scene_object.get_object_pose(env, is_relative=True),
-                expected_environment_relative_pose,
-            )
-
-            # The compatibility conversion must not modify ArenaWorld's live pose buffer.
-            torch.testing.assert_close(
-                arena_world.get_pose_w(scene_object.name),
-                world_pose_before_relative_query,
+                arena_world.get_pose_w(scene_key),
+                T_W_F,
             )
     finally:
         env.close()
@@ -144,12 +136,12 @@ def test_object_on_microwave_tray_termination():
     assert result, "Test failed"
 
 
-def test_object_pose_queries_use_arena_world():
+def test_arena_world_pose_frames():
     result = run_function_with_persistent_simulation_app(
-        _check_object_pose_queries_use_arena_world,
+        _check_arena_world_pose_frames,
         headless=HEADLESS,
     )
-    assert result, "Object pose queries did not preserve ArenaWorld poses and relative-frame conversion."
+    assert result, "ArenaWorld did not preserve world poses while converting them to the environment frame."
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/tests/test_object_pose_randomization.py
+++ b/isaaclab_arena/tests/test_object_pose_randomization.py
@@ -62,7 +62,7 @@ def _test_object_pose_randomization(simulation_app):
                     actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
                     env.step(actions)
 
-            pose = cracker_box.get_object_pose(env)
+            pose = env.unwrapped.arena_world.get_pose_e(cracker_box.name)
             print(f"pose: {pose}")
             pose_per_reset.append(pose)
 


### PR DESCRIPTION
## Summary

Route ObjectBase pose reads through ArenaWorld and removes ObjectBase's FrameView workaround

## Detailed description

- Adds live articulation root-link pose support to ArenaWorld.
- Keeps FrameView access in the scene-extra pose reader, where it is shared by all callers.