### PR TITLE
(release/0.3.0) Fix viewport camera recording in parallel env and video reference in html

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -15,6 +15,7 @@ from isaaclab_arena.metrics.metrics_manager import MetricsManager
 from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderManager
 from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
 from isaaclab_arena.variations.variation_recorder import VariationRecorder
+from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
 
 
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
@@ -29,6 +30,11 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         variation_recorder: VariationRecorder | None = None,
         **kwargs,
     ):
+        if isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
+            cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
+            cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
+            cfg.video_recorder.viewer_asset_name = cfg.viewer.asset_name
+            cfg.video_recorder.viewer_body_name = cfg.viewer.body_name
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -17,6 +17,8 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_tasks.utils import PresetCfg
 
+from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
+
 
 @configclass
 class ArenaPhysicsCfg(PresetCfg):
@@ -65,6 +67,9 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     commands = None
     rewards = None
     curriculum = None
+
+    video_recorder: ArenaViewportVideoRecorderCfg = ArenaViewportVideoRecorderCfg()
+    """Frame-aware report video recorder that does not move the interactive viewport."""
 
     metrics: object | None = None
 

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -132,6 +132,7 @@ def build_and_run(
                 video_cfg,
                 video_base_dir=output_dir,
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
+                viewport_name_prefix=f"viewport-rebuild{rebuild_index}-env0-viewport",
             )
             rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
             env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)

--- a/isaaclab_arena/tests/test_report.py
+++ b/isaaclab_arena/tests/test_report.py
@@ -56,6 +56,20 @@ def test_episode_video_filename_roundtrip_no_rebuild():
     )
 
 
+def test_legacy_viewport_video_filename_is_parsed():
+    parsed = parse_episode_video_filename("rl-video-step-0.mp4")
+
+    assert parsed is not None
+    assert (parsed.prefix, parsed.rebuild_index, parsed.env_index, parsed.camera_name, parsed.episode_index) == (
+        "rl-video",
+        0,
+        0,
+        "viewport",
+        0,
+    )
+    assert parse_episode_video_filename("rl-video-step-100.mp4") is None
+
+
 def test_unique_slugs_deduplicates_names_with_the_same_safe_form():
     slugs = unique_slugs(["my run", "my+run"])
 
@@ -224,6 +238,18 @@ def test_run_page_defers_every_video_until_it_scrolls_into_view(tmp_path):
         assert f'data-video-src="../banana_in_bowl_pi0/{name}"' in run_page
     assert run_page.count("data-video-src=") == len(video_names)
     assert "not-a-recorder-file.mp4" not in run_page
+
+
+def test_run_page_includes_legacy_viewport_video(tmp_path):
+    _write_run(tmp_path, "banana_in_bowl_pi0", num_episodes=1, cameras=())
+    viewport_video = tmp_path / "banana_in_bowl_pi0" / "rl-video-step-0.mp4"
+    viewport_video.write_bytes(b"")
+
+    build_report(tmp_path)
+
+    run_page = (tmp_path / "report" / "job_banana_in_bowl_pi0.html").read_text(encoding="utf-8")
+    assert 'data-video-src="../banana_in_bowl_pi0/rl-video-step-0.mp4"' in run_page
+    assert "viewport" in run_page
 
 
 def test_run_pages_are_paginated(tmp_path):

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -63,6 +63,7 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     run = _run()
     rollout_limits = []
     received_run_cfgs = []
+    received_video_cfgs = []
 
     def make_environment(cfg, render_mode):
         received_run_cfgs.append(cfg)
@@ -70,7 +71,12 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
 
     monkeypatch.setattr(run_execution, "_build_environment_from_cfg", make_environment)
     monkeypatch.setattr(run_execution, "_build_policy_from_cfg", lambda cfg: _Policy())
-    monkeypatch.setattr(run_execution, "wrap_env_for_video", lambda env, video_cfg, steps, episodes: env)
+
+    def wrap_for_video(env, video_cfg, steps, episodes):
+        received_video_cfgs.append(video_cfg)
+        return env
+
+    monkeypatch.setattr(run_execution, "wrap_env_for_video", wrap_for_video)
     monkeypatch.setattr(run_execution, "close_run_resources", lambda policy, env: None)
 
     def record_rollout(env, policy, num_steps, num_episodes):
