### PR TITLE
Document camera-free experiment benchmarking

### DIFF
--- a/docs/images/performance/distributed_run_speedup.svg
+++ b/docs/images/performance/distributed_run_speedup.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img">
+  <title>Active Arena execution speedup with OSMO</title>
+  <desc>Speedup is 1.00 times with 1 concurrent GPU, 2.02 times with 2 GPUs, 4.05 times with 4 GPUs, and 7.95 times with 8 GPUs.</desc>
+  <rect width="960" height="540" fill="#ffffff"/>
+  <g font-family="Arial, Helvetica, sans-serif" fill="#222222">
+    <text x="480" y="42" text-anchor="middle" font-size="26" font-weight="700">Active Arena execution speedup with OSMO</text>
+    <text x="480" y="70" text-anchor="middle" font-size="15" fill="#555555">One Experiment containing eight independent Runs</text>
+
+    <g stroke="#d9d9d9" stroke-width="1">
+      <line x1="105" y1="420" x2="925" y2="420"/>
+      <line x1="105" y1="344" x2="925" y2="344"/>
+      <line x1="105" y1="267" x2="925" y2="267"/>
+      <line x1="105" y1="191" x2="925" y2="191"/>
+      <line x1="105" y1="114" x2="925" y2="114"/>
+    </g>
+
+    <g font-size="14" text-anchor="end" fill="#555555">
+      <text x="92" y="425">0</text>
+      <text x="92" y="349">2</text>
+      <text x="92" y="272">4</text>
+      <text x="92" y="196">6</text>
+      <text x="92" y="119">8</text>
+    </g>
+
+    <g stroke="#333333" stroke-width="1.5">
+      <line x1="105" y1="95" x2="105" y2="420"/>
+      <line x1="105" y1="420" x2="925" y2="420"/>
+    </g>
+
+    <g fill="#76b900" stroke="#65a000" stroke-width="2">
+      <rect x="140" y="381.8" width="100" height="38.2"/>
+      <rect x="355" y="342.8" width="100" height="77.2"/>
+      <rect x="570" y="265.2" width="100" height="154.8"/>
+      <rect x="785" y="116.0" width="100" height="304.0"/>
+    </g>
+
+    <g font-size="18" font-weight="700" text-anchor="middle">
+      <text x="190" y="355">1.00x</text>
+      <text x="405" y="316">2.02x</text>
+      <text x="620" y="238">4.05x</text>
+      <text x="835" y="90">7.95x</text>
+    </g>
+    <g font-size="16" text-anchor="middle">
+      <text x="190" y="451">1</text>
+      <text x="405" y="451">2</text>
+      <text x="620" y="451">4</text>
+      <text x="835" y="451">8</text>
+    </g>
+
+    <text x="515" y="486" text-anchor="middle" font-size="17">Concurrent one-GPU Runs</text>
+    <text x="30" y="258" text-anchor="middle" font-size="17" transform="rotate(-90 30 258)">Active Arena execution speedup</text>
+    <text x="515" y="522" text-anchor="middle" font-size="14" fill="#666666">Eight Runs · 256 environments per Run · OSMO preparation and collection excluded</text>
+  </g>
+</svg>

