### PR TITLE
Instrument the rollout with nested timers (fresh branch of #1198)

### DIFF
--- a/isaaclab_arena/evaluation/arena_experiment_result.py
+++ b/isaaclab_arena/evaluation/arena_experiment_result.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from isaaclab_arena.evaluation.arena_run import ArenaRunCfg
 
 ARENA_EXPERIMENT_RESULT_FILENAME = "arena_experiment_result.json"
+ARENA_EXPERIMENT_TIMINGS_FILENAME = "arena_experiment_timings.json"
 
 
 class ArenaEpisodeResultData(TypedDict):

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -12,8 +12,8 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
-from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
+from isaaclab_arena.evaluation.experiment_timings import aggregate_experiment_timings
 from isaaclab_arena.evaluation.legacy_experiment_runner import (
     legacy_json_experiment_requires_cameras,
     load_legacy_json_experiment_config,
@@ -21,7 +21,6 @@ from isaaclab_arena.evaluation.legacy_experiment_runner import (
 )
 from isaaclab_arena.hydra.typed_experiment_yaml_search import typed_experiment_requires_cameras
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
-from isaaclab_arena.utils.timer import print_timer_stats, write_timer_stats_json
 from isaaclab_arena.video.video_recording import timestamped_run_dir
 
 if TYPE_CHECKING:
@@ -149,7 +148,7 @@ def main():
 
     with SimulationAppContext(args_cli):
         from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
-        from isaaclab_arena.evaluation.arena_run import build_runs_info_table
+        from isaaclab_arena.evaluation.arena_run import RunStatus, build_runs_info_table
         from isaaclab_arena.evaluation.run_execution import execute_experiment
         from isaaclab_arena.metrics.metrics_logger import MetricsLogger
         from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
@@ -185,11 +184,11 @@ def main():
 
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
 
-        # Report where the rollouts spent their time.
-        print_timer_stats()
-        timings_path = write_timer_stats_json(
-            experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
-            app_name="experiment_runner",
+        # Each Run wrote its own timings as it finished. Combine them the same way the OSMO
+        # collect task does, so both routes leave the same files behind.
+        timings_path = aggregate_experiment_timings(
+            experiment_output_directory,
+            [run_result.run_name for run_result in run_results if run_result.status is RunStatus.COMPLETED],
         )
         print(f"Wrote Arena Experiment timings to: {timings_path}")
 

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -12,6 +12,7 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     load_arena_experiment_from_config_file,
     validate_experiment_config_path,
 )
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
 from isaaclab_arena.evaluation.legacy_experiment_runner import (
     legacy_json_experiment_requires_cameras,
@@ -185,8 +186,6 @@ def main():
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
 
         # Report where the rollouts spent their time.
-        from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
-
         print_timer_stats()
         timings_path = write_timer_stats_json(
             experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -20,6 +20,7 @@ from isaaclab_arena.evaluation.legacy_experiment_runner import (
 )
 from isaaclab_arena.hydra.typed_experiment_yaml_search import typed_experiment_requires_cameras
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
+from isaaclab_arena.utils.timer import print_timer_stats, write_timer_stats_json
 from isaaclab_arena.video.video_recording import timestamped_run_dir
 
 if TYPE_CHECKING:
@@ -182,6 +183,16 @@ def main():
         metrics_logger.print_metrics()
 
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
+
+        # Report where the rollouts spent their time.
+        from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
+
+        print_timer_stats()
+        timings_path = write_timer_stats_json(
+            experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+            app_name="experiment_runner",
+        )
+        print(f"Wrote Arena Experiment timings to: {timings_path}")
 
         # Write HTML report.
         report_path = build_report(experiment_output_directory)

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -184,12 +184,10 @@ def main():
 
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
 
-        # Each Run wrote its own timings as it finished. Combine them the same way the OSMO
-        # collect task does, so both routes leave the same files behind.
-        timings_path = aggregate_experiment_timings(
-            experiment_output_directory,
-            [run_result.run_name for run_result in run_results if run_result.status is RunStatus.COMPLETED],
-        )
+        completed_run_names = [
+            run_result.run_name for run_result in run_results if run_result.status is RunStatus.COMPLETED
+        ]
+        timings_path = aggregate_experiment_timings(experiment_output_directory, completed_run_names)
         print(f"Wrote Arena Experiment timings to: {timings_path}")
 
         # Write HTML report.

--- a/isaaclab_arena/evaluation/experiment_runner.py
+++ b/isaaclab_arena/evaluation/experiment_runner.py
@@ -13,7 +13,6 @@ from isaaclab_arena.evaluation.arena_experiment_config_loader import (
     validate_experiment_config_path,
 )
 from isaaclab_arena.evaluation.experiment_runner_cli import parse_experiment_runner_args
-from isaaclab_arena.evaluation.experiment_timings import aggregate_experiment_timings
 from isaaclab_arena.evaluation.legacy_experiment_runner import (
     legacy_json_experiment_requires_cameras,
     load_legacy_json_experiment_config,
@@ -183,6 +182,8 @@ def main():
         metrics_logger.print_metrics()
 
         _write_arena_experiment_result(experiment_cfg, run_results, experiment_output_directory)
+
+        from isaaclab_arena.evaluation.experiment_timings import aggregate_experiment_timings
 
         completed_run_names = [
             run_result.run_name for run_result in run_results if run_result.status is RunStatus.COMPLETED

--- a/isaaclab_arena/evaluation/experiment_timings.py
+++ b/isaaclab_arena/evaluation/experiment_timings.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Write Arena Experiment timings as one file per Run plus one combined file for the Experiment.
+
+Timers accumulate in a process-wide registry, so the Experiment Runner clears it between Runs and
+writes each Run's timings into that Run's output directory. OSMO gets the same per-Run split for
+free by running each Run in its own process. Both then combine those files with the same function,
+so an Experiment produces the same timings layout whichever way it was run.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
+from isaaclab_arena.utils.timer import merge_timer_stats_json, write_timer_stats_json
+
+EXPERIMENT_RUNNER_APP_NAME = "experiment_runner"
+"""Identifier recorded in every timing entry the Experiment Runner writes."""
+
+
+def write_run_timings(run_output_directory: Path) -> Path:
+    """Write the timers recorded so far into one Run's output directory.
+
+    Args:
+        run_output_directory: The Run's output directory, created if it does not already exist.
+
+    Returns:
+        The path that was written.
+    """
+    run_output_directory.mkdir(parents=True, exist_ok=True)
+    return write_timer_stats_json(
+        run_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+        app_name=EXPERIMENT_RUNNER_APP_NAME,
+    )
+
+
+def aggregate_experiment_timings(experiment_output_directory: Path, run_names: Iterable[str]) -> Path:
+    """Combine the named Runs' timings files into one Experiment timings file.
+
+    Args:
+        experiment_output_directory: Experiment output holding one output directory per Run.
+        run_names: Runs to include, normally the completed ones. Included in sorted order so that
+            the combined file does not depend on the order the Runs were executed or collected in.
+
+    Returns:
+        Path to the written Experiment timings file.
+    """
+    run_records: list[dict[str, object]] = []
+    for run_name in sorted(run_names):
+        run_timings_path = experiment_output_directory / run_name / ARENA_EXPERIMENT_TIMINGS_FILENAME
+        assert run_timings_path.is_file(), f"Run '{run_name}' is missing its timings file: '{run_timings_path}'"
+        run_records.extend(
+            {"run_name": run_name, **record} for record in json.loads(run_timings_path.read_text(encoding="utf-8"))
+        )
+
+    experiment_timings_path = experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
+    experiment_timings_path.write_text(
+        json.dumps({"totals": merge_timer_stats_json(run_records), "runs": run_records}, allow_nan=False, indent=2)
+        + "\n",
+        encoding="utf-8",
+    )
+    return experiment_timings_path

--- a/isaaclab_arena/evaluation/experiment_timings.py
+++ b/isaaclab_arena/evaluation/experiment_timings.py
@@ -3,13 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Write Arena Experiment timings as one file per Run plus one combined file for the Experiment.
-
-Timers accumulate in a process-wide registry, so the Experiment Runner clears it between Runs and
-writes each Run's timings into that Run's output directory. OSMO gets the same per-Run split for
-free by running each Run in its own process. Both then combine those files with the same function,
-so an Experiment produces the same timings layout whichever way it was run.
-"""
+"""Write Arena Experiment timings as one file per Run plus one combined file for the Experiment."""
 
 from __future__ import annotations
 
@@ -25,14 +19,7 @@ EXPERIMENT_RUNNER_APP_NAME = "experiment_runner"
 
 
 def write_run_timings(run_output_directory: Path) -> Path:
-    """Write the timers recorded so far into one Run's output directory.
-
-    Args:
-        run_output_directory: The Run's output directory, created if it does not already exist.
-
-    Returns:
-        The path that was written.
-    """
+    """Write the timers recorded so far into one Run's output directory, returning the path written."""
     run_output_directory.mkdir(parents=True, exist_ok=True)
     return write_timer_stats_json(
         run_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
@@ -43,10 +30,12 @@ def write_run_timings(run_output_directory: Path) -> Path:
 def aggregate_experiment_timings(experiment_output_directory: Path, run_names: Iterable[str]) -> Path:
     """Combine the named Runs' timings files into one Experiment timings file.
 
+    The combined file holds "totals", one entry per timer name summed over every Run, and "runs",
+    every Run's own entries with the Run's name added to each as "run_name".
+
     Args:
         experiment_output_directory: Experiment output holding one output directory per Run.
-        run_names: Runs to include, normally the completed ones. Included in sorted order so that
-            the combined file does not depend on the order the Runs were executed or collected in.
+        run_names: Runs to include, sorted so the file does not depend on the order given.
 
     Returns:
         Path to the written Experiment timings file.

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -22,6 +22,7 @@ from isaaclab_arena.metrics.metrics_logger import metrics_to_plain_python_types
 from isaaclab_arena.utils.hydra_overrides import assert_hydra_overrides
 from isaaclab_arena.utils.isaaclab_utils.simulation_app import SimulationAppContext
 from isaaclab_arena.utils.multiprocess import get_local_rank, get_world_size
+from isaaclab_arena.utils.timer import Timer
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, timestamped_run_dir, wrap_env_for_video
 from isaaclab_arena.visualization.report import build_report, serve_until_ctrl_c
 from isaaclab_arena_environments.cli import get_arena_builder_from_cli, get_isaaclab_arena_environments_cli_parser
@@ -62,6 +63,19 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     )
 
 
+STEP_TIMER_NAME = "step"
+"""Timer covering one whole iteration of the rollout loop, including episode-boundary work."""
+
+POLICY_INFERENCE_TIMER_NAME = "policy_inference"
+"""Timer covering the policy's action computation, nested under STEP_TIMER_NAME."""
+
+ENV_STEP_TIMER_NAME = "env_step"
+"""Timer covering the outermost env step, nested under STEP_TIMER_NAME.
+
+This is measured above the video recorders, so it includes their cost.
+"""
+
+
 def rollout_policy(
     env,
     policy: PolicyBase,
@@ -89,9 +103,13 @@ def rollout_policy(
         num_steps_completed = 0
 
         while True:
-            with torch.inference_mode():
-                actions = policy.get_action(env, obs)
-                obs, _, terminated, truncated, _ = env.step(actions)
+            # The three timers below are the rollout's cost breakdown: STEP_TIMER_NAME is the whole
+            # loop body, and the two inside it are the parts that dominate it.
+            with torch.inference_mode(), Timer(STEP_TIMER_NAME):
+                with Timer(POLICY_INFERENCE_TIMER_NAME):
+                    actions = policy.get_action(env, obs)
+                with Timer(ENV_STEP_TIMER_NAME):
+                    obs, _, terminated, truncated, _ = env.step(actions)
 
                 if terminated.any() or truncated.any():
                     # Only reset policy for those envs that are terminated or truncated

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -90,9 +90,6 @@ def rollout_policy(
         num_steps_completed = 0
 
         while True:
-            # The rollout's cost breakdown: "step" is the whole loop body, and the two nested
-            # inside it are the parts that dominate it. "env_step" is measured above the video
-            # recorders, so it includes their cost.
             with torch.inference_mode(), Timer("step"):
                 with Timer("policy_inference"):
                     actions = policy.get_action(env, obs)

--- a/isaaclab_arena/evaluation/policy_runner.py
+++ b/isaaclab_arena/evaluation/policy_runner.py
@@ -63,19 +63,6 @@ def is_distributed(args_cli: argparse.Namespace) -> bool:
     )
 
 
-STEP_TIMER_NAME = "step"
-"""Timer covering one whole iteration of the rollout loop, including episode-boundary work."""
-
-POLICY_INFERENCE_TIMER_NAME = "policy_inference"
-"""Timer covering the policy's action computation, nested under STEP_TIMER_NAME."""
-
-ENV_STEP_TIMER_NAME = "env_step"
-"""Timer covering the outermost env step, nested under STEP_TIMER_NAME.
-
-This is measured above the video recorders, so it includes their cost.
-"""
-
-
 def rollout_policy(
     env,
     policy: PolicyBase,
@@ -103,12 +90,13 @@ def rollout_policy(
         num_steps_completed = 0
 
         while True:
-            # The three timers below are the rollout's cost breakdown: STEP_TIMER_NAME is the whole
-            # loop body, and the two inside it are the parts that dominate it.
-            with torch.inference_mode(), Timer(STEP_TIMER_NAME):
-                with Timer(POLICY_INFERENCE_TIMER_NAME):
+            # The rollout's cost breakdown: "step" is the whole loop body, and the two nested
+            # inside it are the parts that dominate it. "env_step" is measured above the video
+            # recorders, so it includes their cost.
+            with torch.inference_mode(), Timer("step"):
+                with Timer("policy_inference"):
                     actions = policy.get_action(env, obs)
-                with Timer(ENV_STEP_TIMER_NAME):
+                with Timer("env_step"):
                     obs, _, terminated, truncated, _ = env.step(actions)
 
                 if terminated.any() or truncated.any():

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -60,8 +60,7 @@ def execute_experiment(
     for run_cfg in experiment_cfg.runs.values():
         print(f"Running run '{run_cfg.name}'", flush=True)
         run_output_dir = output_dir / run_cfg.name
-        # Timers accumulate process-wide, so clear them to time this Run alone. OSMO gets the same
-        # per-Run split by running each Run in its own process.
+        # Clear timers.
         reset_timer_stats()
         try:
             result = build_and_run(

--- a/isaaclab_arena/evaluation/run_execution.py
+++ b/isaaclab_arena/evaluation/run_execution.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from isaaclab_arena.assets.registries import EnvironmentRegistry, PolicyRegistry
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg, ArenaRunResult, RunStatus
+from isaaclab_arena.evaluation.experiment_timings import write_run_timings
 from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
     LegacyGraphEnvironmentCfg,
     build_arena_builder_from_legacy_graph,
@@ -24,6 +25,7 @@ from isaaclab_arena.evaluation.legacy_graph_environment_cli import (
 from isaaclab_arena.evaluation.policy_runner import rollout_policy
 from isaaclab_arena.evaluation.resource_cleanup import close_run_resources
 from isaaclab_arena.metrics.aggregate_metrics import aggregate_metrics
+from isaaclab_arena.utils.timer import print_timer_stats, reset_timer_stats
 from isaaclab_arena.variations.variations_hydra import overrides_from_dict
 from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
 
@@ -58,6 +60,9 @@ def execute_experiment(
     for run_cfg in experiment_cfg.runs.values():
         print(f"Running run '{run_cfg.name}'", flush=True)
         run_output_dir = output_dir / run_cfg.name
+        # Timers accumulate process-wide, so clear them to time this Run alone. OSMO gets the same
+        # per-Run split by running each Run in its own process.
+        reset_timer_stats()
         try:
             result = build_and_run(
                 run_cfg,
@@ -76,6 +81,8 @@ def execute_experiment(
                 raise
             continue
 
+        print_timer_stats()
+        write_run_timings(run_output_dir)
         results.append(result)
     return results
 

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -244,14 +244,14 @@ def test_frame_writing_is_timed_separately_from_finalizing(tmp_path):
 
         stats = get_timer_stats()
         assert stats["record_camera_frames"].count == 2
-        assert "camera_finalize" not in stats
+        assert "record_camera_finalize" not in stats
 
         _configure_step(env, done_envs=[0])
         recorder.step(None)
 
         stats = get_timer_stats()
         assert stats["record_camera_frames"].count == 3
-        assert stats["camera_finalize"].count == 1
+        assert stats["record_camera_finalize"].count == 1
 
 
 def test_recording_stack_reports_its_costs_under_the_enclosing_step_timer(tmp_path):

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -243,14 +243,14 @@ def test_frame_writing_is_timed_separately_from_finalizing(tmp_path):
         recorder.step(None)
 
         stats = get_timer_stats()
-        assert stats["camera_frames"].count == 2
+        assert stats["record_camera_frames"].count == 2
         assert "camera_finalize" not in stats
 
         _configure_step(env, done_envs=[0])
         recorder.step(None)
 
         stats = get_timer_stats()
-        assert stats["camera_frames"].count == 3
+        assert stats["record_camera_frames"].count == 3
         assert stats["camera_finalize"].count == 1
 
 
@@ -280,7 +280,7 @@ def test_recording_stack_reports_its_costs_under_the_enclosing_step_timer(tmp_pa
     stats = get_timer_stats()
     assert stats["env_step"].count == 1
     assert stats["env_step/sim_step"].count == 1
-    assert stats["env_step/camera_frames"].count == 1
+    assert stats["env_step/record_camera_frames"].count == 1
     assert stats["env_step"].total_ms >= stats["env_step/sim_step"].total_ms
 
 
@@ -304,7 +304,7 @@ def test_no_timing_recorded_without_camera_observations(tmp_path):
 
         recorder.step(None)  # _StubEnv returns an empty obs until _configure_step is called
 
-        assert "camera_frames" not in get_timer_stats()
+        assert "record_camera_frames" not in get_timer_stats()
 
 
 def test_post_reset_frame_not_recorded(tmp_path):

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -18,7 +18,15 @@ from unittest.mock import patch
 
 import pytest
 
-from isaaclab_arena.video.camera_observation_video_recorder import CAMERA_OBS_GROUP_KEY, CameraObsVideoRecorder
+from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
+from isaaclab_arena.utils.timer import Timer, get_timer_stats, reset_timer_stats
+from isaaclab_arena.video.camera_observation_video_recorder import (
+    CAMERA_FINALIZE_TIMER_NAME,
+    CAMERA_FRAMES_TIMER_NAME,
+    CAMERA_OBS_GROUP_KEY,
+    CameraObsVideoRecorder,
+)
+from isaaclab_arena.video.video_recording import SIM_STEP_TIMER_NAME, VideoRecordingCfg, wrap_env_for_video
 
 # ---------------------------------------------------------------------------
 # Minimal gym.Env stub — satisfies gymnasium.Wrapper's isinstance check
@@ -226,6 +234,82 @@ def test_no_video_written_for_empty_episode(tmp_path):
         # per-episode results record).
         assert not any(writer.filename.endswith("env0-front-episode-0.mp4") for writer in writers)
         assert env.get_episode_index(0) == 1
+
+
+def test_frame_writing_is_timed_separately_from_finalizing(tmp_path):
+    """Frame writes are timed on every recorded step; finalizing is timed only on a reset."""
+    reset_timer_stats()
+    env = _make_env()
+    with _patched_writers():
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        _configure_step(env)
+        recorder.step(None)
+        recorder.step(None)
+
+        stats = get_timer_stats()
+        assert stats[CAMERA_FRAMES_TIMER_NAME].count == 2
+        assert CAMERA_FINALIZE_TIMER_NAME not in stats
+
+        _configure_step(env, done_envs=[0])
+        recorder.step(None)
+
+        stats = get_timer_stats()
+        assert stats[CAMERA_FRAMES_TIMER_NAME].count == 3
+        assert stats[CAMERA_FINALIZE_TIMER_NAME].count == 1
+
+
+def test_recording_stack_reports_its_costs_under_the_enclosing_step_timer(tmp_path):
+    """Stepping the recording stack from inside a step timer reproduces the rollout's breakdown."""
+    reset_timer_stats()
+    env = _make_env()
+    _configure_step(env)
+
+    wrapped = wrap_env_for_video(
+        env,
+        VideoRecordingCfg(record_camera_video=True, video_base_dir=str(tmp_path)),
+        num_steps=1,
+        num_episodes=None,
+    )
+
+    assert isinstance(wrapped, CameraObsVideoRecorder)
+    assert isinstance(wrapped.env, EnvStepTimerWrapper)
+    assert wrapped.env.env is env
+
+    with _patched_writers():
+        with Timer("env_step"):  # Stands in for the rollout's env step timer.
+            wrapped.step(None)
+
+    # The sim step and the recording cost are siblings below the env step, so subtracting them
+    # from it is what isolates the recording overhead.
+    stats = get_timer_stats()
+    assert stats["env_step"].count == 1
+    assert stats[f"env_step/{SIM_STEP_TIMER_NAME}"].count == 1
+    assert stats[f"env_step/{CAMERA_FRAMES_TIMER_NAME}"].count == 1
+    assert stats["env_step"].total_ms >= stats[f"env_step/{SIM_STEP_TIMER_NAME}"].total_ms
+
+
+def test_wrap_env_for_video_adds_no_timer_when_recording_is_disabled(tmp_path):
+    """With no recorder requested the env is returned unchanged and nothing is timed."""
+    reset_timer_stats()
+    env = _make_env()
+
+    wrapped = wrap_env_for_video(env, VideoRecordingCfg(video_base_dir=str(tmp_path)), 1, None)
+
+    assert wrapped is env
+    assert get_timer_stats() == {}
+
+
+def test_no_timing_recorded_without_camera_observations(tmp_path):
+    """A step carrying no camera observations does no recording work, so nothing is timed."""
+    reset_timer_stats()
+    env = _make_env()
+    with _patched_writers():
+        recorder = CameraObsVideoRecorder(env, video_folder=str(tmp_path))
+
+        recorder.step(None)  # _StubEnv returns an empty obs until _configure_step is called
+
+        assert CAMERA_FRAMES_TIMER_NAME not in get_timer_stats()
 
 
 def test_post_reset_frame_not_recorded(tmp_path):

--- a/isaaclab_arena/tests/test_camera_observation_video_recorder.py
+++ b/isaaclab_arena/tests/test_camera_observation_video_recorder.py
@@ -20,13 +20,8 @@ import pytest
 
 from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
 from isaaclab_arena.utils.timer import Timer, get_timer_stats, reset_timer_stats
-from isaaclab_arena.video.camera_observation_video_recorder import (
-    CAMERA_FINALIZE_TIMER_NAME,
-    CAMERA_FRAMES_TIMER_NAME,
-    CAMERA_OBS_GROUP_KEY,
-    CameraObsVideoRecorder,
-)
-from isaaclab_arena.video.video_recording import SIM_STEP_TIMER_NAME, VideoRecordingCfg, wrap_env_for_video
+from isaaclab_arena.video.camera_observation_video_recorder import CAMERA_OBS_GROUP_KEY, CameraObsVideoRecorder
+from isaaclab_arena.video.video_recording import VideoRecordingCfg, wrap_env_for_video
 
 # ---------------------------------------------------------------------------
 # Minimal gym.Env stub — satisfies gymnasium.Wrapper's isinstance check
@@ -248,15 +243,15 @@ def test_frame_writing_is_timed_separately_from_finalizing(tmp_path):
         recorder.step(None)
 
         stats = get_timer_stats()
-        assert stats[CAMERA_FRAMES_TIMER_NAME].count == 2
-        assert CAMERA_FINALIZE_TIMER_NAME not in stats
+        assert stats["camera_frames"].count == 2
+        assert "camera_finalize" not in stats
 
         _configure_step(env, done_envs=[0])
         recorder.step(None)
 
         stats = get_timer_stats()
-        assert stats[CAMERA_FRAMES_TIMER_NAME].count == 3
-        assert stats[CAMERA_FINALIZE_TIMER_NAME].count == 1
+        assert stats["camera_frames"].count == 3
+        assert stats["camera_finalize"].count == 1
 
 
 def test_recording_stack_reports_its_costs_under_the_enclosing_step_timer(tmp_path):
@@ -284,9 +279,9 @@ def test_recording_stack_reports_its_costs_under_the_enclosing_step_timer(tmp_pa
     # from it is what isolates the recording overhead.
     stats = get_timer_stats()
     assert stats["env_step"].count == 1
-    assert stats[f"env_step/{SIM_STEP_TIMER_NAME}"].count == 1
-    assert stats[f"env_step/{CAMERA_FRAMES_TIMER_NAME}"].count == 1
-    assert stats["env_step"].total_ms >= stats[f"env_step/{SIM_STEP_TIMER_NAME}"].total_ms
+    assert stats["env_step/sim_step"].count == 1
+    assert stats["env_step/camera_frames"].count == 1
+    assert stats["env_step"].total_ms >= stats["env_step/sim_step"].total_ms
 
 
 def test_wrap_env_for_video_adds_no_timer_when_recording_is_disabled(tmp_path):
@@ -309,7 +304,7 @@ def test_no_timing_recorded_without_camera_observations(tmp_path):
 
         recorder.step(None)  # _StubEnv returns an empty obs until _configure_step is called
 
-        assert CAMERA_FRAMES_TIMER_NAME not in get_timer_stats()
+        assert "camera_frames" not in get_timer_stats()
 
 
 def test_post_reset_frame_not_recorded(tmp_path):

--- a/isaaclab_arena/tests/test_env_step_timer.py
+++ b/isaaclab_arena/tests/test_env_step_timer.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for EnvStepTimerWrapper. No Isaac Sim or GPU required."""
+
+import gymnasium as gym
+
+from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
+from isaaclab_arena.utils.timer import Timer, get_timer_stats, reset_timer_stats
+
+
+class _StubEnv(gym.Env):
+    """Minimal env that returns a fixed step result."""
+
+    observation_space = gym.spaces.Dict({})
+    action_space = gym.spaces.Discrete(1)
+
+    def __init__(self):
+        super().__init__()
+        self.num_steps = 0
+
+    def reset(self, **kwargs):
+        return {}, {}
+
+    def step(self, action):
+        self.num_steps += 1
+        return {}, 0.0, False, False, {}
+
+
+def test_records_one_measurement_per_step():
+    """Each step through the wrapper adds one measurement under the configured name."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="inner_step")
+
+    for _ in range(3):
+        env.step(None)
+
+    stats = get_timer_stats()
+    assert stats["inner_step"].count == 3
+    assert env.env.num_steps == 3
+
+
+def test_step_result_is_passed_through():
+    """The wrapper returns the wrapped env's step result unchanged."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="inner_step")
+
+    assert env.step(None) == ({}, 0.0, False, False, {})
+
+
+def test_reset_is_not_timed():
+    """Only step is measured, so a reset leaves the registry untouched."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="inner_step")
+
+    env.reset()
+
+    assert "inner_step" not in get_timer_stats()
+
+
+def test_measurement_nests_under_an_enclosing_timer():
+    """The wrapper sits below the rollout's step timer, so its name is qualified by it."""
+    reset_timer_stats()
+    env = EnvStepTimerWrapper(_StubEnv(), timer_name="inner_step")
+
+    with Timer("env_step"):
+        env.step(None)
+
+    assert get_timer_stats()["env_step/inner_step"].count == 1

--- a/isaaclab_arena/tests/test_experiment_timings.py
+++ b/isaaclab_arena/tests/test_experiment_timings.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for per-Run and Experiment-level timings files. No Isaac Sim or GPU required."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
+from isaaclab_arena.evaluation.experiment_timings import aggregate_experiment_timings, write_run_timings
+from isaaclab_arena.utils.timer import Timer, reset_timer_stats
+
+
+def _write_run_timings_file(run_output_directory: Path, timer_names: list[str]) -> Path:
+    """Record one measurement per named timer and write them as that Run's timings."""
+    reset_timer_stats()
+    for timer_name in timer_names:
+        with Timer(timer_name):
+            pass
+    return write_run_timings(run_output_directory)
+
+
+def test_writes_a_runs_timings_into_its_output_directory(tmp_path):
+    written_path = _write_run_timings_file(tmp_path / "first", ["step"])
+
+    assert written_path == tmp_path / "first" / ARENA_EXPERIMENT_TIMINGS_FILENAME
+    assert written_path.is_file()
+    records = json.loads(written_path.read_text(encoding="utf-8"))
+    assert [record["name"] for record in records] == ["step"]
+    assert records[0]["app_name"] == "experiment_runner"
+
+
+def test_creates_the_run_output_directory_if_it_is_missing(tmp_path):
+    reset_timer_stats()
+    with Timer("step"):
+        pass
+
+    written_path = write_run_timings(tmp_path / "not_yet_there")
+
+    assert written_path.is_file()
+
+
+def test_combines_runs_into_totals_and_per_run_records(tmp_path):
+    _write_run_timings_file(tmp_path / "first", ["step"])
+    _write_run_timings_file(tmp_path / "second", ["step"])
+
+    experiment_timings_path = aggregate_experiment_timings(tmp_path, ["first", "second"])
+
+    experiment_timings = json.loads(experiment_timings_path.read_text(encoding="utf-8"))
+    assert experiment_timings_path == tmp_path / ARENA_EXPERIMENT_TIMINGS_FILENAME
+    assert [total["name"] for total in experiment_timings["totals"]] == ["step"]
+    # One measurement per Run, combined into the Experiment total.
+    assert experiment_timings["totals"][0]["count"] == 2
+    assert [(record["run_name"], record["name"]) for record in experiment_timings["runs"]] == [
+        ("first", "step"),
+        ("second", "step"),
+    ]
+
+
+def test_orders_runs_by_name_regardless_of_the_order_given(tmp_path):
+    """Sorting here is what keeps the local and OSMO files identical for the same Experiment."""
+    _write_run_timings_file(tmp_path / "alpha", ["step"])
+    _write_run_timings_file(tmp_path / "zulu", ["step"])
+
+    experiment_timings_path = aggregate_experiment_timings(tmp_path, ["zulu", "alpha"])
+
+    experiment_timings = json.loads(experiment_timings_path.read_text(encoding="utf-8"))
+    assert [record["run_name"] for record in experiment_timings["runs"]] == ["alpha", "zulu"]
+
+
+def test_excludes_a_run_that_was_not_named(tmp_path):
+    """Failed Runs are left out by the caller, and their directory is never read."""
+    _write_run_timings_file(tmp_path / "passing", ["step"])
+    (tmp_path / "failing").mkdir()
+
+    experiment_timings_path = aggregate_experiment_timings(tmp_path, ["passing"])
+
+    experiment_timings = json.loads(experiment_timings_path.read_text(encoding="utf-8"))
+    assert [record["run_name"] for record in experiment_timings["runs"]] == ["passing"]
+
+
+def test_rejects_a_named_run_without_a_timings_file(tmp_path):
+    _write_run_timings_file(tmp_path / "first", ["step"])
+
+    with pytest.raises(AssertionError, match="missing its timings file"):
+        aggregate_experiment_timings(tmp_path, ["first", "never_ran"])
+
+
+def test_writes_an_empty_experiment_file_when_no_runs_completed(tmp_path):
+    experiment_timings_path = aggregate_experiment_timings(tmp_path, [])
+
+    experiment_timings = json.loads(experiment_timings_path.read_text(encoding="utf-8"))
+    assert experiment_timings == {"totals": [], "runs": []}

--- a/isaaclab_arena/tests/test_osmo_build_experiment_output.py
+++ b/isaaclab_arena/tests/test_osmo_build_experiment_output.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 
-from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_RESULT_FILENAME
+from isaaclab_arena.evaluation.arena_experiment_result import (
+    ARENA_EXPERIMENT_RESULT_FILENAME,
+    ARENA_EXPERIMENT_TIMINGS_FILENAME,
+)
 from isaaclab_arena.evaluation.arena_run import RunStatus
 from isaaclab_arena.visualization.report import RunExecutionReport
 from osmo.scripts.build_experiment_output import (
@@ -42,6 +45,34 @@ def _write_run_output(run_output_directory: Path, run_name: str, success: bool) 
     }
     (run_output_directory / "episode_results_rebuild0.jsonl").write_text(
         json.dumps(episode_result) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _timing_record(name: str, count: int, total_ms: float) -> dict[str, object]:
+    return {
+        "type": "timing",
+        "name": name,
+        "app_name": "experiment_runner",
+        "count": count,
+        "mean_ms": total_ms / count,
+        "total_ms": total_ms,
+        "min_ms": total_ms / count,
+        "max_ms": total_ms / count,
+        "p10_ms": total_ms / count,
+        "p50_ms": total_ms / count,
+        "p90_ms": total_ms / count,
+    }
+
+
+def _write_run_timings(
+    experiment_runner_output_directory: Path,
+    timing_records: list[dict[str, object]],
+) -> None:
+    """Write the timings the Experiment Runner leaves beside its Run output directory."""
+    experiment_runner_output_directory.mkdir(parents=True, exist_ok=True)
+    (experiment_runner_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).write_text(
+        json.dumps(timing_records) + "\n",
         encoding="utf-8",
     )
 
@@ -148,6 +179,7 @@ def test_rejects_completed_experiment_runner_output_without_the_requested_run(tm
 def test_collects_run_outputs_without_building_report(tmp_path):
     experiment_runner_output_directory = tmp_path / "experiment-runner-0-output"
     _write_run_output(experiment_runner_output_directory / "first", "first", True)
+    _write_run_timings(experiment_runner_output_directory, [_timing_record("step", 1, 10.0)])
     first_run_metadata = _run_metadata("first-environment", "pi05")
     _write_experiment_runner_result(
         experiment_runner_output_directory,
@@ -173,7 +205,25 @@ def test_collects_run_outputs_without_building_report(tmp_path):
     }
     assert (experiment_output_directory / "first/episode_results_rebuild0.jsonl").is_file()
     assert (experiment_output_directory / "first" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
+    assert (experiment_output_directory / "first" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
     assert not (experiment_output_directory / "index.html").exists()
+
+
+def test_rejects_completed_experiment_runner_output_without_timings(tmp_path):
+    experiment_runner_output_directory = tmp_path / "experiment-runner-0-output"
+    _write_run_output(experiment_runner_output_directory / "first", "first", True)
+    _write_experiment_runner_result(
+        experiment_runner_output_directory,
+        RunStatus.COMPLETED,
+        0,
+        {"first": _run_metadata("first-environment", "pi05")},
+    )
+
+    with pytest.raises(AssertionError, match="Completed Run 'first' is missing its timings file"):
+        collect_run_outputs_into_experiment_output(
+            {"first": experiment_runner_output_directory},
+            tmp_path / "experiment-output",
+        )
 
 
 def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_path):
@@ -183,6 +233,14 @@ def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_pa
     second_run_output_directory = second_experiment_runner_output_directory / "second"
     _write_run_output(first_run_output_directory, "first", True)
     _write_run_output(second_run_output_directory, "second", False)
+    _write_run_timings(
+        first_experiment_runner_output_directory,
+        [_timing_record("step", 1, 10.0), _timing_record("step/policy_inference", 1, 4.0)],
+    )
+    _write_run_timings(
+        second_experiment_runner_output_directory,
+        [_timing_record("step", 3, 30.0)],
+    )
     _write_experiment_runner_result(
         first_experiment_runner_output_directory,
         RunStatus.COMPLETED,
@@ -230,6 +288,20 @@ def test_builds_experiment_output_from_separate_experiment_runner_outputs(tmp_pa
     }]
     assert set(first_run_result) == {"environment", "policy_variant", "status", "rebuilds"}
     assert experiment_result["runs"]["second"]["policy_variant"] == "cosmos"
+    assert (experiment_output_directory / "first" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    assert (experiment_output_directory / "second" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert experiment_timings["totals"] == [
+        {"name": "step", "count": 4, "total_ms": 40.0, "min_ms": 10.0, "max_ms": 10.0, "mean_ms": 10.0},
+        {"name": "step/policy_inference", "count": 1, "total_ms": 4.0, "min_ms": 4.0, "max_ms": 4.0, "mean_ms": 4.0},
+    ]
+    assert [(record["run_name"], record["name"]) for record in experiment_timings["runs"]] == [
+        ("first", "step"),
+        ("first", "step/policy_inference"),
+        ("second", "step"),
+    ]
     report_contents = report_path.read_text(encoding="utf-8")
     assert "first" in report_contents
     assert "second" in report_contents
@@ -242,6 +314,8 @@ def test_reports_failed_runner_without_its_partial_artifacts(tmp_path):
     failed_runner_output_directory = tmp_path / "failed-runner-output"
     _write_run_output(completed_runner_output_directory / "completed-run", "completed-run", True)
     _write_run_output(failed_runner_output_directory / "failed-run", "failed-run", False)
+    _write_run_timings(completed_runner_output_directory, [_timing_record("step", 1, 10.0)])
+    _write_run_timings(failed_runner_output_directory, [_timing_record("step", 1, 99.0)])
     _write_experiment_runner_result(
         completed_runner_output_directory,
         RunStatus.COMPLETED,
@@ -267,6 +341,14 @@ def test_reports_failed_runner_without_its_partial_artifacts(tmp_path):
 
     assert (experiment_output_directory / "completed-run/episode_results_rebuild0.jsonl").is_file()
     assert not (experiment_output_directory / "failed-run/episode_results_rebuild0.jsonl").exists()
+    # A failed Run's timings describe a partial execution, so they are excluded like its episode results.
+    assert (experiment_output_directory / "completed-run" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()
+    assert not (experiment_output_directory / "failed-run" / ARENA_EXPERIMENT_TIMINGS_FILENAME).exists()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert [record["run_name"] for record in experiment_timings["runs"]] == ["completed-run"]
+    assert experiment_timings["totals"][0]["total_ms"] == 10.0
     failed_result_path = experiment_output_directory / "failed-run" / EXPERIMENT_RUNNER_RESULT_FILE_NAME
     assert json.loads(failed_result_path.read_text(encoding="utf-8")) == {
         "execution_status": RunStatus.FAILED.value,
@@ -317,6 +399,10 @@ def test_builds_failure_report_when_every_runner_failed(tmp_path):
 
     assert (experiment_output_directory / "first" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
     assert (experiment_output_directory / "second" / EXPERIMENT_RUNNER_RESULT_FILE_NAME).is_file()
+    experiment_timings = json.loads(
+        (experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8")
+    )
+    assert experiment_timings == {"totals": [], "runs": []}
     experiment_result = json.loads(
         (experiment_output_directory / ARENA_EXPERIMENT_RESULT_FILENAME).read_text(encoding="utf-8")
     )

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -284,6 +284,7 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     assert "def build_experiment_output" in experiment_output_script_file["contents"]
     assert "from isaaclab_arena.evaluation.arena_experiment_result import" in experiment_output_script_file["contents"]
     assert EXPERIMENT_RUNNER_RESULT_FILE_NAME in experiment_output_script_file["contents"]
+    assert "from isaaclab_arena.evaluation.experiment_timings import" in experiment_output_script_file["contents"]
     assert "aggregate_experiment_timings(" in experiment_output_script_file["contents"]
     experiment_output_command = _task_file(experiment_output_task, "/tmp/entry.sh")["contents"]
     assert experiment_output_command.startswith("set -euo pipefail")

--- a/isaaclab_arena/tests/test_osmo_experiment_workflow.py
+++ b/isaaclab_arena/tests/test_osmo_experiment_workflow.py
@@ -282,11 +282,9 @@ def test_fans_out_single_run_experiments_with_dedicated_pi0_servers_and_one_expe
     experiment_output_script_file = _task_file(experiment_output_task, _REMOTE_BUILD_EXPERIMENT_OUTPUT_SCRIPT_PATH)
     assert "localpath" not in experiment_output_script_file
     assert "def build_experiment_output" in experiment_output_script_file["contents"]
-    assert (
-        "from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult"
-        in experiment_output_script_file["contents"]
-    )
+    assert "from isaaclab_arena.evaluation.arena_experiment_result import" in experiment_output_script_file["contents"]
     assert EXPERIMENT_RUNNER_RESULT_FILE_NAME in experiment_output_script_file["contents"]
+    assert "aggregate_experiment_timings(" in experiment_output_script_file["contents"]
     experiment_output_command = _task_file(experiment_output_task, "/tmp/entry.sh")["contents"]
     assert experiment_output_command.startswith("set -euo pipefail")
     assert _REMOTE_BUILD_EXPERIMENT_OUTPUT_SCRIPT_PATH in experiment_output_command

--- a/isaaclab_arena/tests/test_run_execution.py
+++ b/isaaclab_arena/tests/test_run_execution.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from copy import deepcopy
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -12,8 +13,10 @@ import pytest
 from isaaclab_arena.environments.arena_environment_factory import ArenaEnvironmentCfg
 from isaaclab_arena.evaluation import run_execution
 from isaaclab_arena.evaluation.arena_experiment import ArenaExperimentCfg
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME
 from isaaclab_arena.evaluation.arena_run import ArenaRunCfg, ArenaRunResult, RolloutLimitCfg, RunStatus
 from isaaclab_arena.policy.policy_base import PolicyCfg
+from isaaclab_arena.utils.timer import Timer
 
 
 @dataclass
@@ -228,3 +231,46 @@ def test_execute_experiment_stops_on_failure_by_default(monkeypatch, tmp_path):
         )
 
     assert attempted == ["failing"]
+
+
+def test_execute_experiment_writes_one_timings_file_per_run(monkeypatch, tmp_path):
+    """Each Run's timings cover that Run alone, matching what OSMO produces per process."""
+
+    def build_and_run(run_cfg, output_dir, video_cfg):
+        with Timer(run_cfg.name):
+            pass
+        return ArenaRunResult(run_name=run_cfg.name, status=RunStatus.COMPLETED)
+
+    monkeypatch.setattr(run_execution, "build_and_run", build_and_run)
+
+    run_execution.execute_experiment(_experiment(_run(name="first"), _run(name="second")), output_dir=tmp_path)
+
+    for run_name in ("first", "second"):
+        records = json.loads(
+            (tmp_path / run_name / ARENA_EXPERIMENT_TIMINGS_FILENAME).read_text(encoding="utf-8"),
+        )
+        # The registry is cleared between Runs, so a Run's file holds only its own timer.
+        assert [record["name"] for record in records] == [run_name]
+        assert records[0]["app_name"] == "experiment_runner"
+
+
+def test_execute_experiment_writes_no_timings_for_a_failed_run(monkeypatch, tmp_path):
+    """A failed Run leaves no timings file, which is what the Experiment aggregation expects."""
+
+    def build_and_run(run_cfg, output_dir, video_cfg):
+        if run_cfg.name == "failing":
+            raise RuntimeError("rollout failed")
+        with Timer("step"):
+            pass
+        return ArenaRunResult(run_name=run_cfg.name, status=RunStatus.COMPLETED)
+
+    monkeypatch.setattr(run_execution, "build_and_run", build_and_run)
+
+    run_execution.execute_experiment(
+        _experiment(_run(name="failing"), _run(name="passing")),
+        output_dir=tmp_path,
+        continue_on_error=True,
+    )
+
+    assert not (tmp_path / "failing" / ARENA_EXPERIMENT_TIMINGS_FILENAME).exists()
+    assert (tmp_path / "passing" / ARENA_EXPERIMENT_TIMINGS_FILENAME).is_file()

--- a/isaaclab_arena/tests/test_timer.py
+++ b/isaaclab_arena/tests/test_timer.py
@@ -136,7 +136,72 @@ class TestTimer:
                 pass
 
         stats = get_timer_stats()
-        assert stats["outer"].total_ms >= stats["inner"].total_ms
+        assert stats["outer"].total_ms >= stats["outer/inner"].total_ms
+
+    def test_nested_name_is_qualified_by_its_enclosing_timers(self) -> None:
+        """Verify each nesting level appends its name to the enclosing name."""
+        with Timer("a"):
+            with Timer("b"):
+                with Timer("c"):
+                    pass
+
+        assert set(get_timer_stats()) == {"a", "a/b", "a/b/c"}
+
+    def test_same_name_records_separately_per_nesting_position(self) -> None:
+        """Verify a name used at two depths does not collapse into one entry."""
+        with Timer("step"):
+            pass
+        with Timer("outer"):
+            with Timer("step"):
+                pass
+
+        stats = get_timer_stats()
+        assert stats["step"].count == 1
+        assert stats["outer/step"].count == 1
+
+    def test_siblings_share_the_enclosing_name(self) -> None:
+        """Verify timers nested side by side each hang off the same enclosing name."""
+        with Timer("step"):
+            with Timer("policy"):
+                pass
+            with Timer("env"):
+                pass
+
+        assert set(get_timer_stats()) == {"step", "step/policy", "step/env"}
+
+    def test_nesting_unwinds_when_an_inner_timer_raises(self) -> None:
+        """Verify a timer that exits on an exception still leaves the enclosing name correct."""
+        with Timer("outer"):
+            with pytest.raises(ValueError, match="inner error"):
+                with Timer("failing"):
+                    raise ValueError("inner error")
+            with Timer("after"):
+                pass
+
+        assert set(get_timer_stats()) == {"outer", "outer/failing", "outer/after"}
+
+    def test_name_returns_to_top_level_after_the_enclosing_timer_exits(self) -> None:
+        """Verify the enclosing name is not leaked into timers entered after it closes."""
+        with Timer("outer"):
+            with Timer("inner"):
+                pass
+
+        with Timer("later"):
+            pass
+
+        assert "later" in get_timer_stats()
+
+    def test_rejects_a_name_containing_the_separator(self) -> None:
+        """Verify names cannot smuggle in a nesting level, which the separator is reserved for."""
+        with pytest.raises(AssertionError, match="must not contain"):
+            Timer("a/b")
+
+    def test_qualified_name_is_exposed_on_the_timer(self) -> None:
+        """Verify the resolved registry key is readable from the timer itself."""
+        with Timer("outer"):
+            with Timer("inner") as inner_timer:
+                assert inner_timer.name == "inner"
+                assert inner_timer.qualified_name == "outer/inner"
 
     def test_exception_propagation(self) -> None:
         """Verify exceptions propagate and stats are still recorded."""

--- a/isaaclab_arena/tests/test_timer.py
+++ b/isaaclab_arena/tests/test_timer.py
@@ -191,18 +191,6 @@ class TestTimer:
 
         assert "later" in get_timer_stats()
 
-    def test_rejects_a_name_containing_the_separator(self) -> None:
-        """Verify names cannot smuggle in a nesting level, which the separator is reserved for."""
-        with pytest.raises(AssertionError, match="must not contain"):
-            Timer("a/b")
-
-    def test_qualified_name_is_exposed_on_the_timer(self) -> None:
-        """Verify the resolved registry key is readable from the timer itself."""
-        with Timer("outer"):
-            with Timer("inner") as inner_timer:
-                assert inner_timer.name == "inner"
-                assert inner_timer.qualified_name == "outer/inner"
-
     def test_exception_propagation(self) -> None:
         """Verify exceptions propagate and stats are still recorded."""
         with pytest.raises(ValueError, match="test error"):

--- a/isaaclab_arena/utils/env_step_timer.py
+++ b/isaaclab_arena/utils/env_step_timer.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, The Isaac Lab Arena Project Developers (https://github.com/isaac-sim/IsaacLab-Arena/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gym wrapper that times the env it wraps, so the cost of the wrappers above it can be separated."""
+
+from __future__ import annotations
+
+import gymnasium as gym
+
+from isaaclab_arena.utils.timer import Timer
+
+
+class EnvStepTimerWrapper(gym.Wrapper):
+    """Record the wall time of the wrapped env's step under a timer name.
+
+    The timer covers everything below this wrapper and nothing above it, so placing it under a
+    stack of wrappers attributes the difference against an outer measurement to those wrappers.
+    """
+
+    def __init__(self, env: gym.Env, timer_name: str) -> None:
+        """Wrap an env and record each of its steps under the given timer name.
+
+        Args:
+            env: The env whose step is timed.
+            timer_name: Name the measurements accumulate under, qualified by any enclosing timers.
+        """
+        super().__init__(env)
+        self.timer_name = timer_name
+
+    def step(self, action):
+        """Step the wrapped env, recording how long it took."""
+        with Timer(self.timer_name):
+            return self.env.step(action)

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -27,7 +27,6 @@ import json
 import random
 import threading
 import time
-import torch
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -145,6 +144,10 @@ class Timer:
 
     def __enter__(self) -> Timer:
         """Start the timer, qualifying its name by any enclosing timers and pushing an NVTX range."""
+        # Imported here, not at module scope: Isaac Sim must start before torch initializes, and
+        # this module is imported by entry points that run before the SimulationApp launches.
+        import torch
+
         if torch.compiler.is_compiling():
             return self
         self.qualified_name = "/".join([*_open_timer_names.names, self.name])
@@ -157,6 +160,8 @@ class Timer:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Stop the timer, popping the NVTX range and recording the elapsed wall time."""
+        import torch
+
         if torch.compiler.is_compiling():
             return
         if Timer._sync_cuda:

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -7,12 +7,16 @@
 
 Adapted from nvblox_next.system.timer.
 
+Timers nest: a block entered inside another block records under the enclosing timer's name
+joined with its own, so the registry keys spell out the call tree.
+
 Usage:
     from isaaclab_arena.utils.timer import Timer, print_timer_stats
 
     for episode in episodes:
-        with Timer("rollout"):
-            rollout_policy(env, policy)
+        with Timer("rollout"):            # records under "rollout"
+            with Timer("step"):           # records under "rollout/step"
+                env.step(actions)
 
     print_timer_stats()
 """
@@ -21,6 +25,7 @@ from __future__ import annotations
 
 import json
 import random
+import threading
 import time
 import torch
 from collections.abc import Iterable, Mapping
@@ -31,8 +36,12 @@ from typing import Any
 # Keep reservoir sampling independent from application randomness.
 _reservoir_random_generator = random.Random()
 
-# Timing statistics accumulated over the process lifetime, keyed by timer name.
+# Timing statistics accumulated over the process lifetime, keyed by qualified timer name.
 _timer_registry: dict[str, TimerStats] = {}
+
+# Names of the timers currently open on this thread, outermost first. A timer entered while this
+# is non-empty qualifies its name with the enclosing names, so nesting is visible in the registry.
+_open_timer_names = threading.local()
 
 
 @dataclass
@@ -88,6 +97,15 @@ class TimerStats:
         return sorted_buf[idx]
 
 
+def _enclosing_timer_names() -> list[str]:
+    """Return the mutable stack of timer names open on the calling thread, outermost first."""
+    names = getattr(_open_timer_names, "names", None)
+    if names is None:
+        names = []
+        _open_timer_names.names = names
+    return names
+
+
 def _update_stats(name: str, elapsed_ms: float) -> None:
     """Create or update the registry entry for the given timer name."""
     if name in _timer_registry:
@@ -101,7 +119,9 @@ def _update_stats(name: str, elapsed_ms: float) -> None:
 class Timer:
     """Context manager that records wall-clock durations under a name.
 
-    Measurements accumulate in a process-wide registry until reset_timer_stats() is called.
+    A timer entered inside another records under the enclosing timer's name joined with its own,
+    so a "step" block inside an "episode" block accumulates under "episode/step". Measurements
+    accumulate in a process-wide registry until reset_timer_stats() is called.
     """
 
     _sync_cuda: bool = False
@@ -115,19 +135,25 @@ class Timer:
         """Create a new timer with the given name.
 
         Args:
-            name: Registry key that this block's measurements accumulate under.
+            name: Name of this block, qualified by any enclosing timers to form the registry key.
+                Must not contain the "/" separator, which the qualified name is built from.
         """
+        assert "/" not in name, f"Timer name must not contain '/', it separates nesting levels: '{name}'"
         self.name = name
+        self.qualified_name = name
         self._start_time: float = 0.0
 
     def __enter__(self) -> Timer:
-        """Start the timer, recording wall time and pushing an NVTX range."""
+        """Start the timer, qualifying its name by any enclosing timers and pushing an NVTX range."""
         if torch.compiler.is_compiling():
             return self
+        open_timer_names = _enclosing_timer_names()
+        self.qualified_name = "/".join([*open_timer_names, self.name])
+        open_timer_names.append(self.name)
         if Timer._sync_cuda:
             torch.cuda.synchronize()
         self._start_time = time.perf_counter()
-        torch.cuda.nvtx.range_push(self.name)
+        torch.cuda.nvtx.range_push(self.qualified_name)
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
@@ -138,7 +164,8 @@ class Timer:
             torch.cuda.synchronize()
         torch.cuda.nvtx.range_pop()
         elapsed_ms = (time.perf_counter() - self._start_time) * 1e3
-        _update_stats(self.name, elapsed_ms)
+        _enclosing_timer_names().pop()
+        _update_stats(self.qualified_name, elapsed_ms)
 
 
 def get_timer_stats() -> dict[str, TimerStats]:

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -39,9 +39,21 @@ _reservoir_random_generator = random.Random()
 # Timing statistics accumulated over the process lifetime, keyed by qualified timer name.
 _timer_registry: dict[str, TimerStats] = {}
 
-# Names of the timers currently open on this thread, outermost first. A timer entered while this
-# is non-empty qualifies its name with the enclosing names, so nesting is visible in the registry.
-_open_timer_names = threading.local()
+
+class _OpenTimerNames(threading.local):
+    """Names of the timers currently open on one thread, outermost first.
+
+    A timer entered while this is non-empty qualifies its name with the enclosing names, so
+    nesting is visible in the registry. Subclassing threading.local runs __init__ once per
+    thread, which gives every thread its own stack without a lazy lookup at each use.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.names: list[str] = []
+
+
+_open_timer_names = _OpenTimerNames()
 
 
 @dataclass
@@ -97,15 +109,6 @@ class TimerStats:
         return sorted_buf[idx]
 
 
-def _enclosing_timer_names() -> list[str]:
-    """Return the mutable stack of timer names open on the calling thread, outermost first."""
-    names = getattr(_open_timer_names, "names", None)
-    if names is None:
-        names = []
-        _open_timer_names.names = names
-    return names
-
-
 def _update_stats(name: str, elapsed_ms: float) -> None:
     """Create or update the registry entry for the given timer name."""
     if name in _timer_registry:
@@ -140,16 +143,16 @@ class Timer:
         """
         assert "/" not in name, f"Timer name must not contain '/', it separates nesting levels: '{name}'"
         self.name = name
-        self.qualified_name = name
+        self.qualified_name: str | None = None
+        """Registry key this block records under, resolved on entry once the enclosing timers are known."""
         self._start_time: float = 0.0
 
     def __enter__(self) -> Timer:
         """Start the timer, qualifying its name by any enclosing timers and pushing an NVTX range."""
         if torch.compiler.is_compiling():
             return self
-        open_timer_names = _enclosing_timer_names()
-        self.qualified_name = "/".join([*open_timer_names, self.name])
-        open_timer_names.append(self.name)
+        self.qualified_name = "/".join([*_open_timer_names.names, self.name])
+        _open_timer_names.names.append(self.name)
         if Timer._sync_cuda:
             torch.cuda.synchronize()
         self._start_time = time.perf_counter()
@@ -164,7 +167,8 @@ class Timer:
             torch.cuda.synchronize()
         torch.cuda.nvtx.range_pop()
         elapsed_ms = (time.perf_counter() - self._start_time) * 1e3
-        _enclosing_timer_names().pop()
+        _open_timer_names.names.pop()
+        assert self.qualified_name is not None, "Timer name is resolved on entry"
         _update_stats(self.qualified_name, elapsed_ms)
 
 

--- a/isaaclab_arena/utils/timer.py
+++ b/isaaclab_arena/utils/timer.py
@@ -41,14 +41,10 @@ _timer_registry: dict[str, TimerStats] = {}
 
 
 class _OpenTimerNames(threading.local):
-    """Names of the timers currently open on one thread, outermost first.
-
-    A timer entered while this is non-empty qualifies its name with the enclosing names, so
-    nesting is visible in the registry. Subclassing threading.local runs __init__ once per
-    thread, which gives every thread its own stack without a lazy lookup at each use.
-    """
+    """Names of the timers currently open on one thread."""
 
     def __init__(self) -> None:
+        # Subclassing threading.local runs __init__ once per thread.
         super().__init__()
         self.names: list[str] = []
 

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -36,15 +36,6 @@ from isaaclab_arena.utils.timer import Timer
 
 CAMERA_OBS_GROUP_KEY = "camera_obs"
 
-CAMERA_FRAMES_TIMER_NAME = "camera_frames"
-"""Timer covering the per-step camera frame copy and encoder writes.
-
-Nested inside the wrapped env's step timer, so it reports as "<enclosing>/camera_frames".
-"""
-
-CAMERA_FINALIZE_TIMER_NAME = "camera_finalize"
-"""Timer covering the encoder shutdown that finalises one episode's mp4 files."""
-
 # Regular expression to parse the filename of an episode video.
 _EPISODE_VIDEO_FILENAME_PATTERN = re.compile(
     r"^(?P<prefix>.+?)(?:-rebuild(?P<rebuild>\d+))?-env(?P<env>\d+)-(?P<camera>.+)-episode-(?P<episode>\d+)\.mp4$"
@@ -154,8 +145,9 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_set = set(done_envs)
 
             # Timed separately from the env step: this covers the device-to-host copy of every
-            # camera frame and the encoder writes, which is the per-step cost of recording.
-            with Timer(CAMERA_FRAMES_TIMER_NAME):
+            # camera frame and the encoder writes, which is the per-step cost of recording. Both
+            # timers here nest inside the enclosing step timer, reporting as "<enclosing>/...".
+            with Timer("camera_frames"):
                 for camera_name, frames in cam_obs.items():
                     if camera_name not in self.writers:
                         self.writers[camera_name] = [None] * n_envs
@@ -164,7 +156,8 @@ class CameraObsVideoRecorder(gym.Wrapper):
                             self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
 
             if done_envs:
-                with Timer(CAMERA_FINALIZE_TIMER_NAME):
+                # The encoder shutdown that finalises one episode's mp4 files.
+                with Timer("camera_finalize"):
                     self._finish_envs(done_envs)
 
         return result

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -32,7 +32,18 @@ from dataclasses import dataclass
 
 from moviepy.video.io.ffmpeg_writer import FFMPEG_VideoWriter
 
+from isaaclab_arena.utils.timer import Timer
+
 CAMERA_OBS_GROUP_KEY = "camera_obs"
+
+CAMERA_FRAMES_TIMER_NAME = "camera_frames"
+"""Timer covering the per-step camera frame copy and encoder writes.
+
+Nested inside the wrapped env's step timer, so it reports as "<enclosing>/camera_frames".
+"""
+
+CAMERA_FINALIZE_TIMER_NAME = "camera_finalize"
+"""Timer covering the encoder shutdown that finalises one episode's mp4 files."""
 
 # Regular expression to parse the filename of an episode video.
 _EPISODE_VIDEO_FILENAME_PATTERN = re.compile(
@@ -142,15 +153,19 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_envs = (terminated | truncated).nonzero().flatten().tolist()
             done_set = set(done_envs)
 
-            for camera_name, frames in cam_obs.items():
-                if camera_name not in self.writers:
-                    self.writers[camera_name] = [None] * n_envs
-                for env_idx in range(n_envs):
-                    if env_idx not in done_set:
-                        self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
+            # Timed separately from the env step: this covers the device-to-host copy of every
+            # camera frame and the encoder writes, which is the per-step cost of recording.
+            with Timer(CAMERA_FRAMES_TIMER_NAME):
+                for camera_name, frames in cam_obs.items():
+                    if camera_name not in self.writers:
+                        self.writers[camera_name] = [None] * n_envs
+                    for env_idx in range(n_envs):
+                        if env_idx not in done_set:
+                            self._write_frame(camera_name, env_idx, _to_uint8(frames[env_idx]))
 
             if done_envs:
-                self._finish_envs(done_envs)
+                with Timer(CAMERA_FINALIZE_TIMER_NAME):
+                    self._finish_envs(done_envs)
 
         return result
 

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -144,10 +144,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
             done_envs = (terminated | truncated).nonzero().flatten().tolist()
             done_set = set(done_envs)
 
-            # Timed separately from the env step: this covers the device-to-host copy of every
-            # camera frame and the encoder writes, which is the per-step cost of recording. Both
-            # timers here nest inside the enclosing step timer, reporting as "<enclosing>/...".
-            with Timer("camera_frames"):
+            with Timer("record_camera_frames"):
                 for camera_name, frames in cam_obs.items():
                     if camera_name not in self.writers:
                         self.writers[camera_name] = [None] * n_envs

--- a/isaaclab_arena/video/camera_observation_video_recorder.py
+++ b/isaaclab_arena/video/camera_observation_video_recorder.py
@@ -154,7 +154,7 @@ class CameraObsVideoRecorder(gym.Wrapper):
 
             if done_envs:
                 # The encoder shutdown that finalises one episode's mp4 files.
-                with Timer("camera_finalize"):
+                with Timer("record_camera_finalize"):
                     self._finish_envs(done_envs)
 
         return result

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -9,6 +9,15 @@ import dataclasses
 import datetime
 import os
 
+SIM_STEP_TIMER_NAME = "sim_step"
+"""Timer covering the env step below every recorder, so recording cost separates from it.
+
+The rollout's ``env_step`` timer measures the outermost wrapper, so the difference between it and
+this timer is the total cost of recording. ``camera_frames`` and ``camera_finalize`` break out the
+camera recorder's share; whatever remains is the viewport recorder's ``env.render()``. This timer
+only exists while a recorder is enabled, and nests as ``env_step/sim_step``.
+"""
+
 
 @dataclasses.dataclass
 class VideoRecordingCfg:
@@ -79,6 +88,11 @@ def wrap_env_for_video(
         return env
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
+
+    # Sits below every recorder, so its measurement excludes them.
+    from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
+
+    env = EnvStepTimerWrapper(env, timer_name=SIM_STEP_TIMER_NAME)
 
     # Record the kit viewport (via env.render()).
     if video_cfg.record_viewport_video:

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -80,10 +80,8 @@ def wrap_env_for_video(
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
 
-    # Sits below every recorder, so its measurement excludes them. The rollout's "env_step" timer
-    # measures the outermost wrapper, so the difference between it and this one is the total cost
-    # of recording; "camera_frames" and "camera_finalize" break out the camera recorder's share and
-    # whatever remains is the viewport recorder's env.render(). Only present while recording.
+    # Wrap the env in a step timer before adding the camera recording to get a without-recording
+    # step measurement.
     from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
 
     env = EnvStepTimerWrapper(env, timer_name="sim_step")

--- a/isaaclab_arena/video/video_recording.py
+++ b/isaaclab_arena/video/video_recording.py
@@ -9,15 +9,6 @@ import dataclasses
 import datetime
 import os
 
-SIM_STEP_TIMER_NAME = "sim_step"
-"""Timer covering the env step below every recorder, so recording cost separates from it.
-
-The rollout's ``env_step`` timer measures the outermost wrapper, so the difference between it and
-this timer is the total cost of recording. ``camera_frames`` and ``camera_finalize`` break out the
-camera recorder's share; whatever remains is the viewport recorder's ``env.render()``. This timer
-only exists while a recorder is enabled, and nests as ``env_step/sim_step``.
-"""
-
 
 @dataclasses.dataclass
 class VideoRecordingCfg:
@@ -89,10 +80,13 @@ def wrap_env_for_video(
 
     os.makedirs(video_cfg.video_base_dir, exist_ok=True)
 
-    # Sits below every recorder, so its measurement excludes them.
+    # Sits below every recorder, so its measurement excludes them. The rollout's "env_step" timer
+    # measures the outermost wrapper, so the difference between it and this one is the total cost
+    # of recording; "camera_frames" and "camera_finalize" break out the camera recorder's share and
+    # whatever remains is the viewport recorder's env.render(). Only present while recording.
     from isaaclab_arena.utils.env_step_timer import EnvStepTimerWrapper
 
-    env = EnvStepTimerWrapper(env, timer_name=SIM_STEP_TIMER_NAME)
+    env = EnvStepTimerWrapper(env, timer_name="sim_step")
 
     # Record the kit viewport (via env.render()).
     if video_cfg.record_viewport_video:

--- a/osmo/scripts/build_experiment_output.py
+++ b/osmo/scripts/build_experiment_output.py
@@ -9,7 +9,7 @@ The input JSON maps each Run name to its Experiment Runner task's output directo
 its ``<run-name>/...`` output is included. Completed Run directories are copied into the
 ``<experiment-output>/<run-name>`` layout, while failed results are preserved without partial Run artifacts. The
 ``arena_experiment_result.json`` and ``index.html`` report list every Run execution and include episode details only
-from completed Runs.
+from completed Runs. ``arena_experiment_timings.json`` holds each completed Run's timings and their per-timer totals.
 """
 
 from __future__ import annotations
@@ -17,11 +17,12 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
-from isaaclab_arena.evaluation.arena_experiment_result import ArenaExperimentResult
+from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME, ArenaExperimentResult
 from isaaclab_arena.evaluation.arena_run import RunStatus
+from isaaclab_arena.utils.timer import merge_timer_stats_json
 from isaaclab_arena.visualization.report import RunExecutionReport, build_report
 
 EXPERIMENT_RUNNER_RESULT_FILE_NAME = "experiment_runner_result.json"
@@ -147,10 +148,56 @@ def collect_run_outputs_into_experiment_output(
             experiment_runner_result_path,
             destination_run_output_directory / EXPERIMENT_RUNNER_RESULT_FILE_NAME,
         )
+        # The runner writes its timings beside the Run directory, so copy them in alongside the episode results.
+        source_run_timings_path = experiment_runner_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
+        assert (
+            source_run_timings_path.is_file()
+        ), f"Completed Run '{run_name}' is missing its timings file: '{source_run_timings_path}'"
+        shutil.copy2(
+            source_run_timings_path,
+            destination_run_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME,
+        )
     return (
         sorted(run_execution_reports, key=lambda run_execution_report: run_execution_report.run_name),
         run_metadata_by_name,
     )
+
+
+def aggregate_experiment_timings(
+    experiment_output_directory: Path,
+    run_execution_reports: Sequence[RunExecutionReport],
+) -> Path:
+    """Combine every completed Run's timings into one Experiment timings file.
+
+    Args:
+        experiment_output_directory: Experiment output containing one collected directory per Run.
+        run_execution_reports: Validated execution results for every declared Run.
+
+    Returns:
+        Path to the written Experiment timings file.
+    """
+    run_records: list[dict[str, object]] = []
+    for run_execution_report in run_execution_reports:
+        if run_execution_report.status is not RunStatus.COMPLETED:
+            continue
+        run_name = run_execution_report.run_name
+        run_timings_path = experiment_output_directory / run_name / ARENA_EXPERIMENT_TIMINGS_FILENAME
+        run_records.extend(
+            {"run_name": run_name, **record} for record in json.loads(run_timings_path.read_text(encoding="utf-8"))
+        )
+
+    experiment_timings_path = experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
+    experiment_timings_path.write_text(
+        json.dumps(
+            {"totals": merge_timer_stats_json(run_records), "runs": run_records},
+            allow_nan=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote Arena Experiment timings to: {experiment_timings_path}")
+    return experiment_timings_path
 
 
 def build_experiment_output(
@@ -173,6 +220,7 @@ def build_experiment_output(
         experiment_output_directory,
     )
     ArenaExperimentResult(experiment_output_directory, run_metadata_by_name).write()
+    aggregate_experiment_timings(experiment_output_directory, run_execution_reports)
     return build_report(experiment_output_directory, run_executions=run_execution_reports)
 
 

--- a/osmo/scripts/build_experiment_output.py
+++ b/osmo/scripts/build_experiment_output.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from pathlib import Path
 
 from isaaclab_arena.evaluation.arena_experiment_result import ARENA_EXPERIMENT_TIMINGS_FILENAME, ArenaExperimentResult
 from isaaclab_arena.evaluation.arena_run import RunStatus
-from isaaclab_arena.utils.timer import merge_timer_stats_json
+from isaaclab_arena.evaluation.experiment_timings import aggregate_experiment_timings
 from isaaclab_arena.visualization.report import RunExecutionReport, build_report
 
 EXPERIMENT_RUNNER_RESULT_FILE_NAME = "experiment_runner_result.json"
@@ -163,43 +163,6 @@ def collect_run_outputs_into_experiment_output(
     )
 
 
-def aggregate_experiment_timings(
-    experiment_output_directory: Path,
-    run_execution_reports: Sequence[RunExecutionReport],
-) -> Path:
-    """Combine every completed Run's timings into one Experiment timings file.
-
-    Args:
-        experiment_output_directory: Experiment output containing one collected directory per Run.
-        run_execution_reports: Validated execution results for every declared Run.
-
-    Returns:
-        Path to the written Experiment timings file.
-    """
-    run_records: list[dict[str, object]] = []
-    for run_execution_report in run_execution_reports:
-        if run_execution_report.status is not RunStatus.COMPLETED:
-            continue
-        run_name = run_execution_report.run_name
-        run_timings_path = experiment_output_directory / run_name / ARENA_EXPERIMENT_TIMINGS_FILENAME
-        run_records.extend(
-            {"run_name": run_name, **record} for record in json.loads(run_timings_path.read_text(encoding="utf-8"))
-        )
-
-    experiment_timings_path = experiment_output_directory / ARENA_EXPERIMENT_TIMINGS_FILENAME
-    experiment_timings_path.write_text(
-        json.dumps(
-            {"totals": merge_timer_stats_json(run_records), "runs": run_records},
-            allow_nan=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    print(f"Wrote Arena Experiment timings to: {experiment_timings_path}")
-    return experiment_timings_path
-
-
 def build_experiment_output(
     experiment_runner_output_directories_by_run_name: Mapping[str, Path],
     experiment_output_directory: Path,
@@ -220,7 +183,11 @@ def build_experiment_output(
         experiment_output_directory,
     )
     ArenaExperimentResult(experiment_output_directory, run_metadata_by_name).write()
-    aggregate_experiment_timings(experiment_output_directory, run_execution_reports)
+    experiment_timings_path = aggregate_experiment_timings(
+        experiment_output_directory,
+        [report.run_name for report in run_execution_reports if report.status is RunStatus.COMPLETED],
+    )
+    print(f"Wrote Arena Experiment timings to: {experiment_timings_path}")
     return build_report(experiment_output_directory, run_executions=run_execution_reports)
 
 

--- a/osmo/tasks/collect_experiment_outputs_task.py
+++ b/osmo/tasks/collect_experiment_outputs_task.py
@@ -32,9 +32,9 @@ class CollectExperimentOutputsTask(BaseTask):
 
     For each Run, OSMO exposes its Experiment Runner task output at ``{{input:<runner-task>}}``. The embedded script
     copies completed Run outputs to ``{{output}}/<run-name>/...``, preserves failed runner results without partial Run
-    artifacts, and writes ``{{output}}/arena_experiment_result.json`` plus ``{{output}}/index.html``. Both list failed
-    Run executions but exclude their partial episode artifacts. Only this final task output is published to Swift;
-    the Experiment Runner task outputs remain workflow-local.
+    artifacts, and writes ``{{output}}/arena_experiment_result.json``, ``{{output}}/arena_experiment_timings.json``,
+    plus ``{{output}}/index.html``. These list failed Run executions but exclude their partial episode artifacts.
+    Only this final task output is published to Swift; the Experiment Runner task outputs remain workflow-local.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary
Same commits as #1198, on a fresh branch to rule out branch-scoped CI state.

## Detailed description
- `Run tests with subprocess` has failed repeatedly on `alex/feature/timing_2`, always with an Isaac Sim startup crash (`appState = 'startup'`) that then stalls the crash reporter for the full 900s subprocess timeout.
- The same failure hits `main` and nine other branches (23 of 24 readable subprocess-job failures in the last week carry that signature), and 40 local runs of the most-affected test plus repeated local Phase 3 runs have not reproduced any crash.
- This branch points at the identical commit as #1198 (`0517d499c`, which already merges current `main`), so any difference in CI outcome is attributable to per-branch runner state — for example the `actions/cache` scope used by the *Setup Isaac Sim kit cache* step — rather than to the code.
- Draft, and not for merge: #1198 remains the PR under review. Close this once the question is settled.