### PR TITLE
Fix viewpoint camera pose in parallel environments

### DIFF
--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -33,8 +33,11 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         # Isaac Lab forwards only the viewer eye and target to the video recorder, so pass the
         # frame they are measured in as well. Must happen before the recorder is built in super().
         if isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
-            cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
-            cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
+            # Replaced rather than assigned so the frame is checked by the config's __post_init__.
+            cfg.video_recorder = cfg.video_recorder.replace(
+                viewer_origin_type=cfg.viewer.origin_type,
+                viewer_env_index=cfg.viewer.env_index,
+            )
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -15,6 +15,7 @@ from isaaclab_arena.metrics.metrics_manager import MetricsManager
 from isaaclab_arena.recording.episode_recorder_manager import EpisodeRecorderManager
 from isaaclab_arena.tasks.predicates.object_settling import ObjectInitialRestPoseRecorder
 from isaaclab_arena.variations.variation_recorder import VariationRecorder
+from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
 
 
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
@@ -29,6 +30,11 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         variation_recorder: VariationRecorder | None = None,
         **kwargs,
     ):
+        # Isaac Lab forwards only the viewer eye and target to the video recorder, so pass the
+        # frame they are measured in as well. Must happen before the recorder is built in super().
+        if isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
+            cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
+            cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -33,11 +33,8 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         # Isaac Lab forwards only the viewer eye and target to the video recorder, so pass the
         # frame they are measured in as well. Must happen before the recorder is built in super().
         if isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
-            # Replaced rather than assigned so the frame is checked by the config's __post_init__.
-            cfg.video_recorder = cfg.video_recorder.replace(
-                viewer_origin_type=cfg.viewer.origin_type,
-                viewer_env_index=cfg.viewer.env_index,
-            )
+            cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
+            cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env.py
@@ -18,6 +18,21 @@ from isaaclab_arena.variations.variation_recorder import VariationRecorder
 from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
 
 
+def forward_viewer_frame_to_video_recorder(cfg: IsaacLabArenaManagerBasedRLEnvCfg) -> None:
+    """Pass the task's viewer frame to the report video recorder.
+
+    Isaac Lab forwards only the viewer eye and target, so the frame they are measured in has to be
+    supplied separately. Call before the recorder is built in ``ManagerBasedEnv.__init__``.
+
+    Args:
+        cfg: Environment configuration whose video recorder is updated in place.
+    """
+    if not isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
+        return
+    cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
+    cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
+
+
 class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
     """Arena extension to ManagerBasedRLEnv that adds additional Arena-specific functionality."""
 
@@ -30,11 +45,7 @@ class IsaacLabArenaManagerBasedRLEnv(ManagerBasedRLEnv):
         variation_recorder: VariationRecorder | None = None,
         **kwargs,
     ):
-        # Isaac Lab forwards only the viewer eye and target to the video recorder, so pass the
-        # frame they are measured in as well. Must happen before the recorder is built in super().
-        if isinstance(cfg.video_recorder, ArenaViewportVideoRecorderCfg):
-            cfg.video_recorder.viewer_origin_type = cfg.viewer.origin_type
-            cfg.video_recorder.viewer_env_index = cfg.viewer.env_index
+        forward_viewer_frame_to_video_recorder(cfg)
         self._object_initial_rest_pose_recorder = ObjectInitialRestPoseRecorder(
             num_envs=cfg.scene.num_envs, device=cfg.sim.device
         )

--- a/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
+++ b/isaaclab_arena/environments/isaaclab_arena_manager_based_env_cfg.py
@@ -17,6 +17,8 @@ from isaaclab_newton.physics import MJWarpSolverCfg, NewtonCfg
 from isaaclab_physx.physics import PhysxCfg
 from isaaclab_tasks.utils import PresetCfg
 
+from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
+
 
 @configclass
 class ArenaPhysicsCfg(PresetCfg):
@@ -65,6 +67,9 @@ class IsaacLabArenaManagerBasedRLEnvCfg(ManagerBasedRLEnvCfg):
     commands = None
     rewards = None
     curriculum = None
