### PR TITLE
Exclude procedural objects from agent asset catalogue

### DIFF
--- a/isaaclab_arena/agentic_environment_generation/catalogues.py
+++ b/isaaclab_arena/agentic_environment_generation/catalogues.py
@@ -74,6 +74,8 @@ def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalog
             catalogue.backgrounds.append({"name": name, "tags": [t for t in tags if t != "background"]})
         # Only assets existed in the catalogue are exposed.
         elif "object" in tags:
+            if "procedural" in tags:
+                continue
             # Exposed so the agent can honour type constraints, e.g. object-set members must be rigid.
             object_type = getattr(cls, "object_type", None)
             catalogue.objects.append({

--- a/isaaclab_arena/agentic_environment_generation/catalogues.py
+++ b/isaaclab_arena/agentic_environment_generation/catalogues.py
@@ -68,14 +68,15 @@ def build_asset_catalogue(registry: AssetRegistry | None = None) -> AssetCatalog
     for name in registry.get_all_keys():
         cls = registry.get_asset_by_name(name)
         tags = getattr(cls, "tags", None) or []
+        # TODO(xinjieyao): Support agentic environment generation consuming procedural assets.
+        if "procedural" in tags:
+            continue
         if "embodiment" in tags:
             catalogue.embodiments.append({"name": name, "tags": [t for t in tags if t != "embodiment"]})
         elif "background" in tags:
             catalogue.backgrounds.append({"name": name, "tags": [t for t in tags if t != "background"]})
         # Only assets existed in the catalogue are exposed.
         elif "object" in tags:
-            if "procedural" in tags:
-                continue
             # Exposed so the agent can honour type constraints, e.g. object-set members must be rigid.
             object_type = getattr(cls, "object_type", None)
             catalogue.objects.append({

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -377,6 +377,13 @@ def test_asset_catalogue_withholds_the_generic_simready_object():
     assert SIMREADY_USD_OBJECT_REGISTRY_NAME not in catalog_string
 
 
+def test_asset_catalogue_withholds_procedural_objects():
+    catalog_string = build_asset_catalogue().to_catalog_string()
+
+    assert AssetRegistry().is_registered("procedural_cube")
+    assert "procedural_cube" not in catalog_string
+
+
 # ---------------------------------------------------------------------------
 # Live endpoint (network + auth required)
 # ---------------------------------------------------------------------------

--- a/isaaclab_arena/tests/test_environment_generation_agent.py
+++ b/isaaclab_arena/tests/test_environment_generation_agent.py
@@ -377,11 +377,14 @@ def test_asset_catalogue_withholds_the_generic_simready_object():
     assert SIMREADY_USD_OBJECT_REGISTRY_NAME not in catalog_string
 
 
-def test_asset_catalogue_withholds_procedural_objects():
+def test_asset_catalogue_withholds_procedural_assets():
     catalog_string = build_asset_catalogue().to_catalog_string()
 
-    assert AssetRegistry().is_registered("procedural_cube")
+    registry = AssetRegistry()
+    assert registry.is_registered("procedural_cube")
+    assert registry.is_registered("procedural_table")
     assert "procedural_cube" not in catalog_string
+    assert "procedural_table" not in catalog_string
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Exclude procedural objects from agent asset catalogue

## Detailed description
- Procedural cuboids are intended for hand-authored graph specs, not LLM environment generation.
- `build_asset_catalogue()` now skips registered objects tagged `procedural`.
- Added a unit test ensuring `procedural_cube` stays registered but is omitted from the catalogue string.