### PR TITLE
Separate rooted object behavior from ObjectBase

### DIFF
--- a/isaaclab_arena/assets/background.py
+++ b/isaaclab_arena/assets/background.py
@@ -13,7 +13,7 @@ from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.sim.utils import clone
 
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.utils.pose import Pose
 from isaaclab_arena.utils.usd_prim_tree import load_usd_physics_roots
 

--- a/isaaclab_arena/assets/object.py
+++ b/isaaclab_arena/assets/object.py
@@ -12,7 +12,8 @@ from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab.sim.spawners.from_files.from_files_cfg import UsdFileCfg
 from isaaclab.sim.spawners.spawner_cfg import SpawnerCfg
 
-from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.assets.object_base import ObjectBase, RootedObjectBase
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.object_utils import detect_object_type
 from isaaclab_arena.relations.relations import RelationBase
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
@@ -21,7 +22,7 @@ from isaaclab_arena.utils.usd.rigid_bodies import find_shallowest_rigid_body
 from isaaclab_arena.utils.usd_helpers import compute_local_bounding_box_from_usd, has_light, open_stage
 
 
-class Object(ObjectBase):
+class Object(RootedObjectBase):
     """Pick-up object config for a pick-and-place environment."""
 
     def __init__(

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -59,8 +59,19 @@ class ObjectBase(PlaceableAsset, ABC):
 class RootedObjectBase(ObjectBase):
     """Parent class for rigid, articulated, and static rooted objects."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        name: str,
+        prim_path: str | None = None,
+        object_type: ObjectType = ObjectType.BASE,
+        **kwargs,
+    ):
+        super().__init__(name=name, prim_path=prim_path, object_type=object_type, **kwargs)
+        assert self.object_type in {
+            ObjectType.BASE,
+            ObjectType.RIGID,
+            ObjectType.ARTICULATION,
+        }, f"RootedObjectBase does not support object type '{self.object_type}'."
         if self.object_type == ObjectType.RIGID:
             self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -47,6 +47,9 @@ class ObjectBase(PlaceableAsset, ABC):
 
     def get_object_cfg(self) -> tuple[str, AssetBaseCfg]:
         """Return the scene key and concrete asset config."""
+        assert (
+            self.object_cfg is not None
+        ), f"Object '{self.name}' ({type(self).__name__}) did not initialize its object config."
         return self.name, self.object_cfg
 
     def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:

--- a/isaaclab_arena/assets/object_base.py
+++ b/isaaclab_arena/assets/object_base.py
@@ -14,10 +14,6 @@ from isaaclab.managers import EventTermCfg, SceneEntityCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 from isaaclab_tasks.contrib.stack.mdp.franka_stack_events import randomize_object_pose
 
-# Re-export ObjectType from the lightweight module so existing
-# `from isaaclab_arena.assets.object_base import ObjectType` consumers keep working,
-# while pure-Python spec modules can import from `object_type` directly without
-# pulling in isaaclab/omni/pxr at module-load time.
 from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.relations.placement_asset import PlaceableAsset
 from isaaclab_arena.terms.events import set_object_pose, set_object_pose_per_env
@@ -25,14 +21,9 @@ from isaaclab_arena.utils.pose import Pose, PosePerEnv, PoseRange
 from isaaclab_arena.utils.velocity import Velocity
 from isaaclab_arena.variations.object_mass_variation import ObjectMassVariation
 
-__all__ = [
-    "ObjectBase",
-    "ObjectType",
-]
-
 
 class ObjectBase(PlaceableAsset, ABC):
-    """Parent class for (spawnable) Object and ObjectReference."""
+    """Parent class for Arena scene objects."""
 
     def __init__(
         self,
@@ -46,10 +37,30 @@ class ObjectBase(PlaceableAsset, ABC):
             prim_path = "{ENV_REGEX_NS}/" + self.name
         self.prim_path = prim_path
         self.object_type = object_type
+        self.object_cfg: AssetBaseCfg | None = None
+
+    def set_prim_path(self, prim_path: str) -> None:
+        self.prim_path = prim_path
+
+    def get_prim_path(self) -> str:
+        return self.prim_path
+
+    def get_object_cfg(self) -> tuple[str, AssetBaseCfg]:
+        """Return the scene key and concrete asset config."""
+        return self.name, self.object_cfg
+
+    def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
+        return self.name, self._pose_event_cfg
+
+
+class RootedObjectBase(ObjectBase):
+    """Parent class for rigid, articulated, and static rooted objects."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.object_type == ObjectType.RIGID:
             self.add_variation(ObjectMassVariation(self.name))
         self.initial_velocity: Velocity | None = None
-        self.object_cfg = None
 
     def _set_initial_pose(self, pose: Pose | PoseRange | PosePerEnv) -> None:
         """Store the pose and write its construction values into the object config."""
@@ -121,18 +132,6 @@ class ObjectBase(PlaceableAsset, ABC):
                     "velocity": self.initial_velocity,
                 },
             )
