### PR TITLE
[release 0.3.0] Move CI to release images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       NVIDIA_API_KEY: ${{ secrets.ARENA_NVIDIA_API_KEY }}
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:release_v0.3.0
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}
@@ -184,7 +184,7 @@ jobs:
     needs: [pre_commit]
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:release_v0.3.0
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}
@@ -223,7 +223,7 @@ jobs:
       GR00T_REMOTE_E2E_TIMEOUT: "900"
 
     container:
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:latest
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:release_v0.3.0
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}
@@ -285,7 +285,7 @@ jobs:
 
     container:
       # The cuRobo-enabled image (built with ./docker/run_docker.sh -c / push_to_ngc.sh -c).
-      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:curobo
+      image: nvcr.io/nvstaging/isaac-amr/isaaclab_arena:release_v0.3.0_curobo
       credentials:
         username: $oauthtoken
         password: ${{ env.NGC_API_KEY }}


### PR DESCRIPTION
## Summary
Point release CI at the release_v0.3.0 image

## Detailed description
- **Why**
  - The release branch was running CI on `:latest` tags.
  - These tags are linked to `main` and lab3.0 GA + Isaac Sim 6.1
- **What**
  - Moves the `release/0.3.0` branch to image tags `release_v0.3.0` and `release_v0.3.0_curobo`