@@ -93,6 +99,10 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     assert rollout_limits == [(None, 3), (None, 2)]
     # Runs are the same except for their seeds.
     assert received_run_cfgs == [run_seed_0, run_seed_1]
+    assert [cfg.viewport_name_prefix for cfg in received_video_cfgs] == [
+        "viewport-rebuild0-env0-viewport",
+        "viewport-rebuild1-env0-viewport",
+    ]
     # The original config is never mutated.
     assert run.rollout_limit == RolloutLimitCfg(num_episodes=5)
     assert run.environment_builder.seed == base_seed

--- a/isaaclab_arena/tests/test_video_recording.py
+++ b/isaaclab_arena/tests/test_video_recording.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from isaaclab_arena.video import video_recording
+
+
+def test_viewport_recorder_writes_report_compatible_episode_filename(monkeypatch, tmp_path):
+    captured = {}
+    env = SimpleNamespace(unwrapped=SimpleNamespace(max_episode_length=10))
+
+    def record_video(wrapped_env, **kwargs):
+        captured.update(kwargs)
+        return wrapped_env
+
+    monkeypatch.setattr(video_recording, "RecordVideo", record_video)
+    video_cfg = video_recording.VideoRecordingCfg(
+        record_viewport_video=True,
+        video_base_dir=str(tmp_path),
+        viewport_name_prefix="viewport-rebuild2-env0-viewport",
+    )
+
+    assert video_recording.wrap_env_for_video(env, video_cfg, num_steps=20, num_episodes=None) is env
+    assert captured["name_prefix"] == "viewport-rebuild2-env0-viewport"
+    assert captured["episode_trigger"](0)
+    assert not captured["episode_trigger"](1)
+    assert "step_trigger" not in captured
+    assert captured["video_length"] == 20

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Arena's frame-aware viewport video recorder."""
+
+import numpy as np
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from isaaclab.envs.utils.video_recorder import VideoRecorder
+
+from isaaclab_arena.video.viewport_video_recorder import (
+    ArenaViewportVideoRecorder,
+    ArenaViewportVideoRecorderCfg,
+    resolve_viewer_camera_pose,
+)
+
+
+def test_env_relative_camera_uses_selected_parallel_environment_origin():
+    """Environment-relative camera coordinates include the selected clone's world offset."""
+    scene = SimpleNamespace(
+        env_origins=np.array([
+            [15.0, -15.0, 0.0],
+            [15.0, 15.0, 0.0],
+            [-15.0, -15.0, 0.0],
+            [-15.0, 15.0, 0.0],
+        ])
+    )
+    cfg = ArenaViewportVideoRecorderCfg(viewer_origin_type="env", viewer_env_index=0)
+
+    eye, lookat = resolve_viewer_camera_pose(
+        scene,
+        cfg,
+        eye=np.array([-0.9, -1.3, 1.6]),
+        lookat=np.array([0.6, 0.2, 0.1]),
+    )
+
+    assert np.allclose(eye, (14.1, -16.3, 1.6))
+    assert np.allclose(lookat, (15.6, -14.8, 0.1))
+
+
+def test_world_relative_camera_does_not_apply_an_environment_origin():
+    """World-relative camera coordinates remain unchanged for parallel scenes."""
+    scene = SimpleNamespace(env_origins=np.array([[15.0, -15.0, 0.0]]))
+    cfg = ArenaViewportVideoRecorderCfg(viewer_origin_type="world")
+
+    eye, lookat = resolve_viewer_camera_pose(
+        scene,
+        cfg,
+        eye=np.array([1.0, 2.0, 3.0]),
+        lookat=np.array([4.0, 5.0, 6.0]),
+    )
+
+    assert eye == (1.0, 2.0, 3.0)
+    assert lookat == (4.0, 5.0, 6.0)
+
+
+def test_kit_recording_uses_dedicated_camera_without_moving_viewport(monkeypatch):
+    """Kit report frames update ArenaReportCamera rather than OmniverseKit_Persp."""
+
+    class _Capture:
+        def __init__(self):
+            self.cfg = SimpleNamespace(camera_prim_path="/OmniverseKit_Persp", eye=None, lookat=None)
+
+        def render_rgb_array(self):
+            return np.zeros((2, 2, 3), dtype=np.uint8)
+
+    def _fake_video_recorder_init(self, cfg, scene):
+        # Mirror the base recorder replacing the task camera from a visualizer cfg.
+        cfg.eye = (4.0, -4.0, 3.0)
+        cfg.lookat = (0.0, 0.0, 0.0)
+        self.cfg = cfg
+        self._scene = scene
+        self._backend = "kit"
+        self._capture = _Capture()
+        self._matched_visualizer = "kit"
+
+    monkeypatch.setattr(VideoRecorder, "__init__", _fake_video_recorder_init)
+    scene = SimpleNamespace(env_origins=np.array([[10.0, 20.0, 0.0]]), stage=MagicMock())
+    cfg = ArenaViewportVideoRecorderCfg(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(0.0, 0.0, 1.0),
+        viewer_origin_type="env",
+        viewer_env_index=0,
+    )
+    recorder = ArenaViewportVideoRecorder(cfg, scene)
+
+    with patch("isaaclab_physx.renderers.kit_viewport_utils.set_kit_renderer_camera_view") as set_camera_view:
+        frame = recorder.render_rgb_array()
+
+    scene.stage.DefinePrim.assert_called_once_with("/World/ArenaReportCamera", "Camera")
+    set_camera_view.assert_called_once_with(
+        eye=(11.0, 22.0, 3.0),
+        target=(10.0, 20.0, 1.0),
+        camera_prim_path="/World/ArenaReportCamera",
+    )
+    assert recorder._capture.cfg.camera_prim_path == "/World/ArenaReportCamera"
+    assert frame.shape == (2, 2, 3)

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -14,8 +14,38 @@ from isaaclab.envs.utils.video_recorder import VideoRecorder
 from isaaclab_arena.video.viewport_video_recorder import (
     ArenaViewportVideoRecorder,
     ArenaViewportVideoRecorderCfg,
+    _define_camera_with_matching_intrinsics,
     resolve_viewer_camera_pose,
 )
