### PR TITLE
Reactivate fabics after they were fixed in Isaac Sim 6.1

### DIFF
--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -35,33 +35,6 @@ if TYPE_CHECKING:
     from isaaclab_arena.policy.policy_base import PolicyBase, PolicyCfg
 
 
-def disable_fabric_for_runs(experiment_cfg: ArenaExperimentCfg) -> None:
-    """Disable Fabric and force the CPU device on every run that will be built more than once.
-
-    Args:
-        experiment_cfg: Experiment whose run configurations are mutated in place.
-    """
-    # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove this once the render after
-    # rebuild bug is solved in Lab.
-    # Under GPU+Fabric every in-process build after the first has rendering artifacts due to incorrect
-    # poses for some geometry (for example, the robot's gripper has been seen to appear at the origin).
-    # As a workaround, we therefore disable Fabric and force the CPU device (the bug is GPU+Fabric only)
-    # whenever this process will build the env more than once (multiple runs and/or num_rebuilds > 1).
-    builds_in_process = sum(run_cfg.num_rebuilds for run_cfg in experiment_cfg.runs.values())
-    if builds_in_process <= 1:
-        return
-    print(
-        "Disabling Fabric and forcing the CPU device for all builds: this process will build the "
-        f"environment {builds_in_process} time(s) across {len(experiment_cfg.runs)} run(s), and the "
-        "GPU+Fabric post-rebuild rendering bug corrupts every build after the first "
-        "(slower than running on GPU with Fabric).",
-        flush=True,
-    )
-    for run_cfg in experiment_cfg.runs.values():
-        run_cfg.environment_builder.disable_fabric = True
-        run_cfg.environment_builder.device = "cpu"
-
-
 def execute_experiment(
     experiment_cfg: ArenaExperimentCfg,
     output_dir: Path,
@@ -81,8 +54,6 @@ def execute_experiment(
     Returns:
         One result per attempted run, in execution order.
     """
-    disable_fabric_for_runs(experiment_cfg)
-
     results = []
     for run_cfg in experiment_cfg.runs.values():
         print(f"Running run '{run_cfg.name}'", flush=True)

--- a/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_prims_after_stage_rebuild.py
@@ -182,14 +182,9 @@ def test_prims_after_stage_rebuild_without_fabric():
         partial(_test_prims_after_stage_rebuild, disable_fabric=True),
         headless=HEADLESS,
         enable_cameras=True,
-        force_disable_fabric=True,
     )
 
 
-# TODO(alexmillane, 2026-09-02): [lab-render-after-rebuild-bug] Remove once the render after rebuild bug
-# is solved in Lab. Under GPU+Fabric every build after the first leaves prims at an identity Fabric world
-# matrix, which is the mechanism this test detects.
-@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds lose Fabric world matrices under GPU+Fabric.")
 @pytest.mark.with_cameras
 def test_prims_after_stage_rebuild_with_fabric():
     """Rebuilds should keep the Fabric world matrix of every prim USD places off the origin."""
@@ -197,6 +192,4 @@ def test_prims_after_stage_rebuild_with_fabric():
         partial(_test_prims_after_stage_rebuild, disable_fabric=False),
         headless=HEADLESS,
         enable_cameras=True,
-        # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
-        force_disable_fabric=False,
     )

--- a/isaaclab_arena/tests/test_render_after_stage_rebuild.py
+++ b/isaaclab_arena/tests/test_render_after_stage_rebuild.py
@@ -167,14 +167,9 @@ def test_render_after_stage_rebuild_without_fabric():
         partial(_test_render_after_stage_rebuild, disable_fabric=True),
         headless=HEADLESS,
         enable_cameras=True,
-        force_disable_fabric=True,
     )
 
 
-# TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Un-skip once the render after rebuild
-# bug is solved in Lab. Under GPU+Fabric every build after the first renders some geometry at the wrong
-# pose (the DROID gripper has been seen at the origin), which is what this test would catch.
-@pytest.mark.skip(reason="[lab-render-after-rebuild-bug] Rebuilds render incorrectly under GPU+Fabric.")
 @pytest.mark.with_cameras
 def test_render_after_stage_rebuild_with_fabric():
     """Rebuilds should also render correctly with Fabric on, which is the default outside this bug."""
@@ -182,6 +177,4 @@ def test_render_after_stage_rebuild_with_fabric():
         partial(_test_render_after_stage_rebuild, disable_fabric=False),
         headless=HEADLESS,
         enable_cameras=True,
-        # Opt out of the suite-wide override, which would otherwise build this variant Fabric-off too.
-        force_disable_fabric=False,
     )

--- a/isaaclab_arena/tests/utils/persistent_simulation_app.py
+++ b/isaaclab_arena/tests/utils/persistent_simulation_app.py
@@ -7,9 +7,7 @@ import atexit
 import os
 import sys
 import traceback
-from collections.abc import Callable, Iterator
-from contextlib import contextmanager
-from unittest.mock import patch
+from collections.abc import Callable
 
 from isaaclab.app import AppLauncher
 from isaacsim import SimulationApp
@@ -99,42 +97,10 @@ def get_persistent_simulation_app(headless: bool, enable_cameras: bool = False) 
     return _PERSISTENT_SIM_APP_LAUNCHER.app
 
 
-@contextmanager
-def _fabric_disabled_for_env_builds(force_disable_fabric: bool) -> Iterator[None]:
-    """Force Fabric off for every environment built inside the ``with`` block.
-
-    Patches the builder's single ``parse_env_cfg`` call rather than the builder config, so it holds
-    for every env a test builds without each test opting in.
-
-    Args:
-        force_disable_fabric: Whether to force Fabric off. Pass False for a test that must build
-            with Fabric on, which is otherwise impossible on the shared app.
-    """
-    if not force_disable_fabric:
-        yield
-        return
-
-    # TODO(alexmillane, 2026-08-31): [lab-render-after-rebuild-bug] Remove once the render-after-rebuild
-    # bug is fixed in Lab. The persistent app rebuilds the stage once per test, and under GPU+Fabric
-    # every build after the first renders some geometry at the wrong pose (the DROID gripper has been
-    # seen at the origin), which would surface as unrelated tests failing on their rendered output.
-    # Imported here because Lab modules are only importable once the SimulationApp is running.
-    from isaaclab_arena.environments import arena_env_builder
-
-    unpatched_parse_env_cfg = arena_env_builder.parse_env_cfg
-
-    def parse_env_cfg_without_fabric(*args, **kwargs):
-        return unpatched_parse_env_cfg(*args, **{**kwargs, "use_fabric": False})
-
-    with patch.object(arena_env_builder, "parse_env_cfg", parse_env_cfg_without_fabric):
-        yield
-
-
 def run_function_with_persistent_simulation_app(
     function: Callable[..., bool],
     headless: bool = True,
     enable_cameras: bool = False,
-    force_disable_fabric: bool = True,
     **kwargs,
 ) -> bool:
     """Run a function with the persistent SimulationApp in the current pytest process.
@@ -147,8 +113,6 @@ def run_function_with_persistent_simulation_app(
             and returns whether the test passed.
         headless: Whether to create the SimulationApp without a GUI.
         enable_cameras: Whether to enable camera rendering.
-        force_disable_fabric: Whether to force every environment built by the function to disable
-            Fabric, regardless of the builder config it was given.
         **kwargs: Additional keyword arguments forwarded to the function.
 
     Returns:
@@ -157,8 +121,7 @@ def run_function_with_persistent_simulation_app(
     # Get a persistent simulation app
     try:
         simulation_app = get_persistent_simulation_app(headless=headless, enable_cameras=enable_cameras)
-        with _fabric_disabled_for_env_builds(force_disable_fabric):
-            test_result = bool(function(simulation_app, **kwargs))
+        test_result = bool(function(simulation_app, **kwargs))
         if not test_result:
             subprocess_utils._AT_LEAST_ONE_TEST_FAILED = True
         return test_result


### PR DESCRIPTION
## Summary
Reactivate fabrics in workflows requiring stage rebuilds.

## Detailed description
- We disabled fabrics in #1168 due to bugs in Isaac Sim 6.0.
- With the upgrade to Isaac Sim 6.1 we can re-enable fabrics and re-enable the corresponding tests.
