### PR TITLE
Add PhysX deformable pick-and-place support

### DIFF
--- a/isaaclab_arena/assets/deformable_object.py
+++ b/isaaclab_arena/assets/deformable_object.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arena deformable object with backend-specific physics properties."""
+
+from __future__ import annotations
+
+import torch
+from typing import Any
+
+from isaaclab.assets import AssetBaseCfg, DeformableObjectCfg
+from isaaclab.envs import ManagerBasedEnv
+from isaaclab.managers import EventTermCfg, SceneEntityCfg
+from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+from isaaclab.sim.spawners.meshes.meshes_cfg import MeshCuboidCfg, MeshRectangleCfg
+from isaaclab.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+from isaaclab_physx.sim.schemas import PhysxDeformableBodyPropertiesCfg
+
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.terms.events import set_deformable_object_pose, set_deformable_object_pose_per_env
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
+from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd
+from isaaclab_arena.utils.velocity import Velocity
+
+
+class DeformableObject(ObjectBase):
+    """Spawned deformable with an explicit physics backend."""
+
+    def __init__(
+        self,
+        name: str,
+        spawner_cfg: DeformableObjectSpawnerCfg,
+        prim_path: str | None = None,
+        initial_pose: Pose | PosePerEnv | None = None,
+        asset_cfg_addon: dict[str, Any] | None = None,
+        **kwargs,
+    ):
+        super().__init__(name=name, prim_path=prim_path, object_type=ObjectType.DEFORMABLE, **kwargs)
+        self.spawner_cfg = spawner_cfg
+        self.physics_preset = self._infer_physics_preset(spawner_cfg)
+        self.asset_cfg_addon = asset_cfg_addon or {}
+        self._bounding_box = self._bounding_box_from_spawner(spawner_cfg)
+        self.initial_pose = initial_pose
+        self.initial_velocity: Velocity | None = None
+        self.object_cfg = self._build_object_cfg()
+        self._pose_event_cfg = self._build_reset_event()
+
+    @staticmethod
+    def _infer_physics_preset(spawner_cfg: DeformableObjectSpawnerCfg) -> str:
+        """Infer the backend from the deformable properties."""
+        deformable_props = spawner_cfg.deformable_props
+        assert deformable_props is not None, "Deformable spawners require backend-specific deformable_props"
+        if isinstance(deformable_props, PhysxDeformableBodyPropertiesCfg):
+            return "physx"
+        if isinstance(deformable_props, NewtonDeformableBodyPropertiesCfg):
+            return "newton"
+        raise TypeError(f"Unsupported deformable properties type: {type(deformable_props).__name__}")
+
+    @staticmethod
+    def _bounding_box_from_spawner(
+        spawner_cfg: DeformableObjectSpawnerCfg | None,
+    ) -> AxisAlignedBoundingBox | None:
+        """Infer undeformed local bounds for supported primitive-mesh sources."""
+        if isinstance(spawner_cfg, MeshCuboidCfg):
+            half_size = tuple(size * 0.5 for size in spawner_cfg.size)
+        elif isinstance(spawner_cfg, MeshRectangleCfg):
+            half_size = (*tuple(size * 0.5 for size in spawner_cfg.size), 0.0)
+        else:
+            return None
+        return AxisAlignedBoundingBox(
+            min_point=tuple(-value for value in half_size),
+            max_point=half_size,
+        )
+
+    def get_object_cfg(self) -> tuple[str, AssetBaseCfg]:
+        """Return the available deformable config."""
+        return self.name, self.object_cfg
+
+    def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None):
+        """Reject contact sensors, which Isaac Lab does not support for deformables."""
+        del contact_against_object
+        raise NotImplementedError(f"{type(self).__name__} does not support contact sensors")
+
+    def _build_object_cfg(self) -> DeformableObjectCfg:
+        """Build the concrete Isaac Lab deformable config."""
+        object_cfg = DeformableObjectCfg(
+            prim_path=self.prim_path,
+            spawn=self.spawner_cfg,
+            **self.asset_cfg_addon,
+        )
+        initial_pose = self._get_initial_pose_as_pose()
+        if initial_pose is not None:
+            object_cfg.init_state.pos = initial_pose.position_xyz
+            object_cfg.init_state.rot = initial_pose.rotation_xyzw
+        return object_cfg
+
+    def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
+        assert isinstance(pose, (Pose, PosePerEnv)), "Deformables support fixed Pose or PosePerEnv only"
+        super()._set_initial_pose(pose)
+        initial_pose = self._get_initial_pose_as_pose()
+        assert initial_pose is not None
+        self.object_cfg.init_state.pos = initial_pose.position_xyz
+        self.object_cfg.init_state.rot = initial_pose.rotation_xyzw
+
+    def set_initial_velocity(self, velocity: Velocity) -> None:
+        """Set the linear velocity restored by the deformable reset event."""
+        self.initial_velocity = velocity
+        self._pose_event_cfg = self._build_reset_event()
+
+    def _build_reset_event(self) -> EventTermCfg | None:
+        """Build a nodal reset event for the configured centroid pose."""
+        if self.initial_pose is None:
+            return None
+        if isinstance(self.initial_pose, PosePerEnv):
+            return EventTermCfg(
+                func=set_deformable_object_pose_per_env,
+                mode="reset",
+                params={"asset_cfg": SceneEntityCfg(self.name), "pose_list": self.initial_pose.poses},
+            )
+        return EventTermCfg(
+            func=set_deformable_object_pose,
+            mode="reset",
+            params={
+                "asset_cfg": SceneEntityCfg(self.name),
+                "pose": self.initial_pose,
+                "velocity": self.initial_velocity,
+            },
+        )
+
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Return undeformed local bounds used for initial placement."""
+        if self._bounding_box is None and isinstance(self.spawner_cfg, UsdFileCfg):
+            self._bounding_box = compute_local_bounding_box_from_usd(
+                self.spawner_cfg.usd_path,
+                tuple(self.spawner_cfg.scale or (1.0, 1.0, 1.0)),
+            )
+        assert (
+            self._bounding_box is not None
+        ), f"Bounding-box inference is not supported for {type(self.spawner_cfg).__name__}"
+        return self._bounding_box
+
+    def write_layout_pose_to_sim(self, env: ManagerBasedEnv, env_id: int, layout_pose: Pose) -> None:
+        """Apply a solved pose by transforming this deformable's nodal state."""
+        env_ids = torch.tensor([env_id], device=env.device)
+        set_deformable_object_pose(env, env_ids, SceneEntityCfg(self.name), layout_pose)

--- a/isaaclab_arena/assets/deformable_object_library.py
+++ b/isaaclab_arena/assets/deformable_object_library.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PhysX deformable objects sourced from Isaac Lab examples."""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+import isaaclab.sim as sim_utils
+from isaaclab.sim.spawners.spawner_cfg import DeformableObjectSpawnerCfg
+from isaaclab.utils.assets import ISAACLAB_NUCLEUS_DIR
+from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxDeformableBodyPropertiesCfg
+from isaaclab_physx.sim.spawners.materials import PhysxDeformableBodyMaterialCfg, PhysxSurfaceDeformableBodyMaterialCfg
+
+from isaaclab_arena.assets.deformable_object import DeformableObject
+from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+
+class LibraryDeformableObject(DeformableObject):
+    """Base class for registered deformable objects."""
+
+    name: str
+    tags = ["object", "deformable", "physx"]
+    spawner_cfg: DeformableObjectSpawnerCfg
+
+    def __init__(
+        self,
+        instance_name: str | None = None,
+        prim_path: str | None = None,
+        initial_pose: Pose | PosePerEnv | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(
+            name=instance_name or self.name,
+            prim_path=prim_path,
+            tags=self.tags,
+            spawner_cfg=copy.deepcopy(self.spawner_cfg),
+            initial_pose=initial_pose,
+            **kwargs,
+        )
+
+
+@register_asset
+class DeformableCube(LibraryDeformableObject):
+    """PhysX deformable cube used by the DROID pick-and-place environment."""
+
+    name = "deformable_cube"
+    spawner_cfg = sim_utils.MeshCuboidCfg(
+        size=(0.15, 0.04, 0.04),
+        deformable_props=PhysxDeformableBodyPropertiesCfg(linear_damping=0.0),
+        collision_props=[PhysxCollisionCfg(rest_offset=0.0, contact_offset=0.0025)],
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.95, 0.85, 0.1)),
+        physics_material=PhysxDeformableBodyMaterialCfg(
+            youngs_modulus=8.0e4,
+            poissons_ratio=0.25,
+            density=300.0,
+        ),
+    )
+
+
+@register_asset
+class DeformableSurface(LibraryDeformableObject):
+    """PhysX surface matching Isaac Lab's Franka cloth lift geometry."""
+
+    name = "deformable_surface"
+    spawner_cfg = sim_utils.MeshRectangleCfg(
+        size=(0.2, 0.2),
+        resolution=(30, 30),
+        deformable_props=PhysxDeformableBodyPropertiesCfg(),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.95, 0.85, 0.1)),
+        physics_material=PhysxSurfaceDeformableBodyMaterialCfg(),
+    )
+
+
+@register_asset
+class DeformableTeddyBear(LibraryDeformableObject):
+    """PhysX teddy bear from Isaac Lab's Franka lift environment."""
+
+    name = "deformable_teddy_bear"
+    spawner_cfg = sim_utils.UsdFileCfg(
+        usd_path=f"{ISAACLAB_NUCLEUS_DIR}/Objects/Teddy_Bear/teddy_bear.usd",
+        scale=(0.01, 0.01, 0.01),
+        deformable_props=PhysxDeformableBodyPropertiesCfg(),
+        physics_material=PhysxDeformableBodyMaterialCfg(),
+    )

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -12,7 +12,7 @@ from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.sim.spawners.spawner_cfg import SpawnerCfg
 
-from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType, RootedObjectBase
 from isaaclab_arena.assets.object_utils import detect_object_type
 from isaaclab_arena.relations.relations import RelationBase
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
@@ -21,7 +21,7 @@ from isaaclab_arena.utils.usd.rigid_bodies import find_shallowest_rigid_body
 from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd, has_light, open_stage
 
 
-class Object(ObjectBase):
+class Object(RootedObjectBase):
     """Pick-up object config for a pick-and-place environment."""
 
     def __init__(

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -91,6 +91,10 @@ class Object(RootedObjectBase):
         self, contact_against_object: ObjectBase | None = None, usd_path: str | None = None
     ) -> ContactSensorCfg:
         assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        if contact_against_object is not None:
+            assert (
+                contact_against_object.object_type != ObjectType.DEFORMABLE
+            ), "Contact sensor filtering against deformable objects is not supported"
         # We override this function from the parent class because in some assets, the rigid body
         # is not at the root of the USD file. To be robust to this, we find the shallowest rigid body
         # and add the contact sensor to it.

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -57,8 +57,8 @@ class ObjectBase(PlaceableAsset, ABC):
         return self.prim_path
 
     @abstractmethod
-    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
-        """Return the scene key and concrete Isaac Lab config."""
+    def get_object_cfg(self) -> tuple[str, AssetBaseCfg]:
+        """Return the scene key and concrete asset config."""
 
     def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
         return self.name, self._pose_event_cfg
@@ -83,6 +83,10 @@ class RootedObjectBase(ObjectBase):
             frame_view.close()
             self._base_frame_view = None
             self._base_frame_view_stage = None
