### PR TITLE
Fix procedural cube support in graph-spec pick-and-place

### DIFF
--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -71,10 +71,7 @@ class Object(ObjectBase):
         return self.bounding_box
 
     def get_corners(self, pos: torch.Tensor) -> torch.Tensor:
-        assert self.usd_path is not None
-        if self.bounding_box is None:
-            self.bounding_box = compute_local_bounding_box_from_usd(self.usd_path, self.scale)
-        return self.bounding_box.get_corners_at(pos)
+        return self.get_bounding_box().get_corners_at(pos)
 
     def is_initial_pose_set(self) -> bool:
         return self.initial_pose is not None
@@ -91,6 +88,9 @@ class Object(ObjectBase):
         self, contact_against_object: ObjectBase | None = None, usd_path: str | None = None
     ) -> ContactSensorCfg:
         assert self.object_type == ObjectType.RIGID, "Contact sensor is only supported for rigid objects"
+        if self.usd_path is None:
+            assert self.spawner_cfg is not None, f"{self.name} has no USD path or spawner config."
+            return super().get_contact_sensor_cfg(contact_against_object)
         # We override this function from the parent class because in some assets, the rigid body
         # is not at the root of the USD file. To be robust to this, we find the shallowest rigid body
         # and add the contact sensor to it.
@@ -116,16 +116,22 @@ class Object(ObjectBase):
             assert (
                 contact_against_object.object_type == ObjectType.RIGID
             ), "Contact sensor is only supported for rigid objects"
-            contact_against_relative_path = find_shallowest_rigid_body(
-                contact_against_object.usd_path,
-                relative_to_root=True,
-                variants=(contact_against_object.spawn_cfg_addon or {}).get("variants"),
-            )
-            assert contact_against_relative_path is not None, (
-                f"No rigid body found in {contact_against_object.name} USD file: {contact_against_object.usd_path}."
-                " Can't add contact sensor."
-            )
-            filter_prim_paths = [contact_against_object.get_prim_path() + contact_against_relative_path]
+            if contact_against_object.usd_path is None:
+                assert (
+                    contact_against_object.spawner_cfg is not None
+                ), f"{contact_against_object.name} has no USD path or spawner config."
+                filter_prim_paths = [contact_against_object.get_prim_path()]
+            else:
+                contact_against_relative_path = find_shallowest_rigid_body(
+                    contact_against_object.usd_path,
+                    relative_to_root=True,
+                    variants=(contact_against_object.spawn_cfg_addon or {}).get("variants"),
+                )
+                assert contact_against_relative_path is not None, (
+                    f"No rigid body found in {contact_against_object.name} USD file:"
+                    f" {contact_against_object.usd_path}. Can't add contact sensor."
+                )
+                filter_prim_paths = [contact_against_object.get_prim_path() + contact_against_relative_path]
         elif isinstance(contact_against_object, ObjectBase):
             filter_prim_paths = [contact_against_object.get_prim_path()]
         elif contact_against_object is None:
@@ -138,6 +144,8 @@ class Object(ObjectBase):
     def _get_spawn_cfg(self, activate_contact_sensors: bool = False):
         """Return the spawn config to use: custom spawner_cfg if set, else a UsdFileCfg."""
         if self.spawner_cfg is not None:
