### PR TITLE
Align agentic environment warnings

### DIFF
--- a/docs/pages/concepts/agentic_environment_generation/index.rst
+++ b/docs/pages/concepts/agentic_environment_generation/index.rst
@@ -139,7 +139,14 @@ Arena's environment generation agent explicitly does not provide the following:
    gui_runner
    cli_runner
 
-.. note::
+.. warning::
 
-   Agentic environment generation is experimental. Generated specs should be
-   reviewed and validated before they are used for policy evaluation.
+   Agentic environment generation is experimental and changing quickly. Generated
+   specs should be reviewed and validated before they are used for policy evaluation.
+   Prompt formats, generated spec structure, GUI behavior, and policy evaluation
+   integrations may change across releases.
+
+   We are actively working on:
+
+   * Support for more complex scene layouts and object placements.
+   * Support for more diverse task specifications.

--- a/docs/pages/example_workflows/agentic_env_gen/index.rst
+++ b/docs/pages/example_workflows/agentic_env_gen/index.rst
@@ -138,9 +138,11 @@ and can be used directly for policy evaluation:
   Benchmark Catalog <../kitchen_bench_catalog>`.
 
 .. warning::
-   Agentic environment generation is experimental and changing quickly. The
-   current prompt formats, generated spec structure, GUI behavior, and policy
-   evaluation integrations may change across releases.
+
+   Agentic environment generation is experimental and changing quickly. Generated
+   specs should be reviewed and validated before they are used for policy evaluation.
+   Prompt formats, generated spec structure, GUI behavior, and policy evaluation
+   integrations may change across releases.
 
    We are actively working on:
 


### PR DESCRIPTION
## Summary

Align agentic environment warnings

## Detailed description

The concept and workflow pages currently show different warnings for agentic environment generation. This change standardizes the warning so both pages display the same guidance.

Documentation-only change with no runtime impact.