### PR TITLE
Temporarily disable the native uv test job

### DIFF
--- a/.github/workflows/uv-ci.yml
+++ b/.github/workflows/uv-ci.yml
@@ -51,11 +51,16 @@ jobs:
     runs-on: [self-hosted, gpu-arena]
     timeout-minutes: 120
     needs: [uv_changes]
+    # TODO(alexmillane) [public-isaac-sim-wheel-unavailable] Reactivate when public Isaac Sim 6.1
+    # wheel available. Until then the leading `false &&` below short-circuits the whole condition,
+    # so this job always skips. Delete that one line to restore the behaviour described next.
+    #
     # Runs nightly, on push to main, and on manual dispatch; on pull requests
     # only when the PR touches the uv-managed dependency files or this workflow.
     # The !cancelled() guard keeps the job alive when uv_changes is skipped on
     # non-PR events.
     if: >-
+      false &&
       !cancelled() &&
       (github.event_name != 'pull_request' ||
        needs.uv_changes.outputs.uv == 'true')


### PR DESCRIPTION
## Summary
Skip the native uv test job until a public Isaac Sim 6.1 wheel exists.

## Detailed description
- **Why**
  - `Run tests (native uv, source)` cannot pass without a public Isaac Sim 6.1 wheel, so it fails on every push to `main`
- **What**
  - Prefixes the job's `if:` with `false &&`, which short-circuits the whole uv testing stage.
  - The job still appears and reports as *skipped*, so any required-status-check configuration keeps being satisfied