+            if activate_contact_sensors and not getattr(self.spawner_cfg, "activate_contact_sensors", False):
+                return self.spawner_cfg.replace(activate_contact_sensors=True)
             return self.spawner_cfg
         return UsdFileCfg(
             usd_path=self.usd_path,

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -13,7 +13,6 @@ import isaaclab.sim as sim_utils
 if TYPE_CHECKING:
     from isaaclab_arena.assets.hdr_image import HDRImage
 
-from isaaclab.assets import RigidObjectCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import GroundPlaneCfg
 from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR
 
@@ -31,6 +30,7 @@ from isaaclab_arena.assets.object_utils import (
     RIGID_BODY_PROPS_MEDIUM_PRECISION,
 )
 from isaaclab_arena.assets.register import register_asset
+from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose
 
 
@@ -1927,21 +1927,24 @@ class ProceduralTable(Object):
             name=resolved_name,
             prim_path=resolved_prim,
             object_type=ObjectType.RIGID,
-            usd_path="",
+            spawner_cfg=_PROCEDURAL_TABLE_SPAWN_CFG,
             initial_pose=initial_pose,
         )
 
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_TABLE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Return root-relative bounds for the spawned cuboid."""
+        if self.bounding_box is None:
+            half_x, half_y, half_z = (dim / 2.0 for dim in _PROCEDURAL_TABLE_SPAWN_CFG.size)
+            self.bounding_box = AxisAlignedBoundingBox(
+                min_point=(-half_x, -half_y, -half_z),
+                max_point=(half_x, half_y, half_z),
+            )
+        return self.bounding_box
 
 
+_PROCEDURAL_CUBE_SIZE = (0.05, 0.1, 0.1)
 _PROCEDURAL_CUBE_SPAWN_CFG = sim_utils.CuboidCfg(
-    size=(0.05, 0.1, 0.1),
+    size=_PROCEDURAL_CUBE_SIZE,
     physics_material=sim_utils.RigidBodyMaterialCfg(static_friction=0.5),
     rigid_props=sim_utils.RigidBodyPropertiesCfg(
         solver_position_iteration_count=16,
@@ -1972,14 +1975,16 @@ class ProceduralCube(Object):
             name=resolved_name,
             prim_path=resolved_prim,
             object_type=ObjectType.RIGID,
-            usd_path="",
+            spawner_cfg=_PROCEDURAL_CUBE_SPAWN_CFG,
             initial_pose=initial_pose,
         )
 
-    def _generate_rigid_cfg(self) -> RigidObjectCfg:
-        cfg = RigidObjectCfg(
-            prim_path=self.prim_path,
-            spawn=_PROCEDURAL_CUBE_SPAWN_CFG,
-            **self.asset_cfg_addon,
-        )
-        return self._add_initial_pose_to_cfg(cfg)
+    def get_bounding_box(self) -> AxisAlignedBoundingBox:
+        """Return root-relative bounds for the spawned cuboid."""
+        if self.bounding_box is None:
+            half_x, half_y, half_z = (dim / 2.0 for dim in _PROCEDURAL_CUBE_SIZE)
+            self.bounding_box = AxisAlignedBoundingBox(
+                min_point=(-half_x, -half_y, -half_z),
+                max_point=(half_x, half_y, half_z),
+            )
+        return self.bounding_box

--- a/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
+++ b/isaaclab_arena/environment_spec/arena_env_graph_conversion_utils.py
@@ -124,7 +124,7 @@ def _scene_already_has_light(graph_spec: ArenaEnvGraphSpec, assets_by_node_id: d
     for asset_spec in [graph_spec.background, *graph_spec.objects]:
         asset = assets_by_node_id[asset_spec.id]
         usd_path = getattr(asset, "usd_path", None)
-        if usd_path is not None and getattr(asset, "spawner_cfg", None) is None:
+        if usd_path and getattr(asset, "spawner_cfg", None) is None:
             with open_stage(usd_path) as stage:
                 if has_light(stage):
                     return True

--- a/isaaclab_arena_environments/robolab/scenes/rubiks_cube_bowl.yaml
+++ b/isaaclab_arena_environments/robolab/scenes/rubiks_cube_bowl.yaml
@@ -13,7 +13,7 @@ background:
   params: {}
 objects:
 - id: rubiks_cube
-  registry_name: rubiks_cube_hot3d_robolab
+  registry_name: procedural_cube
   params: {}
 - id: bowl
   registry_name: bowl_ycb_robolab


### PR DESCRIPTION
## Summary
Fix procedural cube in graph-spec pick-and-place

## Detailed description
- Graph-spec pick-and-place tasks failed when a scene used `procedural_cube` because the asset had no USD path for lighting, placement, and contact-sensor setup.
- Procedural cube/table now use `spawner_cfg`; `Object` enables contact reporters on spawner-only rigid bodies and skips empty USD probes.
- `rubiks_cube_bowl.yaml` now references `procedural_cube` instead of the Hot3D rubiks cube asset.