--- a/docs/images/performance/parallel_environment_throughput.svg
+++ b/docs/images/performance/parallel_environment_throughput.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="600" viewBox="0 0 960 600" role="img">
+  <title>Rollout throughput on one GPU</title>
+  <desc>Throughput is 5.41 environment-steps per second with 1 environment, 319.93 with 64 environments, 1,092.18 with 256 environments, 1,824.90 with 512 environments, and 2,390.22 with 1,024 environments.</desc>
+  <rect width="960" height="600" fill="#ffffff"/>
+  <g font-family="Arial, Helvetica, sans-serif" fill="#222222">
+    <text x="480" y="42" text-anchor="middle" font-size="26" font-weight="700">Rollout throughput on one GPU</text>
+    <text x="480" y="70" text-anchor="middle" font-size="15" fill="#555555">One vectorized step advances every parallel environment</text>
+
+    <g stroke="#d9d9d9" stroke-width="1">
+      <line x1="105" y1="440" x2="925" y2="440"/>
+      <line x1="105" y1="374" x2="925" y2="374"/>
+      <line x1="105" y1="308" x2="925" y2="308"/>
+      <line x1="105" y1="242" x2="925" y2="242"/>
+      <line x1="105" y1="176" x2="925" y2="176"/>
+      <line x1="105" y1="110" x2="925" y2="110"/>
+    </g>
+
+    <g font-size="14" text-anchor="end" fill="#555555">
+      <text x="92" y="445">0</text>
+      <text x="92" y="379">500</text>
+      <text x="92" y="313">1,000</text>
+      <text x="92" y="247">1,500</text>
+      <text x="92" y="181">2,000</text>
+      <text x="92" y="115">2,500</text>
+    </g>
+
+    <g stroke="#333333" stroke-width="1.5">
+      <line x1="105" y1="95" x2="105" y2="440"/>
+      <line x1="105" y1="440" x2="925" y2="440"/>
+    </g>
+
+    <g fill="#76b900" stroke="#65a000" stroke-width="2">
+      <rect x="124" y="439.3" width="92" height="0.7"/>
+      <rect x="294" y="397.8" width="92" height="42.2"/>
+      <rect x="464" y="295.8" width="92" height="144.2"/>
+      <rect x="634" y="199.1" width="92" height="240.9"/>
+      <rect x="804" y="124.5" width="92" height="315.5"/>
+    </g>
+
+    <g font-size="18" font-weight="700" text-anchor="middle">
+      <text x="170" y="412">5.41</text>
+      <text x="340" y="371">319.93</text>
+      <text x="510" y="269">1,092.18</text>
+      <text x="680" y="172">1,824.90</text>
+      <text x="850" y="99">2,390.22</text>
+    </g>
+    <g font-size="16" text-anchor="middle">
+      <text x="170" y="471">1</text>
+      <text x="340" y="471">64</text>
+      <text x="510" y="471">256</text>
+      <text x="680" y="471">512</text>
+      <text x="850" y="471">1,024</text>
+    </g>
+
+    <text x="515" y="506" text-anchor="middle" font-size="17">Parallel environments in one Run</text>
+    <text x="30" y="268" text-anchor="middle" font-size="17" transform="rotate(-90 30 268)">Environment-steps/s</text>
+
+    <text x="515" y="550" text-anchor="middle" font-size="14" fill="#666666">Camera-free zero-action workload · 300 vectorized steps · RTX 5880 Ada Generation</text>
+  </g>
+</svg>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -477,9 +477,9 @@ Execute large-scale parallel policy evaluations
             orchestrator such as OSMO to distribute across multi-node compute. Arena returns
             aggregate metrics for a high-level summary and per-episode results for detailed
             analysis.
-            A preliminary :ref:`OSMO scaling benchmark <performance-distributed-runs>` achieved a
-            7.95x speedup in active Arena execution for eight Runs when all eight ran concurrently
-            on eight L40 GPUs rather than sequentially on one L40 GPU.
+            A preliminary :ref:`OSMO scaling benchmark <performance-distributed-runs>` showed that
+            active execution time decreased nearly in proportion to the number of GPUs used to
+            run independent Runs concurrently.
 
       .. grid-item::
          :columns: 12 12 7 7

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -445,6 +445,9 @@ Execute large-scale parallel policy evaluations
             environments instead of sequential rollouts to speed up policy evaluation.
             `Lightwheel case study <https://lightwheel.ai/media/il-arena-benchmark-study>`_
             reports 10x faster despite using higher fidelity assets.
+            A preliminary camera-free :ref:`scaling benchmark
+            <performance-parallel-environments>` measured 2,390 environment-steps/s of rollout
+            throughput with 1,024 parallel environments on one RTX 5880 Ada Generation GPU.
 
       .. grid-item::
          :columns: 12 12 7 7
@@ -474,6 +477,9 @@ Execute large-scale parallel policy evaluations
             orchestrator such as OSMO to distribute across multi-node compute. Arena returns
             aggregate metrics for a high-level summary and per-episode results for detailed
             analysis.
+            A preliminary :ref:`OSMO scaling benchmark <performance-distributed-runs>` achieved a
+            7.95x speedup in active Arena execution for eight Runs when all eight ran concurrently
+            on eight L40 GPUs rather than sequentially on one L40 GPU.
 
       .. grid-item::
          :columns: 12 12 7 7