+
+    def get_object_cfg(self) -> tuple[str, AssetBaseCfg]:
+        """Return the rooted-object config."""
+        return self.name, self.object_cfg
 
     def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
         """Store the pose and write its construction values into the object config."""
@@ -154,9 +158,6 @@ class RootedObjectBase(ObjectBase):
                     "velocity": self.initial_velocity,
                 },
             )
-
-    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
-        return self.name, self.object_cfg
 
     def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
         if self.object_type == ObjectType.RIGID:
@@ -240,6 +241,10 @@ class RootedObjectBase(ObjectBase):
 
     def get_contact_sensor_cfg(self, contact_against_object: ObjectBase | None = None) -> ContactSensorCfg:
         assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        if contact_against_object is not None:
+            assert (
+                contact_against_object.object_type != ObjectType.DEFORMABLE
+            ), "Contact sensor filtering against deformable objects is not supported"
         filter_prim_paths = [contact_against_object.get_prim_path()] if contact_against_object else []
         return ContactSensorCfg(
             prim_path=self.prim_path,

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -30,11 +30,12 @@ from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 __all__ = [
     "ObjectBase",
     "ObjectType",
+    "RootedObjectBase",
 ]
 
 
 class ObjectBase(PlaceableAsset, ABC):
-    """Parent class for (spawnable) Object and ObjectReference."""
+    """Parent class for Arena scene objects."""
 
     def __init__(
         self,
@@ -48,6 +49,26 @@ class ObjectBase(PlaceableAsset, ABC):
             prim_path = "{ENV_REGEX_NS}/" + self.name
         self.prim_path = prim_path
         self.object_type = object_type
+
+    def set_prim_path(self, prim_path: str) -> None:
+        self.prim_path = prim_path
+
+    def get_prim_path(self) -> str:
+        return self.prim_path
+
+    @abstractmethod
+    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
+        """Return the scene key and concrete Isaac Lab config."""
+
+    def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
+        return self.name, self._pose_event_cfg
+
+
+class RootedObjectBase(ObjectBase):
+    """Parent class for rigid, articulated, and static rooted objects."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.object_type == ObjectType.RIGID:
             self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None
@@ -134,17 +155,8 @@ class ObjectBase(PlaceableAsset, ABC):
                 },
             )
 
-    def set_prim_path(self, prim_path: str) -> None:
-        self.prim_path = prim_path
-
-    def get_prim_path(self) -> str:
-        return self.prim_path
-
     def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
         return self.name, self.object_cfg
-
-    def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
-        return self.name, self._pose_event_cfg
 
     def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
         if self.object_type == ObjectType.RIGID:

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -13,7 +13,7 @@ from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.affordances.pressable import Pressable
 from isaaclab_arena.affordances.turnable import Turnable
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.assets.object_base import ObjectBase, ObjectType, RootedObjectBase
 from isaaclab_arena.relations.relations import IsAnchor, RelationBase
 from isaaclab_arena.terms.events import reset_articulation_pose_and_joints
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, quaternion_to_90_deg_z_quarters
@@ -27,7 +27,7 @@ from isaaclab_arena.utils.usd_helpers import (
 from isaaclab_arena.utils.usd_pose_helpers import get_prim_pose_in_default_prim_frame
 
 
-class ObjectReference(ObjectBase):
+class ObjectReference(RootedObjectBase):
     """An object which *refers* to an existing element in the scene"""
 
     def __init__(self, parent_asset: Object, **kwargs):

--- a/isaaclab_arena/assets/object_type.py
+++ b/isaaclab_arena/assets/object_type.py
@@ -22,3 +22,4 @@ class ObjectType(str, Enum):
     BASE = "base"
     RIGID = "rigid"
     ARTICULATION = "articulation"
+    DEFORMABLE = "deformable"

--- a/isaaclab_arena/assets/registries.py
+++ b/isaaclab_arena/assets/registries.py
@@ -371,6 +371,7 @@ def ensure_assets_registered():
     try:
         # Import modules to trigger asset registration via decorators
         import isaaclab_arena.assets.background_library  # noqa: F401
+        import isaaclab_arena.assets.deformable_object_library  # noqa: F401
         import isaaclab_arena.assets.device_library  # noqa: F401
         import isaaclab_arena.assets.hdr_image_library  # noqa: F401
         import isaaclab_arena.assets.object_library  # noqa: F401

--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -19,6 +19,7 @@ from isaaclab_tasks.utils import parse_env_cfg
 from isaaclab_teleop import IsaacTeleopCfg
 
 import isaaclab_arena_curobo  # noqa: F401
+from isaaclab_arena.assets.deformable_object import DeformableObject
 from isaaclab_arena.assets.registries import DeviceRegistry
 from isaaclab_arena.embodiments.no_embodiment import NoEmbodiment
 from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
@@ -172,6 +173,18 @@ class ArenaEnvBuilder:
                     continue
                 variation.configure_at_build_time()
 
+    def _validate_deformable_physics_presets(self) -> None:
+        """Check that every deformable object supports the selected physics preset."""
+        selected_preset = self.cfg.presets or "physx"
+        if selected_preset == "default":
+            selected_preset = "physx"
+        for asset in self.arena_env.scene.assets.values():
+            if isinstance(asset, DeformableObject) and asset.physics_preset != selected_preset:
+                raise ValueError(
+                    f"DeformableObject '{asset.name}' is configured for {asset.physics_preset!r}, "
+                    f"not the selected preset {selected_preset!r}"
+                )
+
     def _modify_recorder_cfg_dataset_filename(self, recorder_cfg: RecorderManagerBaseCfg) -> RecorderManagerBaseCfg:
         """Modify the recorder dataset filename to include the timestamp and rank."""
         base = getattr(recorder_cfg, "dataset_filename", "dataset")
@@ -231,6 +244,7 @@ class ArenaEnvBuilder:
 
         # Apply build-time variations now, before scene_cfg is materialised.
         self._apply_build_time_variations()
+        self._validate_deformable_physics_presets()
 
         # Constructing the environment by combining inputs from the scene, embodiment, and task.
         embodiment = self.arena_env.embodiment or NoEmbodiment()

--- a/isaaclab_arena/environments/arena_world.py
+++ b/isaaclab_arena/environments/arena_world.py
@@ -23,9 +23,10 @@ from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
 
 class ArenaWorld:
-    """Provide name-based runtime access to rigid objects and scene extras.
+    """Provide name-based runtime access to rigid, deformable, and extra entities.
 
-    Poses are read live for both supported scene categories, along with root linear velocities for rigid objects.
+    Poses are read live for all supported scene categories, along with root linear velocities for rigid and
+    deformable objects.
     Local-frame geometry bounds are computed lazily from the cloned prim hierarchy and cached for the environment
     lifetime. They remain valid under whole-subtree motion, but not when descendants move relative to frame F.
     A moving part must therefore have its own supported scene key.
@@ -44,16 +45,23 @@ class ArenaWorld:
         """
         scene = self._scene
         is_rigid_object = scene_key in scene.rigid_objects
+        deformable_objects = getattr(scene, "deformable_objects", {})
+        is_deformable_object = scene_key in deformable_objects
         is_scene_extra = scene_key in scene.extras
-        assert is_rigid_object or is_scene_extra, (
-            "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects or "
-            f"InteractiveScene.extras; '{scene_key}' is registered in neither."
+        assert is_rigid_object or is_deformable_object or is_scene_extra, (
+            "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects, "
+            f"InteractiveScene.deformable_objects, or InteractiveScene.extras; '{scene_key}' is registered in none."
         )
 
-        # Rigid objects expose live root state directly. Scene extras are plain cloned prims,
+        # Rigid and deformable objects expose live root state directly. Deformables have no aggregate
+        # orientation, so their pose uses the identity rotation. Scene extras are plain cloned prims,
         # so their live post-clone poses require a FrameView-backed reader.
         if is_rigid_object:
             T_W_F = scene.rigid_objects[scene_key].data.root_pose_w.torch
+        elif is_deformable_object:
+            root_pos_w = deformable_objects[scene_key].data.root_pos_w.torch
+            identity_quat = root_pos_w.new_tensor((0.0, 0.0, 0.0, 1.0)).expand(scene.num_envs, 4)
+            T_W_F = torch.cat((root_pos_w, identity_quat), dim=-1)
         else:
             pose_reader = self._get_scene_extra_pose_reader(scene, scene_key)
             T_W_F = pose_reader.get_pose_w()
@@ -64,17 +72,21 @@ class ArenaWorld:
         ), f"Pose for scene key '{scene_key}' has shape {tuple(T_W_F.shape)}; expected ({scene.num_envs}, 7)."
         return T_W_F
 
-    def get_root_linear_velocity_w(self, rigid_object_name: str) -> torch.Tensor:
-        """Return a rigid object's current world-frame root linear velocity.
+    def get_root_linear_velocity_w(self, scene_key: str) -> torch.Tensor:
+        """Return a rigid or deformable object's current world-frame root linear velocity.
 
         The tensor has shape (num_envs, 3).
         """
         scene = self._scene
-        assert rigid_object_name in scene.rigid_objects, f"'{rigid_object_name}' must name a rigid object."
-        root_linear_velocity_w = scene.rigid_objects[rigid_object_name].data.root_lin_vel_w.torch
+        if scene_key in scene.rigid_objects:
+            root_linear_velocity_w = scene.rigid_objects[scene_key].data.root_lin_vel_w.torch
+        else:
+            deformable_objects = getattr(scene, "deformable_objects", {})
+            assert scene_key in deformable_objects, f"'{scene_key}' must name a rigid or deformable object."
+            root_linear_velocity_w = deformable_objects[scene_key].data.root_vel_w.torch
         assert root_linear_velocity_w.shape == (scene.num_envs, 3), (
-            f"Rigid object '{rigid_object_name}' returned root linear velocity shape "
-            f"{tuple(root_linear_velocity_w.shape)}; expected ({scene.num_envs}, 3)."
+            f"Scene object '{scene_key}' returned root linear velocity shape {tuple(root_linear_velocity_w.shape)}; "
+            f"expected ({scene.num_envs}, 3)."
         )
         return root_linear_velocity_w
 

--- a/isaaclab_arena/environments/arena_world_scene_access.py
+++ b/isaaclab_arena/environments/arena_world_scene_access.py
@@ -111,9 +111,10 @@ def compute_spawned_geometry_bounds_in_local_frame(
         valid under whole-subtree motion, but not when descendants move relative
         to frame F.
     """
-    assert scene_key in scene.rigid_objects or scene_key in scene.extras, (
-        "ArenaWorld geometry queries require a scene key registered in InteractiveScene.rigid_objects or "
-        f"InteractiveScene.extras; '{scene_key}' is registered in neither."
+    deformable_objects = getattr(scene, "deformable_objects", {})
+    assert scene_key in scene.rigid_objects or scene_key in deformable_objects or scene_key in scene.extras, (
+        "ArenaWorld geometry queries require a scene key registered in InteractiveScene.rigid_objects, "
+        f"InteractiveScene.deformable_objects, or InteractiveScene.extras; '{scene_key}' is registered in none."
     )
     is_rigid_object = scene_key in scene.rigid_objects
     resolved_geometry_prim_path = getattr(scene.cfg, scene_key).prim_path.format(ENV_REGEX_NS=scene.env_regex_ns)

--- a/isaaclab_arena/metrics/object_moved.py
+++ b/isaaclab_arena/metrics/object_moved.py
@@ -6,7 +6,6 @@
 import numpy as np
 from dataclasses import MISSING
 
-import warp as wp
 from isaaclab.envs.manager_based_rl_env import ManagerBasedEnv
 from isaaclab.managers.recorder_manager import RecorderTerm, RecorderTermCfg
 from isaaclab.utils.configclass import configclass
@@ -26,8 +25,7 @@ class ObjectVelocityRecorder(RecorderTerm):
         self.object_name = cfg.object_name
 
     def record_post_step(self):
-        # NOTE(alexmillane, 2025-09-30): This assumes the the object is a rigid object.
-        object_linear_velocity = wp.to_torch(self._env.scene[self.object_name].data.root_link_vel_w)[:, :3]
+        object_linear_velocity = self._env.arena_world.get_root_linear_velocity_w(self.object_name)
         assert object_linear_velocity.shape == (self._env.num_envs, 3)
         return self.name, object_linear_velocity
 

--- a/isaaclab_arena/relations/placement_asset.py
+++ b/isaaclab_arena/relations/placement_asset.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import torch
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -15,10 +16,12 @@ from isaaclab_arena.relations.collision_mode import CollisionMode
 from isaaclab_arena.relations.relations import IsAnchor, Relation, RelationBase, RequiresReachability, UnaryRelation
 from isaaclab_arena.utils.bounding_box import quaternion_to_90_deg_z_quarters
 from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
+from isaaclab_arena.utils.velocity import Velocity
 
 if TYPE_CHECKING:
     import trimesh
 
+    from isaaclab.envs import ManagerBasedEnv
     from isaaclab.managers import EventTermCfg
 
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
@@ -129,6 +132,17 @@ class PlaceableAsset(Asset, ABC):
         outside that root override this to emit additional writes.
         """
         return [(self.get_scene_key(), layout_pose)]
+
+    def write_layout_pose_to_sim(self, env: ManagerBasedEnv, env_id: int, layout_pose: Pose) -> None:
+        """Write a solved environment-local pose to this asset's runtime scene entries."""
+        env_ids = torch.tensor([env_id], device=env.device)
+        zero_velocity = Velocity.zero().to_tensor(device=env.device).unsqueeze(0)
+        for scene_name, pose in self.layout_pose_to_scene_writes(layout_pose):
+            scene_asset = env.scene[scene_name]
+            pose_tensor = pose.to_tensor(device=env.device).unsqueeze(0)
+            pose_tensor[0, :3] += env.scene.env_origins[env_id]
+            scene_asset.write_root_pose_to_sim(pose_tensor, env_ids=env_ids)
+            scene_asset.write_root_velocity_to_sim(zero_velocity, env_ids=env_ids)
 
     def has_pose_reset_event(self) -> bool:
         """Return whether the asset owns a root-pose reset event."""

--- a/isaaclab_arena/relations/placement_events.py
+++ b/isaaclab_arena/relations/placement_events.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 from isaaclab_arena.relations.relations import RotateAroundSolution, get_anchor_objects
 from isaaclab_arena.utils.pose import Pose
-from isaaclab_arena.utils.velocity import Velocity
 from isaaclab_arena.utils.yaw import rotate_quat_by_yaw, yaw_from_quat_xyzw
 
 if TYPE_CHECKING:
@@ -120,8 +119,6 @@ def write_layout_to_sim(
         anchor_assets: The set of anchor assets.
         base_rotations: The base rotations for all assets.
     """
-    env_id_tensor = torch.tensor([env_id], device=env.device)
-    zero_velocity = Velocity.zero().to_tensor(device=env.device).unsqueeze(0)
     missing_assets = [
         asset.name for asset in base_rotations if asset not in anchor_assets and asset not in result.positions
     ]
@@ -130,12 +127,7 @@ def write_layout_to_sim(
         if asset in anchor_assets:
             continue
         layout_pose = get_pose_from_layout(asset, result)
-        for scene_name, pose in asset.layout_pose_to_scene_writes(layout_pose):
-            scene_asset = env.scene[scene_name]
-            pose_tensor = pose.to_tensor(device=env.device).unsqueeze(0)
-            pose_tensor[0, :3] += env.scene.env_origins[env_id, :]
-            scene_asset.write_root_pose_to_sim(pose_tensor, env_ids=env_id_tensor)
-            scene_asset.write_root_velocity_to_sim(zero_velocity, env_ids=env_id_tensor)
+        asset.write_layout_pose_to_sim(env, env_id, layout_pose)
 
 
 def solve_and_place_objects(

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -17,6 +17,7 @@ from isaaclab_arena.assets.object import Object
 from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_reference import ObjectReference
 from isaaclab_arena.assets.object_set import RigidObjectSet
+from isaaclab_arena.relations.placement_asset import PlaceableAsset
 from isaaclab_arena.utils.configclass import make_configclass
 from isaaclab_arena.utils.phyx_utils import add_contact_report
 from isaaclab_arena.variations.variation_base import VariationBase
@@ -145,11 +146,11 @@ class Scene:
             asset_name_to_variations[asset.name] = asset.get_variations()
         return asset_name_to_variations
 
-    def get_objects_with_relations(self) -> list[Object | ObjectReference]:
-        """Return scene objects that have at least one relation used in placement optimization."""
-        objects_with_relations: list[Object | ObjectReference] = []
+    def get_objects_with_relations(self) -> list[PlaceableAsset]:
+        """Return placeable assets that have relations used in placement optimization."""
+        objects_with_relations: list[PlaceableAsset] = []
         for asset in self.assets.values():
-            if not isinstance(asset, (Object, ObjectReference)):
+            if not isinstance(asset, PlaceableAsset):
                 continue
             # Those with spatial relations or an anchor, exclude those are only used in validation, e.g. RequiresReachability.
             if asset.get_spatial_relations() or asset.is_anchor:

--- a/isaaclab_arena/scripts/diagnose_deformable_teddy_bear_placement.py
+++ b/isaaclab_arena/scripts/diagnose_deformable_teddy_bear_placement.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reproduce and classify teddy-bear penetration in the DROID deformable environment.
+
+Run inside the Arena development container:
+
+    /isaac-sim/python.sh isaaclab_arena/scripts/diagnose_deformable_teddy_bear_placement.py
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse simulation and diagnostic arguments."""
+    parser = get_isaaclab_arena_cli_parser()
+    parser.set_defaults(num_envs=1, presets="physx", solve_relations=True)
+    parser.add_argument("--diagnostic_steps", type=int, default=120)
+    parser.add_argument("--report_every", type=int, default=10)
+    parser.add_argument("--penetration_tolerance", type=float, default=1.0e-3)
+    args = parser.parse_args()
+    assert args.num_envs == 1, "This diagnostic requires --num_envs 1"
+    assert args.presets in (None, "default", "physx"), "The teddy-bear asset is PhysX-only"
+    assert args.diagnostic_steps >= 0, "--diagnostic_steps must be non-negative"
+    assert args.report_every > 0, "--report_every must be positive"
+    return args
+
+
+def _env_zero_pose(asset):
+    """Return environment zero's solved pose."""
+    from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+    pose = asset.get_initial_pose()
+    if isinstance(pose, PosePerEnv):
+        return pose.poses[0]
+    assert isinstance(pose, Pose), f"Expected a solved Pose or PosePerEnv, got {type(pose).__name__}"
+    return pose
+
+
+def _run_diagnostic(args: argparse.Namespace) -> None:
+    """Build the exact environment and report planned versus simulated clearances."""
+    import torch
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena_environments.droid_deformable_pick_and_place_environment import (
+        DroidDeformablePickAndPlaceEnvironment,
+        DroidDeformablePickAndPlaceEnvironmentCfg,
+    )
+
+    arena_env = DroidDeformablePickAndPlaceEnvironment().build(
+        DroidDeformablePickAndPlaceEnvironmentCfg(
+            pick_object="teddy_bear",
+            embodiment="droid_differential_ik",
+        )
+    )
+    builder = ArenaEnvBuilder(
+        arena_env,
+        ArenaEnvBuilderCfg(
+            num_envs=1,
+            presets="physx",
+            solve_relations=True,
+        ),
+    )
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    env = builder.make_registered(env_cfg, env_kwargs)
+
+    try:
+        env.reset()
+        unwrapped = env.unwrapped
+        bear_description = arena_env.scene.assets["pick_object"]
+        table_description = arena_env.scene.assets["table"]
+        bear = unwrapped.scene["pick_object"]
+
+        bear_bbox = bear_description.get_bounding_box().to(unwrapped.device)
+        table_bbox = table_description.get_bounding_box().to(unwrapped.device)
+        bear_layout_pose = _env_zero_pose(bear_description)
+        table_pose_w = unwrapped.arena_world.get_pose_w("table")[0, :3]
+        table_top_w = table_pose_w[2] + table_bbox.max_point[0, 2]
+        predicted_bear_bottom_w = bear_layout_pose.position_xyz[2] + bear_bbox.min_point[0, 2].item()
+        predicted_clearance = predicted_bear_bottom_w - table_top_w.item()
+
+        print(f"inferred_bear_bbox_min={bear_bbox.min_point[0].tolist()}")
+        print(f"inferred_bear_bbox_max={bear_bbox.max_point[0].tolist()}")
+        print(f"solved_bear_pose={bear_layout_pose}")
+        print(f"table_top_w={table_top_w.item():.6f}")
+        print(f"solver_predicted_bottom_w={predicted_bear_bottom_w:.6f}")
+        print(f"solver_predicted_clearance={predicted_clearance:.6f}")
+
+        minimum_clearance = float("inf")
+        initial_clearance = None
+        initial_offset_error = None
+        sim_dt = unwrapped.sim.get_physics_dt()
+
+        with torch.inference_mode():
+            for step in range(args.diagnostic_steps + 1):
+                nodal_pos_w = bear.data.nodal_pos_w.torch[0]
+                centroid_z = nodal_pos_w[:, 2].mean()
+                nodal_min_z = nodal_pos_w[:, 2].min()
+                actual_clearance = (nodal_min_z - table_top_w).item()
+                nodal_min_from_centroid = (nodal_min_z - centroid_z).item()
+                bbox_min_from_layout_origin = bear_bbox.min_point[0, 2].item()
+                offset_error = nodal_min_from_centroid - bbox_min_from_layout_origin
+                minimum_clearance = min(minimum_clearance, actual_clearance)
+
+                if step == 0:
+                    initial_clearance = actual_clearance
+                    initial_offset_error = offset_error
+                if step == 0 or step == args.diagnostic_steps or step % args.report_every == 0:
+                    print(
+                        f"step={step:04d} centroid_z={centroid_z.item():.6f} "
+                        f"nodal_min_z={nodal_min_z.item():.6f} clearance={actual_clearance:.6f} "
+                        f"nodal_min_from_centroid={nodal_min_from_centroid:.6f} "
+                        f"bbox_min_from_layout_origin={bbox_min_from_layout_origin:.6f}"
+                    )
+
+                if step < args.diagnostic_steps:
+                    unwrapped.scene.write_data_to_sim()
+                    unwrapped.sim.step(render=False)
+                    unwrapped.scene.update(sim_dt)
+
+        assert initial_clearance is not None and initial_offset_error is not None
+        tolerance = args.penetration_tolerance
+        print(f"minimum_clearance={minimum_clearance:.6f}")
+        if predicted_clearance >= -tolerance and initial_clearance < -tolerance:
+            print(
+                "ROOT_CAUSE=placement uses USD-root-relative bounds, but deformable pose writes interpret the "
+                "solved position as a nodal-centroid target"
+            )
+        elif initial_clearance >= -tolerance and minimum_clearance < -tolerance:
+            print("ROOT_CAUSE=the initially valid placement penetrates only after PhysX simulation")
+        elif minimum_clearance < -tolerance:
+            print("ROOT_CAUSE=the relation solver itself planned a penetrating placement")
+        else:
+            print("NOT_REPRODUCED=no table penetration exceeded the configured tolerance")
+    finally:
+        env.close()
+
+
+def main() -> None:
+    """Launch Isaac Sim and run the placement diagnostic."""
+    args = _parse_args()
+    with SimulationAppContext(args):
+        _run_diagnostic(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/isaaclab_arena/tasks/pick_and_place_task.py
+++ b/isaaclab_arena/tasks/pick_and_place_task.py
@@ -16,6 +16,7 @@ from isaaclab.managers import SceneEntityCfg, TerminationTermCfg
 from isaaclab.utils.configclass import configclass
 
 from isaaclab_arena.assets.asset import Asset
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.register import agent_ready, register_task
 from isaaclab_arena.assets.registries import ObjectRelationLibraryRegistry
 from isaaclab_arena.embodiments.common.arm_mode import ArmMode
@@ -37,11 +38,11 @@ from isaaclab_arena.utils.configclass import make_configclass
 class PickAndPlaceTask(TaskBase):
     """Pick an object up and place it on or in a destination.
 
-    Success requires the object's bounds center over the destination footprint, upward support
-    force, and low linear speed. Failure occurs when the object falls below the background.
+    Success requires the object's bounds center over the destination footprint and low linear speed.
+    Rigid object pairs must also have upward support force. Failure occurs when the object falls below the background.
 
     Args:
-        pick_up_object: Rigid object or rigid object set to pick up.
+        pick_up_object: Object or rigid object set to pick up.
         destination_location: Destination whose live pose and spawned geometry define placement.
             It must be included in the environment scene.
         background_scene: Background whose minimum object height defines the drop failure.
@@ -74,7 +75,11 @@ class PickAndPlaceTask(TaskBase):
         self.destination_object = destination_object
         self.background_scene = background_scene
         self.destination_location = destination_location
-        self.contact_sensor_name = f"contact_sensor_{pick_up_object.name}"
+        self._uses_deformable = (
+            pick_up_object.object_type == ObjectType.DEFORMABLE
+            or destination_location.object_type == ObjectType.DEFORMABLE
+        )
+        self.contact_sensor_name = None if self._uses_deformable else f"contact_sensor_{pick_up_object.name}"
         self.scene_config = self.make_scene_cfg()
         self.force_threshold = force_threshold
         assert velocity_threshold >= 0.0, f"velocity_threshold must be non-negative, got {velocity_threshold}"
@@ -97,6 +102,9 @@ class PickAndPlaceTask(TaskBase):
         self._apply_reachability_constraints([self.pick_up_object, self.destination_location])
 
     def make_scene_cfg(self):
+        if self._uses_deformable:
+            return None
+        assert self.contact_sensor_name is not None
         contact_sensor_cfg = self.pick_up_object.get_contact_sensor_cfg(
             contact_against_object=self.destination_location,
         )
@@ -113,12 +121,13 @@ class PickAndPlaceTask(TaskBase):
         return self.termination_cfg
 
     def make_termination_cfg(self):
+        contact_sensor_cfg = None if self.contact_sensor_name is None else SceneEntityCfg(self.contact_sensor_name)
         success = TerminationTermCfg(
             func=object_on_destination,
             params={
                 "object_cfg": SceneEntityCfg(self.pick_up_object.name),
                 "destination_cfg": SceneEntityCfg(self.destination_location.name),
-                "contact_sensor_cfg": SceneEntityCfg(self.contact_sensor_name),
+                "contact_sensor_cfg": contact_sensor_cfg,
                 "force_threshold": self.force_threshold,
                 "velocity_threshold": self.velocity_threshold,
                 "support_cone_half_angle_rad": self.support_cone_half_angle_rad,
@@ -158,6 +167,7 @@ class PickAndPlaceTask(TaskBase):
         return [SuccessRateMetric(), ObjectMovedRateMetric(self.pick_up_object)]
 
     def get_progress_objectives(self) -> list[ProgressObjective]:
+        contact_sensor_cfg = None if self.contact_sensor_name is None else SceneEntityCfg(self.contact_sensor_name)
         return [
             ProgressObjective(
                 name="pick_and_place",
@@ -175,7 +185,7 @@ class PickAndPlaceTask(TaskBase):
                         object_on_destination,
                         object_cfg=SceneEntityCfg(self.pick_up_object.name),
                         destination_cfg=SceneEntityCfg(self.destination_location.name),
-                        contact_sensor_cfg=SceneEntityCfg(self.contact_sensor_name),
+                        contact_sensor_cfg=contact_sensor_cfg,
                         force_threshold=self.force_threshold,
                         velocity_threshold=self.velocity_threshold,
                         support_cone_half_angle_rad=self.support_cone_half_angle_rad,

--- a/isaaclab_arena/tasks/predicates/object_settling.py
+++ b/isaaclab_arena/tasks/predicates/object_settling.py
@@ -17,8 +17,8 @@ import torch
 
 from isaaclab_arena.tasks.predicates.predicate_utils import (
     get_env,
+    get_max_point_speed_w,
     get_root_ang_vel_w,
-    get_root_lin_vel_w,
     get_root_pos_w,
     select,
 )
@@ -102,15 +102,14 @@ def objects_settled(
 ) -> torch.Tensor:
     """True per env when every object in the env is at rest, records each object's rest pose on first settle.
 
-    An object is at rest when both its linear speed (m/s) and its angular speed (rad/s) are below the
-    respective thresholds. The recorded rest poses are readable via ``get_object_initial_rest_state``.
+    Rigid objects use root linear and angular speed. Deformable objects use maximum nodal speed and
+    have no angular-speed condition. Recorded rest poses are readable via ``get_object_initial_rest_state``.
     """
 
-    lin_speeds = torch.stack(
-        [torch.linalg.vector_norm(get_root_lin_vel_w(env, name), dim=-1) for name in object_names], dim=0
-    )
+    lin_speeds = torch.stack([get_max_point_speed_w(env, name) for name in object_names], dim=0)
     ang_speeds = torch.stack(
-        [torch.linalg.vector_norm(get_root_ang_vel_w(env, name), dim=-1) for name in object_names], dim=0
+        [torch.linalg.vector_norm(get_root_ang_vel_w(env, name, required=False), dim=-1) for name in object_names],
+        dim=0,
     )
     settled = torch.all((lin_speeds < lin_vel_threshold) & (ang_speeds < ang_vel_threshold), dim=0)
 

--- a/isaaclab_arena/tasks/predicates/predicate_utils.py
+++ b/isaaclab_arena/tasks/predicates/predicate_utils.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import torch
 
-import warp as wp
 from isaaclab.assets import RigidObject
 
 
@@ -26,18 +25,31 @@ def get_rigid_object(env, name: str) -> RigidObject:
 
 
 def get_root_pos_w(env, name: str) -> torch.Tensor:
-    """Get the root position of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_pos_w)
+    """Get the aggregate object position in the world frame."""
+    return get_env(env).arena_world.get_pose_w(name)[:, :3]
 
 
 def get_root_lin_vel_w(env, name: str) -> torch.Tensor:
-    """Get the root linear velocity of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_lin_vel_w)
+    """Get the aggregate object linear velocity in the world frame."""
+    return get_env(env).arena_world.get_root_linear_velocity_w(name)
 
 
-def get_root_ang_vel_w(env, name: str) -> torch.Tensor:
-    """Get the root angular velocity of a rigid object in the world frame."""
-    return wp.to_torch(get_rigid_object(env, name).data.root_ang_vel_w)
+def get_root_ang_vel_w(env, name: str, required: bool = True) -> torch.Tensor:
+    """Get root angular velocity, optionally returning zero for a deformable object."""
+    unwrapped_env = get_env(env)
+    if name in unwrapped_env.scene.deformable_objects:
+        assert not required, f"Deformable object {name!r} has no aggregate angular velocity"
+        return torch.zeros_like(unwrapped_env.arena_world.get_root_linear_velocity_w(name))
+    return get_rigid_object(unwrapped_env, name).data.root_ang_vel_w.torch
+
+
+def get_max_point_speed_w(env, name: str) -> torch.Tensor:
+    """Get maximum nodal speed for a deformable, or root speed for a rigid object."""
+    unwrapped_env = get_env(env)
+    if name in unwrapped_env.scene.deformable_objects:
+        nodal_velocity_w = unwrapped_env.scene.deformable_objects[name].data.nodal_vel_w.torch
+        return torch.linalg.vector_norm(nodal_velocity_w, dim=-1).amax(dim=1)
+    return torch.linalg.vector_norm(get_root_lin_vel_w(unwrapped_env, name), dim=-1)
 
 
 def select(result: torch.Tensor, env_id: int | None) -> torch.Tensor:

--- a/isaaclab_arena/tasks/predicates/spatial.py
+++ b/isaaclab_arena/tasks/predicates/spatial.py
@@ -196,7 +196,7 @@ def object_on_destination(
     env: IsaacLabArenaManagerBasedRLEnv,
     object_cfg: SceneEntityCfg,
     destination_cfg: SceneEntityCfg,
-    contact_sensor_cfg: SceneEntityCfg,
+    contact_sensor_cfg: SceneEntityCfg | None,
     force_threshold: float,
     velocity_threshold: float,
     support_cone_half_angle_rad: float = math.pi / 4,
@@ -204,14 +204,14 @@ def object_on_destination(
     """Check whether an object is stably placed on its destination.
 
     The object's spawned-bounds center must be over the destination footprint
-    and above its bottom. The destination must exert an upward support force,
-    and the object's linear speed must be below the configured threshold.
+    and above its bottom, and the object's linear speed must be below the configured threshold.
+    Rigid object pairs must also have upward support force.
 
     Args:
         env: The wrapped or unwrapped manager-based environment.
-        object_cfg: The rigid object being placed.
-        destination_cfg: The rigid object or scene entry receiving the object.
-        contact_sensor_cfg: The object's contact sensor filtered to the destination.
+        object_cfg: The object being placed.
+        destination_cfg: The object or scene entry receiving the object.
+        contact_sensor_cfg: The object's contact sensor filtered to the destination, or None for deformables.
         force_threshold: Minimum upward support force in newtons.
         velocity_threshold: Maximum object linear speed in meters per second.
         support_cone_half_angle_rad: Maximum angle in radians from world ``+Z`` for the support force.
@@ -231,21 +231,27 @@ def object_on_destination(
         destination_bounds_D=arena_world.get_aabb_in_local_frame(destination_cfg.name),
     )
 
-    contact_sensor: ContactSensor = unwrapped_env.scene[contact_sensor_cfg.name]
-    force_matrix_w = contact_sensor.data.force_matrix_w
-    assert force_matrix_w is not None, f"Contact sensor '{contact_sensor_cfg.name}' has no filtered force matrix."
-    force_matrix_w = force_matrix_w.torch
-    assert force_matrix_w.shape == (unwrapped_env.num_envs, 1, 1, 3), (
-        f"Contact sensor '{contact_sensor_cfg.name}' must provide one sensed body and one filtered body; "
-        f"got force shape {tuple(force_matrix_w.shape)}."
-    )
-    # The two zeros select the sensor's single sensed body and single filtered destination body.
-    support_force_on_object_w = force_matrix_w[:, 0, 0, :]
-    destination_provides_upward_support = contact_force_is_upward_support(
-        contact_force_w=support_force_on_object_w,
-        force_threshold=force_threshold,
-        support_cone_half_angle_rad=support_cone_half_angle_rad,
-    )
+    deformable_objects = unwrapped_env.scene.deformable_objects
+    uses_deformable = object_cfg.name in deformable_objects or destination_cfg.name in deformable_objects
+    if uses_deformable:
+        destination_provides_upward_support = torch.ones_like(object_center_over_destination)
+    else:
+        assert contact_sensor_cfg is not None, "Rigid object placement requires a contact sensor"
+        contact_sensor: ContactSensor = unwrapped_env.scene[contact_sensor_cfg.name]
+        force_matrix_w = contact_sensor.data.force_matrix_w
+        assert force_matrix_w is not None, f"Contact sensor '{contact_sensor_cfg.name}' has no filtered force matrix."
+        force_matrix_w = force_matrix_w.torch
+        assert force_matrix_w.shape == (unwrapped_env.num_envs, 1, 1, 3), (
+            f"Contact sensor '{contact_sensor_cfg.name}' must provide one sensed body and one filtered body; "
+            f"got force shape {tuple(force_matrix_w.shape)}."
+        )
+        # The two zeros select the sensor's single sensed body and single filtered destination body.
+        support_force_on_object_w = force_matrix_w[:, 0, 0, :]
+        destination_provides_upward_support = contact_force_is_upward_support(
+            contact_force_w=support_force_on_object_w,
+            force_threshold=force_threshold,
+            support_cone_half_angle_rad=support_cone_half_angle_rad,
+        )
 
     object_root_linear_velocity_w = arena_world.get_root_linear_velocity_w(object_cfg.name)
     object_moves_slowly = object_is_moving_slowly(object_root_linear_velocity_w, velocity_threshold)

--- a/isaaclab_arena/terms/events.py
+++ b/isaaclab_arena/terms/events.py
@@ -11,11 +11,85 @@ import warp as wp
 from isaaclab.assets import ArticulationCfg, RigidObjectCfg
 from isaaclab.envs import ManagerBasedEnv
 from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
+from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+from isaaclab.utils import math as math_utils
 
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.usd_prim_tree import exclude_referenced_physics_roots, find_nested_physics_roots
 from isaaclab_arena.utils.velocity import Velocity
+
+
+def _deformable_nodal_state_for_pose(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose: Pose,
+    velocity: Velocity | None = None,
+) -> torch.Tensor:
+    """Transform an asset's default nodal state to an environment-local pose."""
+    asset = env.scene[asset_cfg.name]
+    nodal_state = asset.data.default_nodal_state_w.torch[env_ids].clone()
+    default_pos_w = nodal_state[..., :3]
+    default_centroid_w = default_pos_w.mean(dim=1)
+
+    target_root_pos_w = torch.tensor(pose.position_xyz, device=env.device).repeat(len(env_ids), 1)
+    target_root_pos_w += env.scene.env_origins[env_ids]
+    target_quat = torch.tensor(pose.rotation_xyzw, device=env.device).repeat(len(env_ids), 1)
+    default_quat = torch.tensor(asset.cfg.init_state.rot, device=env.device).repeat(len(env_ids), 1)
+    delta_quat = math_utils.quat_mul(target_quat, math_utils.quat_inv(default_quat))
+    if isinstance(asset.cfg.spawn, UsdFileCfg):
+        default_root_pos_w = torch.tensor(asset.cfg.init_state.pos, device=env.device).repeat(len(env_ids), 1)
+        default_root_pos_w += env.scene.env_origins[env_ids]
+        root_to_centroid_w = default_centroid_w - default_root_pos_w
+        target_centroid_w = target_root_pos_w + math_utils.quat_apply(delta_quat, root_to_centroid_w)
+    else:
+        target_centroid_w = target_root_pos_w
+    nodal_state[..., :3] = asset.transform_nodal_pos(
+        default_pos_w,
+        target_centroid_w - default_centroid_w,
+        delta_quat,
+    )
+    if velocity is None:
+        nodal_state[..., 3:] = 0.0
+    else:
+        nodal_state[..., 3:] = torch.tensor(velocity.linear_xyz, device=env.device)
+    return nodal_state
+
+
+def set_deformable_object_pose(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose: Pose,
+    velocity: Velocity | None = None,
+) -> None:
+    """Restore a deformable by transforming its default nodal state."""
+    if env_ids is None:
+        return
+    asset = env.scene[asset_cfg.name]
+    nodal_state = _deformable_nodal_state_for_pose(env, env_ids, asset_cfg, pose, velocity)
+    asset.write_nodal_state_to_sim_index(nodal_state, env_ids=env_ids)
+    asset.reset(env_ids=env_ids)
+
+
+def set_deformable_object_pose_per_env(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    asset_cfg: SceneEntityCfg,
+    pose_list: list[Pose],
+) -> None:
+    """Restore selected deformable instances from absolute environment-indexed poses."""
+    if env_ids is None:
+        return
+    assert env_ids.ndim == 1, "env_ids must be one-dimensional"
+    assert len(pose_list) == env.scene.env_origins.shape[0], "pose_list must contain one pose per environment"
+    asset = env.scene[asset_cfg.name]
+    for current_env in env_ids.tolist():
+        current_env_ids = torch.tensor([current_env], device=env.device)
+        nodal_state = _deformable_nodal_state_for_pose(env, current_env_ids, asset_cfg, pose_list[current_env])
+        asset.write_nodal_state_to_sim_index(nodal_state, env_ids=current_env_ids)
+    asset.reset(env_ids=env_ids)
 
 
 @dataclass(frozen=True)
@@ -155,7 +229,7 @@ class ResetBackgroundPhysics(ManagerTermBase):
                             joint_position=asset.data.joint_pos.torch[0].clone(),
                         )
                     )
-                else:
+                elif object_type == ObjectType.RIGID:
                     asset_cfg = RigidObjectCfg(prim_path=prim_path)
                     asset = self._initialize_asset(asset_cfg, prim_path, "rigid body")
                     if asset is None:
@@ -166,6 +240,8 @@ class ResetBackgroundPhysics(ManagerTermBase):
                             root_pose_local=self._env_local_root_pose(asset, env),
                         )
                     )
