### PR TITLE
Fix viewport video camera isolation

### DIFF
--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -104,8 +104,10 @@ def main():
     )
 
     # AppLauncher must enable camera support before SimulationApp starts. Check if this is required.
-    if args_cli.record_camera_video or _experiment_requires_cameras(
-        experiment_config_path, legacy_experiment_config, experiment_overrides
+    if (
+        args_cli.record_viewport_video
+        or args_cli.record_camera_video
+        or _experiment_requires_cameras(experiment_config_path, legacy_experiment_config, experiment_overrides)
     ):
         args_cli.enable_cameras = True
 

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -161,8 +161,8 @@ def main():
         args_cli.device = f"cuda:{local_rank}"
         print(f"[Rank {local_rank}/{world_size}] One Isaac Lab instance per process on cuda:{local_rank}")
 
-    # --record_camera_video requires cameras to be enabled at sim startup, before SimulationAppContext.
-    if "--record_camera_video" in unknown:
+    # Both video recorders require rendering support at sim startup, before SimulationAppContext.
+    if "--record_viewport_video" in unknown or "--record_camera_video" in unknown:
         args_cli.enable_cameras = True
 
     with SimulationAppContext(args_cli):
@@ -198,10 +198,10 @@ def main():
                 args_cli.seed += local_rank
 
         # Re-apply enable_cameras: the full parse resets it to default False.
-        if args_cli.record_camera_video:
+        if args_cli.record_viewport_video or args_cli.record_camera_video:
             args_cli.enable_cameras = True
 
-        # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.
+        # Build the scene before attaching the step-driven video recorders.
         arena_builder = get_arena_builder_from_cli(args_cli, hydra_overrides=hydra_overrides)
 
         output_dir = timestamped_run_dir(args_cli.output_base_dir)

--- a/isaaclab_arena/evaluation/policy_runner_cli.py
+++ b/isaaclab_arena/evaluation/policy_runner_cli.py
@@ -96,7 +96,7 @@ def add_policy_runner_arguments(parser: argparse.ArgumentParser) -> None:
         "--record_viewport_video",
         action="store_true",
         default=False,
-        help="Record an mp4 video of the rollout viewport (uses gymnasium.wrappers.RecordVideo).",
+        help="Record an mp4 video from the configured third-person report camera.",
     )
     parser.add_argument(
         "--output_base_dir",

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -103,6 +103,7 @@ def build_and_run(
                 video_cfg,
                 video_base_dir=output_dir,
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
+                viewport_name_prefix=f"viewport-rebuild{rebuild_index}-env0-viewport",
             )
             rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
             env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)

--- a/isaaclab_arena/tests/test_arena_experiment_config_loader.py
+++ b/isaaclab_arena/tests/test_arena_experiment_config_loader.py
@@ -298,6 +298,44 @@ def test_typed_experiment_enables_camera_support_from_its_config(
     assert launched_with_cameras is expected_enable_cameras
 
 
+def test_viewport_recording_enables_camera_support_before_launch(monkeypatch):
+    """The report camera must select the rendering AppLauncher experience."""
+    launched_with_cameras = None
+
+    class _SimulationAppContext:
+        def __init__(self, args_cli):
+            nonlocal launched_with_cameras
+            launched_with_cameras = args_cli.enable_cameras
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, _exception_type, _exception, _traceback):
+            pass
+
+    monkeypatch.setattr(experiment_runner, "SimulationAppContext", _SimulationAppContext)
+    monkeypatch.setattr(
+        experiment_runner,
+        "load_arena_experiment_from_config_file",
+        lambda *_args, **_kwargs: _experiment_cfg(),
+    )
+    monkeypatch.setattr(experiment_runner, "list_variations", lambda _experiment: None)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "experiment_runner.py",
+            "--experiment_config",
+            str(GETTING_STARTED_YAML_PATH),
+            "--record_viewport_video",
+            "--list_variations",
+        ],
+    )
+
+    experiment_runner.main()
+
+    assert launched_with_cameras is True
+
+
 def test_legacy_json_camera_detection_is_preserved():
     legacy_experiment_config = {"jobs": [{"arena_env_args": {}}, {"arena_env_args": {"enable_cameras": True}}]}
 

