### PR TITLE
Cherry-pick (#1224) to release/0.3.0: Add uv tabs to the getting started pages

### DIFF
--- a/docs/pages/quickstart/arena_env.rst
+++ b/docs/pages/quickstart/arena_env.rst
@@ -53,9 +53,21 @@ actions, so no policy or model weights are required. It keeps running until you 
 ``Ctrl-C``. While it runs, hold ``Shift`` and left-drag an object to move it and inspect its physical
 behavior.
 
-Start or enter the Base Docker container from the repository root:
+Prepare the runtime from the repository root, using either a native ``uv`` environment or the base
+Docker container (see :doc:`installation` for the full setup):
 
-:docker_run_default:
+.. tab-set::
+
+   .. tab-item:: Native uv
+      :selected:
+
+      :uv_run_source:
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
+Every command below is identical in both runtimes.
 
 
 Run the reference scene

--- a/docs/pages/quickstart/arena_experiment.rst
+++ b/docs/pages/quickstart/arena_experiment.rst
@@ -70,11 +70,21 @@ results.
 Run the Experiment locally
 --------------------------
 
-Start or enter the Base Docker container from the repository root:
+Prepare the runtime from the repository root, using either a native ``uv`` environment or the base
+Docker container (see :doc:`installation` for the full setup):
 
-:docker_run_default:
+.. tab-set::
 
-Then run it inside the container:
+   .. tab-item:: Native uv
+      :selected:
+
+      :uv_run_source:
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
+Then run the Experiment:
 
 .. code-block:: bash
 

--- a/docs/pages/quickstart/environment_variations.rst
+++ b/docs/pages/quickstart/environment_variations.rst
@@ -45,11 +45,21 @@ still, and five environment rebuilds make the visual changes easy to inspect.
    .. literalinclude:: ../../../isaaclab_arena_environments/experiment_configs/droid_pnp_variations_experiment.yaml
       :language: yaml
 
-Start or enter the Base Docker container from the repository root:
+Prepare the runtime from the repository root, using either a native ``uv`` environment or the base
+Docker container (see :doc:`installation` for the full setup):
 
-:docker_run_default:
+.. tab-set::
 
-Then run the example inside the container:
+   .. tab-item:: Native uv
+      :selected:
+
+      :uv_run_source:
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
+Then run the example:
 
 .. code-block:: bash
 

--- a/docs/pages/quickstart/running_a_real_policy/gr00t.rst
+++ b/docs/pages/quickstart/running_a_real_policy/gr00t.rst
@@ -43,13 +43,6 @@ reuse the local cache. Leave this server running.
 Run GR00T with the Experiment Runner
 ------------------------------------
 
-If you run Arena from its native ``uv`` environment, install the GR00T client
-package:
-
-.. code-block:: bash
-
-   uv sync --group gr00t-client
-
 Arena includes a one-Run YAML configuration for the first rollout. It selects the
 DROID environment, connects the GR00T policy to the server, and stops after three episodes.
 
@@ -64,7 +57,27 @@ GR00T N1.6-DROID uses absolute joint positions. The YAML therefore selects
 instruction belongs to the environment builder, while the server connection belongs to the
 policy.
 
-Open another shell, enter the Arena container, and start the rollout with the Experiment Runner:
+Open another shell and prepare the Arena runtime from the repository root, using either a native
+``uv`` environment or the base Docker container (see :doc:`../installation` for the full setup):
+
+.. tab-set::
+
+   .. tab-item:: Native uv
+      :selected:
+
+      The GR00T client is not part of a default sync, so select its dependency group:
+
+      .. code-block:: bash
+
+         uv sync --extra dev --group gr00t-client
+         source .venv/bin/activate
+         export OMNI_KIT_ACCEPT_EULA=YES ACCEPT_EULA=Y
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
+Then start the rollout with the Experiment Runner:
 
 .. code-block:: bash
 

--- a/docs/pages/quickstart/running_a_real_policy/openpi.rst
+++ b/docs/pages/quickstart/running_a_real_policy/openpi.rst
@@ -53,7 +53,21 @@ Terminal 2 — Experiment Runner
 
 **Run pi05 closed-loop**
 
-Open a second terminal and enter the Arena container with ``./docker/run_docker.sh``.
+Open a second terminal and prepare the Arena runtime from the repository root, using either a
+native ``uv`` environment or the base Docker container (see
+:doc:`../installation` for the full setup):
+
+.. tab-set::
+
+   .. tab-item:: Native uv
+      :selected:
+
+      :uv_run_source:
+
+   .. tab-item:: Docker Container
+
+      :docker_run_default:
+
 Arena includes a one-Run YAML configuration for this rollout:
 
 .. dropdown:: Configuration file (``droid_pnp_openpi_experiment.yaml``)


### PR DESCRIPTION
## Summary
Cherry-pick #1224 to release/0.3.0

## Detailed description
- Cherry-pick of 3afeb0381 from `main` (#1224), where it is already merged.
- The getting-started pages referred only to the Docker launch route; each now offers a "Native uv" / "Docker Container" tab-set, matching the uv route `installation.rst` already documents.
- Docs-only, 5 files. Applied cleanly with no conflicts; all five files are byte-identical to `main`.
- Verified on this branch: the `:uv_run_source:` / `:docker_run_default:` substitutions and the `sphinx_design` extension the tab-set needs are all present here, and a local Sphinx build renders both tabs on all five pages with no unexpanded placeholders.