+                else:
+                    raise ValueError(f"Unsupported nested background physics type: {object_type}")
         self._is_initialized = True
 
     @staticmethod

--- a/isaaclab_arena/tests/test_arena_world_scene_access.py
+++ b/isaaclab_arena/tests/test_arena_world_scene_access.py
@@ -124,6 +124,44 @@ def _check_rigid_object_reads_and_local_aabb_cache(
     assert geometry_build_calls == ["object", "destination"]
 
 
+def _check_deformable_object_reads(arena_world_module) -> None:
+    """Check live aggregate position and velocity reads for a deformable object."""
+
+    class RuntimeBufferDouble:
+        def __init__(self, tensor: torch.Tensor):
+            self.torch = tensor
+
+    root_pos_w = torch.tensor([[0.1, 0.2, 0.3], [1.1, 1.2, 1.3]])
+    root_vel_w = torch.tensor([[0.0, 0.1, 0.2], [0.3, 0.4, 0.5]])
+    deformable = SimpleNamespace(
+        data=SimpleNamespace(
+            root_pos_w=RuntimeBufferDouble(root_pos_w),
+            root_vel_w=RuntimeBufferDouble(root_vel_w),
+        )
+    )
+    scene = SimpleNamespace(
+        num_envs=2,
+        rigid_objects={},
+        deformable_objects={"deformable": deformable},
+        extras={},
+    )
+    arena_world = arena_world_module.ArenaWorld(scene)
+
+    expected_pose_w = torch.cat(
+        (root_pos_w, torch.tensor([0.0, 0.0, 0.0, 1.0]).expand(scene.num_envs, 4)),
+        dim=-1,
+    )
+    torch.testing.assert_close(arena_world.get_pose_w("deformable"), expected_pose_w)
+    torch.testing.assert_close(arena_world.get_root_linear_velocity_w("deformable"), root_vel_w)
+
+    changed_root_pos_w = root_pos_w + 1.0
+    changed_root_vel_w = root_vel_w - 0.5
+    deformable.data.root_pos_w.torch = changed_root_pos_w
+    deformable.data.root_vel_w.torch = changed_root_vel_w
+    torch.testing.assert_close(arena_world.get_pose_w("deformable")[:, :3], changed_root_pos_w)
+    torch.testing.assert_close(arena_world.get_root_linear_velocity_w("deformable"), changed_root_vel_w)
+
+
 def _check_arena_world_reuses_scene_extra_pose_reader(
     arena_world_module,
     scene_access_module,
@@ -174,8 +212,8 @@ def _check_arena_world_rejects_unsupported_pose_scene_key(arena_world_module) ->
     except AssertionError as error:
         assert (
             str(error)
-            == "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects or "
-            "InteractiveScene.extras; 'robot' is registered in neither."
+            == "ArenaWorld pose queries require a scene key registered in InteractiveScene.rigid_objects, "
+            "InteractiveScene.deformable_objects, or InteractiveScene.extras; 'robot' is registered in none."
         )
     else:
         raise AssertionError("ArenaWorld accepted an unsupported pose scene key.")
@@ -249,6 +287,7 @@ def _test_arena_world_scene_access(_simulation_app) -> bool:
         scene_access,
         AxisAlignedBoundingBox,
     )
+    _check_deformable_object_reads(arena_world)
     _check_arena_world_reuses_scene_extra_pose_reader(arena_world, scene_access)
     _check_arena_world_rejects_unsupported_pose_scene_key(arena_world)
     _check_scene_extra_pose_reader_uses_current_frame_view_poses(scene_access)

--- a/isaaclab_arena/tests/test_deformable_object.py
+++ b/isaaclab_arena/tests/test_deformable_object.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration and backend smoke tests for deformables."""
+
+import importlib.util
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+HEADLESS = True
+PYTETWILD_AVAILABLE = importlib.util.find_spec("pytetwild") is not None
+
+
+def _make_soft_cube(physics_preset, initial_pose=None):
+    import isaaclab.sim as sim_utils
+    from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+    from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
+    from isaaclab_physx.sim.schemas import PhysxCollisionCfg, PhysxDeformableBodyPropertiesCfg
+    from isaaclab_physx.sim.spawners.materials import PhysxDeformableBodyMaterialCfg
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+
+    if physics_preset == "physx":
+        deformable_props = PhysxDeformableBodyPropertiesCfg()
+        collision_props = [PhysxCollisionCfg(rest_offset=0.0025, contact_offset=0.01)]
+        physics_material = PhysxDeformableBodyMaterialCfg(
+            youngs_modulus=8.0e4,
+            poissons_ratio=0.4,
+            density=300.0,
+        )
+    else:
+        deformable_props = NewtonDeformableBodyPropertiesCfg()
+        collision_props = None
+        physics_material = NewtonDeformableBodyMaterialCfg(
+            k_mu=8.0e4 / (2.0 * (1.0 + 0.4)),
+            k_lambda=8.0e4 * 0.4 / ((1.0 + 0.4) * (1.0 - 2.0 * 0.4)),
+            density=300.0,
+            particle_radius=0.01,
+        )
+    return DeformableObject(
+        name="soft_cube",
+        spawner_cfg=sim_utils.MeshCuboidCfg(
+            size=(0.1, 0.1, 0.1),
+            deformable_props=deformable_props,
+            collision_props=collision_props,
+            physics_material=physics_material,
+        ),
+        initial_pose=initial_pose,
+    )
+
+
+def _test_backend_specific_deformable_config(simulation_app) -> bool:
+    import isaaclab.sim as sim_utils
+    from isaaclab.assets import DeformableObjectCfg
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+    from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+    from isaaclab_newton.sim.spawners.materials import NewtonDeformableBodyMaterialCfg
+    from isaaclab_physx.sim.schemas import PhysxDeformableBodyPropertiesCfg
+    from isaaclab_physx.sim.spawners.materials import (
+        PhysxDeformableBodyMaterialCfg,
+        PhysxSurfaceDeformableBodyMaterialCfg,
+    )
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+    from isaaclab_arena.assets.deformable_object_library import DeformableCube, DeformableSurface, DeformableTeddyBear
+    from isaaclab_arena.assets.object import Object
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.relations.relations import IsAnchor
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.pose import Pose, PoseRange
+
+    pose = Pose(position_xyz=(0.1, -0.2, 0.3), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
+    soft_cube = _make_soft_cube("physx", initial_pose=pose)
+    cfg_name, physx_cfg = soft_cube.get_object_cfg()
+
+    assert cfg_name == soft_cube.name
+    assert isinstance(physx_cfg, DeformableObjectCfg)
+    assert isinstance(physx_cfg.spawn.deformable_props, PhysxDeformableBodyPropertiesCfg)
+    assert isinstance(physx_cfg.spawn.physics_material, PhysxDeformableBodyMaterialCfg)
+    assert physx_cfg.spawn.physics_material.youngs_modulus == pytest.approx(8.0e4)
+    assert physx_cfg.spawn.physics_material.poissons_ratio == pytest.approx(0.4)
+    assert physx_cfg.spawn.physics_material.density == pytest.approx(300.0)
+    assert physx_cfg.init_state.pos == pose.position_xyz
+    assert physx_cfg.init_state.rot == pose.rotation_xyzw
+    assert soft_cube.object_type is ObjectType.DEFORMABLE
+    assert soft_cube.get_object_cfg()[1] is physx_cfg
+    assert soft_cube.get_event_cfg()[1] is not None
+    assert not hasattr(soft_cube, "reset_pose")
+    assert not hasattr(soft_cube, "disable_reset_pose")
+    assert not hasattr(soft_cube, "enable_reset_pose")
+
+    newton_cube = _make_soft_cube("newton", initial_pose=pose)
+    _, newton_cfg = newton_cube.get_object_cfg()
+    assert isinstance(newton_cfg.spawn.deformable_props, NewtonDeformableBodyPropertiesCfg)
+    assert isinstance(newton_cfg.spawn.physics_material, NewtonDeformableBodyMaterialCfg)
+    expected_mu = 8.0e4 / (2.0 * (1.0 + 0.4))
+    expected_lambda = 8.0e4 * 0.4 / ((1.0 + 0.4) * (1.0 - 2.0 * 0.4))
+    assert newton_cfg.spawn.physics_material.k_mu == pytest.approx(expected_mu)
+    assert newton_cfg.spawn.physics_material.k_lambda == pytest.approx(expected_lambda)
+    assert newton_cfg.spawn.physics_material.density == pytest.approx(300.0)
+    assert newton_cube.get_object_cfg()[1] is newton_cfg
+
+    with pytest.raises(AssertionError, match="backend-specific deformable_props"):
+        DeformableObject(
+            name="authored_soft_body",
+            spawner_cfg=UsdFileCfg(usd_path="/tmp/authored_soft_body.usd"),
+        )
+
+    for asset_type, asset_name, material_type in (
+        (DeformableCube, "deformable_cube", PhysxDeformableBodyMaterialCfg),
+        (DeformableSurface, "deformable_surface", PhysxSurfaceDeformableBodyMaterialCfg),
+        (DeformableTeddyBear, "deformable_teddy_bear", PhysxDeformableBodyMaterialCfg),
+    ):
+        library_object = asset_type()
+        assert AssetRegistry().get_asset_by_name(asset_name) is asset_type
+        assert library_object.physics_preset == "physx"
+        assert isinstance(library_object.spawner_cfg.deformable_props, PhysxDeformableBodyPropertiesCfg)
+        assert isinstance(library_object.spawner_cfg.physics_material, material_type)
+
+    library_cube = DeformableCube()
+    assert library_cube.spawner_cfg.size == (0.15, 0.04, 0.04)
+    assert library_cube.spawner_cfg.collision_props[0].rest_offset == 0.0
+    assert library_cube.spawner_cfg.collision_props[0].contact_offset == pytest.approx(0.0025)
+    assert library_cube.spawner_cfg.deformable_props.linear_damping == 0.0
+    assert library_cube.spawner_cfg.physics_material.youngs_modulus == pytest.approx(8.0e4)
+    assert library_cube.spawner_cfg.physics_material.poissons_ratio == pytest.approx(0.25)
+    assert library_cube.spawner_cfg.physics_material.density == pytest.approx(300.0)
+    assert library_cube.spawner_cfg.visual_material.diffuse_color == (0.95, 0.85, 0.1)
+    assert library_cube.get_bounding_box().size[0].tolist() == pytest.approx([0.15, 0.04, 0.04])
+
+    library_surface = DeformableSurface()
+    assert library_surface.spawner_cfg.size == (0.2, 0.2)
+    assert library_surface.spawner_cfg.resolution == (30, 30)
+    assert library_surface.spawner_cfg.visual_material.diffuse_color == (0.95, 0.85, 0.1)
+    assert library_surface.get_bounding_box().min_point[0].tolist() == pytest.approx([-0.1, -0.1, 0.0])
+    assert library_surface.get_bounding_box().max_point[0].tolist() == pytest.approx([0.1, 0.1, 0.0])
+
+    library_teddy_bear = DeformableTeddyBear()
+    assert library_teddy_bear._bounding_box is None
+    teddy_bear_bbox = library_teddy_bear.get_bounding_box()
+    assert library_teddy_bear._bounding_box is teddy_bear_bbox
+    assert (teddy_bear_bbox.size[0] > 0.0).all()
+    assert (teddy_bear_bbox.size[0] < 1.0).all()
+
+    updated_pose = Pose(position_xyz=(0.4, 0.0, 0.5))
+    soft_cube.set_initial_pose(updated_pose)
+    assert soft_cube.get_object_cfg()[1] is physx_cfg
+    assert physx_cfg.init_state.pos == updated_pose.position_xyz
+    with pytest.raises(AssertionError, match="fixed Pose or PosePerEnv"):
+        soft_cube.set_initial_pose(PoseRange())
+
+    soft_cube.add_relation(IsAnchor())
+    scene = Scene(assets=[soft_cube])
+    assert scene.get_objects_with_relations() == [soft_cube]
+
+    rigid = Object(
+        name="rigid",
+        object_type=ObjectType.RIGID,
+        spawner_cfg=sim_utils.MeshCuboidCfg(size=(0.1, 0.1, 0.1)),
+    )
+    with pytest.raises(NotImplementedError, match="does not support contact sensors"):
+        soft_cube.get_contact_sensor_cfg(rigid)
+    with pytest.raises(AssertionError, match="against deformable objects"):
+        rigid.get_contact_sensor_cfg(soft_cube)
+    return True
+
+
+def _test_builder_validates_deformable_preset(simulation_app) -> bool:
+    from isaaclab_newton.sim.schemas import NewtonDeformableBodyPropertiesCfg
+    from isaaclab_physx.sim.schemas import PhysxDeformableBodyPropertiesCfg
+
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+
+    for preset, properties_type in (
+        ("physx", PhysxDeformableBodyPropertiesCfg),
+        ("newton", NewtonDeformableBodyPropertiesCfg),
+    ):
+        soft_cube = _make_soft_cube(preset)
+        arena_env = IsaacLabArenaEnvironment(
+            name=f"{preset}_deformable_config",
+            scene=Scene(assets=[soft_cube]),
+        )
+        builder = ArenaEnvBuilder(
+            arena_env,
+            ArenaEnvBuilderCfg(num_envs=1, presets=preset, solve_relations=False),
+        )
+        env_cfg, _ = builder.compose_manager_cfg()
+        assert isinstance(env_cfg.scene.soft_cube.spawn.deformable_props, properties_type)
+
+    mismatched_builder = ArenaEnvBuilder(
+        IsaacLabArenaEnvironment(
+            name="mismatched_deformable_config",
+            scene=Scene(assets=[_make_soft_cube("physx")]),
+        ),
+        ArenaEnvBuilderCfg(num_envs=1, presets="newton", solve_relations=False),
+    )
+    with pytest.raises(ValueError, match="configured for 'physx'.*selected preset 'newton'"):
+        mismatched_builder.compose_manager_cfg()
+    return True
+
+
+def _test_deformable_nodal_reset_terms(simulation_app) -> bool:
+    import torch
+    from types import SimpleNamespace
+
+    from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
+    from isaaclab.utils import math as math_utils
+
+    from isaaclab_arena.terms.events import set_deformable_object_pose, set_deformable_object_pose_per_env
+    from isaaclab_arena.utils.pose import Pose
+    from isaaclab_arena.utils.velocity import Velocity
+
+    class FakeAsset:
+        def __init__(self, usd_backed: bool = False):
+            default_state = torch.zeros((2, 2, 6))
+            default_state[0, :, :3] = torch.tensor([[-0.05, 0.0, 0.5], [0.05, 0.0, 0.5]])
+            default_state[1, :, :3] = torch.tensor([[9.95, 0.0, 0.5], [10.05, 0.0, 0.5]])
+            self.data = SimpleNamespace(default_nodal_state_w=SimpleNamespace(torch=default_state))
+            spawn = UsdFileCfg(usd_path="/tmp/fake.usd") if usd_backed else SimpleNamespace()
+            self.cfg = SimpleNamespace(
+                init_state=SimpleNamespace(pos=(0.0, 0.0, 0.0), rot=(0.0, 0.0, 0.0, 1.0)),
+                spawn=spawn,
+            )
+            self.written_state = default_state.clone()
+            self.reset_env_ids = None
+
+        def write_nodal_state_to_sim_index(self, nodal_state, env_ids):
+            self.written_state[env_ids] = nodal_state
+
+        def transform_nodal_pos(self, nodal_pos, pos, quat):
+            mean_nodal_pos = nodal_pos.mean(dim=1, keepdim=True)
+            return math_utils.transform_points(nodal_pos - mean_nodal_pos, pos, quat) + mean_nodal_pos
+
+        def reset(self, env_ids):
+            self.reset_env_ids = env_ids.clone()
+
+    class FakeScene(dict):
+        def __init__(self, asset):
+            super().__init__(soft_cube=asset)
+            self.env_origins = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+
+    asset = FakeAsset()
+    env = SimpleNamespace(scene=FakeScene(asset), device=torch.device("cpu"))
+    asset_cfg = SimpleNamespace(name="soft_cube")
+    env_ids = torch.tensor([0, 1])
+
+    fixed_pose = Pose(position_xyz=(1.0, 2.0, 3.0))
+    set_deformable_object_pose(
+        env,
+        env_ids,
+        asset_cfg,
+        fixed_pose,
+        Velocity(linear_xyz=(0.1, 0.2, 0.3)),
+    )
+    torch.testing.assert_close(
+        asset.written_state[..., :3].mean(dim=1),
+        torch.tensor([[1.0, 2.0, 3.0], [11.0, 2.0, 3.0]]),
+    )
+    torch.testing.assert_close(asset.written_state[..., 3:], torch.tensor([0.1, 0.2, 0.3]).expand(2, 2, 3))
+
+    poses = [Pose(position_xyz=(0.0, 1.0, 2.0)), Pose(position_xyz=(3.0, 4.0, 5.0))]
+    set_deformable_object_pose_per_env(env, env_ids, asset_cfg, poses)
+    torch.testing.assert_close(
+        asset.written_state[..., :3].mean(dim=1),
+        torch.tensor([[0.0, 1.0, 2.0], [13.0, 4.0, 5.0]]),
+    )
+    torch.testing.assert_close(asset.written_state[..., 3:], torch.zeros((2, 2, 3)))
+    torch.testing.assert_close(asset.reset_env_ids, env_ids)
+
+    usd_asset = FakeAsset(usd_backed=True)
+    usd_env = SimpleNamespace(scene=FakeScene(usd_asset), device=torch.device("cpu"))
+    set_deformable_object_pose(usd_env, env_ids, asset_cfg, fixed_pose)
+    torch.testing.assert_close(
+        usd_asset.written_state[..., :3].mean(dim=1),
+        torch.tensor([[1.0, 2.0, 3.5], [11.0, 2.0, 3.5]]),
+    )
+    return True
+
+
+def _test_deformable_reset_and_initial_pose(simulation_app) -> bool:
+    import torch
+
+    from isaaclab.assets import DeformableObjectCfg
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.utils.pose import Pose, PosePerEnv
+
+    poses = PosePerEnv(
+        poses=[
+            Pose(position_xyz=(0.0, 0.0, 0.5), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+            Pose(position_xyz=(0.2, 0.0, 0.6), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)),
+        ]
+    )
+    physics_preset = "physx"
+    soft_cube = AssetRegistry().get_asset_by_name("deformable_cube")(instance_name="soft_cube")
+    soft_cube.set_initial_pose(poses)
+    arena_env = IsaacLabArenaEnvironment(
+        name=f"{physics_preset}_deformable_reset_and_initial_pose",
+        scene=Scene(assets=[soft_cube]),
+    )
+    builder = ArenaEnvBuilder(
+        arena_env,
+        ArenaEnvBuilderCfg(num_envs=2, presets=physics_preset, solve_relations=False),
+    )
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    assert isinstance(env_cfg.scene.soft_cube, DeformableObjectCfg)
+    env = builder.make_registered(env_cfg, env_kwargs)
+    env.reset()
+
+    try:
+        deformable_asset = env.unwrapped.scene[soft_cube.name]
+        initial_nodal_state = deformable_asset.data.nodal_state_w.torch.clone()
+        assert torch.isfinite(initial_nodal_state).all()
+        expected = torch.tensor([pose.position_xyz for pose in poses.poses], device=env.unwrapped.device)
+        aggregate_positions = deformable_asset.data.root_pos_w.torch - env.unwrapped.scene.env_origins
+        torch.testing.assert_close(aggregate_positions, expected, atol=2.0e-3, rtol=0.0)
+
+        displaced = initial_nodal_state.clone()
+        displaced[..., 0] += 0.25
+        displaced[..., 1] += torch.linspace(
+            0.0,
+            0.05,
+            displaced.shape[1],
+            device=displaced.device,
+        )
+        displaced[..., 3:] = 0.5
+        deformable_asset.write_nodal_state_to_sim_index(displaced)
+        env.reset()
+        restored_nodal_state = deformable_asset.data.nodal_state_w.torch.clone()
+        torch.testing.assert_close(restored_nodal_state, initial_nodal_state)
+    finally:
+        env.close()
+    return True
+
+
+def test_backend_specific_deformable_config():
+    assert run_function_with_persistent_simulation_app(_test_backend_specific_deformable_config, headless=HEADLESS)
+
+
+def test_builder_validates_deformable_preset():
+    assert run_function_with_persistent_simulation_app(_test_builder_validates_deformable_preset, headless=HEADLESS)
+
+
+def test_deformable_nodal_reset_terms():
+    assert run_function_with_persistent_simulation_app(_test_deformable_nodal_reset_terms, headless=HEADLESS)
+
+
+@pytest.mark.skipif(not PYTETWILD_AVAILABLE, reason="requires Isaac Lab's optional tetrahedralization dependencies")
+def test_deformable_reset_and_initial_pose():
+    assert run_function_with_persistent_simulation_app(
+        _test_deformable_reset_and_initial_pose,
+        headless=HEADLESS,
+    )

--- a/isaaclab_arena/tests/test_deformable_object.py
+++ b/isaaclab_arena/tests/test_deformable_object.py
@@ -90,9 +90,6 @@ def _test_backend_specific_deformable_config(simulation_app) -> bool:
     assert soft_cube.object_type is ObjectType.DEFORMABLE
     assert soft_cube.get_object_cfg()[1] is physx_cfg
     assert soft_cube.get_event_cfg()[1] is not None
-    assert not hasattr(soft_cube, "reset_pose")
-    assert not hasattr(soft_cube, "disable_reset_pose")
-    assert not hasattr(soft_cube, "enable_reset_pose")
 
     newton_cube = _make_soft_cube("newton", initial_pose=pose)
     _, newton_cfg = newton_cube.get_object_cfg()
@@ -345,6 +342,52 @@ def _test_deformable_reset_and_initial_pose(simulation_app) -> bool:
     return True
 
 
+def _test_deformable_pick_and_place_success(simulation_app) -> bool:
+    import torch
+
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.arena_env_builder_cfg import ArenaEnvBuilderCfg
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+    from isaaclab_arena.utils.pose import Pose
+
+    soft_cube = AssetRegistry().get_asset_by_name("deformable_cube")(instance_name="soft_cube")
+    soft_cube.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.05)))
+    table = AssetRegistry().get_asset_by_name("procedural_table")(
+        instance_name="destination",
+        initial_pose=Pose(position_xyz=(0.0, 0.0, 0.0)),
+    )
+    task = PickAndPlaceTask(
+        pick_up_object=soft_cube,
+        destination_location=table,
+        background_scene=table,
+    )
+    arena_env = IsaacLabArenaEnvironment(
+        name="deformable_pick_and_place_success",
+        scene=Scene(assets=[soft_cube, table]),
+        task=task,
+    )
+    builder = ArenaEnvBuilder(
+        arena_env,
+        ArenaEnvBuilderCfg(num_envs=1, presets="physx", solve_relations=False),
+    )
+    env_cfg, env_kwargs = builder.compose_manager_cfg()
+    env = builder.make_registered(env_cfg, env_kwargs)
+
+    try:
+        env.reset()
+        assert task.contact_sensor_name is None
+        assert len(env.unwrapped.scene.sensors) == 0
+        success_term = task.get_termination_cfg().success
+        success = success_term.func(env, **success_term.params)
+        torch.testing.assert_close(success, torch.ones(1, dtype=torch.bool, device=env.unwrapped.device))
+    finally:
+        env.close()
+    return True
+
+
 def test_backend_specific_deformable_config():
     assert run_function_with_persistent_simulation_app(_test_backend_specific_deformable_config, headless=HEADLESS)
 
@@ -361,5 +404,13 @@ def test_deformable_nodal_reset_terms():
 def test_deformable_reset_and_initial_pose():
     assert run_function_with_persistent_simulation_app(
         _test_deformable_reset_and_initial_pose,
+        headless=HEADLESS,
+    )
+
+
+@pytest.mark.skipif(not PYTETWILD_AVAILABLE, reason="requires Isaac Lab's optional tetrahedralization dependencies")
+def test_deformable_pick_and_place_success():
+    assert run_function_with_persistent_simulation_app(
+        _test_deformable_pick_and_place_success,
         headless=HEADLESS,
     )

--- a/isaaclab_arena/tests/test_droid_deformable_pick_and_place_environment.py
+++ b/isaaclab_arena/tests/test_droid_deformable_pick_and_place_environment.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registration, configuration, and PhysX smoke tests for the deformable-object environment."""
+
+from __future__ import annotations
+
+import torch
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+ENVIRONMENT_NAME = "droid_deformable_pick_and_place"
+
+
+def _test_droid_deformable_environment_registration_and_config(simulation_app) -> bool:
+    """The registered factory builds the selected deformable object and DROID embodiment."""
+    import isaaclab.sim as sim_utils
+
+    from isaaclab_arena.assets.deformable_object import DeformableObject
+    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_reference import ObjectReference
+    from isaaclab_arena.assets.registries import EnvironmentRegistry
+    from isaaclab_arena.relations.relations import NextTo, On, Side, get_relation
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+    from isaaclab_arena_environments.cli import (
+        ensure_environments_registered,
+        get_arena_builder_from_cli,
+        get_isaaclab_arena_environments_cli_parser,
+    )
+    from isaaclab_arena_environments.droid_deformable_pick_and_place_environment import (
+        DroidDeformablePickAndPlaceEnvironment,
+        DroidDeformablePickAndPlaceEnvironmentCfg,
+    )
+
+    ensure_environments_registered()
+    registry = EnvironmentRegistry()
+    factory_type = registry.get_component_by_name(ENVIRONMENT_NAME)
+    assert factory_type is DroidDeformablePickAndPlaceEnvironment
+    assert registry.get_environment_cfg_type(factory_type) is DroidDeformablePickAndPlaceEnvironmentCfg
+
+    arena_env = factory_type().build(DroidDeformablePickAndPlaceEnvironmentCfg())
+    assert arena_env.embodiment.name == "droid_abs_joint_pos"
+    assert isinstance(arena_env.task, PickAndPlaceTask)
+
+    pick_object = arena_env.scene.assets["pick_object"]
+    destination = arena_env.scene.assets["plate"]
+    table = arena_env.scene.assets["maple_table_robolab"]
+    table_reference = arena_env.scene.assets["table"]
+    assert isinstance(pick_object, DeformableObject)
+    assert isinstance(pick_object.spawner_cfg, sim_utils.MeshCuboidCfg)
+    assert pick_object.spawner_cfg.size == (0.15, 0.04, 0.04)
+    assert pick_object.object_type is ObjectType.DEFORMABLE
+    assert destination.object_type is ObjectType.RIGID
+    assert isinstance(table_reference, ObjectReference)
+    assert table_reference.is_anchor
+    assert get_relation(pick_object, On).parent is table_reference
+    assert get_relation(destination, On).parent is table_reference
+    next_to = get_relation(pick_object, NextTo)
+    assert next_to.parent is destination
+    assert next_to.side is Side.POSITIVE_Y
+    assert arena_env.task.pick_up_object is pick_object
+    assert arena_env.task.destination_location is destination
+    assert arena_env.task.background_scene is table
+    assert arena_env.task.contact_sensor_name is None
+
+    parser = get_isaaclab_arena_environments_cli_parser()
+    args_cli = parser.parse_args(
+        [ENVIRONMENT_NAME, "--pick_object", "teddy_bear", "--embodiment", "droid_differential_ik"]
+    )
+    teddy_env = get_arena_builder_from_cli(args_cli).arena_env
+    assert teddy_env.embodiment.name == "droid_differential_ik"
+    assert isinstance(teddy_env.scene.assets["pick_object"].spawner_cfg, sim_utils.UsdFileCfg)
+
+    args_cli = parser.parse_args([ENVIRONMENT_NAME, "--pick_object", "surface"])
+    surface_env = get_arena_builder_from_cli(args_cli).arena_env
+    assert isinstance(surface_env.scene.assets["pick_object"].spawner_cfg, sim_utils.MeshRectangleCfg)
+    assert surface_env.scene.assets["pick_object"].spawner_cfg.size == (0.2, 0.2)
+    assert surface_env.scene.assets["pick_object"].spawner_cfg.resolution == (30, 30)
+    return True
+
+
+def test_droid_deformable_environment_registration_and_config() -> None:
+    """The registered factory builds each supported CLI-selected object."""
+    assert run_function_with_persistent_simulation_app(
+        _test_droid_deformable_environment_registration_and_config,
+        headless=True,
+    )
+
+
+def _test_droid_deformable_physx_smoke(simulation_app) -> bool:
+    """Spawn, reset, step, evaluate placement, and close through the runner construction path."""
+    from isaaclab_arena.cli.isaaclab_arena_cli import get_isaaclab_arena_cli_parser
+    from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
+
+    env = None
+    try:
+        parser = get_isaaclab_arena_environments_cli_parser(get_isaaclab_arena_cli_parser())
+        args_cli = parser.parse_args(["--num_envs", "1", ENVIRONMENT_NAME])
+        builder = get_arena_builder_from_cli(args_cli)
+        env_cfg, env_kwargs = builder.compose_manager_cfg()
+
+        env = builder.make_registered(env_cfg, env_kwargs)
+        assert "isaaclab_physx" in str(env.unwrapped.sim.physics_manager)
+        observation, _ = env.reset()
+        assert observation is not None
+        assert {
+            "robot",
+            "pick_object",
+            "plate",
+            "table",
+            "maple_table_robolab",
+        } <= set(env.unwrapped.scene.keys())
+
+        actions = torch.zeros(env.action_space.shape, device=env.unwrapped.device)
+        with torch.inference_mode():
+            env.step(actions)
+            env.step(actions)
+
+            success_term = builder.arena_env.task.get_termination_cfg().success
+            placement_result = success_term.func(env, **success_term.params)
+        assert placement_result.shape == (1,)
+        assert placement_result.dtype == torch.bool
+        return True
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_droid_deformable_physx_smoke() -> None:
+    """The registered environment completes its PhysX lifecycle without errors."""
+    assert run_function_with_persistent_simulation_app(
+        _test_droid_deformable_physx_smoke,
+        headless=True,
+    )

--- a/isaaclab_arena/tests/test_object_on_destination.py
+++ b/isaaclab_arena/tests/test_object_on_destination.py
@@ -103,11 +103,16 @@ def _check_object_on_destination(
             self.root_linear_velocity_queries.append(rigid_object_name)
             return self.root_linear_velocities_w_by_scene_key[rigid_object_name]
 
+    class SceneDouble(dict):
+        def __init__(self, contact_sensor):
+            super().__init__(contact_sensor=contact_sensor)
+            self.deformable_objects = {}
+
     class EnvironmentDouble:
         def __init__(self, arena_world, contact_sensor):
             self.num_envs = 4
             self.arena_world = arena_world
-            self.scene = {"contact_sensor": contact_sensor}
+            self.scene = SceneDouble(contact_sensor)
 
     class RuntimeBufferDouble:
         def __init__(self, tensor: torch.Tensor):
@@ -175,18 +180,54 @@ def _check_object_on_destination(
     predicate_result = spatial.object_on_destination(wrapped_env, **predicate_parameters)
     torch.testing.assert_close(predicate_result, torch.tensor([True, False, False, False]))
 
+    # Contact support is unavailable for deformables, so success uses geometry and velocity only.
+    env.scene.deformable_objects = {"object": object()}
+    deformable_parameters = {**predicate_parameters, "contact_sensor_cfg": None}
+    deformable_result = spatial.object_on_destination(env, **deformable_parameters)
+    torch.testing.assert_close(deformable_result, torch.tensor([True, False, True, False]))
+
     # Exercise the unwrapped call path with changed live state.
+    env.scene.deformable_objects = {}
     T_W_O[0, 0] = 2.0
     assert not spatial.object_on_destination(env, **predicate_parameters)[0]
-    assert arena_world.pose_queries == ["object", "destination", "object", "destination"]
-    assert arena_world.local_aabb_queries == ["object", "destination", "object", "destination"]
-    assert arena_world.root_linear_velocity_queries == ["object", "object"]
+    assert arena_world.pose_queries == ["object", "destination"] * 3
+    assert arena_world.local_aabb_queries == ["object", "destination"] * 3
+    assert arena_world.root_linear_velocity_queries == ["object"] * 3
+
+
+def _check_pick_and_place_deformable_skips_contact_sensor(pick_and_place_task_type, object_type) -> None:
+    """Check that task configuration omits contact sensors for either deformable endpoint."""
+
+    class AssetDouble:
+        def __init__(self, name, asset_object_type):
+            self.name = name
+            self.object_type = asset_object_type
+            self.object_min_z = -1.0
+
+        def get_contact_sensor_cfg(self, contact_against_object=None):
+            raise AssertionError(f"Unexpected contact sensor request against {contact_against_object}")
+
+    rigid_object = AssetDouble("rigid", object_type.RIGID)
+    deformable_object = AssetDouble("deformable", object_type.DEFORMABLE)
+    background = AssetDouble("background", object_type.BASE)
+
+    for pick_up_object, destination in (
+        (deformable_object, rigid_object),
+        (rigid_object, deformable_object),
+    ):
+        task = pick_and_place_task_type(pick_up_object, destination, background)
+        assert task.contact_sensor_name is None
+        assert task.get_scene_cfg() is None
+        assert task.get_termination_cfg().success.params["contact_sensor_cfg"] is None
+        assert task.get_progress_objectives()[0].predicate_groups[-1].keywords["contact_sensor_cfg"] is None
 
 
 def _test_object_on_destination(_simulation_app) -> bool:
     from isaaclab.managers import SceneEntityCfg
 
     import isaaclab_arena.tasks.predicates.spatial as spatial
+    from isaaclab_arena.assets.object_type import ObjectType
+    from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
     _check_bounds_center_over_destination(spatial, AxisAlignedBoundingBox)
@@ -196,6 +237,7 @@ def _test_object_on_destination(_simulation_app) -> bool:
         AxisAlignedBoundingBox,
         SceneEntityCfg,
     )
+    _check_pick_and_place_deformable_skips_contact_sensor(PickAndPlaceTask, ObjectType)
     return True
 
 

--- a/isaaclab_arena_environments/droid_deformable_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/droid_deformable_pick_and_place_environment.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+r"""DROID PhysX deformable-object pick-and-place environment.
+
+Launch a short headless rollout from the development container:
+
+    /isaac-sim/python.sh -m isaaclab_arena.evaluation.policy_runner \
+        --headless --policy_type zero_action --num_steps 10 \
+        droid_deformable_pick_and_place
+
+Select another deformable object with ``--pick_object teddy_bear`` or
+``--pick_object surface``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from isaaclab_arena.assets.register import register_environment
+from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg, ArenaEnvironmentFactory
+
+if TYPE_CHECKING:
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+
+_PICK_OBJECT_ALIASES = {
+    "cube": "deformable_cube",
+    "surface": "deformable_surface",
+    "teddy_bear": "deformable_teddy_bear",
+}
+
+
+@dataclass
+class DroidDeformablePickAndPlaceEnvironmentCfg(ArenaEnvironmentCfg):
+    """Configure the DROID deformable-object pick-and-place environment."""
+
+    pick_object: str = "cube"
+    """Deformable object alias or asset registry name, exposed as ``--pick_object``."""
+
+    embodiment: str = "droid_abs_joint_pos"
+    """DROID embodiment registry name, exposed as ``--embodiment``."""
+
+
+@register_environment
+class DroidDeformablePickAndPlaceEnvironment(ArenaEnvironmentFactory[DroidDeformablePickAndPlaceEnvironmentCfg]):
+    """Build the fixed-pose PhysX deformable-object example."""
+
+    name = "droid_deformable_pick_and_place"
+    _legacy_argparse_cfg_type = DroidDeformablePickAndPlaceEnvironmentCfg
+
+    def build(self, cfg: DroidDeformablePickAndPlaceEnvironmentCfg) -> IsaacLabArenaEnvironment:
+        """Build the environment from its typed configuration."""
+        from isaaclab_arena.assets.deformable_object import DeformableObject
+        from isaaclab_arena.assets.object_base import ObjectType
+        from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+        from isaaclab_arena.relations.relations import IsAnchor, NextTo, On, Side
+        from isaaclab_arena.scene.scene import Scene
+        from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask
+        from isaaclab_arena.utils.pose import Pose
+
+        table = self.asset_registry.get_asset_by_name("maple_table_robolab")()
+        light = self.asset_registry.get_asset_by_name("light")()
+        directional_light = self.asset_registry.get_asset_by_name("directional_light")()
+        table_reference = ObjectReference(
+            name="table",
+            prim_path="{ENV_REGEX_NS}/maple_table_robolab/table",
+            parent_asset=table,
+            object_type=ObjectType.RIGID,
+        )
+        table_reference.add_relation(IsAnchor())
+        destination = self.asset_registry.get_asset_by_name("plate_large_vomp_robolab")(instance_name="plate")
+
+        pick_object_registry_name = _PICK_OBJECT_ALIASES.get(cfg.pick_object, cfg.pick_object)
+        pick_object = self.asset_registry.get_asset_by_name(pick_object_registry_name)(instance_name="pick_object")
+        assert isinstance(
+            pick_object, DeformableObject
+        ), f"Pick object {cfg.pick_object!r} resolves to {pick_object_registry_name!r}, which is not deformable."
+        destination.add_relation(On(table_reference))
+        pick_object.add_relation(On(table_reference))
+        pick_object.add_relation(NextTo(destination, side=Side.POSITIVE_Y))
+
+        assert cfg.embodiment in {"droid_abs_joint_pos", "droid_differential_ik"}, (
+            "The deformable pick-and-place example supports droid_abs_joint_pos and droid_differential_ik, "
+            f"got {cfg.embodiment!r}."
+        )
+        embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(
+            enable_cameras=cfg.enable_cameras,
+        )
+        embodiment.set_initial_pose(Pose(position_xyz=(0.0, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+        task = PickAndPlaceTask(
+            pick_up_object=pick_object,
+            destination_location=destination,
+            background_scene=table,
+            episode_length_s=30.0,
+            task_description=f"Pick up the {cfg.pick_object.replace('_', ' ')} and place it on the plate.",
+        )
+        return IsaacLabArenaEnvironment(
+            name=self.name,
+            embodiment=embodiment,
+            scene=Scene(assets=[table, table_reference, light, directional_light, destination, pick_object]),
+            task=task,
+        )


### PR DESCRIPTION
## Summary
Add PhysX deformable pick-and-place support

## Detailed description
- Introduces `DeformableObject` with PhysX/Newton backend-specific spawner configs, nodal reset events, and placement integration on top of the existing `ObjectBase` / `ObjectReference` model.
- Extends `PickAndPlaceTask`, spatial predicates, and `ArenaWorld` so deformable pick objects use placement-only success (no contact sensor) and expose live root pose/velocity queries.
- Adds the `droid_deformable_pick_and_place` environment with selectable deformable assets (cube, surface, teddy bear) and PhysX smoke/regression tests.
- Rebased onto `main` after #1173; the duplicate ArenaWorld scene-queries commit was dropped during rebase.