-
-    def set_prim_path(self, prim_path: str) -> None:
-        self.prim_path = prim_path
-
-    def get_prim_path(self) -> str:
-        return self.prim_path
-
-    def get_object_cfg(self) -> tuple[str, RigidObjectCfg | ArticulationCfg | AssetBaseCfg]:
-        return self.name, self.object_cfg
-
-    def get_event_cfg(self) -> tuple[str, EventTermCfg | None]:
-        return self.name, self._pose_event_cfg
 
     def _init_object_cfg(self) -> RigidObjectCfg | ArticulationCfg | AssetBaseCfg:
         if self.object_type == ObjectType.RIGID:

--- a/isaaclab_arena/assets/object_library.py
+++ b/isaaclab_arena/assets/object_library.py
@@ -24,7 +24,7 @@ from isaaclab_arena.affordances.turnable import Turnable
 from isaaclab_arena.assets.lightwheel_lazy import LightwheelLazyPath
 from isaaclab_arena.assets.nucleus import ARENA_NUCLEUS_DIR
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.object_utils import (
     EMPTY_ARTICULATION_INIT_STATE_CFG,
     RIGID_BODY_PROPS_HIGH_PRECISION,

--- a/isaaclab_arena/assets/object_reference.py
+++ b/isaaclab_arena/assets/object_reference.py
@@ -13,7 +13,8 @@ from isaaclab_arena.affordances.openable import Openable
 from isaaclab_arena.affordances.pressable import Pressable
 from isaaclab_arena.affordances.turnable import Turnable
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.assets.object_base import ObjectBase, RootedObjectBase
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.relations.relations import IsAnchor, RelationBase
 from isaaclab_arena.terms.events import reset_articulation_pose_and_joints
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox, quaternion_to_90_deg_z_quarters
@@ -27,7 +28,7 @@ from isaaclab_arena.utils.usd_helpers import (
 from isaaclab_arena.utils.usd_pose_helpers import get_prim_pose_in_default_prim_frame
 
 
-class ObjectReference(ObjectBase):
+class ObjectReference(RootedObjectBase):
     """An object which *refers* to an existing element in the scene"""
 
     def __init__(self, parent_asset: Object, **kwargs):

--- a/isaaclab_arena/assets/object_set.py
+++ b/isaaclab_arena/assets/object_set.py
@@ -10,7 +10,8 @@ from isaaclab.assets import RigidObjectCfg
 from isaaclab.sensors.contact_sensor.contact_sensor_cfg import ContactSensorCfg
 
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectBase, ObjectType
+from isaaclab_arena.assets.object_base import ObjectBase
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.object_utils import detect_object_type
 from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 from isaaclab_arena.utils.pose import Pose

--- a/isaaclab_arena/assets/object_type.py
+++ b/isaaclab_arena/assets/object_type.py
@@ -9,10 +9,6 @@ Kept dependency-free so it can be imported by pure-Python spec / schema modules
 (e.g. arena_env_graph_spec.py) without dragging in isaaclab/omni/pxr. This is
 important because importing pxr before SimulationApp starts breaks Kit
 extensions like omni.kit.usd.mdl during pytest collection.
-
-`isaaclab_arena.assets.object_base` re-exports `ObjectType` from here so existing
-`from isaaclab_arena.assets.object_base import ObjectType` consumers keep
-working with a single source of truth.
 """
 
 from enum import Enum

--- a/isaaclab_arena/assets/object_utils.py
+++ b/isaaclab_arena/assets/object_utils.py
@@ -8,7 +8,7 @@ import isaaclab.sim as sim_utils
 from isaaclab.assets import ArticulationCfg
 from pxr import Usd
 
-from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.utils.usd.rigid_bodies import apply_usd_variant_selections
 from isaaclab_arena.utils.usd_helpers import get_prim_depth, is_articulation_root, is_rigid_body
 

--- a/isaaclab_arena/assets/simready_object_library.py
+++ b/isaaclab_arena/assets/simready_object_library.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectType
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.assets.register import register_asset
 from isaaclab_arena.assets.registries import AssetRegistry
 from isaaclab_arena.assets.simready_constants import (

--- a/isaaclab_arena/scene/scene.py
+++ b/isaaclab_arena/scene/scene.py
@@ -14,9 +14,9 @@ from pxr import Gf, Usd, UsdGeom
 from isaaclab_arena.assets.asset import Asset
 from isaaclab_arena.assets.background import Background
 from isaaclab_arena.assets.object import Object
-from isaaclab_arena.assets.object_base import ObjectType
 from isaaclab_arena.assets.object_reference import ObjectReference
 from isaaclab_arena.assets.object_set import RigidObjectSet
+from isaaclab_arena.assets.object_type import ObjectType
 from isaaclab_arena.utils.configclass import make_configclass
 from isaaclab_arena.utils.phyx_utils import add_contact_report
 from isaaclab_arena.variations.variation_base import VariationBase

--- a/isaaclab_arena/tests/test_background_physics_reset.py
+++ b/isaaclab_arena/tests/test_background_physics_reset.py
@@ -84,8 +84,8 @@ def _test_background_physics_discovery_and_reset(
     from pxr import UsdPhysics
 
     from isaaclab_arena.assets.background import Background
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_reference import ObjectReference
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
@@ -296,7 +296,7 @@ def _test_maple_table_pose_restored_on_reset(_) -> bool:
     """Move the nested Maple table body and verify reset restores its cached pose."""
     import torch
 
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder

--- a/isaaclab_arena/tests/test_detect_object_type.py
+++ b/isaaclab_arena/tests/test_detect_object_type.py
@@ -19,7 +19,7 @@ def _test_detect_object_type(simulation_app):
 
     from pxr import Usd, UsdPhysics
 
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.object_utils import detect_object_type
     from isaaclab_arena.tests.utils.usd_stages import add_body, new_stage
 
@@ -100,7 +100,7 @@ def _test_detect_object_type_for_all_objects(simulation_app):
 def _test_auto_object_type(simulation_app):
 
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder

--- a/isaaclab_arena/tests/test_galbot_embodiment.py
+++ b/isaaclab_arena/tests/test_galbot_embodiment.py
@@ -18,8 +18,8 @@ INITIAL_POSITION_EPS = 1e-6
 
 def get_galbot_test_environment(num_envs: int = 1):
     """Returns a kitchen scene with Galbot embodiment for testing."""
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_reference import ObjectReference
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.embodiments.common.arm_mode import ArmMode

--- a/isaaclab_arena/tests/test_heterogeneous_placement.py
+++ b/isaaclab_arena/tests/test_heterogeneous_placement.py
@@ -173,8 +173,8 @@ def test_dummy_object_preserves_constructor_relations():
 def test_object_preserves_constructor_relations():
     """Object should keep relations passed at construction time."""
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     anchor_relation = IsAnchor()
     obj = Object(
@@ -906,8 +906,8 @@ def test_real_rigid_object_set_through_pooled_placer():
     from unittest.mock import patch
 
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.relations.bounding_box_helpers import has_heterogeneous_objects
 
     desk = _make_desk()

--- a/isaaclab_arena/tests/test_object_mass_variation.py
+++ b/isaaclab_arena/tests/test_object_mass_variation.py
@@ -63,9 +63,9 @@ def _test_object_mass_variation_registration(simulation_app):
     from unittest.mock import patch
 
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_reference import ObjectReference
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
     from isaaclab_arena.utils.pose import Pose

--- a/isaaclab_arena/tests/test_object_of_type_base.py
+++ b/isaaclab_arena/tests/test_object_of_type_base.py
@@ -16,8 +16,8 @@ MOVEMENT_EPS = 0.001
 
 def _test_object_of_type_base(simulation_app):
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_library import LibraryObject
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.registries import AssetRegistry
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder

--- a/isaaclab_arena/tests/test_object_set.py
+++ b/isaaclab_arena/tests/test_object_set.py
@@ -27,7 +27,7 @@ OBJECT_SET_BOTTLES_PRIM_PATH = "/World/envs/env_.*/ObjectSet_Bottles"
 
 def _make_object_set_variants():
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.utils.bounding_box import AxisAlignedBoundingBox
 
     can_a = Object(name="can_a", object_type=ObjectType.RIGID, usd_path="/tmp/can_a.usd")
@@ -43,8 +43,8 @@ def _test_object_set_samples_and_stores_variant_indices(simulation_app):
     """Variant assignment should be sampled once and reused for spawning and bboxes."""
     import torch
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     can_a, can_b, bbox_a, bbox_b = _make_object_set_variants()
     assigned_variant_indices = [1, 0, 1, 1]
@@ -79,8 +79,8 @@ def _test_object_set_default_variant_indices_follow_member_order(simulation_app)
     """Default object-set assignment should preserve the old deterministic member order."""
     import torch
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     can_a, can_b, bbox_a, bbox_b = _make_object_set_variants()
     with (
@@ -104,8 +104,8 @@ def _test_object_set_default_variant_indices_follow_member_order(simulation_app)
 
 def _test_object_set_random_variant_indices_use_placement_seed(simulation_app):
     """Random variant assignment should be repeatable with the same placement seed."""
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     def _assigned_indices():
         can_a, can_b, _bbox_a, _bbox_b = _make_object_set_variants()
@@ -125,8 +125,8 @@ def _test_object_set_regenerates_variants_with_different_num_envs(simulation_app
     import io
     from contextlib import redirect_stdout
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     can_a, can_b, _bbox_a, _bbox_b = _make_object_set_variants()
     with (
@@ -244,8 +244,8 @@ def _test_empty_object_set(simulation_app):
 
 
 def _test_articulation_object_set(simulation_app):
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_set import RigidObjectSet
+    from isaaclab_arena.assets.object_type import ObjectType
 
     can_a, can_b, _bbox_a, _bbox_b = _make_object_set_variants()
     try:

--- a/isaaclab_arena/tests/test_object_with_cfg_addons.py
+++ b/isaaclab_arena/tests/test_object_with_cfg_addons.py
@@ -11,8 +11,8 @@ HEADLESS = True
 
 def _test_object_with_cfg_addons(simulation_app):
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_library import LibraryObject
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.utils.pose import Pose
 
     class ConeWithCfgAddons(LibraryObject):

--- a/isaaclab_arena/tests/test_reference_objects.py
+++ b/isaaclab_arena/tests/test_reference_objects.py
@@ -329,8 +329,8 @@ def _test_reference_objects_with_background_pose(background_pose: Pose, tmp_path
 
     from isaaclab.managers import SceneEntityCfg
 
-    from isaaclab_arena.assets.object_base import ObjectType
     from isaaclab_arena.assets.object_reference import ObjectReference, OpenableObjectReference
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.embodiments.franka.franka import FrankaIKEmbodiment
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder

--- a/isaaclab_arena/tests/test_relation_solver_background_collision.py
+++ b/isaaclab_arena/tests/test_relation_solver_background_collision.py
@@ -79,7 +79,7 @@ def _mesh_box(name: str, extents: tuple[float, float, float], position: tuple[fl
 def _make_usd_background():
     """Background stub for USD mesh extraction tests."""
     from isaaclab_arena.assets.background import Background
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.utils.pose import Pose
 
     background = Background.__new__(Background)
@@ -156,7 +156,7 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
     import pytest
 
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
     from isaaclab_arena.utils.usd_helpers import UnsupportedCollisionGeometryError
 
@@ -185,7 +185,7 @@ def test_warp_mesh_cache_caches_unsupported_usd_geometry(monkeypatch):
 def test_warp_mesh_cache_keys_exclusions(monkeypatch):
     """Different anchor exclusions cannot reuse a stale whole-background mesh."""
     from isaaclab_arena.assets.object import Object
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.relations.warp_mesh_manager import WarpMeshAndSphereCache
 
     obj = Object.__new__(Object)

--- a/isaaclab_arena/tests/test_simready_object_library.py
+++ b/isaaclab_arena/tests/test_simready_object_library.py
@@ -79,7 +79,7 @@ def test_simready_search_registry_name_derives_an_identifier_from_the_phrase():
 
 
 def test_register_searched_simready_object_makes_it_a_catalogue_entry():
-    from isaaclab_arena.assets.object_base import ObjectType
+    from isaaclab_arena.assets.object_type import ObjectType
     from isaaclab_arena.assets.simready_object_library import register_searched_simready_object
 
     ensure_assets_registered()

--- a/isaaclab_arena_environments/droid_table_multi_object_placement_environment.py
+++ b/isaaclab_arena_environments/droid_table_multi_object_placement_environment.py
@@ -84,8 +84,8 @@ class DroidTableMultiObjectPlacementEnvironment(ArenaEnvironmentFactory[DroidTab
         """Build the environment from its typed configuration."""
         from isaaclab.envs.common import ViewerCfg
 
-        from isaaclab_arena.assets.object_base import ObjectType
         from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.assets.object_type import ObjectType
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.relations.relations import IsAnchor
         from isaaclab_arena.scene.scene import Scene

--- a/isaaclab_arena_environments/galileo_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_pick_and_place_environment.py
@@ -32,8 +32,8 @@ class GalileoPickAndPlaceEnvironment(ArenaEnvironmentFactory[GalileoPickAndPlace
 
     def build(self, cfg: GalileoPickAndPlaceEnvironmentCfg) -> IsaacLabArenaEnvironment:
         """Build the environment from its typed configuration."""
-        from isaaclab_arena.assets.object_base import ObjectType
         from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.assets.object_type import ObjectType
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.scene.scene import Scene
         from isaaclab_arena.tasks.pick_and_place_task import PickAndPlaceTask

--- a/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
+++ b/isaaclab_arena_environments/pick_and_place_maple_table_environment.py
@@ -43,8 +43,8 @@ class PickAndPlaceMapleTableEnvironment(ArenaEnvironmentFactory[PickAndPlaceMapl
         """Build the environment from its typed configuration."""
         from isaaclab.envs.common import ViewerCfg
 
-        from isaaclab_arena.assets.object_base import ObjectType
         from isaaclab_arena.assets.object_reference import ObjectReference
+        from isaaclab_arena.assets.object_type import ObjectType
         from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
         from isaaclab_arena.relations.relations import IsAnchor, On
         from isaaclab_arena.scene.scene import Scene


### PR DESCRIPTION
## Summary
Split generic and rooted object behavior

## Detailed description
- Keep shared scene-object state and configuration access on `ObjectBase`.
- Move rigid, articulated, and static-root behavior into `RootedObjectBase`.
- Update object classes and callers to import `ObjectType` from its lightweight module.