### PR TITLE
Cherry-pick (#1225) to release/0.3.0: Update IL/RL language to reflect interop

### DIFF
--- a/docs/pages/concepts/task/concept_rl_tasks_design.rst
+++ b/docs/pages/concepts/task/concept_rl_tasks_design.rst
@@ -1,8 +1,8 @@
 RL Tasks
 ========
 
-RL tasks extend their imitation learning counterparts with the components
-needed for reinforcement learning training: a command manager that samples
+RL tasks extend their imitation learning counterparts with the components Isaac Lab's
+reinforcement-learning training scripts require: a command manager that samples
 a new goal each episode, reward terms, and goal-conditioned observations.
 
 The pattern is straightforward — an RL task subclasses the corresponding IL task,

--- a/docs/pages/example_workflows/imitation_learning/index.rst
+++ b/docs/pages/example_workflows/imitation_learning/index.rst
@@ -1,9 +1,9 @@
 Imitation Learning
 ==================
 
-The following workflows demonstrate end-to-end imitation learning with Isaac Lab Arena,
-covering teleoperation data collection, data generation, policy post-training, and
-closed-loop evaluation.
+The following workflows build their environments in Isaac Lab Arena and plug them into Isaac
+Lab's imitation-learning workflows, covering teleoperation data collection, data generation with
+Isaac Lab Mimic, policy post-training, and closed-loop evaluation back in Isaac Lab Arena.
 
 Currently, the following imitation learning workflow examples are provided:
 

--- a/docs/pages/example_workflows/locomanipulation/index.rst
+++ b/docs/pages/example_workflows/locomanipulation/index.rst
@@ -1,7 +1,7 @@
 G1 Loco-Manipulation Box Pick and Place Task
 ============================================
 
-This example demonstrates the complete workflow for the **G1 loco-manipulation box pick and place task** in Isaac Lab - Arena, covering environment setup and validation, teleoperation data collection (OpenXR with Meta Quest 3), data generation, policy post-training, and closed-loop evaluation.
+This example demonstrates the complete workflow for the **G1 loco-manipulation box pick and place task**. The environment is built and validated in Isaac Lab Arena, then passed to Isaac Lab for teleoperation data collection (OpenXR with Meta Quest 3) and data generation with Isaac Lab Mimic; the policy is post-trained with Isaac-GR00T and evaluated in closed loop back in Isaac Lab Arena.
 
 .. image:: ../../../images/g1_galileo_arena_box_pnp_locomanip.gif
    :align: center
@@ -39,7 +39,7 @@ including lower body locomotion, squatting, and bimanual manipulation.
    * - **Policy**
      - GR00T N1.6 (vision-language-action foundation model)
    * - **Post-training**
-     - Imitation Learning
+     - Imitation Learning — post-trained with **Isaac-GR00T**
    * - **Dataset**
      - `Arena-G1-Loco-Manipulation-Task <https://huggingface.co/datasets/nvidia/Arena-G1-Loco-Manipulation-Task>`_
    * - **Checkpoint**
@@ -56,8 +56,9 @@ including lower body locomotion, squatting, and bimanual manipulation.
 Workflow
 --------
 
-This tutorial covers the pipeline between creating an environment, collecting teleoperation demonstrations, generating training data,
-fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop.
+This tutorial covers the pipeline between creating an environment in Isaac Lab Arena, collecting
+teleoperation demonstrations and generating training data through Isaac Lab,
+fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop in Isaac Lab Arena.
 A user can follow the whole pipeline, or can start at any intermediate step
 by downloading the pre-generated output of the preceding step(s), which we provide
 (described in the relevant step below).

--- a/docs/pages/example_workflows/python_environment_catalog.rst
+++ b/docs/pages/example_workflows/python_environment_catalog.rst
@@ -453,7 +453,7 @@ the :doc:`reinforcement_learning/index` workflow.
    * - **Task Class**
      - ``LiftObjectTaskRL`` (minimum_height_to_lift = 0.04, episode_length_s = 5)
    * - **Training Method**
-     - Reinforcement Learning (RSL-RL PPO; ``rl_policy_cfg`` = ``base_rsl_rl_policy:RLPolicyCfg``)
+     - Trained in Isaac Lab via Reinforcement Learning (RSL-RL PPO; ``rl_policy_cfg`` = ``base_rsl_rl_policy:RLPolicyCfg``)
    * - **CLI Args**
      - ``--object``, ``--embodiment``, ``--teleop_device``, ``--rl_training_mode``
 

--- a/docs/pages/example_workflows/reinforcement_learning/index.rst
+++ b/docs/pages/example_workflows/reinforcement_learning/index.rst
@@ -1,7 +1,7 @@
 Franka Lift Object Task
 ========================
 
-This example demonstrates the complete workflow for **reinforcement learning-based object lifting** using the Franka Panda robot in Isaac Lab - Arena, covering environment setup, policy training with RSL-RL, and closed-loop evaluation.
+This example demonstrates the complete workflow for **reinforcement learning-based object lifting** with the Franka Panda robot. The environment is built in Isaac Lab Arena and passed to Isaac Lab for policy training with RSL-RL, and the resulting checkpoint is evaluated in closed loop in Isaac Lab Arena.
 
 .. image:: ../../../images/lift_object_rl_task.gif
    :align: center
@@ -35,7 +35,7 @@ Task Overview
    * - **Policy**
      - RSL-RL PPO (learned from scratch)
    * - **Training Method**
-     - Reinforcement Learning (on-policy PPO)
+     - Reinforcement Learning (on-policy PPO) — trained in **Isaac Lab**
    * - **Physics**
      - PhysX (50Hz @ 2 decimation)
    * - **Closed-loop**
@@ -49,9 +49,10 @@ Task Overview
 Workflow
 --------
 
-This tutorial covers the pipeline for creating an RL environment, training a policy using RSL-RL,
-and evaluating the trained policy in closed-loop. A user can follow the whole pipeline, or can start
-at any intermediate step by using the provided checkpoints.
+This tutorial covers the pipeline for creating an RL environment in Isaac Lab Arena, passing it to
+Isaac Lab to train a policy using RSL-RL, and evaluating the trained policy in closed-loop in
+Isaac Lab Arena. A user can follow the whole pipeline, or can start at any intermediate step by
+using the provided checkpoints.
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/reinforcement_learning_workflows/index.rst
+++ b/docs/pages/example_workflows/reinforcement_learning_workflows/index.rst
@@ -1,8 +1,9 @@
 Reinforcement Learning
 ======================
 
-The following workflows demonstrate end-to-end reinforcement learning with Isaac Lab Arena,
-covering environment setup, policy training, and closed-loop evaluation.
+The following workflows build their environments in Isaac Lab Arena and plug them into Isaac
+Lab's reinforcement-learning workflows, covering environment setup, policy training in Isaac
+Lab, and closed-loop evaluation back in Isaac Lab Arena.
 
 Currently, the following reinforcement learning workflow examples are provided:
 

--- a/docs/pages/example_workflows/sequential_static_manipulation/index.rst
+++ b/docs/pages/example_workflows/sequential_static_manipulation/index.rst
@@ -1,10 +1,11 @@
 GR1 Sequential Pick & Place and Close Door Task
 ===============================================
 
-This example demonstrates the complete workflow for the **GR1 sequential manipulation task of picking up an object,
-placing it into a refrigerator, and closing the door** in Isaac Lab - Arena,
-covering environment setup and validation, teleoperation data collection, data generation with
-Isaac Lab Mimic, policy post-training, and closed-loop evaluation.
+This example demonstrates the complete workflow for the **GR1 sequential manipulation task of
+picking up an object, placing it into a refrigerator, and closing the door**. The environment is
+built and validated in Isaac Lab Arena, then passed to Isaac Lab for teleoperation data collection
+and data generation with Isaac Lab Mimic; the policy is post-trained with Isaac-GR00T and
+evaluated in closed loop back in Isaac Lab Arena.
 
 .. image:: ../../../images/gr1_sequential_static_manipulation_env.gif
    :align: center
@@ -40,7 +41,7 @@ Task Overview
    * - **Policy**
      - GR00T N1.6 (vision-language foundation model)
    * - **Post-training**
-     - Imitation Learning
+     - Imitation Learning — post-trained with **Isaac-GR00T**
    * - **Physics**
      - PhysX (200Hz @ 4 decimation)
    * - **Closed-loop**
@@ -50,8 +51,9 @@ Task Overview
 Workflow
 --------
 
-This tutorial covers the pipeline pn creating an environment, generating training data,
-fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop.
+This tutorial covers the pipeline between creating an environment in Isaac Lab Arena, generating
+training data through Isaac Lab, fine-tuning a policy (GR00T N1.6), and evaluating the policy in
+closed-loop in Isaac Lab Arena.
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/docs/pages/example_workflows/static_manipulation/index.rst
+++ b/docs/pages/example_workflows/static_manipulation/index.rst
@@ -1,7 +1,7 @@
 GR1 Open Microwave Door Task
 =============================
 
-This example demonstrates the complete workflow for the **GR1 manipulation task of opening a microwave door** in Isaac Lab - Arena, covering environment setup and validation, teleoperation data collection, data generation with Isaac Lab Mimic, policy post-training, and closed-loop evaluation.
+This example demonstrates the complete workflow for the **GR1 manipulation task of opening a microwave door**. The environment is built and validated in Isaac Lab Arena, then passed to Isaac Lab for teleoperation data collection and data generation with Isaac Lab Mimic; the policy is post-trained with Isaac-GR00T and evaluated in closed loop back in Isaac Lab Arena.
 
 .. image:: ../../../images/kitchen_gr1_arena.gif
    :align: center
@@ -37,7 +37,7 @@ Task Overview
    * - **Policy**
      - GR00T N1.6 (vision-language foundation model)
    * - **Post-training**
-     - Imitation Learning
+     - Imitation Learning — post-trained with **Isaac-GR00T**
    * - **Dataset**
      - `Arena-GR1-Manipulation-Task <https://huggingface.co/datasets/nvidia/Arena-GR1-Manipulation-Task>`_
    * - **Checkpoint**
@@ -53,8 +53,9 @@ Task Overview
 Workflow
 --------
 
-This tutorial covers the pipeline between creating an environment, generating training data,
-fine-tuning a policy (GR00T N1.6), and evaluating the policy in closed-loop.
+This tutorial covers the pipeline between creating an environment in Isaac Lab Arena, generating
+training data through Isaac Lab, fine-tuning a policy (GR00T N1.6), and evaluating the policy in
+closed-loop in Isaac Lab Arena.
 A user can follow the whole pipeline, or can start at any intermediate step
 by downloading the pre-generated output of the preceding step(s), which we provide
 (described in the relevant step below).


### PR DESCRIPTION
## Summary
Cherry-pick #1225 to release/0.3.0

## Detailed description
- Cherry-pick of b67284a73 from `main` (#1225), where it is already merged.
- IL/RL docs said the learning happens "in Isaac Lab Arena"; the language now reflects that Arena builds the environment and passes it to Isaac Lab, matching the interop model already described in `README.md` and the `dexsuite_lift` pages.
- Docs-only, 8 files. Applied cleanly; `python_environment_catalog.rst` auto-merged and keeps this branch's newer `Isaac-Dexsuite-Kuka-Allegro-Lift-v0` / `DexsuiteKukaAllegroPPORunnerCfg` naming, which `main` does not yet carry.
- Verified with a local Sphinx build on this branch: succeeded with zero warnings.