--- a/isaaclab_arena/tests/test_report.py
+++ b/isaaclab_arena/tests/test_report.py
@@ -56,6 +56,20 @@ def test_episode_video_filename_roundtrip_no_rebuild():
     )
 
 
+def test_legacy_viewport_video_filename_is_parsed():
+    parsed = parse_episode_video_filename("rl-video-step-0.mp4")
+
+    assert parsed is not None
+    assert (parsed.prefix, parsed.rebuild_index, parsed.env_index, parsed.camera_name, parsed.episode_index) == (
+        "rl-video",
+        0,
+        0,
+        "viewport",
+        0,
+    )
+    assert parse_episode_video_filename("rl-video-step-100.mp4") is None
+
+
 def test_unique_slugs_deduplicates_names_with_the_same_safe_form():
     slugs = unique_slugs(["my run", "my+run"])
 
@@ -224,6 +238,18 @@ def test_run_page_defers_every_video_until_it_scrolls_into_view(tmp_path):
         assert f'data-video-src="../banana_in_bowl_pi0/{name}"' in run_page
     assert run_page.count("data-video-src=") == len(video_names)
     assert "not-a-recorder-file.mp4" not in run_page
+
+
+def test_run_page_includes_legacy_viewport_video(tmp_path):
+    _write_run(tmp_path, "banana_in_bowl_pi0", num_episodes=1, cameras=())
+    viewport_video = tmp_path / "banana_in_bowl_pi0" / "rl-video-step-0.mp4"
+    viewport_video.write_bytes(b"")
+
+    build_report(tmp_path)
+
+    run_page = (tmp_path / "report" / "job_banana_in_bowl_pi0.html").read_text(encoding="utf-8")
+    assert 'data-video-src="../banana_in_bowl_pi0/rl-video-step-0.mp4"' in run_page
+    assert "viewport" in run_page
 
 
 def test_run_pages_are_paginated(tmp_path):

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -63,6 +63,7 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     run = _run()
     rollout_limits = []
     received_run_cfgs = []
+    received_video_cfgs = []
 
     def make_environment(cfg, render_mode):
         received_run_cfgs.append(cfg)
@@ -70,7 +71,12 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
 
     monkeypatch.setattr(run_execution, "_build_environment_from_cfg", make_environment)
     monkeypatch.setattr(run_execution, "_build_policy_from_cfg", lambda cfg: _Policy())
-    monkeypatch.setattr(run_execution, "wrap_env_for_video", lambda env, video_cfg, steps, episodes: env)
+
+    def wrap_for_video(env, video_cfg, steps, episodes):
+        received_video_cfgs.append(video_cfg)
+        return env
+
+    monkeypatch.setattr(run_execution, "wrap_env_for_video", wrap_for_video)
     monkeypatch.setattr(run_execution, "close_run_resources", lambda policy, env: None)
 
     def record_rollout(env, policy, num_steps, num_episodes):