+
+
+def test_report_camera_copies_viewport_intrinsics_without_copying_its_transform():
+    """The isolated report camera retains the viewport's field of view and optical settings."""
+    source_attributes = {
+        "focalLength": 18.14756,
+        "horizontalAperture": 20.955,
+        "verticalAperture": 11.784375,
+        "clippingRange": (0.01, 1_000_000.0),
+    }
+    source_prim = MagicMock()
+    source_prim.IsValid.return_value = True
+    source_prim.GetAttribute.side_effect = lambda name: SimpleNamespace(
+        IsValid=lambda: name in source_attributes,
+        Get=lambda: source_attributes.get(name),
+    )
+    destination_attributes = {}
+    destination_prim = MagicMock()
+    destination_prim.GetAttribute.side_effect = lambda name: SimpleNamespace(
+        Set=lambda value: destination_attributes.__setitem__(name, value)
+    )
+    stage = MagicMock()
+    stage.GetPrimAtPath.return_value = source_prim
+    stage.DefinePrim.return_value = destination_prim
+
+    _define_camera_with_matching_intrinsics(stage, "/OmniverseKit_Persp", "/World/ArenaReportCamera")
+
+    stage.DefinePrim.assert_called_once_with("/World/ArenaReportCamera", "Camera")
+    assert destination_attributes == source_attributes
 
 
 def test_env_relative_camera_uses_selected_parallel_environment_origin():

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -29,6 +29,9 @@ class VideoRecordingCfg:
     camera_name_prefix: str = "robot-cam"
     """Filename prefix for the per-camera mp4s written by ``CameraObsVideoRecorder``."""
 
+    viewport_name_prefix: str = "viewport-env0-viewport"
+    """Filename prefix for the viewport mp4 written by Gymnasium's ``RecordVideo``."""
+
     @property
     def enabled(self) -> bool:
         """Whether any recorder is requested."""
