### PR TITLE
Fix camera extrinsics variation for Newton

### DIFF
--- a/isaaclab_arena/tests/test_camera_extrinsics_variation.py
+++ b/isaaclab_arena/tests/test_camera_extrinsics_variation.py
@@ -17,7 +17,12 @@ EVENT_NAME = f"{CAMERA_NAME}_extrinsics_variation"
 TEST_DECALIBRATION_VECTOR = [0.01, -0.02, 0.03]
 
 
-def get_test_environment(*, camera_extrinsics_enabled: bool):
+def get_test_environment(
+    *,
+    camera_extrinsics_enabled: bool,
+    sampler_low: list[float] = TEST_DECALIBRATION_VECTOR,
+    sampler_high: list[float] = TEST_DECALIBRATION_VECTOR,
+):
     """Build a minimal arena env with an optional enabled camera extrinsics variation."""
     from isaaclab_arena.embodiments.franka.franka import FrankaIKEmbodiment
     from isaaclab_arena.environments.isaaclab_arena_environment import IsaacLabArenaEnvironment
@@ -27,7 +32,7 @@ def get_test_environment(*, camera_extrinsics_enabled: bool):
 
     embodiment = FrankaIKEmbodiment(enable_cameras=ENABLE_CAMERAS)
     if camera_extrinsics_enabled:
-        sampler_cfg = UniformSamplerCfg(low=TEST_DECALIBRATION_VECTOR, high=TEST_DECALIBRATION_VECTOR)
+        sampler_cfg = UniformSamplerCfg(low=sampler_low, high=sampler_high)
         variation_name = f"camera_extrinsics_{CAMERA_NAME}"
         embodiment.get_variation(variation_name).apply_cfg(CameraExtrinsicsVariationCfg(sampler_cfg=sampler_cfg))
         embodiment.get_variation(variation_name).enable()
@@ -76,15 +81,33 @@ def _test_enabled_camera_extrinsics_variation_in_events_cfg(simulation_app):
     return True
 
 
-def _test_camera_extrinsics_variation_realized_at_runtime(simulation_app):
+def _test_camera_extrinsics_variation_realized_at_runtime(
+    simulation_app,
+    physics_preset: str | None,
+    num_envs: int,
+):
+    import isaaclab.sim as sim_utils
     from isaaclab.utils.math import quat_apply
 
     from isaaclab_arena.cli.isaaclab_arena_cli import arena_env_builder_cfg_from_argparse, get_isaaclab_arena_cli_parser
     from isaaclab_arena.environments.arena_env_builder import ArenaEnvBuilder
 
-    args_cli = get_isaaclab_arena_cli_parser().parse_args(["--num_envs", "1", "--enable_cameras"])
+    # Use a fixed offset for the exact-value check, but a range for multi-env runs so each camera can differ.
+    sampler_low = TEST_DECALIBRATION_VECTOR if num_envs == 1 else [0.005, -0.02, 0.03]
+    sampler_high = TEST_DECALIBRATION_VECTOR if num_envs == 1 else [0.015, -0.02, 0.03]
+
+    # No preset exercises the existing PhysX path, the Newton preset exercises the renderer-sync fix.
+    cli_args = ["--num_envs", str(num_envs), "--enable_cameras"]
+    if physics_preset is not None:
+        cli_args += ["--presets", physics_preset]
+    args_cli = get_isaaclab_arena_cli_parser().parse_args(cli_args)
     env = ArenaEnvBuilder(
-        get_test_environment(camera_extrinsics_enabled=True), arena_env_builder_cfg_from_argparse(args_cli)
+        get_test_environment(
+            camera_extrinsics_enabled=True,
+            sampler_low=sampler_low,
+            sampler_high=sampler_high,
+        ),
+        arena_env_builder_cfg_from_argparse(args_cli),
     ).make_registered()
     env.reset()
 
@@ -100,6 +123,21 @@ def _test_camera_extrinsics_variation_realized_at_runtime(simulation_app):
     t_parent_Cnew_in_parent = t_parent_Cnew_in_parent.torch
     q_parent_Cnew_xyzw = q_parent_Cnew_xyzw.torch
 
+    # Check if simulation-side pose agrees with RTX renders from these USD camera prims
+    camera_prims = sim_utils.find_matching_prims(camera.cfg.prim_path, camera.stage)
+    usd_translations = torch.as_tensor(
+        [list(camera_prim.GetAttribute("xformOp:translate").Get()) for camera_prim in camera_prims],
+        device=t_parent_Cnew_in_parent.device,
+        dtype=t_parent_Cnew_in_parent.dtype,
+    )
+    torch.testing.assert_close(usd_translations, t_parent_Cnew_in_parent, atol=1e-5, rtol=1e-5)
+
+    if num_envs > 1:
+        # Distinct poses prevent the test from passing if every env accidentally updates the same source camera.
+        assert not torch.allclose(
+            t_parent_Cnew_in_parent[0], t_parent_Cnew_in_parent[1]
+        ), "Multi-environment test requires distinct sampled camera poses."
+
     # Difference between the nominal and realized camera positions.
     delta_parent_as_opengl = t_parent_Cnew_in_parent[0] - t_parent_C_in_parent
 
@@ -110,15 +148,17 @@ def _test_camera_extrinsics_variation_realized_at_runtime(simulation_app):
     q_opengl_to_ros_xyzw = torch.tensor((-1.0, 0.0, 0.0, 0.0), device=env.unwrapped.device)
     measured_decalibration = quat_apply(q_opengl_to_ros_xyzw, delta_C_as_opengl)
 