+
+    video_recorder: ArenaViewportVideoRecorderCfg = ArenaViewportVideoRecorderCfg()
+    """Report video recorder that reads its viewpoint in the task's configured viewer frame."""
 
     metrics: object | None = None
 

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -99,8 +99,6 @@ def main():
     )
 
     # AppLauncher must enable camera support before SimulationApp starts. Check if this is required.
-    # The viewport video needs it too: headless runs only load the rendering extensions the report
-    # camera renders through when cameras are enabled, and without them every frame comes out black.
     if (
         args_cli.record_camera_video
         or args_cli.record_viewport_video

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -99,8 +99,12 @@ def main():
     )
 
     # AppLauncher must enable camera support before SimulationApp starts. Check if this is required.
-    if args_cli.record_camera_video or _experiment_requires_cameras(
-        experiment_config_path, legacy_experiment_config, experiment_overrides
+    # The viewport video needs it too: headless runs only load the rendering extensions the report
+    # camera renders through when cameras are enabled, and without them every frame comes out black.
+    if (
+        args_cli.record_camera_video
+        or args_cli.record_viewport_video
+        or _experiment_requires_cameras(experiment_config_path, legacy_experiment_config, experiment_overrides)
     ):
         args_cli.enable_cameras = True
 

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -160,11 +160,8 @@ def main():
         args_cli.device = f"cuda:{local_rank}"
         print(f"[Rank {local_rank}/{world_size}] One Isaac Lab instance per process on cuda:{local_rank}")
 
-    # Both recorders require cameras to be enabled at sim startup, before SimulationAppContext:
-    # --record_camera_video needs the observation sensors, and --record_viewport_video needs the
-    # rendering extensions the report camera renders through. Without them every frame is black.
-    # Matched against the raw argv because these flags are only declared further down, by
-    # add_policy_runner_arguments, so they are still unparsed here.
+    # Both recorders require cameras to be enabled at sim startup, before SimulationAppContext.
+    # Matched against the raw argv because add_policy_runner_arguments has not declared them yet.
     if {"--record_camera_video", "--record_viewport_video"} & set(unknown):
         args_cli.enable_cameras = True
 

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -160,8 +160,12 @@ def main():
         args_cli.device = f"cuda:{local_rank}"
         print(f"[Rank {local_rank}/{world_size}] One Isaac Lab instance per process on cuda:{local_rank}")
 
-    # --record_camera_video requires cameras to be enabled at sim startup, before SimulationAppContext.
-    if "--record_camera_video" in unknown:
+    # Both recorders require cameras to be enabled at sim startup, before SimulationAppContext:
+    # --record_camera_video needs the observation sensors, and --record_viewport_video needs the
+    # rendering extensions the report camera renders through. Without them every frame is black.
+    # Matched against the raw argv because these flags are only declared further down, by
+    # add_policy_runner_arguments, so they are still unparsed here.
+    if {"--record_camera_video", "--record_viewport_video"} & set(unknown):
         args_cli.enable_cameras = True
 
     with SimulationAppContext(args_cli):
@@ -197,7 +201,7 @@ def main():
                 args_cli.seed += local_rank
 
         # Re-apply enable_cameras: the full parse resets it to default False.
-        if args_cli.record_camera_video:
+        if args_cli.record_camera_video or args_cli.record_viewport_video:
             args_cli.enable_cameras = True
 
         # Build scene. Use rgb_array render mode when recording so RecordVideo can grab frames.

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -132,6 +132,7 @@ def build_and_run(
                 video_cfg,
                 video_base_dir=output_dir,
                 camera_name_prefix=f"robot-cam-rebuild{rebuild_index}",
+                viewport_name_prefix=f"viewport-rebuild{rebuild_index}-env0-viewport",
             )
             rebuild_cfg = _seed_cfg_for_rebuild(cfg, rebuild_index)
             env = _build_environment_from_cfg(rebuild_cfg, rebuild_video_cfg.render_mode)

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -25,27 +25,24 @@ def test_viewer_origin_resolves_to_the_selected_environment():
     """Environment-relative viewpoints resolve against the origin of the selected clone."""
     import torch
 
-    from isaaclab_arena.video.viewport_video_recorder import resolve_viewer_origin
+    from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorder
 
+    resolve = ArenaViewportVideoRecorder._resolve_viewer_origin
     scene = SimpleNamespace(env_origins=torch.tensor([[15.0, -15.0, 0.0], [-15.0, 15.0, 0.0]]))
 
-    assert np.allclose(resolve_viewer_origin(scene, "world", 0), (0.0, 0.0, 0.0))
-    assert np.allclose(resolve_viewer_origin(scene, "env", 0), (15.0, -15.0, 0.0))
-    assert np.allclose(resolve_viewer_origin(scene, "env", 1), (-15.0, 15.0, 0.0))
+    assert np.allclose(resolve(scene, "world", 0), (0.0, 0.0, 0.0))
+    assert np.allclose(resolve(scene, "env", 0), (15.0, -15.0, 0.0))
+    assert np.allclose(resolve(scene, "env", 1), (-15.0, 15.0, 0.0))
+    with pytest.raises(AssertionError, match="outside the available range"):
+        resolve(scene, "env", NUM_ENVS)
 
 
-def test_viewer_origin_rejects_frames_it_cannot_resolve():
+def test_config_rejects_viewer_frames_it_cannot_resolve():
     """Unsupported viewer frames fail loudly rather than silently aiming the camera at world zero."""
-    import torch
-
-    from isaaclab_arena.video.viewport_video_recorder import resolve_viewer_origin
-
-    scene = SimpleNamespace(env_origins=torch.tensor([[15.0, -15.0, 0.0], [-15.0, 15.0, 0.0]]))
+    from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
 
     with pytest.raises(AssertionError, match="asset_root"):
-        resolve_viewer_origin(scene, "asset_root", 0)
-    with pytest.raises(AssertionError, match="outside the available range"):
-        resolve_viewer_origin(scene, "env", NUM_ENVS)
+        ArenaViewportVideoRecorderCfg(viewer_origin_type="asset_root")
 
 
 def test_report_recorder_does_not_follow_an_interactive_visualizer():

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the report video recorder's viewer-frame handling and headless capture."""
+
+import numpy as np
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from isaaclab_arena.tests.utils.persistent_simulation_app import run_function_with_persistent_simulation_app
+
+NUM_ENVS = 2
+NUM_STEPS = 8
+HEADLESS = True
+ENABLE_CAMERAS = True
+
+EXPECTED_VIDEO_FILENAME = "viewport-env0-viewport-episode-0.mp4"
+
+
+def test_viewer_origin_resolves_to_the_selected_environment():
+    """Environment-relative viewpoints resolve against the origin of the selected clone."""
+    import torch
+
+    from isaaclab_arena.video.viewport_video_recorder import resolve_viewer_origin
+
+    scene = SimpleNamespace(env_origins=torch.tensor([[15.0, -15.0, 0.0], [-15.0, 15.0, 0.0]]))
+
+    assert np.allclose(resolve_viewer_origin(scene, "world", 0), (0.0, 0.0, 0.0))
+    assert np.allclose(resolve_viewer_origin(scene, "env", 0), (15.0, -15.0, 0.0))
+    assert np.allclose(resolve_viewer_origin(scene, "env", 1), (-15.0, 15.0, 0.0))
+
+
+def test_viewer_origin_rejects_frames_it_cannot_resolve():
+    """Unsupported viewer frames fail loudly rather than silently aiming the camera at world zero."""
+    import torch
+
+    from isaaclab_arena.video.viewport_video_recorder import resolve_viewer_origin
+
+    scene = SimpleNamespace(env_origins=torch.tensor([[15.0, -15.0, 0.0], [-15.0, 15.0, 0.0]]))
+
+    with pytest.raises(AssertionError, match="asset_root"):
+        resolve_viewer_origin(scene, "asset_root", 0)
+    with pytest.raises(AssertionError, match="outside the available range"):
+        resolve_viewer_origin(scene, "env", NUM_ENVS)
+
+
+def _build_multi_env_goal_pose_env(render_mode: str):
+    """Build a two-environment goal-pose environment whose viewer frame is environment-relative."""
+    from isaaclab_arena.assets.registries import AssetRegistry
+    from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
+    from isaaclab_arena.embodiments.franka.franka import FrankaIKEmbodiment
+    from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
+    from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
+    from isaaclab_arena.scene.scene import Scene
+    from isaaclab_arena.tasks.goal_pose_task import GoalPoseTask
+    from isaaclab_arena.utils.pose import Pose
+
+    args_parser = get_isaaclab_arena_cli_parser()
+    args_cli = args_parser.parse_args(["--num_envs", str(NUM_ENVS), "--enable_cameras"])
+
+    asset_registry = AssetRegistry()
+    background = asset_registry.get_asset_by_name("table")()
+    light = asset_registry.get_asset_by_name("light")()
+    dex_cube = asset_registry.get_asset_by_name("dex_cube")()
+    dex_cube.set_initial_pose(Pose(position_xyz=(0.1, 0.0, 0.05), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+    embodiment = FrankaIKEmbodiment()
+    embodiment.set_initial_pose(Pose(position_xyz=(-0.4, 0.0, 0.0), rotation_xyzw=(0.0, 0.0, 0.0, 1.0)))
+
+    arena_environment = IsaacLabArenaEnvironment(
+        name="test_viewport_video_recorder",
+        embodiment=embodiment,
+        scene=Scene(assets=[background, light, dex_cube]),
+        task=GoalPoseTask(dex_cube),
+    )
+    builder = ArenaEnvBuilder(arena_environment, arena_env_builder_cfg_from_argparse(args_cli))
+    return builder.make_registered(render_mode=render_mode)
+
+
+def _test_viewport_video_recording(simulation_app, video_dir: str) -> bool:
+    import torch
+
+    from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
+
+    env = _build_multi_env_goal_pose_env(render_mode="rgb_array")
+
+    # The recorder must aim at the selected environment, not at the same coordinates in world space.
+    viewer_cfg = env.unwrapped.cfg.viewer
+    assert viewer_cfg.origin_type == "env", f"Expected an environment-relative viewer, got '{viewer_cfg.origin_type}'."
+    env_origin = env.unwrapped.scene.env_origins[viewer_cfg.env_index].detach().cpu().numpy()
+    assert (
+        np.linalg.norm(env_origin) > 0.0
+    ), "Environment origin is at the world origin; the test cannot detect the bug."
+
+    recorder_cfg = env.unwrapped.video_recorder.cfg
+    assert np.allclose(recorder_cfg.eye, env_origin + np.asarray(viewer_cfg.eye)), (
+        f"Report camera eye {recorder_cfg.eye} does not match the viewer eye {viewer_cfg.eye} "
+        f"placed at environment origin {env_origin}."
+    )
+    assert np.allclose(recorder_cfg.lookat, env_origin + np.asarray(viewer_cfg.lookat)), (
+        f"Report camera target {recorder_cfg.lookat} does not match the viewer target {viewer_cfg.lookat} "
+        f"placed at environment origin {env_origin}."
+    )
+
+    # Recording must produce a real mp4 with visible content while headless.
+    video_cfg = VideoRecordingCfg(record_viewport_video=True, video_base_dir=video_dir)
+    env = wrap_env_for_video(env, video_cfg, num_steps=NUM_STEPS, num_episodes=None)
+    env.reset()
+    for _ in range(NUM_STEPS):
+        with torch.inference_mode():
+            env.step(torch.zeros(env.action_space.shape, device=env.unwrapped.device))
+
+    frame = env.unwrapped.render()
+    assert frame is not None, "Headless render returned no frame."
+    assert frame.any(), "Headless render returned an all-black frame."
+    env.close()
+
+    videos = sorted(Path(video_dir).glob("*.mp4"))
+    assert [video.name for video in videos] == [EXPECTED_VIDEO_FILENAME], f"Unexpected videos written: {videos}."
+    assert videos[0].stat().st_size > 0, "Viewport video is empty."
+
+    return True
+
+
+@pytest.mark.with_cameras
+def test_viewport_video_recording(tmp_path):
+    result = run_function_with_persistent_simulation_app(
+        _test_viewport_video_recording,
+        headless=HEADLESS,
+        enable_cameras=ENABLE_CAMERAS,
+        video_dir=str(tmp_path),
+    )
+    assert result, "Test failed"
+
+
+if __name__ == "__main__":
+    test_viewport_video_recording(Path("/tmp/test_viewport_video_recorder"))

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -33,16 +33,21 @@ def test_viewer_origin_resolves_to_the_selected_environment():
     assert np.allclose(resolve(scene, "world", 0), (0.0, 0.0, 0.0))
     assert np.allclose(resolve(scene, "env", 0), (15.0, -15.0, 0.0))
     assert np.allclose(resolve(scene, "env", 1), (-15.0, 15.0, 0.0))
-    with pytest.raises(AssertionError, match="outside the available range"):
-        resolve(scene, "env", NUM_ENVS)
 
 
-def test_config_rejects_viewer_frames_it_cannot_resolve():
+def test_viewer_origin_rejects_frames_it_cannot_resolve():
     """Unsupported viewer frames fail loudly rather than silently aiming the camera at world zero."""
-    from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
+    import torch
+
+    from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorder
+
+    resolve = ArenaViewportVideoRecorder._resolve_viewer_origin
+    scene = SimpleNamespace(env_origins=torch.tensor([[15.0, -15.0, 0.0], [-15.0, 15.0, 0.0]]))
 
     with pytest.raises(AssertionError, match="asset_root"):
-        ArenaViewportVideoRecorderCfg(viewer_origin_type="asset_root")
+        resolve(scene, "asset_root", 0)
+    with pytest.raises(AssertionError, match="outside the available range"):
+        resolve(scene, "env", NUM_ENVS)
 
 
 def test_report_recorder_does_not_follow_an_interactive_visualizer():

--- a/isaaclab_arena/tests/test_viewport_video_recorder.py
+++ b/isaaclab_arena/tests/test_viewport_video_recorder.py
@@ -48,6 +48,17 @@ def test_viewer_origin_rejects_frames_it_cannot_resolve():
         resolve_viewer_origin(scene, "env", NUM_ENVS)
 
 
+def test_report_recorder_does_not_follow_an_interactive_visualizer():
+    """An active visualizer must not replace the resolved viewpoint with its own camera.
+
+    Isaac Lab's ``"visualizer"`` backend source overwrites the recorder's eye and target from the
+    visualizer config whenever one is running, which would discard the environment offset.
+    """
+    from isaaclab_arena.video.viewport_video_recorder import ArenaViewportVideoRecorderCfg
+
+    assert ArenaViewportVideoRecorderCfg().backend_source == "renderer"
+
+
 def _build_multi_env_goal_pose_env(render_mode: str):
     """Build a two-environment goal-pose environment whose viewer frame is environment-relative."""
     from isaaclab_arena.assets.registries import AssetRegistry

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -30,11 +30,7 @@ class VideoRecordingCfg:
     """Filename prefix for the per-camera mp4s written by ``CameraObsVideoRecorder``."""
 
     viewport_name_prefix: str = "viewport-env0-viewport"
-    """Filename prefix for the viewport mp4 written by Gymnasium's ``RecordVideo``.
-
-    Shaped so the completed filename parses as an episode result: the report reads mp4s named
-    ``<prefix>[-rebuild<R>]-env<N>-<camera>-episode-<E>.mp4``.
-    """
+    """Filename prefix for the viewport mp4 written by Gymnasium's ``RecordVideo``."""
 
     @property
     def enabled(self) -> bool:

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -29,6 +29,13 @@ class VideoRecordingCfg:
     camera_name_prefix: str = "robot-cam"
     """Filename prefix for the per-camera mp4s written by ``CameraObsVideoRecorder``."""
 
+    viewport_name_prefix: str = "viewport-env0-viewport"
+    """Filename prefix for the viewport mp4 written by Gymnasium's ``RecordVideo``.
+
+    Shaped so the completed filename parses as an episode result: the report reads mp4s named
+    ``<prefix>[-rebuild<R>]-env<N>-<camera>-episode-<E>.mp4``.
+    """
+
     @property
     def enabled(self) -> bool:
         """Whether any recorder is requested."""
@@ -89,8 +96,9 @@ def wrap_env_for_video(
         env = RecordVideo(
             env,
             video_folder=video_cfg.video_base_dir,
-            step_trigger=lambda step: step == 0,
+            episode_trigger=lambda episode: episode == 0,
             video_length=video_length,
+            name_prefix=video_cfg.viewport_name_prefix,
             disable_logger=True,
         )
         print(f"Recording {video_length}-step viewport video to: {video_cfg.video_base_dir}")

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -72,6 +72,14 @@ class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
 
     class_type: type = ArenaViewportVideoRecorder
 
+    backend_source: Literal["visualizer", "renderer"] = "renderer"
+    """Record from the physics/renderer stack rather than following an interactive visualizer.
+
+    Leaving this at Isaac Lab's ``"visualizer"`` default makes the base class overwrite the resolved
+    eye and target with the visualizer's own camera whenever one is active (``--viz kit``), which
+    discards the task viewpoint and the environment offset resolved here.
+    """
+
     viewer_origin_type: Literal["world", "env", "asset_root", "asset_body"] = "world"
     """Frame the configured eye and target are expressed in, mirroring ``ViewerCfg.origin_type``."""
 

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -18,32 +18,6 @@ SUPPORTED_VIEWER_ORIGIN_TYPES = ("world", "env")
 """Viewer frames the report video recorder can resolve."""
 
 
-def resolve_viewer_origin(scene, origin_type: str, env_index: int) -> np.ndarray:
-    """Return the world-frame origin that a task's viewer eye and target are measured from.
-
-    Args:
-        scene: Interactive scene supplying the per-environment origins.
-        origin_type: Viewer frame, mirroring the task's ``ViewerCfg.origin_type``.
-        env_index: Environment supplying the origin when the frame is environment-relative.
-
-    Returns:
-        The world-frame origin, as an XYZ array.
-    """
-    if origin_type == "world":
-        return np.zeros(3, dtype=float)
-    # The asset-tracking frames cannot be resolved here: Isaac Lab builds the video recorder before
-    # sim.reset(), so no asset has a physics view yet and root/body poses are unreadable.
-    assert origin_type == "env", (
-        f"Viewer origin type '{origin_type}' is not supported for report video recording; "
-        f"expected one of {SUPPORTED_VIEWER_ORIGIN_TYPES}."
-    )
-    num_envs = len(scene.env_origins)
-    assert (
-        0 <= env_index < num_envs
-    ), f"Viewer environment index {env_index} is outside the available range [0, {num_envs - 1}]."
-    return scene.env_origins[env_index].detach().cpu().numpy().astype(float)
-
-
 class ArenaViewportVideoRecorder(VideoRecorder):
     """Record the report video from the task's viewpoint, resolved into world coordinates.
 
@@ -60,10 +34,32 @@ class ArenaViewportVideoRecorder(VideoRecorder):
         # config, and that copy is what ultimately aims the camera.
         # ManagerBasedRLEnv re-derives cfg.eye/lookat from cfg.viewer on every environment
         # construction, so overwriting them here cannot accumulate across rebuilds.
-        origin = resolve_viewer_origin(scene, cfg.viewer_origin_type, cfg.viewer_env_index)
-        cfg.eye = tuple(float(x) for x in origin + np.asarray(cfg.eye, dtype=float))
-        cfg.lookat = tuple(float(x) for x in origin + np.asarray(cfg.lookat, dtype=float))
+        origin = self._resolve_viewer_origin(scene, cfg.viewer_origin_type, cfg.viewer_env_index)
+        world_eye = origin + np.asarray(cfg.eye, dtype=float)
+        world_lookat = origin + np.asarray(cfg.lookat, dtype=float)
+        cfg.eye = tuple(world_eye.tolist())
+        cfg.lookat = tuple(world_lookat.tolist())
         super().__init__(cfg, scene)
+
+    @staticmethod
+    def _resolve_viewer_origin(scene, origin_type: str, env_index: int) -> np.ndarray:
+        """Return the world-frame origin that the viewer eye and target are measured from.
+
+        Args:
+            scene: Interactive scene supplying the per-environment origins.
+            origin_type: Viewer frame, already checked against the frames Arena can resolve.
+            env_index: Environment supplying the origin when the frame is environment-relative.
+
+        Returns:
+            The world-frame origin, as an XYZ array.
+        """
+        if origin_type == "world":
+            return np.zeros(3, dtype=float)
+        num_envs = len(scene.env_origins)
+        assert (
+            0 <= env_index < num_envs
+        ), f"Viewer environment index {env_index} is outside the available range [0, {num_envs - 1}]."
+        return scene.env_origins[env_index].detach().cpu().numpy().astype(float)
 
 
 @configclass
@@ -85,3 +81,11 @@ class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
 
     viewer_env_index: int = 0
     """Environment supplying the viewer origin when the frame is environment-relative."""
+
+    def __post_init__(self):
+        # The asset-tracking frames cannot be resolved: Isaac Lab builds the video recorder before
+        # sim.reset(), so no asset has a physics view yet and root/body poses are unreadable.
+        assert self.viewer_origin_type in SUPPORTED_VIEWER_ORIGIN_TYPES, (
+            f"Viewer origin type '{self.viewer_origin_type}' is not supported for report video "
+            f"recording; expected one of {SUPPORTED_VIEWER_ORIGIN_TYPES}."
+        )

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -47,7 +47,7 @@ class ArenaViewportVideoRecorder(VideoRecorder):
 
         Args:
             scene: Interactive scene supplying the per-environment origins.
-            origin_type: Viewer frame, already checked against the frames Arena can resolve.
+            origin_type: Viewer frame, mirroring the task's ``ViewerCfg.origin_type``.
             env_index: Environment supplying the origin when the frame is environment-relative.
 
         Returns:
@@ -55,6 +55,12 @@ class ArenaViewportVideoRecorder(VideoRecorder):
         """
         if origin_type == "world":
             return np.zeros(3, dtype=float)
+        # The asset-tracking frames cannot be resolved here: Isaac Lab builds the video recorder
+        # before sim.reset(), so no asset has a physics view yet and root/body poses are unreadable.
+        assert origin_type == "env", (
+            f"Viewer origin type '{origin_type}' is not supported for report video recording; "
+            f"expected one of {SUPPORTED_VIEWER_ORIGIN_TYPES}."
+        )
         num_envs = len(scene.env_origins)
         assert (
             0 <= env_index < num_envs
@@ -81,11 +87,3 @@ class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
 
     viewer_env_index: int = 0
     """Environment supplying the viewer origin when the frame is environment-relative."""
-
-    def __post_init__(self):
-        # The asset-tracking frames cannot be resolved: Isaac Lab builds the video recorder before
-        # sim.reset(), so no asset has a physics view yet and root/body poses are unreadable.
-        assert self.viewer_origin_type in SUPPORTED_VIEWER_ORIGIN_TYPES, (
-            f"Viewer origin type '{self.viewer_origin_type}' is not supported for report video "
-            f"recording; expected one of {SUPPORTED_VIEWER_ORIGIN_TYPES}."
-        )

--- a/isaaclab_arena/video/viewport_video_recorder.py
+++ b/isaaclab_arena/video/viewport_video_recorder.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report video recording that reads its viewpoint in the task's configured viewer frame."""
+
+from __future__ import annotations
+
+import numpy as np
+from typing import Literal
+
+from isaaclab.envs.utils.video_recorder import VideoRecorder
+from isaaclab.envs.utils.video_recorder_cfg import VideoRecorderCfg
+from isaaclab.utils.configclass import configclass
+
+SUPPORTED_VIEWER_ORIGIN_TYPES = ("world", "env")
+"""Viewer frames the report video recorder can resolve."""
+
+
+def resolve_viewer_origin(scene, origin_type: str, env_index: int) -> np.ndarray:
+    """Return the world-frame origin that a task's viewer eye and target are measured from.
+
+    Args:
+        scene: Interactive scene supplying the per-environment origins.
+        origin_type: Viewer frame, mirroring the task's ``ViewerCfg.origin_type``.
+        env_index: Environment supplying the origin when the frame is environment-relative.
+
+    Returns:
+        The world-frame origin, as an XYZ array.
+    """
+    if origin_type == "world":
+        return np.zeros(3, dtype=float)
+    # The asset-tracking frames cannot be resolved here: Isaac Lab builds the video recorder before
+    # sim.reset(), so no asset has a physics view yet and root/body poses are unreadable.
+    assert origin_type == "env", (
+        f"Viewer origin type '{origin_type}' is not supported for report video recording; "
+        f"expected one of {SUPPORTED_VIEWER_ORIGIN_TYPES}."
+    )
+    num_envs = len(scene.env_origins)
+    assert (
+        0 <= env_index < num_envs
+    ), f"Viewer environment index {env_index} is outside the available range [0, {num_envs - 1}]."
+    return scene.env_origins[env_index].detach().cpu().numpy().astype(float)
+
+
+class ArenaViewportVideoRecorder(VideoRecorder):
+    """Record the report video from the task's viewpoint, resolved into world coordinates.
+
+    Isaac Lab forwards ``ViewerCfg.eye`` and ``ViewerCfg.lookat`` to the recorder but not
+    ``ViewerCfg.origin_type``, so an environment-relative task viewpoint is recorded as though it
+    were already in world coordinates. That aims the camera at empty space whenever the selected
+    environment origin is non-zero, which is every parallel-environment run.
+    """
+
+    cfg: ArenaViewportVideoRecorderCfg
+
+    def __init__(self, cfg: ArenaViewportVideoRecorderCfg, scene):
+        # Resolve before delegating: the base class copies eye/lookat into the backend capture
+        # config, and that copy is what ultimately aims the camera.
+        # ManagerBasedRLEnv re-derives cfg.eye/lookat from cfg.viewer on every environment
+        # construction, so overwriting them here cannot accumulate across rebuilds.
+        origin = resolve_viewer_origin(scene, cfg.viewer_origin_type, cfg.viewer_env_index)
+        cfg.eye = tuple(float(x) for x in origin + np.asarray(cfg.eye, dtype=float))
+        cfg.lookat = tuple(float(x) for x in origin + np.asarray(cfg.lookat, dtype=float))
+        super().__init__(cfg, scene)
+
+
+@configclass
+class ArenaViewportVideoRecorderCfg(VideoRecorderCfg):
+    """Configure the report video recorder to read its viewpoint in the task's viewer frame."""
+
+    class_type: type = ArenaViewportVideoRecorder
+
+    viewer_origin_type: Literal["world", "env", "asset_root", "asset_body"] = "world"
+    """Frame the configured eye and target are expressed in, mirroring ``ViewerCfg.origin_type``."""
+
+    viewer_env_index: int = 0
+    """Environment supplying the viewer origin when the frame is environment-relative."""


### PR DESCRIPTION
## Summary
Fix the report video camera pose in parallel environments.

## Detailed description
- **Why**
  - Isaac Lab forwards `ViewerCfg.eye`/`lookat` to the video recorder but not `origin_type`, so environment-relative task viewpoints were treated as world coordinates.
  - The camera therefore aimed at empty space whenever the environment origin was non-zero, i.e. every parallel-env run, giving all-black mp4s.
- **What**
  - Slimmed down version of #1205
  - Resolve the viewer origin into world coordinates before the recorder is built.
  - Name the viewport mp4 so the existing report parser links it to an episode.
  - Enable camera support for `--record_viewport_video`; without it headless runs load no renderer and every frame is black.
  - Add a headless two-environment test covering the resolved pose and the written mp4.

## Videos

Before fix:

https://github.com/user-attachments/assets/4a5ae53a-8907-4e48-a373-def0af03f2a2

After fix:

https://github.com/user-attachments/assets/a25ae9bc-d727-4fea-b0b6-379776221efe