@@ -83,14 +86,15 @@ def wrap_env_for_video(
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
 
-    # Record the kit viewport (via env.render()).
+    # Record the configured third-person report camera via env.render().
     if video_cfg.record_viewport_video:
         video_length = _resolve_video_length(env, num_steps, num_episodes)
         env = RecordVideo(
             env,
             video_folder=video_cfg.video_base_dir,
-            step_trigger=lambda step: step == 0,
+            episode_trigger=lambda episode: episode == 0,
             video_length=video_length,
+            name_prefix=video_cfg.viewport_name_prefix,
             disable_logger=True,
         )
         print(f"Recording {video_length}-step viewport video to: {video_cfg.video_base_dir}")

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -14,6 +14,39 @@ from isaaclab.envs.utils.video_recorder import VideoRecorder
 from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
 from isaaclab.utils.configclass import configclass
 
+_CAMERA_INTRINSIC_ATTRIBUTES = (
+    "projection",
+    "horizontalAperture",
+    "verticalAperture",
+    "horizontalApertureOffset",
+    "verticalApertureOffset",
+    "focalLength",
+    "clippingRange",
+    "clippingPlanes",
+    "fStop",
+    "focusDistance",
+    "stereoRole",
+    "shutter:open",
+    "shutter:close",
+    "exposure",
+)
+
+
+def _define_camera_with_matching_intrinsics(stage, source_path: str, destination_path: str) -> None:
+    """Define a camera whose optical properties match an existing camera."""
+    source_prim = stage.GetPrimAtPath(source_path)
+    destination_prim = stage.DefinePrim(destination_path, "Camera")
+    if not source_prim.IsValid():
+        return
+
+    for attribute_name in _CAMERA_INTRINSIC_ATTRIBUTES:
+        source_attribute = source_prim.GetAttribute(attribute_name)
+        if not source_attribute.IsValid():
+            continue
+        value = source_attribute.Get()
+        if value is not None:
+            destination_prim.GetAttribute(attribute_name).Set(value)
+
 
 def _as_numpy_xyz(value) -> np.ndarray:
     """Convert an Isaac Lab array-like XYZ value to a CPU NumPy array."""
@@ -92,7 +125,11 @@ class ArenaViewportVideoRecorder(VideoRecorder):
         self._matched_visualizer = None
 
         if self._backend == "kit":
-            scene.stage.DefinePrim(cfg.camera_prim_path, "Camera")
+            _define_camera_with_matching_intrinsics(
+                scene.stage,
+                source_path=self._capture.cfg.camera_prim_path,
+                destination_path=cfg.camera_prim_path,
+            )
             self._capture.cfg.camera_prim_path = cfg.camera_prim_path
 
     def render_rgb_array(self) -> np.ndarray | None:

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Viewport video recording that preserves Arena's configured viewer frame."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Literal
+
+from isaaclab.envs.utils.video_recorder import VideoRecorder
+from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+from isaaclab.utils.configclass import configclass
+
+
+def _as_numpy_xyz(value) -> np.ndarray:
+    """Convert an Isaac Lab array-like XYZ value to a CPU NumPy array."""
+    value = getattr(value, "torch", value)
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    return np.asarray(value, dtype=float)
+
+
+def resolve_viewer_camera_pose(
+    scene,
+    cfg: ArenaViewportVideoRecorderCfg,
+    eye: np.ndarray,
+    lookat: np.ndarray,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    """Resolve viewer-relative eye and target coordinates into the simulation world frame.
+
+    Args:
+        scene: Interactive scene containing environment origins and tracked assets.
+        cfg: Arena viewport video recorder configuration.
+        eye: Camera eye coordinates relative to the configured viewer origin.
+        lookat: Camera target coordinates relative to the configured viewer origin.
+
+    Returns:
+        World-frame camera eye and target coordinates.
+    """
+    origin_type = cfg.viewer_origin_type
+    if origin_type == "world":
+        origin = np.zeros(3, dtype=float)
+    else:
+        assert 0 <= cfg.viewer_env_index < len(scene.env_origins), (
+            f"Viewer environment index {cfg.viewer_env_index} is outside the available range "
+            f"[0, {len(scene.env_origins) - 1}]."
+        )
+        if origin_type == "env":
+            origin = _as_numpy_xyz(scene.env_origins[cfg.viewer_env_index])
+        else:
+            assert cfg.viewer_asset_name is not None, f"Viewer origin type '{origin_type}' requires an asset name."
+            asset = scene[cfg.viewer_asset_name]
+            if origin_type == "asset_root":
+                root_pos_w = getattr(asset.data.root_pos_w, "torch", asset.data.root_pos_w)
+                origin = _as_numpy_xyz(root_pos_w[cfg.viewer_env_index])
+            else:
+                assert origin_type == "asset_body", f"Unsupported viewer origin type: '{origin_type}'."
+                assert cfg.viewer_body_name is not None, "Viewer origin type 'asset_body' requires a body name."
+                body_ids, _ = asset.find_bodies(cfg.viewer_body_name)
+                assert (
+                    len(body_ids) == 1
+                ), f"Viewer body pattern '{cfg.viewer_body_name}' must resolve to exactly one body; got {body_ids}."
+                body_pos_w = getattr(asset.data.body_pos_w, "torch", asset.data.body_pos_w)
+                origin = _as_numpy_xyz(body_pos_w[cfg.viewer_env_index, body_ids[0]])
+
+    world_eye = origin + eye
+    world_lookat = origin + lookat
+    return tuple(float(x) for x in world_eye), tuple(float(x) for x in world_lookat)
+
+
+class ArenaViewportVideoRecorder(VideoRecorder):
+    """Record an Arena viewer pose without moving the interactive Kit viewport camera."""
+
+    cfg: ArenaViewportVideoRecorderCfg
+
+    def __init__(self, cfg: ArenaViewportVideoRecorderCfg, scene):
+        # Isaac Lab may overwrite cfg.eye/lookat from a visualizer configuration during construction.
+        # Preserve the task ViewerCfg values copied into the recorder before that happens.
+        self._viewer_eye = np.asarray(cfg.eye, dtype=float)
+        self._viewer_lookat = np.asarray(cfg.lookat, dtype=float)
+        super().__init__(cfg, scene)
+        cfg.eye = tuple(float(x) for x in self._viewer_eye)
+        cfg.lookat = tuple(float(x) for x in self._viewer_lookat)
+
+        # The report camera follows ViewerCfg, not a visualizer's stale construction-time camera.
+        # In particular, disable VideoRecorder's per-frame Newton visualizer synchronization.
+        self._matched_visualizer = None
+
+        if self._backend == "kit":
+            scene.stage.DefinePrim(cfg.camera_prim_path, "Camera")
+            self._capture.cfg.camera_prim_path = cfg.camera_prim_path
+
+    def render_rgb_array(self) -> np.ndarray | None:
+        """Render the report camera after resolving its configured origin into world coordinates."""
+        if self._backend is None or self._capture is None:
+            return None
+
+        eye, lookat = resolve_viewer_camera_pose(
+            self._scene,
+            self.cfg,
+            self._viewer_eye,
+            self._viewer_lookat,
+        )
+        self.cfg.eye = eye
+        self.cfg.lookat = lookat
+
+        if self._backend == "kit":
+            self._capture.cfg.eye = eye
+            self._capture.cfg.lookat = lookat
+            from isaaclab_physx.renderers.kit_viewport_utils import set_kit_renderer_camera_view
+
+            set_kit_renderer_camera_view(
+                eye=eye,
+                target=lookat,
+                camera_prim_path=self.cfg.camera_prim_path,
+            )
+        else:
+            self._capture.update_camera(eye, lookat)
+
+        return super().render_rgb_array()
+
+
+@configclass
+class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
+    """Configure Arena's frame-aware, viewport-isolated report video recorder."""
+
+    class_type: type = ArenaViewportVideoRecorder
+
+    viewer_origin_type: Literal["world", "env", "asset_root", "asset_body"] = "world"
+    """Frame in which the configured camera eye and target are expressed."""
+
+    viewer_env_index: int = 0
+    """Environment supplying the viewer origin."""
+
+    viewer_asset_name: str | None = None
+    """Asset supplying the viewer origin for asset tracking modes."""
+
+    viewer_body_name: str | None = None
+    """Body supplying the viewer origin for body tracking mode."""
+
+    camera_prim_path: str = "/World/ArenaReportCamera"
+    """Dedicated Kit camera prim used for report recording."""

--- a/isaaclab_arena/visualization/episode_results_files.py
+++ b/isaaclab_arena/visualization/episode_results_files.py
@@ -24,6 +24,11 @@ EPISODE_VIDEO_FILENAME_PATTERN = re.compile(
     r"^(?P<prefix>.+?)(?:-rebuild(?P<rebuild>\d+))?-env(?P<env>\d+)-(?P<camera>.+)-episode-(?P<episode>\d+)\.mp4$"
 )
 
+# Matches viewport videos written by Arena before they adopted the per-episode recorder format.
+LEGACY_VIEWPORT_VIDEO_FILENAME_PATTERN = re.compile(
+    r"^(?P<prefix>rl-video)(?:-rebuild(?P<rebuild>\d+))?-(?P<trigger>step|episode)-(?P<index>\d+)\.mp4$"
+)
+
 
 @dataclass(frozen=True)
 class DataIssue:
@@ -64,15 +69,32 @@ def parse_episode_results_filename(filename: str) -> ParsedEpisodeResultsName | 
 def parse_episode_video_filename(filename: str) -> ParsedEpisodeVideoName | None:
     """Parse a recorder mp4 filename, or return ``None`` if it does not match the recorder format."""
     match = EPISODE_VIDEO_FILENAME_PATTERN.match(filename)
-    if match is None:
+    if match is not None:
+        rebuild = match.group("rebuild")
+        return ParsedEpisodeVideoName(
+            prefix=match.group("prefix"),
+            rebuild_index=0 if rebuild is None else int(rebuild),
+            env_index=int(match.group("env")),
+            camera_name=match.group("camera"),
+            episode_index=int(match.group("episode")),
+        )
+
+    legacy_viewport_match = LEGACY_VIEWPORT_VIDEO_FILENAME_PATTERN.match(filename)
+    if legacy_viewport_match is None:
         return None
-    rebuild = match.group("rebuild")
+    trigger = legacy_viewport_match.group("trigger")
+    index = int(legacy_viewport_match.group("index"))
+    # Arena's former step trigger only recorded one rollout beginning at step zero. Other
+    # step indices cannot be paired reliably with an episode result.
+    if trigger == "step" and index != 0:
+        return None
+    rebuild = legacy_viewport_match.group("rebuild")
     return ParsedEpisodeVideoName(
-        prefix=match.group("prefix"),
+        prefix=legacy_viewport_match.group("prefix"),
         rebuild_index=0 if rebuild is None else int(rebuild),
-        env_index=int(match.group("env")),
-        camera_name=match.group("camera"),
-        episode_index=int(match.group("episode")),
+        env_index=0,
+        camera_name="viewport",
+        episode_index=0 if trigger == "step" else index,
     )
 
 


### PR DESCRIPTION
## Summary
Fix viewport camera recording in parallel env. Observed both locally and by VDR.

## Detailed description
- Previously, viewport recording reused and shifted the interactive camera while ignoring parallel-environment offsets.
- The recorder now resolves the configured environment-relative viewpoint into world coordinates and defaults to environment 0.
- Report video uses a dedicated camera, leaving the interactive viewport unchanged.


### Before this fix
In parallel env, with --enable_viewport_recording, 
viewport on GUI switched from
<img width="962" height="569" alt="Screenshot from 2026-09-08 12-57-41" src="https://github.com/user-attachments/assets/0ee27866-edf3-4be4-9593-f220fe7125b5" />
To
<img width="965" height="603" alt="Screenshot from 2026-09-08 11-13-32" src="https://github.com/user-attachments/assets/ba307ac2-9b94-48b8-a8ab-faf44502b0ca" />
Causing
all black frames in recording mp4 [here](https://drive.google.com/file/d/1aMsv3qF9R9xSmVSiFFNdrXCSmQAGxltw/view)

### After this fix
Recording is not black 
<img width="1270" height="707" alt="Screenshot from 2026-09-08 16-25-42" src="https://github.com/user-attachments/assets/591274db-77d9-4159-95e1-fd5008f02b43" />

Report linked to the exact mp4
<img width="1270" height="707" alt="image" src="https://github.com/user-attachments/assets/3fa11b58-d5e5-4e6b-8e87-ee6c2a702886" />



## Better method (leave it out for now due to its complexity)
1. Collect the environment origins or scene bounding boxes.
2. Compute their combined world-space bounding box.
3. Aim at its center.
4. Project all eight bounding-box corners into the intended camera
     orientation.
5. Move the camera backward until every corner fits within the horizontal
     and vertical FOV.