### PR TITLE
Add OSMO experiment scaling benchmark

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment_metadata.py
+++ b/isaaclab_arena/evaluation/arena_experiment_metadata.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist reproducibility metadata for one Experiment Runner process."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from contextlib import suppress
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import argparse
+
+    from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
+    from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
+
+
+ARENA_EXPERIMENT_METADATA_FILENAME = "arena_experiment_metadata.json"
+"""Filename containing the resolved configuration and process metadata for an Experiment."""
+
+ARENA_EXPERIMENT_METADATA_SCHEMA_VERSION = 1
+"""Schema version for ``arena_experiment_metadata.json``."""
+
+
+def _utc_timestamp() -> str:
+    """Return the current UTC time in an ISO 8601 representation."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _absolute_path(path: str | Path) -> str:
+    """Return a stable absolute representation without requiring the path to exist."""
+    return str(Path(path).expanduser().resolve(strict=False))
+
+
+def _sha256_file(path: Path) -> str | None:
+    """Return the file's SHA-256 digest, or ``None`` when it cannot be read."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _run_git(repo_root: Path, arguments: list[str]) -> subprocess.CompletedProcess[str] | None:
+    """Run a short read-only Git query without allowing it to affect the Experiment."""
+    try:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _git_output(result: subprocess.CompletedProcess[str] | None) -> str | None:
+    """Return stripped stdout from a successful Git query."""
+    if result is None or result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout.strip()
+
+
+def _git_dirty(repo_root: Path) -> bool | None:
+    """Return whether a Git worktree has tracked or untracked changes."""
+    status_result = _run_git(repo_root, ["status", "--porcelain", "--untracked-files=normal"])
+    return bool(status_result.stdout.strip()) if status_result is not None and status_result.returncode == 0 else None
+
+
+def _resolve_source_revision() -> dict[str, Any]:
+    """Resolve Arena and Isaac Lab revisions and worktree states when Git metadata is available."""
+    environment_revision = next(
+        (
+            os.environ.get(variable_name)
+            for variable_name in ("ISAACLAB_ARENA_GIT_COMMIT", "GIT_COMMIT", "CI_COMMIT_SHA", "GITHUB_SHA")
+            if os.environ.get(variable_name)
+        ),
+        None,
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    git_revision = _git_output(_run_git(repo_root, ["rev-parse", "HEAD"]))
+    isaaclab_submodule_root = repo_root / "submodules" / "IsaacLab"
+    isaaclab_revision = _git_output(_run_git(isaaclab_submodule_root, ["rev-parse", "HEAD"]))
+    isaaclab_gitlink_result = _git_output(_run_git(repo_root, ["ls-tree", "HEAD", "submodules/IsaacLab"]))
+    isaaclab_gitlink_revision = (
+        isaaclab_gitlink_result.split()[2]
+        if isaaclab_gitlink_result is not None and len(isaaclab_gitlink_result.split()) >= 3
+        else None
+    )
+    return {
+        "git_commit": environment_revision or git_revision,
+        "git_dirty": _git_dirty(repo_root),
+        "isaaclab_submodule": {
+            "git_commit": isaaclab_revision,
+            "expected_git_commit": isaaclab_gitlink_revision,
+            "matches_superproject": (
+                isaaclab_revision == isaaclab_gitlink_revision
+                if isaaclab_revision is not None and isaaclab_gitlink_revision is not None
+                else None
+            ),
+            "git_dirty": _git_dirty(isaaclab_submodule_root),
+        },
+    }
+
+
+def _namespace_value(arguments: argparse.Namespace, *names: str) -> Any:
+    """Return the first available argparse value among several compatible field names."""
+    for name in names:
+        if hasattr(arguments, name):
+            return getattr(arguments, name)
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert common configuration values to deterministic JSON-compatible data."""
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Enum):
+        return _json_safe(value.value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+def _qualified_type_name(value: Any) -> str:
+    """Return the import-qualified type name for a resolved configuration object."""
+    value_type = type(value)
+    return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+def _resolved_run_metadata(run_cfg: ArenaRunCfg) -> dict[str, Any]:
+    """Build the benchmark-relevant subset of one resolved Run configuration."""
+    environment_builder = run_cfg.environment_builder
+    rollout_limit = run_cfg.rollout_limit
+    cameras_enabled = bool(getattr(run_cfg.environment, "enable_cameras", False))
+    camera_height = getattr(environment_builder, "camera_height", None)
+    camera_width = getattr(environment_builder, "camera_width", None)
+    resolution_is_explicit = camera_height is not None and camera_width is not None
+    camera_resolution_source = None
+    if cameras_enabled:
+        camera_resolution_source = "environment_builder_override" if resolution_is_explicit else "embodiment_default"
+
+    return {
+        "environment_config_type": _qualified_type_name(run_cfg.environment),
+        "policy_config_type": _qualified_type_name(run_cfg.policy),
+        "num_envs": environment_builder.num_envs,
+        "device": environment_builder.device,
+        "seed": environment_builder.seed,
+        "placement_seed": environment_builder.placement_seed,
+        "camera": {
+            "enabled": cameras_enabled,
+            "height": camera_height if resolution_is_explicit else None,
+            "width": camera_width if resolution_is_explicit else None,
+            "resolution_source": camera_resolution_source,
+        },
+        "rollout_limit": {
+            "num_steps": rollout_limit.num_steps,
+            "num_episodes": rollout_limit.num_episodes,
+            "source": (
+                "configured"
+                if rollout_limit.num_steps is not None or rollout_limit.num_episodes is not None
+                else "policy"
+            ),
+        },
+        "num_rebuilds": run_cfg.num_rebuilds,
+        "variations": _json_safe(run_cfg.variations),
+    }
+
+
+def _resolved_runs_metadata(experiment_cfg: ArenaExperimentCfg) -> dict[str, dict[str, Any]]:
+    """Build metadata for every resolved Run while isolating per-Run collection failures."""
+    resolved_runs = {}
+    for run_name, run_cfg in experiment_cfg.runs.items():
+        try:
+            resolved_runs[run_name] = _resolved_run_metadata(run_cfg)
+        except Exception as error:
+            resolved_runs[run_name] = {
+                "metadata_error": {
+                    "type": type(error).__name__,
+                    "message": str(error)[:2000],
+                }
+            }
+    return resolved_runs
+
+
+class ArenaExperimentMetadataRecorder:
+    """Write lifecycle and resolved configuration metadata without failing the Experiment."""
+
+    def __init__(self, output_path: Path, metadata: dict[str, Any]) -> None:
+        self.output_path = output_path
+        self._metadata = metadata
+
+    @classmethod
+    def start(
+        cls,
+        experiment_output_directory: str | Path,
+        experiment_config_path: str | Path,
+        experiment_overrides: list[str],
+        args_cli: argparse.Namespace,
+        command: list[str] | None = None,
+    ) -> ArenaExperimentMetadataRecorder:
+        """Create and immediately persist the initial metadata for an Experiment invocation."""
+        output_directory = Path(experiment_output_directory)
+        config_path = Path(experiment_config_path)
+        metadata: dict[str, Any] = {
+            "schema_version": ARENA_EXPERIMENT_METADATA_SCHEMA_VERSION,
+            "status": "starting",
+            "started_at": None,
+            "resolved_at": None,
+            "finished_at": None,
+            "runs": {},
+        }
+        recorder = cls(output_directory / ARENA_EXPERIMENT_METADATA_FILENAME, metadata)
+        try:
+            metadata.update({
+                "started_at": _utc_timestamp(),
+                "experiment_config": {
+                    "path": _absolute_path(config_path),
+                    "format": config_path.suffix.lower().lstrip("."),
+                    "sha256": _sha256_file(config_path),
+                },
+                "experiment_output_directory": _absolute_path(output_directory),
+                "working_directory": _absolute_path(Path.cwd()),
+                "command": list(command) if command is not None else [sys.executable, *sys.argv],
+                "experiment_overrides": list(experiment_overrides),
+                "runtime": {
+                    "device": _namespace_value(args_cli, "device"),
+                    "headless": _namespace_value(args_cli, "headless"),
+                    "visualizer": _namespace_value(args_cli, "visualizer", "viz"),
+                    "rendering_mode": _namespace_value(args_cli, "rendering_mode"),
+                    "renderer": _namespace_value(args_cli, "renderer"),
+                    "enable_cameras": _namespace_value(args_cli, "enable_cameras"),
+                    "record_viewport_video": _namespace_value(args_cli, "record_viewport_video"),
+                    "record_camera_video": _namespace_value(args_cli, "record_camera_video"),
+                    "environment_render_mode": (
+                        "rgb_array" if bool(_namespace_value(args_cli, "record_viewport_video")) else None
+                    ),
+                },
+            })
+        except Exception as error:
+            metadata["metadata_collection_error"] = {
+                "type": type(error).__name__,
+                "message": str(error)[:2000],
+            }
+            recorder._warn(error)
+        try:
+            metadata["revision"] = _resolve_source_revision()
+        except Exception as error:
+            metadata["revision"] = {
+                "metadata_error": {
+                    "type": type(error).__name__,
+                    "message": str(error)[:2000],
+                }
+            }
+            recorder._warn(error)
+        recorder._write_best_effort()
+        return recorder
+
+    def record_resolved_experiment(self, experiment_cfg: ArenaExperimentCfg) -> None:
+        """Persist resolved per-Run configuration before execution begins."""
+        try:
+            self._metadata["status"] = "running"
+            self._metadata["resolved_at"] = _utc_timestamp()
+            self._metadata["runs"] = _resolved_runs_metadata(experiment_cfg)
+            self._write_best_effort()
+        except Exception as error:
+            self._warn(error)
+
+    def finish(self, status: str, error: BaseException | None = None) -> None:
+        """Persist the final process status and optional error summary."""
+        try:
+            self._metadata["status"] = status
+            self._metadata["finished_at"] = _utc_timestamp()
+            if error is not None:
+                self._metadata["error"] = {
+                    "type": type(error).__name__,
+                    "message": str(error)[:2000],
+                }
+            else:
+                self._metadata.pop("error", None)
+            self._write_best_effort()
+        except Exception as metadata_error:
+            self._warn(metadata_error)
+
+    def _write_best_effort(self) -> None:
+        """Atomically replace the artifact, warning instead of raising when persistence fails."""
+        temporary_path = self.output_path.with_name(f".{self.output_path.name}.tmp")
+        try:
+            contents = json.dumps(_json_safe(self._metadata), allow_nan=False, indent=2) + "\n"
+            temporary_path.write_text(contents, encoding="utf-8")
+            temporary_path.replace(self.output_path)
+        except Exception as error:
+            with suppress(OSError):
+                temporary_path.unlink()
+            self._warn(error)
+
+    def _warn(self, error: BaseException) -> None:
+        """Report a metadata failure without allowing warning output to affect execution."""
+        with suppress(Exception):
+            print(f"[WARN] Could not write Arena Experiment metadata to {self.output_path}: {error}", file=sys.stderr)

--- a/isaaclab_arena/evaluation/arena_experiment_result.py
+++ b/isaaclab_arena/evaluation/arena_experiment_result.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 
 ARENA_EXPERIMENT_RESULT_FILENAME = "arena_experiment_result.json"
+ARENA_EXPERIMENT_TIMINGS_FILENAME = "arena_experiment_timings.json"
 
 
 class ArenaEpisodeResultData(TypedDict):

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -95,6 +96,30 @@ def _write_arena_experiment_result(
     return ArenaExperimentResult(experiment_output_directory, run_metadata_by_name).write()
 
 
+def _write_arena_experiment_timings(
+    experiment_output_directory: Path,
+    original_error: BaseException | None = None,
+) -> Path | None:
+    """Print and write timings without replacing an error already raised by the Experiment."""
+    from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
+    from isaaclab_arena.utils.timer import print_timer_stats, write_timer_stats_json
+
+    try:
+        print_timer_stats()
+        timings_path = write_timer_stats_json(
+            experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+            app_name="experiment_runner",
+        )
+        print(f"Wrote Arena Experiment timings to: {timings_path}")
+        return timings_path
+    except Exception as timing_error:
+        if original_error is None:
+            raise
+        with suppress(Exception):
+            print(f"[WARN] Could not write Arena Experiment timings: {timing_error}")
+        return None
+
+
 def main():
     args_cli, experiment_overrides = parse_experiment_runner_args()
     experiment_config_path = validate_experiment_config_path(args_cli.experiment_config)
@@ -145,48 +170,86 @@ def main():
         experiment_output_directory = Path(timestamped_run_dir(args_cli.output_base_dir))
     experiment_output_directory.mkdir(parents=True, exist_ok=True)
 
-    with SimulationAppContext(args_cli):
-        from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
-        from isaaclab_arena.evaluation.arena_run import build_runs_info_table
-        from isaaclab_arena.evaluation.run_execution import execute_experiment
-        from isaaclab_arena.metrics.metrics_logger import MetricsLogger
-        from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
+    from isaaclab_arena.evaluation.arena_experiment_metadata import ArenaExperimentMetadataRecorder
 
-        experiment_cfg = load_arena_experiment_from_config_file(
-            experiment_config_path,
-            device=args_cli.device,
-            overrides=experiment_overrides,
-        )
-        for run_name in experiment_cfg.runs:
-            ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
-        _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
-        metrics_logger = MetricsLogger()
+    metadata_recorder = ArenaExperimentMetadataRecorder.start(
+        experiment_output_directory,
+        experiment_config_path,
+        experiment_overrides,
+        args_cli,
+    )
+    try:
+        with SimulationAppContext(args_cli):
+            from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
+            from isaaclab_arena.evaluation.arena_run import build_runs_info_table
+            from isaaclab_arena.evaluation.run_execution import execute_experiment
+            from isaaclab_arena.metrics.metrics_logger import MetricsLogger
+            from isaaclab_arena.utils.timer import Timer, reset_timer_stats
+            from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 
-        print(build_runs_info_table(experiment_cfg.runs.values(), []))
+            reset_timer_stats()
+            try:
+                experiment_error = None
+                try:
+                    with Timer("experiment/load_config"):
+                        experiment_cfg = load_arena_experiment_from_config_file(
+                            experiment_config_path,
+                            device=args_cli.device,
+                            overrides=experiment_overrides,
+                        )
+                    metadata_recorder.record_resolved_experiment(experiment_cfg)
+                    for run_name in experiment_cfg.runs:
+                        ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
+                    _assert_camera_support_enabled(experiment_cfg, args_cli.enable_cameras)
+                    metrics_logger = MetricsLogger()
 
-        if args_cli.record_viewport_video:
-            print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_directory}")
+                    print(build_runs_info_table(experiment_cfg.runs.values(), []))
 
-        run_results = execute_experiment(
-            experiment_cfg,
-            output_dir=experiment_output_directory,
-            record_viewport_video=args_cli.record_viewport_video,
-            record_camera_video=args_cli.record_camera_video,
-            continue_on_error=args_cli.continue_on_error,
-        )
-        for run_result in run_results:
-            if run_result.metrics is not None:
-                metrics_logger.append_job_metrics(run_result.run_name, run_result.metrics)
+                    if args_cli.record_viewport_video:
+                        print(f"[INFO] Video recording enabled. Videos will be saved to: {experiment_output_directory}")
 
-        print(build_runs_info_table(experiment_cfg.runs.values(), run_results))
-        metrics_logger.print_metrics()
+                    with Timer("experiment/execute_runs"):
+                        run_results = execute_experiment(
+                            experiment_cfg,
+                            output_dir=experiment_output_directory,
+                            record_viewport_video=args_cli.record_viewport_video,
+                            record_camera_video=args_cli.record_camera_video,
+                            continue_on_error=args_cli.continue_on_error,
+                        )
+                    for run_result in run_results:
+                        if run_result.metrics is not None:
+                            metrics_logger.append_job_metrics(run_result.run_name, run_result.metrics)
 
-        _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
+                    print(build_runs_info_table(experiment_cfg.runs.values(), run_results))
+                    metrics_logger.print_metrics()
 
-        # Write HTML report.
-        report_path = build_report(experiment_output_directory)
-        if args_cli.serve_evaluation_report:
-            serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
+                    _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
+
+                    # Write HTML report.
+                    with Timer("experiment/build_report"):
+                        report_path = build_report(experiment_output_directory)
+                except BaseException as error:
+                    experiment_error = error
+                    raise
+                finally:
+                    # SimulationAppContext may terminate the process from __exit__, so timings must be
+                    # persisted before leaving this block. The finally path also preserves partial timings.
+                    _write_arena_experiment_timings(experiment_output_directory, original_error=experiment_error)
+
+                if args_cli.serve_evaluation_report:
+                    serve_until_ctrl_c(report_path.parent, args_cli.evaluation_report_port, report_path.name)
+            except BaseException as error:
+                # SimulationAppContext uses an immediate process exit for failures, so persist the
+                # error before propagating it to the context manager.
+                metadata_recorder.finish("failed", error)
+                raise
+            else:
+                # Persist before SimulationAppContext.__exit__, which may terminate the process on success.
+                metadata_recorder.finish("completed")
+    except BaseException as error:
+        # Covers failures while starting SimulationApp, before its context body is entered.
+        metadata_recorder.finish("failed", error)
+        raise
 
 
 if __name__ == "__main__":

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -102,11 +102,10 @@ def _write_arena_experiment_timings(
 ) -> Path | None:
     """Print and write timings without replacing an error already raised by the Experiment."""
     from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
-    from isaaclab_arena.utils.timer import print_timer_stats, write_timer_stats_json
 
     try:
-        print_timer_stats()
-        timings_path = write_timer_stats_json(
+        _print_timer_stats()
+        timings_path = _write_timer_stats_json(
             experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
             app_name="experiment_runner",
         )
@@ -118,6 +117,20 @@ def _write_arena_experiment_timings(
         with suppress(Exception):
             print(f"[WARN] Could not write Arena Experiment timings: {timing_error}")
         return None
+
+
+def _print_timer_stats() -> None:
+    """Print timer statistics without importing torch before SimulationApp starts."""
+    from isaaclab_arena.utils.timer import print_timer_stats
+
+    print_timer_stats()
+
+
+def _write_timer_stats_json(output_path: Path, app_name: str) -> Path:
+    """Write timer statistics without importing torch before SimulationApp starts."""
+    from isaaclab_arena.utils.timer import write_timer_stats_json
+
+    return write_timer_stats_json(output_path, app_name)
 
 
 def main():

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -22,6 +22,7 @@ from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
+from isaaclab_arena.utils.timer import Timer
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, timestamped_run_dir, wrap_env_for_video
 from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
@@ -75,9 +76,13 @@ def rollout_policy(
 
     pbar = None
     try:
-        obs, _ = env.reset()
-        policy.reset()
-        policy.set_task_description(env.unwrapped.get_language_instruction())
+        with Timer("rollout/initial_reset"):
+            with Timer("rollout/env_reset"):
+                obs, _ = env.reset()
+            with Timer("rollout/policy_reset"):
+                policy.reset()
+            with Timer("rollout/set_task_description"):
+                policy.set_task_description(env.unwrapped.get_language_instruction())
 
         # Setup progress bar based on num_steps or num_episodes
         if num_steps is not None:
@@ -89,9 +94,11 @@ def rollout_policy(
         num_steps_completed = 0
 
         while True:
-            with torch.inference_mode():
-                actions = policy.get_action(env, obs)
-                obs, _, terminated, truncated, _ = env.step(actions)
+            with torch.inference_mode(), Timer("rollout/step_total"):
+                with Timer("rollout/policy_get_action"):
+                    actions = policy.get_action(env, obs)
+                with Timer("rollout/env_step"):
+                    obs, _, terminated, truncated, _ = env.step(actions)
 
                 if terminated.any() or truncated.any():
                     # Only reset policy for those envs that are terminated or truncated
@@ -100,12 +107,14 @@ def rollout_policy(
                         f" and truncated env_ids: {truncated.nonzero().flatten()}"
                     )
                     env_ids = (terminated | truncated).nonzero().flatten()
-                    policy.reset(env_ids=env_ids)
+                    with Timer("rollout/policy_reset"):
+                        policy.reset(env_ids=env_ids)
                     # Break if number of episodes is reached
                     completed_episodes = env_ids.shape[0]
                     num_episodes_completed += completed_episodes
                     if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-                        metrics = env.unwrapped.compute_metrics()
+                        with Timer("rollout/compute_metrics"):
+                            metrics = env.unwrapped.compute_metrics()
                         tqdm.tqdm.write(
                             f"[Rank {get_local_rank()}/{get_world_size()}] Metrics:"
                             f" {metrics_to_plain_python_types(metrics)}"
@@ -133,7 +142,8 @@ def rollout_policy(
         # Only compute metrics if env has non-None metrics.
         # Use unwrapped to reach the base env through any gym wrappers (e.g. OrderEnforcing)
         if hasattr(env.unwrapped.cfg, "metrics") and env.unwrapped.cfg.metrics is not None:
-            return env.unwrapped.compute_metrics()
+            with Timer("rollout/compute_metrics"):
+                return env.unwrapped.compute_metrics()
         return None
 
 

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -24,6 +24,7 @@ from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
 from isaaclab_arena.evaluation.policy_runner import rollout_policy
 from isaaclab_arena.evaluation.resource_cleanup import close_run_resources
 from isaaclab_arena.metrics.aggregate_metrics import aggregate_metrics
+from isaaclab_arena.utils.timer import Timer
 from isaaclab_arena.variations.variations_hydra import overrides_from_dict
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
 
@@ -134,23 +135,27 @@ def build_and_run(
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
             )
             rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
-            env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
+            with Timer("run/build_environment"):
+                env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)
             results_path = os.path.join(output_dir, f"episode_results_rebuild{rebuild_index}.jsonl")
             env.unwrapped.episode_recorder.set_job_name(cfg.name)
             env.unwrapped.episode_recorder.set_output_path(results_path)
 
-            policy = _build_policy_from_cfg(rebuild_cfg)
+            with Timer("run/build_policy"):
+                policy = _build_policy_from_cfg(rebuild_cfg)
             num_steps, num_episodes = _resolve_rollout_limit(
                 cfg,
                 policy,
                 num_episodes,
             )
             env = wrap_env_for_video(env, rebuild_video_cfg, num_steps, num_episodes)
-            metrics = rollout_policy(env, policy, num_steps=num_steps, num_episodes=num_episodes)
+            with Timer("run/rollout_policy"):
+                metrics = rollout_policy(env, policy, num_steps=num_steps, num_episodes=num_episodes)
             if metrics is not None:
                 metrics_per_rebuild.append(metrics)
         finally:
-            close_run_resources(policy, env)
+            with Timer("run/close_resources"):
+                close_run_resources(policy, env)
 
     return ArenaRunResult(
         run_name=cfg.name,

--- a/isaaclab_arena/tests/test_arena_experiment_metadata.py
+++ b/isaaclab_arena/tests/test_arena_experiment_metadata.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Experiment Runner metadata artifact."""
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import isaaclab_arena.evaluation.arena_experiment_metadata as metadata_module
+from isaaclab_arena.evaluation.arena_experiment_metadata import (
+    ARENA_EXPERIMENT_METADATA_FILENAME,
+    ARENA_EXPERIMENT_METADATA_SCHEMA_VERSION,
+    ArenaExperimentMetadataRecorder,
+)
+
+
+def _runner_arguments() -> SimpleNamespace:
+    """Return the runner fields captured by the metadata recorder."""
+    return SimpleNamespace(
+        device="cuda:1",
+        headless=True,
+        visualizer="none",
+        rendering_mode="balanced",
+        enable_cameras=True,
+        record_viewport_video=False,
+        record_camera_video=True,
+    )
+
+
+def _resolved_experiment(camera_height=360, camera_width=640) -> SimpleNamespace:
+    """Return a minimal resolved Experiment configuration for metadata tests."""
+    run_cfg = SimpleNamespace(
+        environment=SimpleNamespace(enable_cameras=True),
+        policy=SimpleNamespace(),
+        environment_builder=SimpleNamespace(
+            num_envs=64,
+            device="cuda:1",
+            seed=7,
+            placement_seed=11,
+            camera_height=camera_height,
+            camera_width=camera_width,
+        ),
+        rollout_limit=SimpleNamespace(num_steps=500, num_episodes=None),
+        num_rebuilds=3,
+        variations={"object": {"mass": {"enabled": False}}},
+    )
+    return SimpleNamespace(runs={"camera_baseline": run_cfg})
+
+
+def test_metadata_recorder_persists_invocation_and_resolved_run(tmp_path, monkeypatch):
+    """Write the initial artifact early, then enrich it with resolved benchmark fields."""
+    monkeypatch.setattr(
+        metadata_module,
+        "_resolve_source_revision",
+        lambda: {
+            "git_commit": "arena-commit",
+            "git_dirty": False,
+            "isaaclab_submodule": {
+                "git_commit": "isaaclab-commit",
+                "expected_git_commit": "isaaclab-commit",
+                "matches_superproject": True,
+                "git_dirty": False,
+            },
+        },
+    )
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_contents = "runs: {}\n"
+    experiment_config_path.write_text(experiment_config_contents, encoding="utf-8")
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+    command = ["python", "experiment_runner.py", "runs.camera_baseline.environment_builder.num_envs=64"]
+
+    recorder = ArenaExperimentMetadataRecorder.start(
+        output_directory,
+        experiment_config_path,
+        ["runs.camera_baseline.environment_builder.num_envs=64"],
+        _runner_arguments(),
+        command=command,
+    )
+    metadata_path = output_directory / ARENA_EXPERIMENT_METADATA_FILENAME
+    initial_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+    assert initial_metadata["schema_version"] == ARENA_EXPERIMENT_METADATA_SCHEMA_VERSION
+    assert initial_metadata["status"] == "starting"
+    assert initial_metadata["experiment_config"] == {
+        "path": str(experiment_config_path.resolve()),
+        "format": "yaml",
+        "sha256": hashlib.sha256(experiment_config_contents.encode()).hexdigest(),
+    }
+    assert initial_metadata["experiment_output_directory"] == str(output_directory.resolve())
+    assert initial_metadata["command"] == command
+    assert initial_metadata["experiment_overrides"] == ["runs.camera_baseline.environment_builder.num_envs=64"]
+    assert initial_metadata["runtime"]["rendering_mode"] == "balanced"
+    assert initial_metadata["runtime"]["environment_render_mode"] is None
+    assert initial_metadata["revision"]["isaaclab_submodule"]["matches_superproject"] is True
+    assert initial_metadata["runs"] == {}
+
+    recorder.record_resolved_experiment(_resolved_experiment())
+    resolved_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    run_metadata = resolved_metadata["runs"]["camera_baseline"]
+
+    assert resolved_metadata["status"] == "running"
+    assert resolved_metadata["resolved_at"] is not None
+    assert run_metadata["num_envs"] == 64
+    assert run_metadata["device"] == "cuda:1"
+    assert run_metadata["seed"] == 7
+    assert run_metadata["placement_seed"] == 11
+    assert run_metadata["camera"] == {
+        "enabled": True,
+        "height": 360,
+        "width": 640,
+        "resolution_source": "environment_builder_override",
+    }
+    assert run_metadata["rollout_limit"] == {
+        "num_steps": 500,
+        "num_episodes": None,
+        "source": "configured",
+    }
+    assert run_metadata["num_rebuilds"] == 3
+
+    recorder.finish("completed")
+    completed_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert completed_metadata["status"] == "completed"
+    assert completed_metadata["finished_at"] is not None
+    assert "error" not in completed_metadata
+
+
+def test_metadata_marks_unconfigured_camera_dimensions_as_embodiment_defaults(tmp_path, monkeypatch):
+    """Describe enabled production cameras without guessing dimensions absent from the Run config."""
+    monkeypatch.setattr(metadata_module, "_resolve_source_revision", lambda: {})
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text("runs: {}\n", encoding="utf-8")
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+    recorder = ArenaExperimentMetadataRecorder.start(
+        output_directory,
+        experiment_config_path,
+        [],
+        _runner_arguments(),
+        command=["experiment_runner.py"],
+    )
+
+    recorder.record_resolved_experiment(_resolved_experiment(camera_height=None, camera_width=None))
+    metadata = json.loads((output_directory / ARENA_EXPERIMENT_METADATA_FILENAME).read_text(encoding="utf-8"))
+
+    assert metadata["runs"]["camera_baseline"]["camera"] == {
+        "enabled": True,
+        "height": None,
+        "width": None,
+        "resolution_source": "embodiment_default",
+    }
+
+
+def test_metadata_recorder_persists_failure_status(tmp_path, monkeypatch):
+    """Record an ordinary Experiment failure before SimulationApp can terminate the process."""
+    monkeypatch.setattr(metadata_module, "_resolve_source_revision", lambda: {})
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text("runs: {}\n", encoding="utf-8")
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+    recorder = ArenaExperimentMetadataRecorder.start(
+        output_directory,
+        experiment_config_path,
+        [],
+        _runner_arguments(),
+        command=["experiment_runner.py"],
+    )
+
+    recorder.finish("failed", RuntimeError("rollout failed"))
+    metadata = json.loads((output_directory / ARENA_EXPERIMENT_METADATA_FILENAME).read_text(encoding="utf-8"))
+
+    assert metadata["status"] == "failed"
+    assert metadata["finished_at"] is not None
+    assert metadata["error"] == {"type": "RuntimeError", "message": "rollout failed"}
+
+
+def test_revision_collection_failure_never_fails_or_discards_invocation_metadata(tmp_path, monkeypatch):
+    """Isolate best-effort revision failure while retaining the reproducibility fields."""
+
+    def raise_revision_error():
+        raise RuntimeError("revision unavailable")
+
+    monkeypatch.setattr(metadata_module, "_resolve_source_revision", raise_revision_error)
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text("runs: {}\n", encoding="utf-8")
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+
+    ArenaExperimentMetadataRecorder.start(
+        output_directory,
+        experiment_config_path,
+        [],
+        _runner_arguments(),
+        command=["experiment_runner.py"],
+    )
+    metadata = json.loads((output_directory / ARENA_EXPERIMENT_METADATA_FILENAME).read_text(encoding="utf-8"))
+
+    assert metadata["status"] == "starting"
+    assert metadata["experiment_config"]["path"] == str(experiment_config_path.resolve())
+    assert metadata["command"] == ["experiment_runner.py"]
+    assert metadata["revision"] == {
+        "metadata_error": {
+            "type": "RuntimeError",
+            "message": "revision unavailable",
+        }
+    }
+
+
+def test_metadata_write_failure_never_fails_the_experiment(tmp_path, monkeypatch, capsys):
+    """Keep lifecycle calls non-throwing when the artifact path cannot be written."""
+    monkeypatch.setattr(metadata_module, "_resolve_source_revision", lambda: {})
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text("runs: {}\n", encoding="utf-8")
+    output_path_that_is_not_a_directory = tmp_path / "not-a-directory"
+    output_path_that_is_not_a_directory.write_text("occupied", encoding="utf-8")
+
+    recorder = ArenaExperimentMetadataRecorder.start(
+        output_path_that_is_not_a_directory,
+        experiment_config_path,
+        [],
+        _runner_arguments(),
+        command=["experiment_runner.py"],
+    )
+    recorder.record_resolved_experiment(_resolved_experiment())
+    recorder.finish("failed", RuntimeError("rollout failed"))
+
+    assert "Could not write Arena Experiment metadata" in capsys.readouterr().err
+
+
+def test_metadata_serialization_failure_never_fails_the_experiment(tmp_path, monkeypatch, capsys):
+    """Keep the Experiment runnable when unexpected metadata cannot be serialized."""
+    monkeypatch.setattr(metadata_module, "_resolve_source_revision", lambda: {})
+
+    def raise_serialization_error(_value):
+        raise TypeError("cannot serialize metadata")
+
+    monkeypatch.setattr(metadata_module, "_json_safe", raise_serialization_error)
+    experiment_config_path = tmp_path / "experiment.yaml"
+    experiment_config_path.write_text("runs: {}\n", encoding="utf-8")
+    output_directory = tmp_path / "output"
+    output_directory.mkdir()
+
+    recorder = ArenaExperimentMetadataRecorder.start(
+        output_directory,
+        experiment_config_path,
+        [],
+        _runner_arguments(),
+        command=["experiment_runner.py"],
+    )
+    recorder.record_resolved_experiment(_resolved_experiment())
+    recorder.finish("completed")
+
+    assert "cannot serialize metadata" in capsys.readouterr().err

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -9,7 +9,12 @@ import subprocess
 
 import pytest
 
-from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_RESULT_FILENAME
+import isaaclab_arena.evaluation.experiment_runner as experiment_runner_module
+from isaaclab_arena.evaluation.arena_experiment_metadata import ARENA_EXPERIMENT_METADATA_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ARENA_EXPERIMENT_RESULT_FILENAME,
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+)
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
 from isaaclab_arena.tests.utils.constants import TestConstants
 from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