@@ -93,6 +99,10 @@ def test_build_and_run_splits_episode_budget_without_mutating_config(monkeypatch
     assert rollout_limits == [(None, 3), (None, 2)]
     # Runs are the same except for their seeds.
     assert received_run_cfgs == [run_seed_0, run_seed_1]
+    assert [cfg.viewport_name_prefix for cfg in received_video_cfgs] == [
+        "viewport-rebuild0-env0-viewport",
+        "viewport-rebuild1-env0-viewport",
+    ]
     # The original config is never mutated.
     assert run.rollout_limit == RolloutLimitCfg(num_episodes=5)
     assert run.environment_builder.seed == base_seed

--- a/isaaclab_arena/tests/test_video_recording.py
+++ b/isaaclab_arena/tests/test_video_recording.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from isaaclab_arena.video import video_recording, viewport_video_recorder
+
+
+def test_viewport_recorder_writes_report_compatible_episode_filename(monkeypatch, tmp_path):
+    captured = {}
+    viewer = SimpleNamespace(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(0.0, 0.0, 1.0),
+        resolution=(640, 480),
+        origin_type="env",
+        env_index=2,
+        asset_name=None,
+        body_name=None,
+    )
+    base_env = SimpleNamespace(
+        max_episode_length=10,
+        cfg=SimpleNamespace(viewer=viewer),
+        video_recorders=[],
+    )
+    env = SimpleNamespace(unwrapped=base_env)
+
+    def recorder(recorder_cfg, recorder_env):
+        captured["cfg"] = recorder_cfg
+        captured["env"] = recorder_env
+        return "viewport-recorder"
+
+    monkeypatch.setattr(viewport_video_recorder, "ArenaViewportVideoRecorder", recorder)
+    video_cfg = video_recording.VideoRecordingCfg(
+        record_viewport_video=True,
+        video_base_dir=str(tmp_path),
+        viewport_name_prefix="viewport-rebuild2-env0-viewport",
+    )
+
+    assert video_recording.wrap_env_for_video(env, video_cfg, num_steps=20, num_episodes=None) is env
+    assert captured["env"] is base_env
+    assert captured["cfg"].output_filename_prefix == "viewport-rebuild2-env0-viewport"
+    assert captured["cfg"].video_length == 20
+    assert captured["cfg"].eye == (1.0, 2.0, 3.0)
+    assert captured["cfg"].viewer_env_index == 2
+    assert base_env.video_recorders == ["viewport-recorder"]

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from isaaclab.envs.utils.video_recorder import VideoRecorder
+
+from isaaclab_arena.video.viewport_video_recorder import (
+    ArenaViewportVideoRecorder,
+    ArenaViewportVideoRecorderCfg,
+    _define_report_camera,
+    _set_report_camera_pose,
+    resolve_viewer_camera_pose,
+)
+
+
+def test_env_relative_camera_uses_selected_parallel_environment_origin():
+    """Environment-relative camera coordinates include the selected clone's world offset."""
+    scene = SimpleNamespace(
+        env_origins=np.array([
+            [15.0, -15.0, 0.0],
+            [15.0, 15.0, 0.0],
+            [-15.0, -15.0, 0.0],
+            [-15.0, 15.0, 0.0],
+        ])
+    )
+    cfg = ArenaViewportVideoRecorderCfg(viewer_origin_type="env", viewer_env_index=0)
+
+    eye, lookat = resolve_viewer_camera_pose(
+        scene,
+        cfg,
+        eye=np.array([-0.9, -1.3, 1.6]),
+        lookat=np.array([0.6, 0.2, 0.1]),
+    )
+
+    assert np.allclose(eye, (14.1, -16.3, 1.6))
+    assert np.allclose(lookat, (15.6, -14.8, 0.1))
+
+
+def test_world_relative_camera_does_not_apply_an_environment_origin():
+    """World-relative camera coordinates remain unchanged for parallel scenes."""
+    scene = SimpleNamespace(env_origins=np.array([[15.0, -15.0, 0.0]]))
+    cfg = ArenaViewportVideoRecorderCfg(viewer_origin_type="world")
+
+    eye, lookat = resolve_viewer_camera_pose(
+        scene,
+        cfg,
+        eye=np.array([1.0, 2.0, 3.0]),
+        lookat=np.array([4.0, 5.0, 6.0]),
+    )
+
+    assert eye == (1.0, 2.0, 3.0)
+    assert lookat == (4.0, 5.0, 6.0)
+
+
+def test_report_camera_uses_selected_environment_scene_partition():
+    """The dedicated camera sees geometry from the selected parallel environment."""
+    from pxr import Sdf, Usd
+
+    stage = Usd.Stage.CreateInMemory()
+    env_prim = stage.DefinePrim("/World/envs/env_2")
+    env_prim.CreateAttribute("primvars:omni:scenePartition", Sdf.ValueTypeNames.Token).Set("env_2")
+
+    camera_prim = _define_report_camera(stage, "/World/ArenaReportCamera", env_index=2)
+
+    assert camera_prim.GetAttribute("omni:scenePartition").Get() == "env_2"
+
+
+def test_report_camera_pose_is_authored_without_a_viewport():
+    """Headless recording authors the dedicated USD camera without an active viewport."""
+    from pxr import Usd, UsdGeom
+
+    stage = Usd.Stage.CreateInMemory()
+
+    _set_report_camera_pose(
+        stage,
+        "/World/ArenaReportCamera",
+        eye=(1.0, 2.0, 3.0),
+        lookat=(0.0, 0.0, 1.0),
+    )
+
+    camera_prim = stage.GetPrimAtPath("/World/ArenaReportCamera")
+    transform = UsdGeom.Xformable(camera_prim).ComputeLocalToWorldTransform(Usd.TimeCode.Default())
+    assert np.allclose(transform.ExtractTranslation(), (1.0, 2.0, 3.0))
+    assert not stage.GetPrimAtPath("/OmniverseKit_Persp").IsValid()
+
+
+def test_kit_recording_uses_dedicated_camera_without_moving_viewport(monkeypatch):
+    """Kit report frames update ArenaReportCamera rather than OmniverseKit_Persp."""
+
+    def _fake_video_recorder_init(self, cfg, env):
+        self.cfg = cfg
+        self._env = env
+
+    monkeypatch.setattr(VideoRecorder, "__init__", _fake_video_recorder_init)
+    scene = SimpleNamespace(env_origins=np.array([[10.0, 20.0, 0.0]]), stage=MagicMock())
+    env = SimpleNamespace(scene=scene)
+    cfg = ArenaViewportVideoRecorderCfg(
+        eye=(1.0, 2.0, 3.0),
+        lookat=(0.0, 0.0, 1.0),
+        window_width=2,
+        window_height=2,
+        viewer_origin_type="env",
+        viewer_env_index=0,
+    )
+    annotator = MagicMock()
+    annotator.get_data.return_value = np.zeros((2, 2, 4), dtype=np.uint8)
+    render_product = MagicMock()
+    settings = MagicMock()
+    settings.get.side_effect = lambda key, default=None: {
+        "/isaaclab/has_gui": False,
+        "/app/player/playSimulations": True,
+    }.get(key, default)
+    replicator = SimpleNamespace(
+        create=SimpleNamespace(render_product=MagicMock(return_value=render_product)),
+        AnnotatorRegistry=SimpleNamespace(get_annotator=MagicMock(return_value=annotator)),
+    )
+
+    with (
+        patch("isaaclab_arena.video.viewport_video_recorder._define_report_camera") as define_report_camera,
+        patch("isaaclab_arena.video.viewport_video_recorder._set_report_camera_pose") as set_report_camera_pose,
+        patch.dict(
+            sys.modules,
+            {
+                "omni.replicator": SimpleNamespace(core=replicator),
+                "omni.replicator.core": replicator,
+            },
+        ),
+        patch("omni.kit.app.get_app") as get_app,
+        patch("isaaclab.app.settings_manager.get_settings_manager", return_value=settings),
+    ):
+        recorder = ArenaViewportVideoRecorder(cfg, env)
+        frame = recorder.render_rgb_array()
+        recorder.render_rgb_array()
+
+    define_report_camera.assert_called_once_with(scene.stage, "/World/ArenaReportCamera", 0)
+    assert set_report_camera_pose.call_args_list == [
+        ((scene.stage, "/World/ArenaReportCamera", (11.0, 22.0, 3.0), (10.0, 20.0, 1.0)),),
+        ((scene.stage, "/World/ArenaReportCamera", (11.0, 22.0, 3.0), (10.0, 20.0, 1.0)),),
+    ]
+    assert get_app.return_value.update.call_count == 2
+    annotator.attach.assert_called_once_with([render_product])
+    render_product.resume.assert_called_once_with()
+    assert render_product.pause.call_count == 2
+    assert frame.shape == (2, 2, 3)

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -15,7 +15,7 @@ class VideoRecordingCfg:
     """Options describing which rollout video recorders to enable and where to write them."""
 
     record_viewport_video: bool = False
-    """Record the kit viewport (third-person scene view) via ``env.render()``."""
+    """Record the configured third-person report camera without moving the interactive viewport."""
 
     record_camera_video: bool = False
     """Record the embodiment-mounted cameras from ``obs['camera_obs']``."""
@@ -26,15 +26,17 @@ class VideoRecordingCfg:
     camera_name_prefix: str = "robot-cam"
     """Filename prefix for the per-camera mp4s written by ``CameraObsVideoRecorder``."""
 
+    viewport_name_prefix: str = "viewport-env0-viewport"
+    """Filename prefix for the report-camera mp4."""
+
     @property
     def enabled(self) -> bool:
         """Whether any recorder is requested."""
         return self.record_viewport_video or self.record_camera_video
 
     @property
-    def render_mode(self) -> str | None:
-        """The ``render_mode`` the env must be built with to capture the viewport video."""
-        return "rgb_array" if self.record_viewport_video else None
+    def render_mode(self) -> None:
+        """No Gym render mode is needed by the step-driven viewport recorder."""
 
 
 def timestamped_run_dir(base_dir: str) -> str:
@@ -80,18 +82,29 @@ def wrap_env_for_video(
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
 
-    # Record the kit viewport (via env.render()).
+    # Record the configured third-person report camera with Isaac Lab's step-driven recorder.
     if video_cfg.record_viewport_video:
-        from gymnasium.wrappers import RecordVideo
+        from isaaclab_arena.video.viewport_video_recorder import (
+            ArenaViewportVideoRecorder,
+            ArenaViewportVideoRecorderCfg,
+        )
 
         video_length = _resolve_video_length(env, num_steps, num_episodes)
-        env = RecordVideo(
-            env,
-            video_folder=video_cfg.video_base_dir,
-            step_trigger=lambda step: step == 0,
+        viewer = env.unwrapped.cfg.viewer
+        recorder_cfg = ArenaViewportVideoRecorderCfg(
+            output_dir=video_cfg.video_base_dir,
             video_length=video_length,
-            disable_logger=True,
+            output_filename_prefix=video_cfg.viewport_name_prefix,
+            eye=viewer.eye,
+            lookat=viewer.lookat,
+            window_width=viewer.resolution[0],
+            window_height=viewer.resolution[1],
+            viewer_origin_type=viewer.origin_type,
+            viewer_env_index=viewer.env_index,
+            viewer_asset_name=viewer.asset_name,
+            viewer_body_name=viewer.body_name,
         )
+        env.unwrapped.video_recorders.append(ArenaViewportVideoRecorder(recorder_cfg, env.unwrapped))
         print(f"Recording {video_length}-step viewport video to: {video_cfg.video_base_dir}")
 
     # Record the embodiment-mounted cameras (from obs["camera_obs"]),

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Viewport video recording that preserves Arena's configured viewer frame."""
+
+from __future__ import annotations
+
+import contextlib
+import numpy as np
+import os
+from typing import Literal
+
+from isaaclab.envs.utils.video_recorder import VideoRecorder
+from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+from isaaclab.utils.configclass import configclass
+
+
+def _as_numpy_xyz(value) -> np.ndarray:
+    """Convert an Isaac Lab array-like XYZ value to a CPU NumPy array."""
+    value = getattr(value, "torch", value)
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    return np.asarray(value, dtype=float)
+
+
+def resolve_viewer_camera_pose(
+    scene,
+    cfg: ArenaViewportVideoRecorderCfg,
+    eye: np.ndarray,
+    lookat: np.ndarray,
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    """Resolve viewer-relative eye and target coordinates into the simulation world frame.
+
+    Args:
+        scene: Interactive scene containing environment origins and tracked assets.
+        cfg: Arena viewport video recorder configuration.
+        eye: Camera eye coordinates relative to the configured viewer origin.
+        lookat: Camera target coordinates relative to the configured viewer origin.
+
+    Returns:
+        World-frame camera eye and target coordinates.
+    """
+    origin_type = cfg.viewer_origin_type
+    if origin_type == "world":
+        origin = np.zeros(3, dtype=float)
+    else:
+        assert 0 <= cfg.viewer_env_index < len(scene.env_origins), (
+            f"Viewer environment index {cfg.viewer_env_index} is outside the available range "
+            f"[0, {len(scene.env_origins) - 1}]."
+        )
+        if origin_type == "env":
+            origin = _as_numpy_xyz(scene.env_origins[cfg.viewer_env_index])
+        else:
+            assert cfg.viewer_asset_name is not None, f"Viewer origin type '{origin_type}' requires an asset name."
+            asset = scene[cfg.viewer_asset_name]
+            if origin_type == "asset_root":
+                root_pos_w = getattr(asset.data.root_pos_w, "torch", asset.data.root_pos_w)
+                origin = _as_numpy_xyz(root_pos_w[cfg.viewer_env_index])
+            else:
+                assert origin_type == "asset_body", f"Unsupported viewer origin type: '{origin_type}'."
+                assert cfg.viewer_body_name is not None, "Viewer origin type 'asset_body' requires a body name."
+                body_ids, _ = asset.find_bodies(cfg.viewer_body_name)
+                assert (
+                    len(body_ids) == 1
+                ), f"Viewer body pattern '{cfg.viewer_body_name}' must resolve to exactly one body; got {body_ids}."
+                body_pos_w = getattr(asset.data.body_pos_w, "torch", asset.data.body_pos_w)
+                origin = _as_numpy_xyz(body_pos_w[cfg.viewer_env_index, body_ids[0]])
+
+    world_eye = origin + eye
+    world_lookat = origin + lookat
+    return tuple(float(x) for x in world_eye), tuple(float(x) for x in world_lookat)
+
+
+def _define_report_camera(stage, camera_prim_path: str, env_index: int):
+    """Define the report camera and copy the selected environment's RTX scene partition."""
+    from pxr import Sdf, UsdGeom
+
+    camera_prim = UsdGeom.Camera.Define(stage, camera_prim_path).GetPrim()
+    env_prim = stage.GetPrimAtPath(f"/World/envs/env_{env_index}")
+    env_partition_attr = env_prim.GetAttribute("primvars:omni:scenePartition")
+    if env_partition_attr.IsValid() and env_partition_attr.Get() is not None:
+        camera_prim.CreateAttribute(
+            "omni:scenePartition",
+            Sdf.ValueTypeNames.Token,
+            custom=True,
+        ).Set(env_partition_attr.Get())
+    return camera_prim
+
+
+def _set_report_camera_pose(
+    stage,
+    camera_prim_path: str,
+    eye: tuple[float, float, float],
+    lookat: tuple[float, float, float],
+) -> None:
+    """Author a world-frame eye and target directly on the report camera USD prim."""
+    import torch
+
+    from isaaclab.utils.math import create_rotation_matrix_from_view, quat_from_matrix
+    from pxr import Gf, UsdGeom
+
+    eye_tensor = torch.tensor([eye], dtype=torch.float32, device="cpu")
+    lookat_tensor = torch.tensor([lookat], dtype=torch.float32, device="cpu")
+    rotation_matrix = create_rotation_matrix_from_view(
+        eye_tensor,
+        lookat_tensor,
+        up_axis=UsdGeom.GetStageUpAxis(stage),
+        device="cpu",
+    )
+    assert not torch.isnan(rotation_matrix).any(), "Report camera eye and lookat must define a valid view."
+    quat_xyzw = quat_from_matrix(rotation_matrix)[0]
+
+    camera_prim = UsdGeom.Camera.Define(stage, camera_prim_path).GetPrim()
+    camera_xform = UsdGeom.Xformable(camera_prim)
+    camera_xform.ClearXformOpOrder()
+    camera_xform.SetResetXformStack(True)
+
+    translate_attr = camera_prim.GetAttribute("xformOp:translate")
+    translate_op = UsdGeom.XformOp(translate_attr) if translate_attr else camera_xform.AddTranslateOp()
+    orient_attr = camera_prim.GetAttribute("xformOp:orient")
+    orient_op = (
+        UsdGeom.XformOp(orient_attr) if orient_attr else camera_xform.AddOrientOp(UsdGeom.XformOp.PrecisionDouble)
+    )
+    camera_xform.SetXformOpOrder([translate_op, orient_op], camera_xform.GetResetXformStack())
+
+    translate_op.Set(Gf.Vec3d(*eye))
+    orient_op.Set(
+        Gf.Quatd(
+            float(quat_xyzw[3]),
+            Gf.Vec3d(float(quat_xyzw[0]), float(quat_xyzw[1]), float(quat_xyzw[2])),
+        )
+    )
+
+
+class ArenaViewportVideoRecorder(VideoRecorder):
+    """Record an Arena viewer pose without moving the interactive Kit viewport camera."""
+
+    cfg: ArenaViewportVideoRecorderCfg
+
+    def __init__(self, cfg: ArenaViewportVideoRecorderCfg, env):
+        self._viewer_eye = np.asarray(cfg.eye, dtype=float)
+        self._viewer_lookat = np.asarray(cfg.lookat, dtype=float)
+        self._scene = env.scene
+        self._rgb_annotator = None
+        self._render_product = None
+        super().__init__(cfg, env)
+        _define_report_camera(self._scene.stage, cfg.camera_prim_path, cfg.viewer_env_index)
+
+    def _get_frame(self) -> np.ndarray | None:
+        """Capture one frame from Arena's dedicated report camera."""
+        return self.render_rgb_array()
+
+    def _clip_path(self, index: int) -> str:
+        """Return a report-compatible episode video path."""
+        filename = f"{self.cfg.output_filename_prefix}-episode-{index}.mp4"
+        return os.path.join(self._effective_output_dir(), filename)
+
+    def render_rgb_array(self) -> np.ndarray | None:
+        """Render the report camera after resolving its configured origin into world coordinates."""
+        eye, lookat = resolve_viewer_camera_pose(
+            self._scene,
+            self.cfg,
+            self._viewer_eye,
+            self._viewer_lookat,
+        )
+        _set_report_camera_pose(self._scene.stage, self.cfg.camera_prim_path, eye, lookat)
+
+        import omni.kit.app
+        import omni.replicator.core as rep
+        from isaaclab.app.settings_manager import get_settings_manager
+
+        settings = get_settings_manager()
+        headless = not bool(settings.get("/isaaclab/has_gui", False))
+
+        if self._rgb_annotator is None:
+            resolution = (self.cfg.window_width, self.cfg.window_height)
+            self._render_product = rep.create.render_product(self.cfg.camera_prim_path, resolution)
+            self._rgb_annotator = rep.AnnotatorRegistry.get_annotator("rgb", device="cpu")
+            self._rgb_annotator.attach([self._render_product])
+        elif headless and self._render_product is not None:
+            with contextlib.suppress(Exception):
+                self._render_product.resume()
+
+        play_flag = settings.get("/app/player/playSimulations")
+        settings.set_bool("/app/player/playSimulations", False)
+        try:
+            omni.kit.app.get_app().update()
+        finally:
+            settings.set_bool("/app/player/playSimulations", bool(play_flag))
+
+        try:
+            rgb_data = self._rgb_annotator.get_data()
+            if isinstance(rgb_data, dict):
+                rgb_data = rgb_data.get("data", np.array([], dtype=np.uint8))
+            rgb_data = np.asarray(rgb_data, dtype=np.uint8)
+            if rgb_data.size == 0:
+                return np.zeros((self.cfg.window_height, self.cfg.window_width, 3), dtype=np.uint8)
+            if rgb_data.ndim == 1:
+                rgb_data = rgb_data.reshape(self.cfg.window_height, self.cfg.window_width, -1)
+            return rgb_data[:, :, :3]
+        finally:
+            if headless and self._render_product is not None:
+                with contextlib.suppress(Exception):
+                    self._render_product.pause()
+
+    def close(self) -> None:
+        """Flush video frames and release Replicator resources."""
+        super().close()
+        if self._rgb_annotator is not None:
+            with contextlib.suppress(Exception):
+                self._rgb_annotator.detach()
+        if self._render_product is not None:
+            with contextlib.suppress(Exception):
+                self._render_product.destroy()
+        self._rgb_annotator = None
+        self._render_product = None
+
+
+@configclass
+class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
+    """Configure Arena's frame-aware, viewport-isolated report video recorder."""
+
+    viewer_origin_type: Literal["world", "env", "asset_root", "asset_body"] = "world"
+    """Frame in which the configured camera eye and target are expressed."""
+
+    viewer_env_index: int = 0
+    """Environment supplying the viewer origin."""
+
+    viewer_asset_name: str | None = None
+    """Asset supplying the viewer origin for asset tracking modes."""
+
+    viewer_body_name: str | None = None
+    """Body supplying the viewer origin for body tracking mode."""
+
+    camera_prim_path: str = "/World/ArenaReportCamera"
+    """Dedicated Kit camera prim used for report recording."""
+
+    eye: tuple[float, float, float] = (7.5, 7.5, 7.5)
+    """Report camera position relative to the configured viewer origin."""
+
+    lookat: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    """Report camera target relative to the configured viewer origin."""
+
+    window_width: int = 1280
+    """Recorded frame width in pixels."""
+
+    window_height: int = 720
+    """Recorded frame height in pixels."""

--- a/isaaclab_arena/visualization/episode_results_files.py
+++ b/isaaclab_arena/visualization/episode_results_files.py
@@ -24,6 +24,11 @@ EPISODE_VIDEO_FILENAME_PATTERN = re.compile(
     r"^(?P<prefix>.+?)(?:-rebuild(?P<rebuild>\d+))?-env(?P<env>\d+)-(?P<camera>.+)-episode-(?P<episode>\d+)\.mp4$"
 )
 
+# Matches viewport videos written by Arena before they adopted the per-episode recorder format.
+LEGACY_VIEWPORT_VIDEO_FILENAME_PATTERN = re.compile(
+    r"^(?P<prefix>rl-video)(?:-rebuild(?P<rebuild>\d+))?-(?P<trigger>step|episode)-(?P<index>\d+)\.mp4$"
+)
+
 
 @dataclass(frozen=True)
 class DataIssue:
@@ -64,15 +69,32 @@ def parse_episode_results_filename(filename: str) -> ParsedEpisodeResultsName | 
 def parse_episode_video_filename(filename: str) -> ParsedEpisodeVideoName | None:
     """Parse a recorder mp4 filename, or return ``None`` if it does not match the recorder format."""
     match = EPISODE_VIDEO_FILENAME_PATTERN.match(filename)
-    if match is None:
+    if match is not None:
+        rebuild = match.group("rebuild")
+        return ParsedEpisodeVideoName(
+            prefix=match.group("prefix"),
+            rebuild_index=0 if rebuild is None else int(rebuild),
+            env_index=int(match.group("env")),
+            camera_name=match.group("camera"),
+            episode_index=int(match.group("episode")),
+        )
+
+    legacy_viewport_match = LEGACY_VIEWPORT_VIDEO_FILENAME_PATTERN.match(filename)
+    if legacy_viewport_match is None:
         return None
-    rebuild = match.group("rebuild")
+    trigger = legacy_viewport_match.group("trigger")
+    index = int(legacy_viewport_match.group("index"))
+    # Arena's former step trigger only recorded one rollout beginning at step zero. Other
+    # step indices cannot be paired reliably with an episode result.
+    if trigger == "step" and index != 0:
+        return None
+    rebuild = legacy_viewport_match.group("rebuild")
     return ParsedEpisodeVideoName(
-        prefix=match.group("prefix"),
+        prefix=legacy_viewport_match.group("prefix"),
         rebuild_index=0 if rebuild is None else int(rebuild),
-        env_index=int(match.group("env")),
-        camera_name=match.group("camera"),
-        episode_index=int(match.group("episode")),
+        env_index=0,
+        camera_name="viewport",
+        episode_index=0 if trigger == "step" else index,
     )
 
 


### PR DESCRIPTION
## Summary
Fix report viewport camera recording

## Detailed description
- Preserve configured env-relative framing in parallel scenes.
- Record through a dedicated camera without moving the interactive viewport.
- Enable headless RTX rendering and report-compatible video discovery.
- Verify non-black capture with four parallel G1 environments.