### PR TITLE
Opt out of nested background physics reset for Galileo scene

### DIFF
--- a/isaaclab_arena/assets/background_library.py
+++ b/isaaclab_arena/assets/background_library.py
@@ -112,6 +112,10 @@ class GalileoLocomanipBackground(LibraryBackground):
     initial_pose = Pose(position_xyz=(4.420, 1.408, -0.795), rotation_xyzw=(0.0, 0.0, 0.0, 1.0))
     object_min_z = -0.2
 
+    def __init__(self, **kwargs):
+        # NOTE: The dolly in the scene is authored as an articulation root but is not materialized as a PhysX articulation.
+        super().__init__(reset_nested_physics=False, **kwargs)
+
 
 @register_asset
 class Table(LibraryBackground):

--- a/isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py
@@ -89,7 +89,7 @@ class GalileoG1LocomanipPickAndPlaceEnvironment(ArenaEnvironmentFactory[GalileoG
         from isaaclab_arena.tasks.pick_and_place_task import G1PickAndPlaceMimicEnvCfg, PickAndPlaceTask
         from isaaclab_arena.utils.pose import Pose, PoseRange
 
-        background = self.asset_registry.get_asset_by_name("galileo_locomanip")(reset_nested_physics=False)
+        background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
         pick_up_object = self.asset_registry.get_asset_by_name(cfg.object)()
         destination = self.asset_registry.get_asset_by_name(cfg.destination)()
         embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)

--- a/isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py
+++ b/isaaclab_arena_environments/galileo_g1_locomanip_pick_and_place_environment.py
@@ -89,7 +89,7 @@ class GalileoG1LocomanipPickAndPlaceEnvironment(ArenaEnvironmentFactory[GalileoG
         from isaaclab_arena.tasks.pick_and_place_task import G1PickAndPlaceMimicEnvCfg, PickAndPlaceTask
         from isaaclab_arena.utils.pose import Pose, PoseRange
 
-        background = self.asset_registry.get_asset_by_name("galileo_locomanip")()
+        background = self.asset_registry.get_asset_by_name("galileo_locomanip")(reset_nested_physics=False)
         pick_up_object = self.asset_registry.get_asset_by_name(cfg.object)()
         destination = self.asset_registry.get_asset_by_name(cfg.destination)()
         embodiment = self.asset_registry.get_asset_by_name(cfg.embodiment)(enable_cameras=cfg.enable_cameras)


### PR DESCRIPTION
## Summary
Nested background physics reset became enabled by default and opted the Galileo scene into a reset path that it does not use. The Galileo scene contains a dolly prim that identified as an articulation from its USD schema, but PhysX does not expose a corresponding tensor articulation. The user is informed of this via an error message that is not fatal.

This PR disables `reset_nested_physics` to restore prior behaviour and prevent users from getting this error message. 