@@ -18,6 +23,25 @@ from isaaclab_arena.tests.utils.subprocess import run_subprocess
 HEADLESS = True
 NUM_STEPS = 2
 DEFAULT_VISUALIZER = "kit"
+
+
+def test_timing_write_failure_does_not_replace_experiment_error(tmp_path, monkeypatch):
+    """Preserve a rollout error when persisting its partial timings also fails."""
+    experiment_error = RuntimeError("rollout failed")
+
+    def raise_timing_error():
+        raise OSError("timing disk failed")
+
+    monkeypatch.setattr(experiment_runner_module, "print_timer_stats", raise_timing_error)
+
+    with pytest.raises(RuntimeError, match="rollout failed"):
+        try:
+            raise experiment_error
+        finally:
+            experiment_runner_module._write_arena_experiment_timings(
+                tmp_path,
+                original_error=experiment_error,
+            )
 
 
 def test_experiment_runner_parses_native_hydra_overrides():
@@ -187,6 +211,54 @@ runs:
     assert run_result["policy_variant"] == "zero_action"
     assert run_result["status"] == "completed"
     assert set(run_result) == {"environment", "policy_variant", "status", "rebuilds"}
+
+    timing_records = json.loads((tmp_path / "output" / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8"))
+    timings_by_name = {record["name"]: record for record in timing_records}
+    expected_counts_by_name = {
+        "experiment/load_config": 1,
+        "experiment/execute_runs": 1,
+        "experiment/build_report": 1,
+        "run/build_environment": 1,
+        "run/build_policy": 1,
+        "run/rollout_policy": 1,
+        "run/close_resources": 1,
+        "rollout/initial_reset": 1,
+        "rollout/env_reset": 1,
+        "rollout/policy_reset": 1,
+        "rollout/set_task_description": 1,
+        "rollout/step_total": 2,
+        "rollout/policy_get_action": 2,
+        "rollout/env_step": 2,
+    }
+    assert expected_counts_by_name.keys() <= timings_by_name.keys()
+    assert all(record["type"] == "timing" for record in timing_records)
+    assert all(record["app_name"] == "experiment_runner" for record in timing_records)
+    for timing_name, expected_count in expected_counts_by_name.items():
+        assert timings_by_name[timing_name]["count"] == expected_count
+
+    experiment_metadata = json.loads(
+        (tmp_path / "output" / ARENA_EXPERIMENT_METADATA_FILENAME).read_text(encoding="utf-8")
+    )
+    assert experiment_metadata["schema_version"] == 1
+    assert experiment_metadata["status"] == "completed"
+    assert experiment_metadata["finished_at"] is not None
+    assert experiment_metadata["experiment_config"]["path"] == str(experiment_config_path.resolve())
+    assert experiment_metadata["experiment_output_directory"] == str((tmp_path / "output").resolve())
+    assert experiment_metadata["experiment_overrides"] == ["runs.yaml_baseline.rollout_limit.num_steps=2"]
+    run_metadata = experiment_metadata["runs"]["yaml_baseline"]
+    assert run_metadata["num_envs"] == 1
+    assert run_metadata["device"] == "cuda:0"
+    assert run_metadata["camera"] == {
+        "enabled": False,
+        "height": None,
+        "width": None,
+        "resolution_source": None,
+    }
+    assert run_metadata["rollout_limit"] == {
+        "num_steps": 2,
+        "num_episodes": None,
+        "source": "configured",
+    }
 
 
 @pytest.mark.with_subprocess

--- a/isaaclab_arena/tests/test_experiment_runner.py
+++ b/isaaclab_arena/tests/test_experiment_runner.py
@@ -32,7 +32,7 @@ def test_timing_write_failure_does_not_replace_experiment_error(tmp_path, monkey
     def raise_timing_error():
         raise OSError("timing disk failed")
 
-    monkeypatch.setattr(experiment_runner_module, "print_timer_stats", raise_timing_error)
+    monkeypatch.setattr(experiment_runner_module, "_print_timer_stats", raise_timing_error)
 
     with pytest.raises(RuntimeError, match="rollout failed"):
         try:

--- a/isaaclab_arena/tests/test_osmo_build_experiment_output.py
+++ b/isaaclab_arena/tests/test_osmo_build_experiment_output.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 import pytest
 
-from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_RESULT_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_metadata import ARENA_EXPERIMENT_METADATA_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ARENA_EXPERIMENT_RESULT_FILENAME,
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+)
 from isaaclab_arena.evaluation.arena_run import RunStatus
 from isaaclab_arena.visualization.report import RunExecutionReport
 from osmo.scripts.build_experiment_output import (
@@ -174,6 +178,49 @@ def test_collects_run_outputs_without_building_report(tmp_path):
     assert (experiment_output_directory / "first/episode_results_rebuild0.jsonl").is_file()
     assert (experiment_output_directory / "first" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
     assert not (experiment_output_directory / "index.html").exists()
+
+
+@pytest.mark.parametrize(
+    ("execution_status", "process_exit_code"),
+    [
+        (RunStatus.COMPLETED, 0),
+        (RunStatus.FAILED, 17),
+    ],
+)
+def test_preserves_experiment_runner_diagnostics(
+    tmp_path,
+    execution_status: RunStatus,
+    process_exit_code: int,
+):
+    experiment_runner_output_directory = tmp_path / "experiment-runner-output"
+    run_name = "first"
+    if execution_status is RunStatus.COMPLETED:
+        _write_run_output(experiment_runner_output_directory / run_name, run_name, True)
+    _write_experiment_runner_result(
+        experiment_runner_output_directory,
+        execution_status,
+        process_exit_code,
+        {run_name: _run_metadata("first-environment", "pi05")},
+    )
+    diagnostic_contents_by_file_name = {
+        ARENA_EXPERIMENT_TIMINGS_FILENAME: {"timers": {"runner": {"total_seconds": 12.5}}},
+        ARENA_EXPERIMENT_METADATA_FILENAME: {"schema_version": 1, "command": ["experiment_runner.py"]},
+    }
+    for diagnostic_file_name, diagnostic_contents in diagnostic_contents_by_file_name.items():
+        (experiment_runner_output_directory / diagnostic_file_name).write_text(
+            json.dumps(diagnostic_contents),
+            encoding="utf-8",
+        )
+    experiment_output_directory = tmp_path / "experiment-output"
+
+    collect_run_outputs_into_experiment_output(
+        {run_name: experiment_runner_output_directory},
+        experiment_output_directory,
+    )
+
+    for diagnostic_file_name, expected_diagnostic_contents in diagnostic_contents_by_file_name.items():
+        destination_diagnostic_path = experiment_output_directory / run_name / diagnostic_file_name
+        assert json.loads(destination_diagnostic_path.read_text(encoding="utf-8")) == expected_diagnostic_contents
 
 
 def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_path):

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -540,10 +540,83 @@ def test_default_workflow_schedules_all_runs_independently():
     assert all(run_group["tasks"][0]["inputs"] == [] for run_group in run_groups)
 
 
+def test_synchronizes_local_runs_in_barrier_backed_waves():
+    """Co-schedule each bounded wave while retaining lane and collector dependencies."""
+    workflow = ArenaExperimentWorkflow(
+        workflow_cfg=ArenaExperimentWorkflowCfg(max_parallel_runs=3, synchronize_parallel_runs=True),
+        experiment_cfg=_repeated_zero_action_experiment_cfg(num_runs=8),
+    )
+
+    groups = _workflow_groups(workflow.generate_workflow())
+    run_groups = groups[:-1]
+    assert [group["name"] for group in run_groups] == [
+        "arena-run-wave-0",
+        "arena-run-wave-1",
+        "arena-run-wave-2",
+    ]
+    assert [[task["name"] for task in group["tasks"]] for group in run_groups] == [
+        ["experiment-runner-0", "experiment-runner-1", "experiment-runner-2"],
+        ["experiment-runner-3", "experiment-runner-4", "experiment-runner-5"],
+        ["experiment-runner-6", "experiment-runner-7"],
+    ]
+    for run_group in run_groups:
+        assert run_group["barrier"] is True
+        assert run_group["ignoreNonleadStatus"] is False
+        assert [task["lead"] for task in run_group["tasks"]] == [
+            True,
+            *([False] * (len(run_group["tasks"]) - 1)),
+        ]
+
+    experiment_runner_tasks = [task for group in run_groups for task in group["tasks"]]
+    for run_index, experiment_runner_task in enumerate(experiment_runner_tasks):
+        expected_inputs = []
+        if run_index >= 3:
+            expected_inputs = [{
+                "task": f"experiment-runner-{run_index - 3}",
+                "regex": r".*experiment_runner_result\.json$",
+            }]
+        assert experiment_runner_task["inputs"] == expected_inputs
+
+    collector_task = groups[-1]["tasks"][0]
+    assert collector_task["inputs"] == [{"task": f"experiment-runner-{run_index}"} for run_index in range(8)]
+
+
+def test_synchronizes_all_local_runs_in_one_wave_without_parallel_limit():
+    workflow = ArenaExperimentWorkflow(
+        workflow_cfg=ArenaExperimentWorkflowCfg(synchronize_parallel_runs=True),
+        experiment_cfg=_repeated_zero_action_experiment_cfg(num_runs=3),
+    )
+
+    run_groups = _workflow_groups(workflow.generate_workflow())[:-1]
+    assert len(run_groups) == 1
+    assert [task["name"] for task in run_groups[0]["tasks"]] == [
+        "experiment-runner-0",
+        "experiment-runner-1",
+        "experiment-runner-2",
+    ]
+
+
+def test_rejects_synchronized_runs_that_require_policy_servers():
+    with pytest.raises(
+        AssertionError,
+        match=r"synchronize_parallel_runs supports only local-policy Runs; Run 'first'.*Pi0ServerTask",
+    ):
+        ArenaExperimentWorkflow(
+            workflow_cfg=ArenaExperimentWorkflowCfg(synchronize_parallel_runs=True),
+            experiment_cfg=_pi0_experiment_cfg(),
+        )
+
+
 @pytest.mark.parametrize("max_parallel_runs", [-1, 0, 1.5, True, "2"])
 def test_rejects_invalid_max_parallel_runs(max_parallel_runs):
     with pytest.raises(AssertionError, match="max_parallel_runs must be a positive integer"):
         ArenaExperimentWorkflowCfg(max_parallel_runs=max_parallel_runs)
+
+
+@pytest.mark.parametrize("synchronize_parallel_runs", [0, 1, None, "true"])
+def test_rejects_non_boolean_synchronize_parallel_runs(synchronize_parallel_runs):
+    with pytest.raises(AssertionError, match="synchronize_parallel_runs must be a boolean"):
+        ArenaExperimentWorkflowCfg(synchronize_parallel_runs=synchronize_parallel_runs)
 
 
 def test_rejects_more_parallel_runs_than_experiment_runs():
@@ -554,10 +627,14 @@ def test_rejects_more_parallel_runs_than_experiment_runs():
         )
 
 
-def test_submission_composes_max_parallel_runs_override():
-    submission_cfg = _compose_submission(["osmo.max_parallel_runs=4"])
+def test_submission_composes_parallel_run_scheduling_overrides():
+    submission_cfg = _compose_submission([
+        "osmo.max_parallel_runs=4",
+        "osmo.synchronize_parallel_runs=true",
+    ])
 
     assert submission_cfg.osmo.max_parallel_runs == 4
+    assert submission_cfg.osmo.synchronize_parallel_runs is True
 
 
 def test_submission_removes_temporary_workflow(monkeypatch):

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -6,6 +6,7 @@
 """Verify distributed OSMO workflows for Arena Experiments."""
 
 import json
+import subprocess
 import yaml
 from pathlib import Path
 from types import SimpleNamespace
@@ -42,7 +43,7 @@ from osmo.tasks.experiment_runner_task import (
 )
 from osmo.tasks.gr00t_server_task import Gr00tServerTask, Gr00tServerTaskCfg
 from osmo.tasks.pi0_server_task import Pi0ServerTask, Pi0ServerTaskCfg
-from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow
+from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow, ArenaExperimentWorkflowCfg
 from osmo.workflows.workflow import WorkflowCfg
 from osmo.workflows.workflow_constants import DATASET_SWIFT_URL, OSMO_TASK_OUTPUT_DIR, POLICY_SERVER_PORT
 
@@ -53,6 +54,10 @@ pytestmark = pytest.mark.with_subprocess
 REPOSITORY_ROOT = Path(__file__).parents[2]
 OPENPI_EXPERIMENT_CFG_PATH = (
     REPOSITORY_ROOT / "isaaclab_arena_environments/experiment_configs/droid_pnp_srl_openpi_experiment.yaml"
+)
+CAMERA_FREE_SCALING_VALIDATION_CFG_PATH = (
+    REPOSITORY_ROOT
+    / "isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml"
 )
 OPENPI_RUN_NAME = "droid_pnp_srl_openpi_billiard_hall"
 GR00T_CONFIG_YAML_PATH = "isaaclab_arena_gr00t/policy/config/droid_manip_gr00t_closedloop_config.yaml"
@@ -119,6 +124,19 @@ def _zero_action_experiment_cfg() -> ArenaExperimentCfg:
     )
 
 
+def _repeated_zero_action_experiment_cfg(num_runs: int) -> ArenaExperimentCfg:
+    return ArenaExperimentCfg(
+        runs={
+            f"baseline-{run_index}": ArenaRunCfg(
+                name=f"baseline-{run_index}",
+                environment=PickAndPlaceMapleTableEnvironmentCfg(),
+                policy=ZeroActionPolicyCfg(),
+            )
+            for run_index in range(num_runs)
+        }
+    )
+
+
 def _task_file(task: dict, remote_path: str) -> dict:
     return next(file for file in task["files"] if file["path"] == remote_path)
 
@@ -162,11 +180,30 @@ def test_explicit_experiment_composes_typed_defaults():
     assert isinstance(submission_cfg.experiment_cfg, ArenaExperimentCfg)
     assert len(submission_cfg.experiment_cfg.runs) == 9
     assert isinstance(submission_cfg.experiment_cfg.runs[OPENPI_RUN_NAME].policy, Pi0RemotePolicyCfg)
-    assert submission_cfg.osmo == WorkflowCfg()
+    assert submission_cfg.osmo == ArenaExperimentWorkflowCfg()
     assert submission_cfg.osmo.pool == "isaac-dev-l40s-04"
     assert submission_cfg.osmo.platform == "ovx-l40s"
     assert submission_cfg.experiment_runner == ExperimentRunnerTaskCfg()
     assert submission_cfg.experiment_runner.image == "nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest"
+
+
+def test_camera_free_scaling_validation_uses_eight_fixed_runs():
+    experiment_cfg = load_arena_experiment_from_config_file(
+        CAMERA_FREE_SCALING_VALIDATION_CFG_PATH,
+        device="cuda:0",
+    )
+
+    assert list(experiment_cfg.runs) == [f"camera_free_{run_index:03d}" for run_index in range(8)]
+    for run_cfg in experiment_cfg.runs.values():
+        assert isinstance(run_cfg.environment, PickAndPlaceMapleTableEnvironmentCfg)
+        assert run_cfg.environment.enable_cameras is False
+        assert run_cfg.environment.embodiment == "droid_rel_joint_pos"
+        assert run_cfg.environment_builder.num_envs == 256
+        assert run_cfg.environment_builder.seed == 42
+        assert run_cfg.environment_builder.placement_seed == 42
+        assert isinstance(run_cfg.policy, ZeroActionPolicyCfg)
+        assert run_cfg.rollout_limit.num_steps == 300
+        assert run_cfg.num_rebuilds == 1
 
 
 @pytest.mark.parametrize("config_path", ["osmo.not_a_field", "experiment_runner.not_a_field", "servers"])
@@ -238,13 +275,20 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     assert f"--experiment_config {REMOTE_EXPERIMENT_PATH}" in experiment_runner_command
     assert f"--experiment_output_directory '{OSMO_TASK_OUTPUT_DIR}'" in experiment_runner_command
     assert "--output_base_dir" not in experiment_runner_command
-    assert "--enable_cameras" in experiment_runner_command
+    assert "--enable_cameras" not in experiment_runner_command
     assert "--record_camera_video" in experiment_runner_command
     assert "--record_viewport_video" not in experiment_runner_command
     assert "--continue_on_error" not in experiment_runner_command
     assert "experiment_runner_process_exit_code=$?" in experiment_runner_command
     assert "experiment_runner_execution_status=completed" in experiment_runner_command
     assert "experiment_runner_execution_status=failed" in experiment_runner_command
+    assert "experiment_runner_started_at" in experiment_runner_command
+    assert "experiment_runner_finished_at" in experiment_runner_command
+    assert "experiment_runner_elapsed_seconds" in experiment_runner_command
+    assert "LC_ALL=C awk" in experiment_runner_command
+    assert '"process_started_at":"%s"' in experiment_runner_command
+    assert '"process_finished_at":"%s"' in experiment_runner_command
+    assert '"process_elapsed_seconds":%s' in experiment_runner_command
     assert '"runs":%s' in experiment_runner_command
     assert '"policy_variant": "pi05"' in experiment_runner_command
     assert '"name": "pick_and_place_maple_table"' in experiment_runner_command
@@ -253,6 +297,14 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     assert experiment_runner_command.endswith("exit 0\n")
     assert "policy_runner.py" not in experiment_runner_command
     assert "runs." not in experiment_runner_command
+    shell_syntax_check = subprocess.run(
+        ["bash", "-n"],
+        input=experiment_runner_command,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert shell_syntax_check.returncode == 0, shell_syntax_check.stderr
 
     assert first_tasks[0]["outputs"] == []
     assert second_tasks[0]["outputs"] == []
@@ -282,10 +334,8 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     experiment_output_script_file = _task_file(experiment_output_task, _REMOTE_BUILD_EXPERIMENT_OUTPUT_SCRIPT_PATH)
     assert "localpath" not in experiment_output_script_file
     assert "def build_experiment_output" in experiment_output_script_file["contents"]
-    assert (
-        "from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult"
-        in experiment_output_script_file["contents"]
-    )
+    assert "from isaaclab_arena.evaluation.arena_experiment_result import" in experiment_output_script_file["contents"]
+    assert "ArenaExperimentResult" in experiment_output_script_file["contents"]
     assert EXPERIMENT_RUNNER_RESULT_FILE_NAME in experiment_output_script_file["contents"]
     experiment_output_command = _task_file(experiment_output_task, "/tmp/entry.sh")["contents"]
     assert experiment_output_command.startswith("set -euo pipefail")
@@ -456,6 +506,58 @@ def test_all_local_experiment_runs_standalone_without_servers():
     groups = _workflow_groups(workflow.generate_workflow())
     assert [group["name"] for group in groups] == ["arena-run-0", "arena-experiment-output"]
     assert [task["name"] for task in groups[0]["tasks"]] == ["experiment-runner-0"]
+
+
+@pytest.mark.parametrize("max_parallel_runs", [1, 2, 4, 8])
+def test_limits_parallel_runs_with_dependency_lanes(max_parallel_runs):
+    """Each Run after the first lane row waits for the preceding Run in its lane."""
+    workflow = ArenaExperimentWorkflow(
+        workflow_cfg=ArenaExperimentWorkflowCfg(max_parallel_runs=max_parallel_runs),
+        experiment_cfg=_repeated_zero_action_experiment_cfg(num_runs=8),
+    )
+
+    run_groups = _workflow_groups(workflow.generate_workflow())[:-1]
+    assert len(run_groups) == 8
+    for run_index, run_group in enumerate(run_groups):
+        experiment_runner_task = run_group["tasks"][0]
+        expected_inputs = []
+        if run_index >= max_parallel_runs:
+            expected_inputs = [{
+                "task": f"experiment-runner-{run_index - max_parallel_runs}",
+                "regex": r".*experiment_runner_result\.json$",
+            }]
+        assert experiment_runner_task["inputs"] == expected_inputs
+
+
+def test_default_workflow_schedules_all_runs_independently():
+    """Without a concurrency limit, no Run waits for another Run."""
+    workflow = ArenaExperimentWorkflow(
+        workflow_cfg=ArenaExperimentWorkflowCfg(),
+        experiment_cfg=_repeated_zero_action_experiment_cfg(num_runs=8),
+    )
+
+    run_groups = _workflow_groups(workflow.generate_workflow())[:-1]
+    assert all(run_group["tasks"][0]["inputs"] == [] for run_group in run_groups)
+
+
+@pytest.mark.parametrize("max_parallel_runs", [-1, 0, 1.5, True, "2"])
+def test_rejects_invalid_max_parallel_runs(max_parallel_runs):
+    with pytest.raises(AssertionError, match="max_parallel_runs must be a positive integer"):
+        ArenaExperimentWorkflowCfg(max_parallel_runs=max_parallel_runs)
+
+
+def test_rejects_more_parallel_runs_than_experiment_runs():
+    with pytest.raises(AssertionError, match="cannot exceed the number of Experiment Runs"):
+        ArenaExperimentWorkflow(
+            workflow_cfg=ArenaExperimentWorkflowCfg(max_parallel_runs=9),
+            experiment_cfg=_repeated_zero_action_experiment_cfg(num_runs=8),
+        )
+
+
+def test_submission_composes_max_parallel_runs_override():
+    submission_cfg = _compose_submission(["osmo.max_parallel_runs=4"])
+
+    assert submission_cfg.osmo.max_parallel_runs == 4
 
 
 def test_submission_removes_temporary_workflow(monkeypatch):

--- a/isaaclab_arena_environments/experiment_configs/perflab/osmo/README.md
+++ b/isaaclab_arena_environments/experiment_configs/perflab/osmo/README.md
@@ -1,0 +1,60 @@
+# OSMO camera-free scaling validation
+
+This first validation runs the same eight camera-free, zero-action Arena Runs at four concurrency
+limits: 1, 2, 4, and 8. Only the number of Runs allowed to execute concurrently changes. Each Run
+uses 256 parallel environments for 300 steps on one GPU.
+
+`K` is the requested maximum number of concurrent one-GPU Runs. OSMO may execute fewer Runs at
+once when the pool is busy, and may place several Runs on one eight-GPU node.
+
+## Preview and submit
+
+Run these commands in the Arena development environment from the checkout containing this branch.
+Set `ARENA_IMAGE` to the pinned image built from the same commit; do not use a moving `latest` tag
+for measured results.
+
+```bash
+EXPERIMENT_CFG=isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml
+ARENA_IMAGE=nvcr.io/nvstaging/isaac-amr/isaaclab_arena:<pinned-tag>
+MAX_PARALLEL_RUNS=1
+```
+
+Preview the rendered workflow first:
+
+```bash
+python osmo/submit_arena_experiment.py \
+  --experiment_cfg "${EXPERIMENT_CFG}" \
+  --dry_run \
+  osmo.workflow_name="arena-camera-free-k${MAX_PARALLEL_RUNS}" \
+  osmo.pool=isaac-apps-l40-05 \
+  osmo.platform=ovx-l40 \
+  osmo.max_parallel_runs="${MAX_PARALLEL_RUNS}" \
+  experiment_runner.image="${ARENA_IMAGE}" \
+  experiment_runner.record_camera_video=false
+```
+
+Remove `--dry_run` to submit the checked workflow. Complete and inspect `K=1` before submitting
+`K=2`, then repeat for `K=4` and `K=8`. Use a unique workflow name for every submission.
+
+Accept a measurement point only when all eight `experiment_runner_result.json` files report
+`execution_status: completed` with exit code 0. A failed simulator Run may still leave the OSMO
+workflow green so its diagnostics can be collected.
+
+Use the task start and finish timestamps to confirm that the requested number of Runs actually
+overlapped. If fewer than `K` Runs overlapped, report the achieved peak concurrency and do not use
+that point to calculate efficiency for `K`.
+
+## Results
+
+Use OSMO execution timestamps for the primary Experiment completion time and exclude queue time.
+For each `K`, report:
+
+```text
+speedup(K) = T1 / TK
+parallel efficiency(K) = speedup(K) / K * 100%
+```
+
+The collected output stores each Run's `experiment_runner_result.json`,
+`arena_experiment_timings.json`, and `arena_experiment_metadata.json` under its Run directory. The
+result file also records the simulator process start, finish, and elapsed time. These files explain
+individual Run behavior; the OSMO workflow duration remains the primary scaling measurement.

--- a/isaaclab_arena_environments/experiment_configs/perflab/osmo/README.md
+++ b/isaaclab_arena_environments/experiment_configs/perflab/osmo/README.md
@@ -4,20 +4,28 @@ This first validation runs the same eight camera-free, zero-action Arena Runs at
 limits: 1, 2, 4, and 8. Only the number of Runs allowed to execute concurrently changes. Each Run
 uses 256 parallel environments for 300 steps on one GPU.
 
-`K` is the requested maximum number of concurrent one-GPU Runs. OSMO may execute fewer Runs at
-once when the pool is busy, and may place several Runs on one eight-GPU node.
+`K` is the requested maximum number of concurrent one-GPU Runs. Synchronized mode places each wave
+of up to `K` Runs in one native OSMO barrier group. The rendered group has `barrier: true`,
+`ignoreNonleadStatus: false`, and exactly one lead task. Each Run in a later wave depends on the Run
+in the same lane from the preceding wave.
+
+Synchronized mode supports local policies such as `zero_action`. Submission fails when a Run would
+derive a policy-server task, because the server lifecycle still requires one group per Run.
 
 ## Preview and submit
 
 Run these commands in the Arena development environment from the checkout containing this branch.
 Set `ARENA_IMAGE` to the pinned image built from the same commit; do not use a moving `latest` tag
-for measured results.
+for measured results. The validation runs used the image and digest shown below.
 
 ```bash
 EXPERIMENT_CFG=isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml
-ARENA_IMAGE=nvcr.io/nvstaging/isaac-amr/isaaclab_arena:<pinned-tag>
+ARENA_IMAGE=nvcr.io/nvstaging/isaac-amr/isaaclab_arena:osmo-perflab-scaling-4ee056866
 MAX_PARALLEL_RUNS=1
 ```
+
+Tested image digest:
+`sha256:480b3a146e35b5469708eade4cd8298b606cea1ad4b9c0e0e8c59098e3a0c1da`.
 
 Preview the rendered workflow first:
 
@@ -29,6 +37,7 @@ python osmo/submit_arena_experiment.py \
   osmo.pool=isaac-apps-l40-05 \
   osmo.platform=ovx-l40 \
   osmo.max_parallel_runs="${MAX_PARALLEL_RUNS}" \
+  osmo.synchronize_parallel_runs=true \
   experiment_runner.image="${ARENA_IMAGE}" \
   experiment_runner.record_camera_video=false
 ```
@@ -40,21 +49,41 @@ Accept a measurement point only when all eight `experiment_runner_result.json` f
 `execution_status: completed` with exit code 0. A failed simulator Run may still leave the OSMO
 workflow green so its diagnostics can be collected.
 
-Use the task start and finish timestamps to confirm that the requested number of Runs actually
-overlapped. If fewer than `K` Runs overlapped, report the achieved peak concurrency and do not use
-that point to calculate efficiency for `K`.
+OSMO may place several Runs on one eight-GPU node. The group barrier waits for cold image pulls and
+input downloads before starting the wave. Use the process start and finish timestamps to confirm
+that `K` Runs actually overlapped. If fewer than `K` Runs overlapped, report the achieved peak
+concurrency and do not use that point to calculate efficiency for `K`.
+
+## Download outputs
+
+After the workflow completes, download its collected output using its unique workflow name:
+
+```bash
+WORKFLOW_NAME=arena-camera-free-k1-synchronized-1
+OUTPUT_DIRECTORY=outputs/osmo_perflab_scaling/${WORKFLOW_NAME}
+mkdir -p "${OUTPUT_DIRECTORY}"
+osmo data download \
+  "swift://pdx.s8k.io/AUTH_team-isaac/isaaclab_arena/workflows/${WORKFLOW_NAME}" \
+  "${OUTPUT_DIRECTORY}"
+```
 
 ## Results
 
-Use OSMO execution timestamps for the primary Experiment completion time and exclude queue time.
-For each `K`, report:
+Use Runner makespan as the primary scaling time, where `T_K` is the earliest
+`process_started_at` through the latest `process_finished_at` across the eight
+`experiment_runner_result.json` files. This includes transitions between waves but excludes the
+final output collector. For each `K`, report:
 
 ```text
 speedup(K) = T1 / TK
 parallel efficiency(K) = speedup(K) / K * 100%
 ```
 
+Report the full OSMO workflow duration and initial queue time separately. Cold image pulls may occur
+before the first Runner or between waves, so record the cache state and do not present a
+greater-than-ideal speedup as compute scaling without a warm-cache repetition.
+
 The collected output stores each Run's `experiment_runner_result.json`,
 `arena_experiment_timings.json`, and `arena_experiment_metadata.json` under its Run directory. The
 result file also records the simulator process start, finish, and elapsed time. These files explain
-individual Run behavior; the OSMO workflow duration remains the primary scaling measurement.
+individual Run behavior and confirm the achieved concurrency.

--- a/isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml
+++ b/isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Keep this Run set unchanged across the 1, 2, 4, and 8 concurrency points.
+shared:
+  environment:
+    type: pick_and_place_maple_table
+    enable_cameras: false
+    embodiment: droid_rel_joint_pos
+    pick_up_object: rubiks_cube_hot3d_robolab
+    destination_location: bowl_ycb_robolab
+    hdr: home_office_robolab
+  environment_builder:
+    num_envs: 256
+    env_spacing: 2.5
+    seed: 42
+    placement_seed: 42
+    language_instruction: Pick up the Rubik's cube and place it in the bowl.
+  policy:
+    type: zero_action
+  rollout_limit:
+    num_steps: 300
+  num_rebuilds: 1
+
+runs:
+  camera_free_000: {}
+  camera_free_001: {}
+  camera_free_002: {}
+  camera_free_003: {}
+  camera_free_004: {}
+  camera_free_005: {}
+  camera_free_006: {}
+  camera_free_007: {}

--- a/osmo/scripts/build_experiment_output.py
+++ b/osmo/scripts/build_experiment_output.py
@@ -20,11 +20,16 @@ import shutil
 from collections.abc import Mapping
 from pathlib import Path
 
-from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
+from isaaclab_arena.evaluation.arena_experiment_metadata import ARENA_EXPERIMENT_METADATA_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME, ArenaExperimentResult
 from isaaclab_arena.evaluation.arena_run import RunStatus
 from isaaclab_arena.visualization.report import RunExecutionReport, build_report
 
 EXPERIMENT_RUNNER_RESULT_FILE_NAME = "experiment_runner_result.json"
+EXPERIMENT_RUNNER_DIAGNOSTIC_FILE_NAMES = (
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+    ARENA_EXPERIMENT_METADATA_FILENAME,
+)
 
 
 def load_experiment_runner_result(
@@ -97,7 +102,7 @@ def collect_run_outputs_into_experiment_output(
     experiment_runner_output_directories_by_run_name: Mapping[str, Path],
     experiment_output_directory: Path,
 ) -> tuple[list[RunExecutionReport], dict[str, dict[str, object]]]:
-    """Collect completed Run outputs and preserve failed execution results.
+    """Collect Run outputs and preserve Experiment Runner results and diagnostics.
 
     Args:
         experiment_runner_output_directories_by_run_name: Run names mapped to Experiment Runner task output
@@ -129,24 +134,27 @@ def collect_run_outputs_into_experiment_output(
                 f"{run_execution_report.process_exit_code}"
             )
             destination_run_output_directory.mkdir(parents=True)
-            shutil.copy2(
-                experiment_runner_result_path,
-                destination_run_output_directory / EXPERIMENT_RUNNER_RESULT_FILE_NAME,
+        else:
+            source_run_output_directory = experiment_runner_output_directory / run_name
+            assert (
+                source_run_output_directory.is_dir()
+            ), f"Completed Run '{run_name}' is missing its expected output directory: '{source_run_output_directory}'"
+            shutil.copytree(
+                source_run_output_directory,
+                destination_run_output_directory,
             )
-            continue
 
-        source_run_output_directory = experiment_runner_output_directory / run_name
-        assert (
-            source_run_output_directory.is_dir()
-        ), f"Completed Run '{run_name}' is missing its expected output directory: '{source_run_output_directory}'"
-        shutil.copytree(
-            source_run_output_directory,
-            destination_run_output_directory,
-        )
         shutil.copy2(
             experiment_runner_result_path,
             destination_run_output_directory / EXPERIMENT_RUNNER_RESULT_FILE_NAME,
         )
+        for diagnostic_file_name in EXPERIMENT_RUNNER_DIAGNOSTIC_FILE_NAMES:
+            source_diagnostic_path = experiment_runner_output_directory / diagnostic_file_name
+            if source_diagnostic_path.is_file():
+                shutil.copy2(
+                    source_diagnostic_path,
+                    destination_run_output_directory / diagnostic_file_name,
+                )
     return (
         sorted(run_execution_reports, key=lambda run_execution_report: run_execution_report.run_name),
         run_metadata_by_name,

--- a/osmo/submit_arena_experiment.py
+++ b/osmo/submit_arena_experiment.py
@@ -23,8 +23,7 @@ from isaaclab_arena.hydra.typed_experiment_loader import split_shared_run_defaul
 from isaaclab_arena.hydra.typed_experiment_serializer import serialize_arena_experiment_to_yaml
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from osmo.tasks.experiment_runner_task import ExperimentRunnerTaskCfg
-from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow
-from osmo.workflows.workflow import WorkflowCfg
+from osmo.workflows.arena_experiment_workflow import ArenaExperimentWorkflow, ArenaExperimentWorkflowCfg
 
 SUBMISSION_CONFIG_NAME = "osmo_arena_experiment_submission"
 
@@ -36,7 +35,7 @@ class ArenaExperimentSubmissionCfg:
     experiment_cfg: ArenaExperimentCfg
     """Evaluation semantics executed by ``experiment_runner.py``."""
 
-    osmo: WorkflowCfg = field(default_factory=WorkflowCfg)
+    osmo: ArenaExperimentWorkflowCfg = field(default_factory=ArenaExperimentWorkflowCfg)
     """OSMO scheduling, resource, and timeout configuration."""
 
     experiment_runner: ExperimentRunnerTaskCfg = field(default_factory=ExperimentRunnerTaskCfg)

--- a/osmo/tasks/experiment_runner_task.py
+++ b/osmo/tasks/experiment_runner_task.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 from copy import deepcopy
 from dataclasses import dataclass
@@ -56,17 +57,27 @@ class ExperimentRunnerTask(BaseTask):
         *,
         task_name: str,
         published_output_url: str | None = DATASET_SWIFT_URL,
+        predecessor_task_name: str | None = None,
     ) -> None:
         super().__init__(task_name=task_name, task_cfg=task_cfg, lead=lead)
         assert isinstance(experiment_cfg, ArenaExperimentCfg)
+        assert predecessor_task_name is None or (
+            isinstance(predecessor_task_name, str) and predecessor_task_name
+        ), "predecessor_task_name must be a non-empty string or None"
         self.experiment_cfg = deepcopy(experiment_cfg)
         self.published_output_url = published_output_url
+        self.predecessor_task_name = predecessor_task_name
 
     def _get_image(self) -> str:
         return self.task_cfg.image
 
     def _get_inputs(self) -> list[dict[str, Any]]:
-        return []
+        if self.predecessor_task_name is None:
+            return []
+        return [{
+            "task": self.predecessor_task_name,
+            "regex": f".*{re.escape(EXPERIMENT_RUNNER_RESULT_FILE_NAME)}$",
+        }]
 
     def _get_outputs(self) -> list[dict[str, Any]]:
         """Publish this output externally, or leave it workflow-local for a downstream task."""
@@ -91,7 +102,6 @@ class ExperimentRunnerTask(BaseTask):
             OSMO_TASK_OUTPUT_DIR,
             "--viz",
             "none",
-            "--enable_cameras",
         ]
         if self.task_cfg.record_camera_video:
             experiment_runner_command_arguments.append("--record_camera_video")
@@ -106,12 +116,18 @@ class ExperimentRunnerTask(BaseTask):
             })
         )
         write_experiment_runner_result_command = (
-            'printf \'{"execution_status":"%s","process_exit_code":%d,"runs":%s}\\n\' '
+            'printf \'{"execution_status":"%s","process_exit_code":%d,'
+            '"process_started_at":"%s","process_finished_at":"%s",'
+            '"process_elapsed_seconds":%s,"runs":%s}\\n\' '
             '"$experiment_runner_execution_status" "$experiment_runner_process_exit_code" '
+            '"$experiment_runner_started_at" "$experiment_runner_finished_at" '
+            '"$experiment_runner_elapsed_seconds" '
             f"{run_metadata_json} > {experiment_runner_result_path}"
         )
         return "\n".join([
             "# Record the application result without failing the OSMO task.",
+            'experiment_runner_started_at=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")',
+            'experiment_runner_started_epoch_seconds=$(date -u +"%s.%N")',
             f"if {experiment_runner_command}; then",
             "  experiment_runner_process_exit_code=0",
             f"  experiment_runner_execution_status={RunStatus.COMPLETED.value}",
@@ -119,6 +135,13 @@ class ExperimentRunnerTask(BaseTask):
             "  experiment_runner_process_exit_code=$?",
             f"  experiment_runner_execution_status={RunStatus.FAILED.value}",
             "fi",
+            'experiment_runner_finished_at=$(date -u +"%Y-%m-%dT%H:%M:%S.%NZ")',
+            'experiment_runner_finished_epoch_seconds=$(date -u +"%s.%N")',
+            (
+                "experiment_runner_elapsed_seconds=$(LC_ALL=C awk "
+                '-v start="$experiment_runner_started_epoch_seconds" '
+                '-v finish="$experiment_runner_finished_epoch_seconds" \'BEGIN {printf "%.6f", finish - start}\')'
+            ),
             "",
             "# Publish the result for the collector, then always report success to OSMO.",
             write_experiment_runner_result_command,

--- a/osmo/workflows/arena_experiment_workflow.py
+++ b/osmo/workflows/arena_experiment_workflow.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
 
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
@@ -22,11 +23,27 @@ from osmo.workflows.workflow import Workflow, WorkflowCfg
 from osmo.workflows.workflow_constants import POLICY_SERVER_PORT
 
 
+@dataclass
+class ArenaExperimentWorkflowCfg(WorkflowCfg):
+    """Configure scheduling for an Arena Experiment workflow."""
+
+    max_parallel_runs: int | None = None
+    """Maximum concurrently eligible Runs; ``None`` schedules every Run independently."""
+
+    def __post_init__(self) -> None:
+        assert self.max_parallel_runs is None or (
+            isinstance(self.max_parallel_runs, int)
+            and not isinstance(self.max_parallel_runs, bool)
+            and self.max_parallel_runs > 0
+        ), "max_parallel_runs must be a positive integer"
+
+
 class ArenaExperimentWorkflow(Workflow):
     """Run every Arena Experiment Run in its own OSMO group, co-scheduling each Run's server."""
 
     constructs_groups_directly = True
     task_cfg_type = ExperimentRunnerTaskCfg
+    workflow_cfg_type = ArenaExperimentWorkflowCfg
     experiment_output_resource_name = "experiment-output"
 
     def __init__(
@@ -37,7 +54,13 @@ class ArenaExperimentWorkflow(Workflow):
         task_cfg: ExperimentRunnerTaskCfg | None = None,
     ) -> None:
         assert isinstance(experiment_cfg, ArenaExperimentCfg)
+        max_parallel_runs = getattr(workflow_cfg, "max_parallel_runs", None)
+        assert max_parallel_runs is None or max_parallel_runs <= len(experiment_cfg.runs), (
+            "max_parallel_runs cannot exceed the number of Experiment Runs: "
+            f"got {max_parallel_runs} for {len(experiment_cfg.runs)} Runs"
+        )
         self.experiment_cfg = deepcopy(experiment_cfg)
+        self.max_parallel_runs = max_parallel_runs
         super().__init__(
             workflow_cfg=workflow_cfg,
             task_cfg=task_cfg or ExperimentRunnerTaskCfg(),
@@ -48,12 +71,17 @@ class ArenaExperimentWorkflow(Workflow):
         """Create one independently scheduled group per Run, then collect their outputs into one Experiment output."""
         run_group_dicts: list[dict[str, Any]] = []
         experiment_runner_task_names_by_run_name: dict[str, str] = {}
+        max_parallel_runs = self.max_parallel_runs or len(self.experiment_cfg.runs)
         for run_index, (run_name, run_config) in enumerate(self.experiment_cfg.runs.items()):
             ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
+            predecessor_task_name = (
+                f"experiment-runner-{run_index - max_parallel_runs}" if run_index >= max_parallel_runs else None
+            )
             run_group_dict, experiment_runner_task_name = self._create_run_group_dict(
                 run_index,
                 run_name,
                 run_config,
+                predecessor_task_name,
             )
             run_group_dicts.append(run_group_dict)
             experiment_runner_task_names_by_run_name[run_name] = experiment_runner_task_name
@@ -68,6 +96,7 @@ class ArenaExperimentWorkflow(Workflow):
         run_index: int,
         run_name: str,
         run_config: ArenaRunCfg,
+        predecessor_task_name: str | None,
     ) -> tuple[dict[str, Any], str]:
         """Create one OSMO group that executes a single-Run Arena Experiment, plus its server if any."""
         experiment_runner_task_name = f"experiment-runner-{run_index}"
@@ -98,6 +127,7 @@ class ArenaExperimentWorkflow(Workflow):
             lead=True,
             task_name=experiment_runner_task_name,
             published_output_url=None,
+            predecessor_task_name=predecessor_task_name,
         )
         run_group_tasks = [experiment_runner_task, *policy_server_tasks]
 

--- a/osmo/workflows/arena_experiment_workflow.py
+++ b/osmo/workflows/arena_experiment_workflow.py
@@ -30,16 +30,20 @@ class ArenaExperimentWorkflowCfg(WorkflowCfg):
     max_parallel_runs: int | None = None
     """Maximum concurrently eligible Runs; ``None`` schedules every Run independently."""
 
+    synchronize_parallel_runs: bool = False
+    """Co-schedule each wave of local-policy Runs with an OSMO group barrier."""
+
     def __post_init__(self) -> None:
         assert self.max_parallel_runs is None or (
             isinstance(self.max_parallel_runs, int)
             and not isinstance(self.max_parallel_runs, bool)
             and self.max_parallel_runs > 0
         ), "max_parallel_runs must be a positive integer"
+        assert isinstance(self.synchronize_parallel_runs, bool), "synchronize_parallel_runs must be a boolean"
 
 
 class ArenaExperimentWorkflow(Workflow):
-    """Run every Arena Experiment Run in its own OSMO group, co-scheduling each Run's server."""
+    """Run Arena Experiment Runs independently or in synchronized local-policy waves."""
 
     constructs_groups_directly = True
     task_cfg_type = ExperimentRunnerTaskCfg
@@ -61,6 +65,9 @@ class ArenaExperimentWorkflow(Workflow):
         )
         self.experiment_cfg = deepcopy(experiment_cfg)
         self.max_parallel_runs = max_parallel_runs
+        self.synchronize_parallel_runs = getattr(workflow_cfg, "synchronize_parallel_runs", False)
+        if self.synchronize_parallel_runs:
+            self._assert_synchronized_runs_do_not_require_policy_servers()
         super().__init__(
             workflow_cfg=workflow_cfg,
             task_cfg=task_cfg or ExperimentRunnerTaskCfg(),
@@ -68,28 +75,82 @@ class ArenaExperimentWorkflow(Workflow):
         )
 
     def _get_group_dicts(self) -> list[dict[str, Any]]:
-        """Create one independently scheduled group per Run, then collect their outputs into one Experiment output."""
+        """Create Run groups, then collect their outputs into one Experiment output."""
         run_group_dicts: list[dict[str, Any]] = []
         experiment_runner_task_names_by_run_name: dict[str, str] = {}
         max_parallel_runs = self.max_parallel_runs or len(self.experiment_cfg.runs)
-        for run_index, (run_name, run_config) in enumerate(self.experiment_cfg.runs.items()):
-            ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
-            predecessor_task_name = (
-                f"experiment-runner-{run_index - max_parallel_runs}" if run_index >= max_parallel_runs else None
+
+        if self.synchronize_parallel_runs:
+            run_group_dicts, experiment_runner_task_names_by_run_name = self._create_synchronized_run_group_dicts(
+                max_parallel_runs
             )
-            run_group_dict, experiment_runner_task_name = self._create_run_group_dict(
-                run_index,
-                run_name,
-                run_config,
-                predecessor_task_name,
-            )
-            run_group_dicts.append(run_group_dict)
-            experiment_runner_task_names_by_run_name[run_name] = experiment_runner_task_name
+        else:
+            for run_index, (run_name, run_config) in enumerate(self.experiment_cfg.runs.items()):
+                ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
+                predecessor_task_name = (
+                    f"experiment-runner-{run_index - max_parallel_runs}" if run_index >= max_parallel_runs else None
+                )
+                run_group_dict, experiment_runner_task_name = self._create_run_group_dict(
+                    run_index,
+                    run_name,
+                    run_config,
+                    predecessor_task_name,
+                )
+                run_group_dicts.append(run_group_dict)
+                experiment_runner_task_names_by_run_name[run_name] = experiment_runner_task_name
 
         experiment_output_group_dict = self._create_experiment_output_group_dict(
             experiment_runner_task_names_by_run_name
         )
         return [*run_group_dicts, experiment_output_group_dict]
+
+    def _assert_synchronized_runs_do_not_require_policy_servers(self) -> None:
+        """Reject synchronized groups when a Run needs a derived policy server."""
+        server_registry = ServerTaskRegistry()
+        for run_name, run_config in self.experiment_cfg.runs.items():
+            server_type = server_registry.get_server_type_for_policy_cfg(run_config.policy)
+            assert server_type is None, (
+                "synchronize_parallel_runs supports only local-policy Runs; "
+                f"Run '{run_name}' requires the derived policy-server task {server_type.__name__}"
+            )
+
+    def _create_synchronized_run_group_dicts(
+        self,
+        max_parallel_runs: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, str]]:
+        """Create barrier-backed groups containing one wave of local-policy Runs each."""
+        run_items = list(self.experiment_cfg.runs.items())
+        run_group_dicts: list[dict[str, Any]] = []
+        experiment_runner_task_names_by_run_name: dict[str, str] = {}
+
+        for wave_index, wave_start_index in enumerate(range(0, len(run_items), max_parallel_runs)):
+            wave_task_dicts: list[dict[str, Any]] = []
+            wave_items = run_items[wave_start_index : wave_start_index + max_parallel_runs]
+            for wave_task_index, (run_name, run_config) in enumerate(wave_items):
+                run_index = wave_start_index + wave_task_index
+                ArenaExperimentResult.assert_run_name_is_safe_path_component(run_name)
+                predecessor_task_name = (
+                    f"experiment-runner-{run_index - max_parallel_runs}" if run_index >= max_parallel_runs else None
+                )
+                run_group_tasks, experiment_runner_task_name = self._create_run_group_tasks(
+                    run_index,
+                    run_name,
+                    run_config,
+                    predecessor_task_name,
+                    experiment_runner_is_lead=wave_task_index == 0,
+                )
+                assert len(run_group_tasks) == 1, "Synchronized Run groups cannot contain policy-server tasks"
+                wave_task_dicts.extend(run_group_task.create_task_dict() for run_group_task in run_group_tasks)
+                experiment_runner_task_names_by_run_name[run_name] = experiment_runner_task_name
+
+            run_group_dicts.append({
+                "name": f"arena-run-wave-{wave_index}",
+                "barrier": True,
+                "ignoreNonleadStatus": False,
+                "tasks": wave_task_dicts,
+            })
+
+        return run_group_dicts, experiment_runner_task_names_by_run_name
 
     def _create_run_group_dict(
         self,
@@ -99,6 +160,30 @@ class ArenaExperimentWorkflow(Workflow):
         predecessor_task_name: str | None,
     ) -> tuple[dict[str, Any], str]:
         """Create one OSMO group that executes a single-Run Arena Experiment, plus its server if any."""
+        run_group_tasks, experiment_runner_task_name = self._create_run_group_tasks(
+            run_index,
+            run_name,
+            run_config,
+            predecessor_task_name,
+            experiment_runner_is_lead=True,
+        )
+
+        run_group_dict = {
+            "name": f"arena-run-{run_index}",
+            "tasks": [run_group_task.create_task_dict() for run_group_task in run_group_tasks],
+        }
+        return run_group_dict, experiment_runner_task_name
+
+    def _create_run_group_tasks(
+        self,
+        run_index: int,
+        run_name: str,
+        run_config: ArenaRunCfg,
+        predecessor_task_name: str | None,
+        *,
+        experiment_runner_is_lead: bool,
+    ) -> tuple[list[BaseTask], str]:
+        """Create an Experiment Runner and its derived policy-server task, if required."""
         experiment_runner_task_name = f"experiment-runner-{run_index}"
         # Snapshot this Run alone so the Experiment Runner task embeds a single-Run Experiment.
         single_run_experiment_config = ArenaExperimentCfg(runs={run_name: deepcopy(run_config)})
@@ -124,18 +209,13 @@ class ArenaExperimentWorkflow(Workflow):
         experiment_runner_task = ExperimentRunnerTask(
             task_cfg=self.task_cfg,
             experiment_cfg=single_run_experiment_config,
-            lead=True,
+            lead=experiment_runner_is_lead,
             task_name=experiment_runner_task_name,
             published_output_url=None,
             predecessor_task_name=predecessor_task_name,
         )
         run_group_tasks = [experiment_runner_task, *policy_server_tasks]
-
-        run_group_dict = {
-            "name": f"arena-run-{run_index}",
-            "tasks": [run_group_task.create_task_dict() for run_group_task in run_group_tasks],
-        }
-        return run_group_dict, experiment_runner_task_name
+        return run_group_tasks, experiment_runner_task_name
 
     def _create_experiment_output_group_dict(
         self,


### PR DESCRIPTION
## Summary
Add a repeatable OSMO scaling benchmark.

## Detailed description
- Record the Run configuration, process lifecycle, and component timings needed to validate benchmark results.
- Add an eight-Run camera-free experiment and collect every Run's diagnostic output.
- Bound concurrency and start local-policy Runs in barrier-backed waves for comparable K=1, 2, 4, and 8 measurements.
- Document the tested image, submission commands, output download, and scaling calculations.
