### PR TITLE
Cherry pick: Add note in docs for non-deterministic PhysX replay (#1201)

### DIFF
--- a/docs/pages/example_workflows/locomanipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/locomanipulation/step_3_data_generation.rst
@@ -104,6 +104,16 @@ Step 3: Validate Generated Dataset (Optional)
 
 To visualize the data produced, you can replay the dataset using the following command:
 
+.. note::
+
+   Non-determinism may be observed when replaying demonstrations with PhysX because
+   physics in Isaac Lab is not deterministically reproducible across ``env.reset()``
+   calls. A demonstration may therefore fail during replay even though it succeeded
+   during generation; all generated demonstrations remain valid for training.
+
+   This dataset was generated using CPU physics, so the replay command uses
+   ``--device cpu`` to reduce device-related differences between generation and replay.
+
 .. code-block:: bash
 
    python submodules/IsaacLab/scripts/tools/replay_demos.py \
@@ -124,7 +134,3 @@ You should see the robot successfully perform the task.
    :align: center
 
    IsaacLab Arena G1 Locomanip Pick and Place Task View
-
-.. note::
-
-   The dataset was generated using CPU device physics, therefore the replay uses ``--device cpu`` to ensure reproducibility.

--- a/docs/pages/example_workflows/sequential_static_manipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/step_3_data_generation.rst
@@ -139,6 +139,16 @@ In order to validate the generated dataset, you can replay the generated data
 through the robot, in order to check (visually) if the robot is able to perform the task successfully.
 To do so, run the following command:
 
+.. note::
+
+   Non-determinism may be observed when replaying demonstrations with PhysX because
+   physics in Isaac Lab is not deterministically reproducible across ``env.reset()``
+   calls. A demonstration may therefore fail during replay even though it succeeded
+   during generation; all generated demonstrations remain valid for training.
+
+   This dataset was generated using CPU physics, so the replay command uses
+   ``--device cpu`` to reduce device-related differences between generation and replay.
+
 .. code-block:: bash
 
    python submodules/IsaacLab/scripts/tools/replay_demos.py \
@@ -160,7 +170,3 @@ added during data generation.
    :align: center
 
    IsaacLab Arena GR1 picking up and placing an object in a refrigerator and closing the door (with action noise)
-
-.. note::
-
-   The dataset was generated using CPU device physics, therefore the replay uses ``--device cpu`` to ensure reproducibility.

--- a/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
+++ b/docs/pages/example_workflows/static_manipulation/step_3_data_generation.rst
@@ -121,6 +121,16 @@ In order to validation the generated dataset, you can replay the generated data
 through the robot, in order to check (visually) if the robot is able to perform the task successfully.
 To do so, run the following command:
 
+.. note::
+
+   Non-determinism may be observed when replaying demonstrations with PhysX because
+   physics in Isaac Lab is not deterministically reproducible across ``env.reset()``
+   calls. A demonstration may therefore fail during replay even though it succeeded
+   during generation; all generated demonstrations remain valid for training.
+
+   This dataset was generated using CPU physics, so the replay command uses
+   ``--device cpu`` to reduce device-related differences between generation and replay.
+
 .. code-block:: bash
 
    python submodules/IsaacLab/scripts/tools/replay_demos.py \
@@ -140,7 +150,3 @@ You should see the robot successfully perform the task.
    :align: center
 
    IsaacLab Arena GR1 opening the microwave door
-
-.. note::
-
-   The dataset was generated using CPU device physics, therefore the replay uses ``--device cpu`` to ensure reproducibility.


### PR DESCRIPTION
## Summary
PhysX replay is non-deterministic. Add note in our docs to inform users of this and that the data generated in prior steps are still valid even if the replay script is non-deterministic.

(cherry picked from commit 29a4f3607934d134da8f3558705a61aaf01e4576)

