### PR TITLE
(release/0.3.0) Release viewport capture before stage teardown when Replicator is included

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -15,6 +15,7 @@ from isaaclab_arena.metrics.metrics_manager import MetricsManager
 from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderManager
 from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
 from isaaclab_arena.variations.variation_recorder import VariationRecorder
+from isaaclab_arena.video.video_recording import close_viewport_video_recorder
 
 
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
@@ -95,3 +96,10 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
             A MetricsDataCollection instance.
         """
         return self.metrics_manager.compute()
+
+    def close(self) -> None:
+        """Release viewport capture before closing the simulation environment."""
+        try:
+            close_viewport_video_recorder(getattr(self, "video_recorder", None))
+        finally:
+            super().close()

--- a/isaaclab_arena/evaluation/resource_cleanup.py
+++ b/isaaclab_arena/evaluation/resource_cleanup.py
@@ -13,6 +13,7 @@ from isaaclab_arena.utils.isaaclab_utils.simulation_app import (
     collect_garbage_and_clear_cuda_cache,
     teardown_simulation_app,
 )
+from isaaclab_arena.video.video_recording import close_viewport_video_recorder
 
 if TYPE_CHECKING:
     import gymnasium as gym
@@ -30,9 +31,11 @@ def close_policy(policy: PolicyBase | None) -> None:
 
 
 def close_environment(env: gym.Env | None) -> None:
-    """Tear down and close an instantiated environment."""
+    """Release viewport capture, replace the simulation stage, and close the environment."""
     if env is None:
         return
+    base_env = getattr(env, "unwrapped", env)
+    close_viewport_video_recorder(getattr(base_env, "video_recorder", None))
     try:
         teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)
     finally:

--- a/isaaclab_arena/evaluation/resource_cleanup.py
+++ b/isaaclab_arena/evaluation/resource_cleanup.py
@@ -34,7 +34,7 @@ def close_environment(env: gym.Env | None) -> None:
     """Release viewport capture, replace the simulation stage, and close the environment."""
     if env is None:
         return
-    base_env = getattr(env, "unwrapped", env)
+    base_env = env.unwrapped
     close_viewport_video_recorder(getattr(base_env, "video_recorder", None))
     try:
         teardown_simulation_app(suppress_exceptions=False, make_new_stage=True)

--- a/isaaclab_arena/tests/test_resource_cleanup.py
+++ b/isaaclab_arena/tests/test_resource_cleanup.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for evaluation resource cleanup ordering."""
+
+from types import SimpleNamespace
+
+from isaaclab_arena.evaluation import resource_cleanup
+
+
+def test_close_environment_releases_viewport_before_replacing_stage(monkeypatch):
+    calls = []
+    video_recorder = object()
+    env = SimpleNamespace(
+        close=lambda: calls.append("env.close"),
+        unwrapped=SimpleNamespace(video_recorder=video_recorder),
+    )
+
+    monkeypatch.setattr(
+        resource_cleanup,
+        "close_viewport_video_recorder",
+        lambda recorder: calls.append(("close_viewport_video_recorder", recorder)),
+    )
+    monkeypatch.setattr(
+        resource_cleanup,
+        "teardown_simulation_app",
+        lambda **kwargs: calls.append(("teardown_simulation_app", kwargs)),
+    )
+    monkeypatch.setattr(
+        resource_cleanup,
+        "collect_garbage_and_clear_cuda_cache",
+        lambda: calls.append("collect_garbage_and_clear_cuda_cache"),
+    )
+
+    resource_cleanup.close_environment(env)
+
+    assert calls == [
+        ("close_viewport_video_recorder", video_recorder),
+        (
+            "teardown_simulation_app",
+            {"suppress_exceptions": False, "make_new_stage": True},
+        ),
+        "env.close",
+        "collect_garbage_and_clear_cuda_cache",
+    ]

--- a/isaaclab_arena/tests/test_video_recording.py
+++ b/isaaclab_arena/tests/test_video_recording.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for viewport video recorder cleanup."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from isaaclab_arena.video.video_recording import close_viewport_video_recorder
+
+
+def test_close_viewport_video_recorder_releases_replicator_resources_once():
+    """Replicator resources are detached and destroyed exactly once."""
+    capture = SimpleNamespace(
+        _rgb_annotator=MagicMock(),
+        _render_product=MagicMock(),
+    )
+    recorder = SimpleNamespace(_capture=capture)
+    annotator = capture._rgb_annotator
+    render_product = capture._render_product
+
+    close_viewport_video_recorder(recorder)
+    close_viewport_video_recorder(recorder)
+
+    annotator.detach.assert_called_once_with()
+    render_product.destroy.assert_called_once_with()
+    assert capture._rgb_annotator is None
+    assert capture._render_product is None
+    assert recorder._capture is None
+
+
+def test_close_viewport_video_recorder_uses_public_close():
+    """Recorder-owned cleanup is preferred when a public close method exists."""
+    recorder = SimpleNamespace(close=MagicMock())
+
+    close_viewport_video_recorder(recorder)
+
+    recorder.close.assert_called_once_with()

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import os
+from contextlib import suppress
 from gymnasium.wrappers import RecordVideo
 
 from isaaclab_arena.video.camera_observation_video_recorder import CameraObsVideoRecorder
@@ -38,6 +39,48 @@ class VideoRecordingCfg:
     def render_mode(self) -> str | None:
         """The ``render_mode`` the env must be built with to capture the viewport video."""
         return "rgb_array" if self.record_viewport_video else None
+
+
+def close_viewport_video_recorder(video_recorder) -> None:
+    """Release a viewport recorder's capture resources before simulator teardown."""
+    if video_recorder is None:
+        return
+
+    close_recorder = getattr(video_recorder, "close", None)
+    if callable(close_recorder):
+        close_recorder()
+        return
+
+    capture = getattr(video_recorder, "_capture", None)
+    video_recorder._capture = None
+    if capture is None:
+        return
+
+    close_capture = getattr(capture, "close", None)
+    if callable(close_capture):
+        close_capture()
+        return
+
+    # Isaac Lab 3.0 Beta's Kit capture has no public close method. Release its
+    # Replicator resources explicitly so stage replacement cannot wait on them.
+    annotator = getattr(capture, "_rgb_annotator", None)
+    render_product = getattr(capture, "_render_product", None)
+    if annotator is not None:
+        with suppress(Exception):
+            annotator.detach()
+        capture._rgb_annotator = None
+    if render_product is not None:
+        with suppress(Exception):
+            render_product.destroy()
+        capture._render_product = None
+
+    # Newton's capture also lacks a public close method in this release.
+    viewer = getattr(capture, "_viewer", None)
+    close_viewer = getattr(viewer, "close", None)
+    if callable(close_viewer):
+        close_viewer()
+    if hasattr(capture, "_viewer"):
+        capture._viewer = None
 
 
 def timestamped_run_dir(base_dir: str) -> str:


### PR DESCRIPTION
## Summary
Short description of the change (max 50 chars)

## Detailed description
- Issue reported by VDR: When omni.Replicator is included, it hangs during sim shutdown after video is written, html does not output.
Fixes: 
- Stop video recording cleanly before shutting down the simulator.
- Prevent completed evaluations from hanging before the HTML report is written

### Before
MP4 is written, process remains around “Closing simulation app,” and timeout eventually returns 124; index.html is absent.

### After
Process exits 0, and both the MP4 and index.html are present.

```
timeout --signal=TERM --kill-after=30s 180s \
python isaaclab_arena/evaluation/policy_runner.py \
--viz kit --policy_type zero_action \
--record_viewport_video \
--num_episodes 20 \ 
lift_object
```