-    # Check we get out what we put in.
-    expected_decalibration = torch.tensor(
-        TEST_DECALIBRATION_VECTOR,
-        device=measured_decalibration.device,
-        dtype=measured_decalibration.dtype,
-    )
-    print(f"Expected decalibration: {expected_decalibration}")
-    print(f"Measured decalibration: {measured_decalibration}")
-    torch.testing.assert_close(measured_decalibration, expected_decalibration, atol=1e-5, rtol=1e-5)
+    # Only the single-env sampler is deterministic; multi-env coverage checks USD synchronization and indexing.
+    if num_envs == 1:
+        # Check we get out what we put in.
+        expected_decalibration = torch.tensor(
+            TEST_DECALIBRATION_VECTOR,
+            device=measured_decalibration.device,
+            dtype=measured_decalibration.dtype,
+        )
+        print(f"Expected decalibration: {expected_decalibration}")
+        print(f"Measured decalibration: {measured_decalibration}")
+        torch.testing.assert_close(measured_decalibration, expected_decalibration, atol=1e-5, rtol=1e-5)
 
     env.close()
     return True
@@ -143,9 +183,16 @@ def test_enabled_camera_extrinsics_variation_in_events_cfg():
 
 
 @pytest.mark.with_cameras
-def test_camera_extrinsics_variation_realized_at_runtime():
+@pytest.mark.parametrize(
+    ("physics_preset", "num_envs"),
+    [(None, 1), ("newton", 1), ("newton", 2)],
+    ids=["physx", "newton", "newton-multi-env"],
+)
+def test_camera_extrinsics_variation_realized_at_runtime(physics_preset: str | None, num_envs: int):
     assert run_function_with_persistent_simulation_app(
         _test_camera_extrinsics_variation_realized_at_runtime,
         headless=HEADLESS,
         enable_cameras=ENABLE_CAMERAS,
+        physics_preset=physics_preset,
+        num_envs=num_envs,
     )

--- a/isaaclab_arena/variations/camera_extrinsics_variation.py
+++ b/isaaclab_arena/variations/camera_extrinsics_variation.py
@@ -20,11 +20,13 @@ import torch
 from dataclasses import field
 from typing import TYPE_CHECKING
 
+import isaaclab.sim as sim_utils
 import warp as wp
 from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 from isaaclab.sensors import Camera, TiledCamera
 from isaaclab.utils.configclass import configclass
 from isaaclab.utils.math import quat_apply
+from pxr import Sdf
 
 from isaaclab_arena.variations.continuous_sampler import ContinuousSampler
 from isaaclab_arena.variations.uniform_sampler import UniformSamplerCfg
@@ -125,6 +127,11 @@ class apply_camera_extrinsics_from_sampler(ManagerTermBase):
         )
 
         self._camera = camera
+        self._render_camera_prims = sim_utils.find_matching_prims(camera.cfg.prim_path, camera.stage)
+        assert len(self._render_camera_prims) == camera.num_instances, (
+            f"Camera '{asset_cfg.name}' resolved {len(self._render_camera_prims)} rendered USD prims "
+            f"for {camera.num_instances} sensor instances."
+        )
         # Snapshotted on first ``__call__``.
         self._t_parent_C_in_parent: torch.Tensor | None = None
         self._q_parent_C_xyzw: torch.Tensor | None = None
@@ -165,3 +172,24 @@ class apply_camera_extrinsics_from_sampler(ManagerTermBase):
 
         # Apply the the sim.
         view.set_local_poses(translations=t_parent_Cnew_in_parent, orientations=None, indices=wp.from_torch(env_ids))
+
+        # Newton's frame view updates its internal site state but not the USD camera transform consumed by RTX.
+        # Use USD write to keep the rendered camera in sync. The USD write is redundant and harmless when the
+        # frame view already writes through to USD.
+        env_id_list = [int(env_id) for env_id in env_ids.detach().cpu().tolist()]
+        translations = t_parent_Cnew_in_parent.detach().cpu().tolist()
+        with Sdf.ChangeBlock():
+            for env_id, translation in zip(env_id_list, translations, strict=True):
+                prim = self._render_camera_prims[env_id]
+                translate_attr = prim.GetAttribute("xformOp:translate")
+                current_translation = translate_attr.Get()
+                assert (
+                    current_translation is not None
+                ), f"Camera prim '{prim.GetPath()}' has no authored xformOp:translate."
+                updated_translation = type(current_translation)(*(float(value) for value in translation))
+                assert translate_attr.Set(
+                    updated_translation
+                ), f"Failed to update camera prim '{prim.GetPath()}' xformOp:translate."
+
+        # Invalidate cached sensor state so the next observation uses the sampled extrinsics.
+        self._camera.reset(env_ids)


### PR DESCRIPTION
## Summary
Fix camera extrinsics variation so RTX-rendered cameras use the sampled poses with Newton.

- Synchronize each rendered USD camera prim with the Isaac Lab camera view.
- Refresh affected cameras after applying extrinsics variation.
- Add test coverage for PhysX and single- and multi-environment Newton.

Before, CameraExtrinsicsVariation updated only Isaac Lab’s internal camera view. With Newton,
that pose change did not propagate to the USD camera prim. As a result, camera pose queries
showed the sampled extrinsics offset, but RGB observations were still rendered from the original
pose. This made camera randomization ineffective.