@@ -1117,6 +1123,7 @@ Isaac Lab-Arena was built in collaboration with the authors of Robolab (`website
    :hidden:
    :caption: References
 
+   pages/references/performance
    pages/references/release_notes
    pages/references/citing_us
 

--- a/docs/pages/references/performance.rst
+++ b/docs/pages/references/performance.rst
@@ -1,0 +1,166 @@
+.. _performance-and-scaling:
+
+Performance and scaling
+=======================
+
+Arena can shorten an evaluation in two complementary ways. Within one Run, it can advance many
+environments together on one GPU to increase rollout throughput. Across an Experiment, OSMO can
+execute independent Runs at the same time on multiple GPUs to reduce the time needed to finish the
+complete set of Runs.
+
+An environment-step is one simulation step completed by one environment. A vectorized step
+advances every parallel environment in a Run once. For example, one vectorized step with 256
+parallel environments completes 256 environment-steps.
+
+Both benchmarks below used the same camera-free workload: the DROID Rubik's-cube-into-bowl task at
+the Maple table, the ``zero_action`` policy that sends zero-valued actions, and 300 vectorized
+steps per Run.
+
+.. note::
+
+   These are preliminary reference measurements collected for this release. They show how this
+   specific workload scaled on the named hardware; they are not performance guarantees for other
+   tasks or systems.
+
+
+.. _performance-parallel-environments:
+
+Parallel environments within one Run
+------------------------------------
+
+The single-GPU benchmark ran a fresh Arena process for each environment count on one NVIDIA RTX
+5880 Ada Generation GPU with 49,140 MiB of memory. Rollout throughput is the number of parallel
+environments divided by the mean time for one vectorized step. It excludes process startup,
+environment construction, report generation, and shutdown.
+
+The host also used an Intel Core i9-10920X CPU with 12 cores and 24 threads, 62 GiB of system
+memory, Ubuntu 22.04.5, and NVIDIA driver 560.35.05.
+
+.. figure:: ../../images/performance/parallel_environment_throughput.svg
+   :alt: Rollout throughput at 1, 64, 256, 512, and 1,024 parallel environments.
+   :width: 100%
+   :align: center
+
+.. list-table:: Single-GPU rollout results
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Parallel environments
+     - Mean vectorized step
+     - Rollout throughput
+   * - 1
+     - 185.0 ms
+     - 5.41 environment-steps/s
+   * - 64
+     - 200.0 ms
+     - 319.93 environment-steps/s
+   * - 256
+     - 234.4 ms
+     - 1,092.18 environment-steps/s
+   * - 512
+     - 280.6 ms
+     - 1,824.90 environment-steps/s
+   * - 1,024
+     - 428.4 ms
+     - 2,390.22 environment-steps/s
+
+
+.. _performance-distributed-runs:
+
+Independent Runs across GPUs with OSMO
+--------------------------------------
+
+The distributed benchmark used one Experiment containing eight identical Runs. Each Run created
+256 parallel environments, advanced them for 300 steps, and used one NVIDIA L40 GPU. OSMO was
+configured to execute at most 1, 2, 4, or 8 Runs at once.
+
+With fewer than eight GPUs, OSMO executed the Runs in consecutive groups. The active Arena
+execution time below is the sum of the active time for those groups, from the first Arena process
+starting until the last process in each group exited. It includes Arena and Isaac Sim startup,
+environment construction, rollout, and shutdown. It excludes OSMO queueing, container-image
+downloads, inactive time between groups, and final output collection.
+
+.. figure:: ../../images/performance/distributed_run_speedup.svg
+   :alt: Arena execution speedup at 1, 2, 4, and 8 concurrent GPUs.
+   :width: 100%
+   :align: center
+
+.. list-table:: OSMO distributed-Run results
+   :header-rows: 1
+   :widths: 20 27 23 15 15
+
+   * - Concurrent Runs and GPUs
+     - Scheduling of eight Runs
+     - Active Arena execution time
+     - Speedup
+     - Mean Run duration
+   * - 1
+     - Eight consecutive Runs
+     - 1,255.2 s
+     - 1.00x
+     - 156.9 s
+   * - 2
+     - Four groups of two
+     - 621.0 s
+     - 2.02x
+     - 154.6 s
+   * - 4
+     - Two groups of four
+     - 310.2 s
+     - 4.05x
+     - 154.3 s
+   * - 8
+     - All eight together
+     - 157.8 s
+     - 7.95x
+     - 154.0 s
+
+Executing all eight Runs at once reduced active Arena execution time from 20 minutes 55 seconds to
+2 minutes 38 seconds, a 7.95x speedup. The mean duration of an individual Run changed by less than
+2% across the four measurements. All 32 Runs completed successfully; the eight-GPU configuration
+used six worker nodes.
+
+
+Using both scaling axes
+-----------------------
+
+The two approaches address different parts of an evaluation and can be combined. Parallel
+environments increase the amount of simulation work completed by each Run on its GPU. Distributing
+independent Runs lets OSMO execute more of the Experiment at the same time across available GPUs
+and worker nodes.
+
+
+Benchmark scope
+---------------
+
+* Each single-GPU point and each OSMO concurrency level was measured once, so the tables do not
+  show run-to-run variation.
+* The single-GPU test ran on a local engineering workstation, not a controlled performance lab
+  system.
+* The workload did not render cameras or run policy inference. Cameras, policies, scene contents,
+  and physics settings can change both throughput and capacity.
+* The single-GPU and OSMO benchmarks used different GPU models and software builds. Their absolute
+  step times should not be compared directly.
+* Arena's component timers use CPU wall-clock time without explicit CUDA synchronization. They are
+  rollout diagnostics, not GPU kernel measurements.
+* Full OSMO submission time is not used for the distributed speedup because container-image cache
+  state differed between submissions.
+
+
+Tested revisions
+----------------
+
+* **Single-GPU benchmark at 1, 64, and 256 environments, August 27, 2026:** Arena `b0cd0b38e
+  <https://github.com/isaac-sim/IsaacLab-Arena/commit/b0cd0b38e660637ee5bc7f8c962994cb1cac4852>`_,
+  Isaac Lab `af1bab4dc
+  <https://github.com/isaac-sim/IsaacLab/commit/af1bab4dc173ba69b08fab779c14ead61d13fd33>`_, and
+  the `camera-free benchmark configuration
+  <https://github.com/isaac-sim/IsaacLab-Arena/blob/b0cd0b38e660637ee5bc7f8c962994cb1cac4852/isaaclab_arena_environments/experiment_configs/perflab/camera_free_benchmark_experiment.yaml>`_.
+* **Single-GPU follow-up at 512 and 1,024 environments, September 9, 2026:** the same Arena and Isaac
+  Lab revisions and camera-free workload.
+* **OSMO benchmark, September 6, 2026:** Arena `4ee056866
+  <https://github.com/isaac-sim/IsaacLab-Arena/commit/4ee056866b0f222fa166561ed46e2b5bace39445>`_,
+  Isaac Lab `bb0c8e1b9
+  <https://github.com/isaac-sim/IsaacLab/commit/bb0c8e1b9af381bf13064ec3303e17db79e4b6ef>`_, and
+  the `OSMO benchmark configuration
+  <https://github.com/isaac-sim/IsaacLab-Arena/blob/4ee056866b0f222fa166561ed46e2b5bace39445/isaaclab_arena_environments/experiment_configs/perflab/osmo/camera_free_scaling_validation_experiment.yaml>`_.

--- a/docs/pages/references/performance.rst
+++ b/docs/pages/references/performance.rst
@@ -133,8 +133,6 @@ and worker nodes.
 Benchmark scope
 ---------------
 
-* Each single-GPU point and each OSMO concurrency level was measured once, so the tables do not
-  show run-to-run variation.
 * The single-GPU test ran on a local engineering workstation, not a controlled performance lab
   system.
 * The workload did not render cameras or run policy inference. Cameras, policies, scene contents,


### PR DESCRIPTION
## Summary
Add single-GPU throughput and OSMO speedup results for a camera-free Arena experiment.

## Detailed description
- Add single-GPU parallel-environment throughput results and plot.
- Add OSMO distributed-Run speedup results and plot.
- Link the performance reference from the documentation landing page.