### PR TITLE
Add warp empty cpu tensor patch to release/0.3.0 branch

### DIFF
--- a/isaaclab_arena/environments/arena_env_builder.py
+++ b/isaaclab_arena/environments/arena_env_builder.py
@@ -47,6 +47,7 @@ from isaaclab_arena.utils.configclass import combine_configclass_instances, make
 from isaaclab_arena.utils.isaaclab_utils.recorders import ArenaEnvRecorderManagerCfg
 from isaaclab_arena.utils.isaaclab_utils.resolve_clone_plan_source_patch import patch_resolve_clone_plan_source
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import reapply_viewer_cfg
+from isaaclab_arena.utils.isaaclab_utils.warp_patch import install_empty_cpu_warp_to_torch_patch
 from isaaclab_arena.utils.multiprocess import get_local_rank
 from isaaclab_arena.variations import variations_hydra, variations_printing
 from isaaclab_arena.variations.variation_base import RunTimeVariationBase, VariationBase
@@ -462,6 +463,7 @@ class ArenaEnvBuilder:
         Returns:
             A ``(name, cfg, env_kwargs)`` tuple.
         """
+        install_empty_cpu_warp_to_torch_patch()
         name = self.arena_env.name
         if env_cfg is None:
             env_cfg, env_kwargs = self.compose_manager_cfg()

--- a/isaaclab_arena/tests/test_empty_cpu_warp_to_torch_patch.py
+++ b/isaaclab_arena/tests/test_empty_cpu_warp_to_torch_patch.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+
+import pytest
+import warp as wp
+from isaaclab.utils.warp import ProxyArray
+
+from isaaclab_arena.utils.isaaclab_utils.warp_patch import install_empty_cpu_warp_to_torch_patch
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Remove install_empty_cpu_warp_to_torch_patch when native Warp conversion succeeds.",
+)
+def test_native_empty_cpu_warp_array_to_torch():
+    script = """
+import warp as wp
+
+for dtype, expected_shape in ((wp.float32, (1, 0)), (wp.vec2f, (1, 0, 2))):
+    array = wp.empty((1, 0), dtype=dtype, device="cpu")
+    assert wp.to_torch(array).shape == expected_shape
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_shape"),
+    [
+        (wp.float32, (1, 0)),
+        (wp.vec2f, (1, 0, 2)),
+    ],
+)
+def test_empty_cpu_warp_array_to_torch(dtype, expected_shape):
+    install_empty_cpu_warp_to_torch_patch()
+
+    array = wp.empty((1, 0), dtype=dtype, device="cpu")
+
+    assert wp.to_torch(array).shape == expected_shape
+    assert ProxyArray(array).torch.shape == expected_shape
+
+
+def test_nonempty_cpu_warp_array_to_torch_is_unchanged():
+    install_empty_cpu_warp_to_torch_patch()
+
+    array = wp.zeros(2, dtype=wp.float32, device="cpu")
+    tensor = wp.to_torch(array)
+
+    assert tensor.data_ptr() == array.ptr

--- a/isaaclab_arena/tests/test_empty_cpu_warp_to_torch_patch.py
+++ b/isaaclab_arena/tests/test_empty_cpu_warp_to_torch_patch.py
@@ -3,31 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import subprocess
-import sys
-
 import pytest
 import warp as wp
 from isaaclab.utils.warp import ProxyArray
 
 from isaaclab_arena.utils.isaaclab_utils.warp_patch import install_empty_cpu_warp_to_torch_patch
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="Remove install_empty_cpu_warp_to_torch_patch when native Warp conversion succeeds.",
-)
-def test_native_empty_cpu_warp_array_to_torch():
-    script = """
-import warp as wp
-
-for dtype, expected_shape in ((wp.float32, (1, 0)), (wp.vec2f, (1, 0, 2))):
-    array = wp.empty((1, 0), dtype=dtype, device="cpu")
-    assert wp.to_torch(array).shape == expected_shape
-"""
-    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=False)
-
-    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.parametrize(

--- a/isaaclab_arena/utils/isaaclab_utils/warp_patch.py
+++ b/isaaclab_arena/utils/isaaclab_utils/warp_patch.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility helpers for converting Warp arrays to PyTorch tensors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED = False
+
+
+def install_empty_cpu_warp_to_torch_patch() -> None:
+    """Use DLPack when the installed Warp cannot convert empty CPU arrays to Torch."""
+    global _EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED
+
+    # TODO(peterd, 2026-09-02): Remove this workaround once native conversion succeeds. NumPy fixed the
+    # underlying zero-length array-interface bug in https://github.com/numpy/numpy/issues/26037 in version 2.4.
+    # `test_native_empty_cpu_warp_array_to_torch` is a strict xfail that flags when removal is safe.
+
+    if _EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED:
+        return
+
+    import torch
+
+    import warp as wp
+
+    original_to_torch = wp.to_torch
+    probe = wp.empty((1, 0), dtype=wp.float32, device="cpu")
+    try:
+        original_to_torch(probe)
+    except (TypeError, ValueError):
+        pass
+    else:
+        _EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED = True
+        return
+
+    def to_torch_with_empty_cpu_fallback(array: Any, requires_grad: bool | None = None) -> torch.Tensor:
+        """Convert empty CPU arrays through DLPack and delegate all other arrays."""
+        if isinstance(array, wp.array) and array.device.is_cpu and array.size == 0:
+            if requires_grad is None:
+                requires_grad = array.requires_grad
+
+            tensor = torch.from_dlpack(wp.to_dlpack(array))
+            tensor.requires_grad_(requires_grad)
+            tensor._warp_array = array
+
+            if requires_grad and array.grad is not None:
+                tensor.grad = torch.from_dlpack(wp.to_dlpack(array.grad))
+                tensor.grad._warp_grad_array = array.grad
+
+            return tensor
+
+        return original_to_torch(array, requires_grad=requires_grad)
+
+    wp.to_torch = to_torch_with_empty_cpu_fallback
+    _EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED = True

--- a/isaaclab_arena/utils/isaaclab_utils/warp_patch.py
+++ b/isaaclab_arena/utils/isaaclab_utils/warp_patch.py
@@ -18,7 +18,6 @@ def install_empty_cpu_warp_to_torch_patch() -> None:
 
     # TODO(peterd, 2026-09-02): Remove this workaround once native conversion succeeds. NumPy fixed the
     # underlying zero-length array-interface bug in https://github.com/numpy/numpy/issues/26037 in version 2.4.
-    # `test_native_empty_cpu_warp_array_to_torch` is a strict xfail that flags when removal is safe.
 
     if _EMPTY_CPU_TO_TORCH_WORKAROUND_INSTALLED:
         return


### PR DESCRIPTION
## Summary
Add the warp empty cpu tensor error patch to release/0.3.0 branch. This error is caused by numpy <2.24 with warp and has been patched in main branch. 
